### PR TITLE
Prevent duplicate plugin registration

### DIFF
--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -1,6 +1,10 @@
 (function () {
   "use strict";
 
+  // ponytail: Stash re-evaluates plugin scripts after cache resets; hard refresh loads updates.
+  if (window.__stashCuratorPluginLoaded) return;
+  window.__stashCuratorPluginLoaded = true;
+
   const Api = window.PluginApi;
   const { React, ReactDOM, GQL, libraries } = Api;
   const { Button, Nav } = libraries.Bootstrap;

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -105,6 +105,13 @@ def test_curator_tabs_update_browser_history() -> None:
     assert "onClick: () => openView(option.value)" in source
 
 
+def test_plugin_ignores_repeated_script_evaluation() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
+    guard = "if (window.__stashCuratorPluginLoaded) return;"
+    assert source.count(guard) == 1
+    assert source.index(guard) < source.index("const Api = window.PluginApi;")
+
+
 def test_backend_module_loads_without_starting(tmp_path: Path) -> None:
     backend = Path(__file__).parents[2] / "plugin" / "backend.py"
     spec = importlib.util.spec_from_file_location("curator_plugin_backend", backend)


### PR DESCRIPTION
## Summary
- ignore repeated evaluations of the Curator UI script
- prevent Stash cache resets from accumulating routes, listeners, and timers
- add a focused regression check for the early guard

## Root cause
Stash v0.31.1 unmounts and remounts its plugin loader after scan/clean cache resets. It re-evaluates plugin scripts without undoing their registration side effects. Curator therefore registered its page repeatedly.

## Verification
- scripts/verify changed tests/plugin/test_runtime.py: 7 passed
- scripts/verify full: 152 passed
- installed locally; repeated scan behavior confirmed fixed