### PR TITLE
Accelerate model builds and prune queries

### DIFF
--- a/curator/api.py
+++ b/curator/api.py
@@ -15,7 +15,7 @@ from curator.explanations import ExplanationService
 from curator.features import FeatureStore
 from curator.interactions import InteractionStore
 from curator.model import ModelUpdateCoordinator, RecommendationModelStore
-from curator.profiling import record_duration
+from curator.profiling import record_duration, span
 from curator.ranking import SlateBuilder
 from curator.ranking.slate import Slate
 from curator.similarity import SimilarityService
@@ -353,52 +353,60 @@ class CuratorAPI:
         model_id = RecommendationModelStore(self.connection).current_model_id()
         if model_id is None:
             raise RuntimeError("no published model")
-        tagged = {
-            str(row[0])
-            for row in self.connection.execute(
-                """
-                SELECT st.scene_id FROM scene_tag st JOIN source_tag t USING(tag_id)
-                WHERE lower(t.name)=lower(?)
-                """,
-                (tag_name,),
-            )
-        }
+        with span("python", "prune.tagged"):
+            tagged = {
+                str(row[0])
+                for row in self.connection.execute(
+                    """
+                    SELECT scene_id FROM scene_tag WHERE tag_id IN (
+                      SELECT tag_id FROM source_tag WHERE lower(name)=lower(?)
+                    )
+                    """,
+                    (tag_name,),
+                )
+            }
         states = {
             str(row["scene_id"]): str(row["state"])
             for row in self.connection.execute("SELECT scene_id, state FROM pruning_candidate")
         }
-        explicit = {
-            str(row[0])
-            for row in self.connection.execute(
-                """
-                SELECT f.scene_id FROM feedback f
-                WHERE f.reversed_by_id IS NULL AND f.feedback_type IN ('thumb_down', 'never_show')
-                AND f.occurred_at_ms=(
-                  SELECT max(f2.occurred_at_ms) FROM feedback f2
-                  WHERE f2.scene_id=f.scene_id AND f2.reversed_by_id IS NULL
-                  AND f2.feedback_type IN ('thumb_up', 'thumb_down', 'never_show')
-                )
-                """
-            )
-        } | {scene_id for scene_id, state in states.items() if state == "review"}
-        appeal_limit = -0.18 + 0.13 * aggressiveness
-        confidence_limit = 0.55 - 0.20 * aggressiveness
-        scores = (
-            {
-                str(row["scene_id"]): row
+        with span("python", "prune.explicit"):
+            explicit = {
+                str(row[0])
                 for row in self.connection.execute(
                     """
-                    SELECT scene_id, appeal, confidence FROM model_scene_score
-                    WHERE model_id=? AND (scene_id IN (
-                      SELECT scene_id FROM pruning_candidate WHERE state='review'
-                    ) OR appeal<=? AND confidence>=?)
-                    """,
-                    (model_id, appeal_limit, confidence_limit),
+                    SELECT f.scene_id FROM feedback f
+                    WHERE f.reversed_by_id IS NULL
+                    AND f.feedback_type IN ('thumb_down', 'never_show')
+                    AND f.occurred_at_ms=(
+                      SELECT max(f2.occurred_at_ms) FROM feedback f2
+                      WHERE f2.scene_id=f.scene_id AND f2.reversed_by_id IS NULL
+                      AND f2.feedback_type IN ('thumb_up', 'thumb_down', 'never_show')
+                    )
+                    """
                 )
-            }
-            if view != "tagged"
-            else {}
-        )
+            } | {scene_id for scene_id, state in states.items() if state == "review"}
+        appeal_limit = -0.18 + 0.13 * aggressiveness
+        confidence_limit = 0.55 - 0.20 * aggressiveness
+        with span("python", "prune.scores"):
+            scores = (
+                {
+                    str(row["scene_id"]): row
+                    for row in self.connection.execute(
+                        """
+                        SELECT scene_id, appeal, confidence FROM model_scene_score
+                        WHERE model_id=? AND appeal<=? AND confidence>=?
+                        UNION
+                        SELECT scene_id, appeal, confidence FROM model_scene_score
+                        WHERE model_id=? AND scene_id IN (
+                          SELECT scene_id FROM pruning_candidate WHERE state='review'
+                        )
+                        """,
+                        (model_id, appeal_limit, confidence_limit, model_id),
+                    )
+                }
+                if view != "tagged"
+                else {}
+            )
         suspects = {
             scene_id
             for scene_id, score in scores.items()

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -1107,14 +1107,13 @@ class ExpandService:
             )
             if str(row["studio_id"]) in links["studios"]
         }
-        profiles = FeatureStore(self.connection).performer_profiles(feature_version)
         evidence = self._performer_evidence(model_id, links)
         evidence_by_local = {str(item["local_id"]): item for item in evidence.values()}
+        anchor_ids = {key for key, item in evidence_by_local.items() if float(item["strength"]) > 0}
+        profiles = FeatureStore(self.connection).performer_profiles(feature_version, anchor_ids)
         local_studios = {external: local for local, external in links["studios"].items()}
         anchors = [
-            (profiles[key], item)
-            for key, item in evidence_by_local.items()
-            if key in profiles and float(item["strength"]) > 0
+            (profiles[key], item) for key, item in evidence_by_local.items() if key in profiles
         ]
         weights = dict(DEFAULT_CONFIG.feature.performer_block_weights)
         performer_rows: dict[str, dict[str, Any]] = {}

--- a/curator/features/profiles.py
+++ b/curator/features/profiles.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -16,6 +16,18 @@ class ProfileValue:
 class PerformerProfile:
     performer_id: str
     blocks: dict[str, dict[str, ProfileValue]]
+    norms: dict[str, float] = field(init=False, repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "norms",
+            {
+                block: math.sqrt(sum(item.value**2 for item in values.values()))
+                for block, values in self.blocks.items()
+                if block not in NUMERIC_BLOCKS
+            },
+        )
 
 
 @dataclass(frozen=True)
@@ -37,15 +49,19 @@ NUMERIC_SCALES = {
     "hip_to_height": 0.12,
     "age_recording": 8.0,
 }
+NUMERIC_BLOCKS = {"measurements", "height", "age"}
 
 
-def _cosine(left: dict[str, ProfileValue], right: dict[str, ProfileValue]) -> float | None:
+def _cosine(
+    left: dict[str, ProfileValue],
+    right: dict[str, ProfileValue],
+    left_norm: float,
+    right_norm: float,
+) -> float | None:
     shared = set(left) & set(right)
     if not shared:
         return 0.0
     dot = sum(left[key].value * right[key].value for key in shared)
-    left_norm = math.sqrt(sum(item.value**2 for item in left.values()))
-    right_norm = math.sqrt(sum(item.value**2 for item in right.values()))
     if left_norm == 0 or right_norm == 0:
         return None
     confidence = sum(min(left[key].confidence, right[key].confidence) for key in shared) / len(
@@ -73,15 +89,16 @@ def performer_similarity(
 ) -> SimilarityResult:
     similarities: dict[str, float] = {}
     used_weights: dict[str, float] = {}
-    numeric_blocks = {"measurements", "height", "age"}
     for block in sorted(set(left.blocks) & set(right.blocks)):
         weight = block_weights.get(block, 0.0)
         if weight <= 0:
             continue
         similarity = (
             _numeric(left.blocks[block], right.blocks[block])
-            if block in numeric_blocks
-            else _cosine(left.blocks[block], right.blocks[block])
+            if block in NUMERIC_BLOCKS
+            else _cosine(
+                left.blocks[block], right.blocks[block], left.norms[block], right.norms[block]
+            )
         )
         if similarity is None:
             continue

--- a/curator/features/store.py
+++ b/curator/features/store.py
@@ -121,7 +121,7 @@ class FeatureStore:
             f"""
             SELECT ef.entity_id, fd.family, fd.name, ef.value, ef.confidence
             FROM entity_feature ef JOIN feature_definition fd USING(feature_id)
-            WHERE {where} ORDER BY ef.entity_id, fd.family, fd.name
+            WHERE {where} ORDER BY ef.entity_id, ef.feature_id
             """,
             parameters,
         ):

--- a/curator/features/store.py
+++ b/curator/features/store.py
@@ -99,10 +99,10 @@ class FeatureStore:
                 )
                 SELECT other.scene_id AS entity_id, sum(target.value * other.value) AS similarity
                 FROM target JOIN scene_content_search other USING(feature_id)
-                WHERE other.feature_version=? AND other.scene_id<>?
+                WHERE other.scene_id<>?
                 GROUP BY other.scene_id
                 """,
-                (feature_version, scene_id, feature_version, scene_id),
+                (feature_version, scene_id, scene_id),
             )
         }
 

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -19,7 +19,7 @@ from curator.features.profiles import performer_similarity
 from curator.features.store import StoredFeature
 from curator.model.boundaries import scene_eligibility
 from curator.model.curves import blend_appeal, direct_confidence, scene_recovery
-from curator.profiling import record_duration
+from curator.profiling import record_duration, span
 from curator.storage import ModelStore, transaction
 from curator.storage.retention import prune_snapshots
 
@@ -409,23 +409,26 @@ class PreferenceModelBuilder:
         label_mean: float,
         reference_at_ms: int,
     ) -> tuple[_Score, ...]:
-        vectors = FeatureStore(self.connection).scene_content_vectors(feature_version)
+        with span("python", "model.score_vectors"):
+            vectors = FeatureStore(self.connection).scene_content_vectors(feature_version)
         all_scene_ids = [
             str(row[0])
             for row in self.connection.execute(
                 "SELECT scene_id FROM source_scene ORDER BY scene_id"
             )
         ]
-        preference_vectors, discriminative_tag_count = self._preference_content_vectors(
-            vectors, scene_features, affinities
-        )
-        progress_total = len(preference_vectors) + len(all_scene_ids)
-        neighbors = self._content_neighbors(
-            preference_vectors, training_labels, label_mean, progress_total
-        )
-        performer_similarity_scores = self._performer_similarity_scores(
-            feature_version, scene_features, affinities
-        )
+        with span("python", "model.score_neighbors"):
+            preference_vectors, discriminative_tag_count = self._preference_content_vectors(
+                vectors, scene_features, affinities
+            )
+            progress_total = len(preference_vectors) + len(all_scene_ids)
+            neighbors = self._content_neighbors(
+                preference_vectors, training_labels, label_mean, progress_total
+            )
+        with span("python", "model.score_performer_similarity"):
+            performer_similarity_scores = self._performer_similarity_scores(
+                feature_version, scene_features, affinities
+            )
         baseline_support = sum(label.confidence for label in training_labels.values())
         baseline = (
             label_mean * baseline_support / (self.config.model.affinity_prior + baseline_support)
@@ -646,7 +649,7 @@ class PreferenceModelBuilder:
             recovery = self._recovery(last, reference_at_ms)
             cooldown = max(0.0, appeal) * (1 - recovery)
             satiation = self._satiation(scene_id, appeal, recent_context)
-            not_now = self._not_now_penalty(scene_id, reference_at_ms)
+            not_now = self._not_now_penalty(scene_id, reference_at_ms, recent_context)
             current_fit = _clamp(appeal - cooldown - satiation - not_now)
             content_count = len(vectors.get(scene_id, {}))
             performer_profile_count = sum(
@@ -825,16 +828,17 @@ class PreferenceModelBuilder:
         profiles = FeatureStore(self.connection).performer_profiles(feature_version)
         weights = dict(self.config.feature.performer_block_weights)
         known = {key: profiles[key] for key in identity_affinity if key in profiles}
-        result: dict[str, dict[str, object]] = {}
+        matches_by_performer: dict[str, list[dict[str, object]]] = {
+            performer_id: [] for performer_id in profiles
+        }
         for performer_id, profile in profiles.items():
-            matches = []
             for known_id, known_profile in known.items():
-                if known_id == performer_id:
+                if known_id == performer_id or (performer_id in known and known_id < performer_id):
                     continue
                 similarity = performer_similarity(profile, known_profile, weights)
                 if similarity.similarity <= 0:
                     continue
-                matches.append(
+                matches_by_performer[performer_id].append(
                     {
                         "performer_id": known_id,
                         "similarity": similarity.similarity,
@@ -843,6 +847,18 @@ class PreferenceModelBuilder:
                         "blocks": similarity.block_similarities,
                     }
                 )
+                if performer_id in known:
+                    matches_by_performer[known_id].append(
+                        {
+                            "performer_id": performer_id,
+                            "similarity": similarity.similarity,
+                            "affinity": identity_affinity[performer_id][0],
+                            "confidence": identity_affinity[performer_id][1],
+                            "blocks": similarity.block_similarities,
+                        }
+                    )
+        result: dict[str, dict[str, object]] = {}
+        for performer_id, matches in matches_by_performer.items():
             matches.sort(key=lambda item: (-_number(item["similarity"]), str(item["performer_id"])))
             selected = matches[:5]
             denominator = sum(_number(item["similarity"]) ** 3 for item in selected)
@@ -913,6 +929,26 @@ class PreferenceModelBuilder:
     def _recent_context(
         self, reference_at_ms: int, vectors: dict[str, dict[str, float]]
     ) -> dict[str, object]:
+        scene_performers: dict[str, list[str]] = defaultdict(list)
+        for row in self.connection.execute(
+            "SELECT scene_id, performer_id FROM scene_performer ORDER BY scene_id, performer_id"
+        ):
+            scene_performers[str(row["scene_id"])].append(str(row["performer_id"]))
+        scene_studios = {
+            str(row["scene_id"]): str(row["studio_id"])
+            for row in self.connection.execute(
+                "SELECT scene_id, studio_id FROM source_scene WHERE studio_id IS NOT NULL"
+            )
+        }
+        not_now = {
+            str(row["scene_id"]): int(row["occurred_at_ms"])
+            for row in self.connection.execute(
+                """
+                SELECT scene_id, max(occurred_at_ms) AS occurred_at_ms FROM feedback
+                WHERE feedback_type='not_now' AND reversed_by_id IS NULL GROUP BY scene_id
+                """
+            )
+        }
         cutoff = reference_at_ms - 30 * 86_400_000
         rows = self.connection.execute(
             """
@@ -932,10 +968,7 @@ class PreferenceModelBuilder:
                 studios[str(row["studio_id"])] = max(
                     played_at, studios.get(str(row["studio_id"]), 0)
                 )
-            for performer in self.connection.execute(
-                "SELECT performer_id FROM scene_performer WHERE scene_id=?", (scene_id,)
-            ):
-                performer_id = str(performer[0])
+            for performer_id in scene_performers.get(scene_id, ()):
                 performers[performer_id] = max(played_at, performers.get(performer_id, 0))
             if scene_id in vectors:
                 recent_vectors.append((scene_id, played_at, vectors[scene_id]))
@@ -943,6 +976,9 @@ class PreferenceModelBuilder:
             "reference": reference_at_ms,
             "performers": performers,
             "studios": studios,
+            "scene_performers": scene_performers,
+            "scene_studios": scene_studios,
+            "not_now": not_now,
             "vectors": recent_vectors,
             "scene_vectors": vectors,
         }
@@ -956,22 +992,22 @@ class PreferenceModelBuilder:
         reference = reference_value
         performer_times = context["performers"]
         studio_times = context["studios"]
+        scene_performers = context["scene_performers"]
+        scene_studios = context["scene_studios"]
         assert isinstance(performer_times, dict)
         assert isinstance(studio_times, dict)
+        assert isinstance(scene_performers, dict)
+        assert isinstance(scene_studios, dict)
         performer_penalty = 0.0
-        for row in self.connection.execute(
-            "SELECT performer_id FROM scene_performer WHERE scene_id=?", (scene_id,)
-        ):
-            timestamp = performer_times.get(str(row[0]))
+        for performer_id in scene_performers.get(scene_id, ()):
+            timestamp = performer_times.get(str(performer_id))
             if isinstance(timestamp, int):
                 days = max(0.0, (reference - timestamp) / 86_400_000)
                 performer_penalty = max(performer_penalty, 0.06 * math.exp(-days / 7))
-        studio_row = self.connection.execute(
-            "SELECT studio_id FROM source_scene WHERE scene_id=?", (scene_id,)
-        ).fetchone()
         studio_penalty = 0.0
-        if studio_row and studio_row[0] and isinstance(studio_times.get(str(studio_row[0])), int):
-            timestamp = int(studio_times[str(studio_row[0])])
+        studio_id = scene_studios.get(scene_id)
+        if isinstance(studio_id, str) and isinstance(studio_times.get(studio_id), int):
+            timestamp = int(studio_times[studio_id])
             days = max(0.0, (reference - timestamp) / 86_400_000)
             studio_penalty = 0.03 * math.exp(-days / 7)
         content_penalty = 0.0
@@ -994,18 +1030,15 @@ class PreferenceModelBuilder:
             appeal * (performer_penalty + studio_penalty + content_penalty),
         )
 
-    def _not_now_penalty(self, scene_id: str, reference_at_ms: int) -> float:
-        row = self.connection.execute(
-            """
-            SELECT occurred_at_ms FROM feedback
-            WHERE scene_id=? AND feedback_type='not_now' AND reversed_by_id IS NULL
-            ORDER BY occurred_at_ms DESC LIMIT 1
-            """,
-            (scene_id,),
-        ).fetchone()
-        if row is None:
+    def _not_now_penalty(
+        self, scene_id: str, reference_at_ms: int, context: dict[str, object]
+    ) -> float:
+        not_now = context["not_now"]
+        assert isinstance(not_now, dict)
+        occurred_at_ms = not_now.get(scene_id)
+        if not isinstance(occurred_at_ms, int):
             return 0.0
-        age_days = max(0.0, (reference_at_ms - int(row[0])) / 86_400_000)
+        age_days = max(0.0, (reference_at_ms - occurred_at_ms) / 86_400_000)
         if age_days >= self.config.model.not_now_days:
             return 0.0
         return self.config.model.not_now_penalty * (1 - age_days / self.config.model.not_now_days)

--- a/curator/profiling.py
+++ b/curator/profiling.py
@@ -52,7 +52,15 @@ class Trace:
         with self._lock:
             if len(self.events) >= MAX_EVENTS - 2:
                 self.dropped_events += 1
-                return
+                if category == "sqlite":
+                    return
+                try:
+                    index = next(
+                        i for i, event in enumerate(self.events) if event["cat"] == "sqlite"
+                    )
+                    del self.events[index]
+                except StopIteration:
+                    return
             event: dict[str, object] = {
                 "name": name,
                 "cat": category,

--- a/curator/similarity.py
+++ b/curator/similarity.py
@@ -114,8 +114,8 @@ class SimilarityService:
             "python", "similarity.performer_similarity", self.timings_ms["performer_similarity"]
         )
         started = time.perf_counter()
-        target_studio = self._studios().get(scene_id)
         studios = self._studios()
+        target_studio = studios.get(scene_id)
         target_structure = min(1.0, max(0, len(target_performers) - 1) / 3)
         names = {
             f"tag:{row['tag_id']}": str(row["name"])

--- a/curator/storage/sql/0014_prune_indexes.sql
+++ b/curator/storage/sql/0014_prune_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX model_scene_score_prune_idx
+ON model_scene_score(model_id, appeal, confidence, scene_id);

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -620,6 +620,18 @@ def _job_status(connection: Any) -> dict[str, object]:
     return {"schema_version": SCHEMA_VERSION, "jobs": jobs}
 
 
+def _classify_lanes(connection: Any, model: Any) -> int:
+    if model.reused:
+        count = int(
+            connection.execute(
+                "SELECT count(*) FROM model_scene_lane WHERE model_id=?", (model.model_id,)
+            ).fetchone()[0]
+        )
+        if count:
+            return count
+    return len(LanePolicy(connection).classify(model.model_id))
+
+
 def _run_task_body(
     payload: dict[str, Any], mode: str, settings: dict[str, Any]
 ) -> dict[str, object]:
@@ -715,7 +727,7 @@ def _run_task_body(
             _progress(0.94)
             _log("i", "Organizing scenes into recommendation lanes")
             with span("python", "task.lane_classification"):
-                lane_count = len(LanePolicy(connection).classify(model.model_id))
+                lane_count = _classify_lanes(connection, model)
             _progress(0.98)
             _log("i", f"Published recommendation model {model.model_id}")
             summary: dict[str, object] = {
@@ -754,7 +766,7 @@ def _run_task_body(
                 _progress(0.94)
                 _log("i", "Organizing scenes into recommendation lanes")
                 with span("python", "task.lane_classification"):
-                    lane_count = len(LanePolicy(connection).classify(model.model_id))
+                    lane_count = _classify_lanes(connection, model)
                 _progress(0.98)
                 summary = {
                     "updated": True,

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -194,17 +194,11 @@
     return request;
   }
 
-  async function prefetchLanes(activeLane) {
-    const generation = cacheGeneration;
-    for (const option of LANES) {
-      if (generation !== cacheGeneration) return;
-      if (option.value === activeLane) continue;
-      try {
-        await loadSlate(option.value, true);
-      } catch (_) {
-        // Opening the lane will retry and show any error in context.
-      }
-    }
+  function prefetchLane(lane) {
+    if (!laneByValue.has(lane)) return;
+    loadSlate(lane, true).catch(() => {
+      // Opening the lane will retry and show any error in context.
+    });
   }
 
   async function runTask(taskName) {
@@ -1064,7 +1058,6 @@
           if (!active) return;
           setSlate(data);
           setLoading(false);
-          prefetchLanes(lane);
         },
         (failure) => active && (setError(failure.message), setLoading(false))
       );
@@ -1127,7 +1120,7 @@
           NAV_ITEMS.map((option) =>
             React.createElement(
               Nav.Link,
-              { key: option.value, as: "button", className: `curator-lane-${option.value}`, active: lane === option.value, onClick: () => openView(option.value), role: "tab", title: option.description, "aria-label": `${option.label}: ${option.description}`, "aria-selected": lane === option.value },
+              { key: option.value, as: "button", className: `curator-lane-${option.value}`, active: lane === option.value, onClick: () => openView(option.value), onMouseEnter: () => prefetchLane(option.value), onFocus: () => prefetchLane(option.value), role: "tab", title: option.description, "aria-label": `${option.label}: ${option.description}`, "aria-selected": lane === option.value },
               React.createElement(FontAwesomeIcon, { icon: option.icon }),
               React.createElement("span", null, option.label)
             )

--- a/scripts/stashdb_poc.py
+++ b/scripts/stashdb_poc.py
@@ -356,9 +356,15 @@ def _external_profiles(
     for identifier, values in content.items():
         norm = math.sqrt(sum(value * value for value in values.values())) or 1.0
         confidence = min(1.0, scene_counts[identifier] / 5)
-        profiles[identifier].blocks["content"] = {
-            name: ProfileValue(value / norm, confidence) for name, value in values.items()
-        }
+        profiles[identifier] = PerformerProfile(
+            identifier,
+            {
+                **profiles[identifier].blocks,
+                "content": {
+                    name: ProfileValue(value / norm, confidence) for name, value in values.items()
+                },
+            },
+        )
     return profiles, raw_performers
 
 

--- a/tests/features/test_builder.py
+++ b/tests/features/test_builder.py
@@ -132,7 +132,15 @@ def test_feature_build_is_deterministic_versioned_and_explainable(tmp_path: Path
     families = {feature.family for feature in scene_features["scene-1"]}
     assert {"content", "performer_identity", "studio"} <= families
 
+    statements = []
+    connection.set_trace_callback(statements.append)
     profiles = FeatureStore(connection).performer_profiles(first.feature_version)
+    connection.set_trace_callback(None)
+    profile_query = next(
+        statement for statement in statements if "fd.family LIKE 'profile:%'" in statement
+    )
+    plan = connection.execute(f"EXPLAIN QUERY PLAN {profile_query}")
+    assert not any("USE TEMP B-TREE" in row["detail"] for row in plan)
     assert {"content", "measurements", "height", "age", "augmentation", "eyes"} <= set(
         profiles["performer-1"].blocks
     )

--- a/tests/features/test_builder.py
+++ b/tests/features/test_builder.py
@@ -118,10 +118,16 @@ def test_feature_build_is_deterministic_versioned_and_explainable(tmp_path: Path
     assert "tag:content" in vectors["scene-1"]
     assert "tag:parent" in vectors["scene-1"]
     assert "tag:admin" not in vectors["scene-1"]
+    statements: list[str] = []
+    connection.set_trace_callback(statements.append)
     assert (
         FeatureStore(connection).scene_content_overlaps(first.feature_version, "scene-1")["scene-2"]
         > 0
     )
+    connection.set_trace_callback(None)
+    overlap_query = next(statement for statement in statements if "WITH target AS" in statement)
+    plan = connection.execute(f"EXPLAIN QUERY PLAN {overlap_query}")
+    assert any("SEARCH other USING PRIMARY KEY (feature_id=?)" in row["detail"] for row in plan)
     scene_features = FeatureStore(connection).entity_features(first.feature_version, "scene")
     families = {feature.family for feature in scene_features["scene-1"]}
     assert {"content", "performer_identity", "studio"} <= families

--- a/tests/features/test_profiles.py
+++ b/tests/features/test_profiles.py
@@ -1,3 +1,6 @@
+from unittest.mock import Mock
+
+import curator.features.profiles as profiles_module
 from curator.features.profiles import PerformerProfile, ProfileValue, performer_similarity
 
 WEIGHTS = {
@@ -59,3 +62,14 @@ def test_cup_and_augmentation_conflicts_reduce_similarity() -> None:
         performer_similarity(close, close, WEIGHTS).similarity
         > performer_similarity(close, conflict, WEIGHTS).similarity
     )
+
+
+def test_cosine_norms_are_computed_once(monkeypatch) -> None:
+    sqrt = Mock(wraps=profiles_module.math.sqrt)
+    monkeypatch.setattr(profiles_module.math, "sqrt", sqrt)
+    profile = PerformerProfile("profile", {"eyes": {"eye:blue": ProfileValue(1, 1)}})
+
+    performer_similarity(profile, profile, WEIGHTS)
+    performer_similarity(profile, profile, WEIGHTS)
+
+    assert sqrt.call_count == 1

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -2,9 +2,11 @@ import json
 import sqlite3
 from dataclasses import replace
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 
+import curator.model.builder as builder_module
 from curator.cli import run
 from curator.config import DEFAULT_CONFIG
 from curator.model import PreferenceModelBuilder, RecommendationModelStore
@@ -125,6 +127,8 @@ def _database(path: Path) -> sqlite3.Connection:
 
 def test_complete_model_is_bounded_reproducible_and_applies_cooldown(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
+    statements: list[str] = []
+    connection.set_trace_callback(statements.append)
     builder = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS)
 
     first = builder.build()
@@ -144,6 +148,15 @@ def test_complete_model_is_bounded_reproducible_and_applies_cooldown(tmp_path: P
     assert all(-1 <= score.appeal <= 1 for score in scores.values())
     assert all(-1 <= score.current_fit <= 1 for score in scores.values())
     assert all(0 <= score.confidence <= 1 for score in scores.values())
+    assert not any(
+        query in " ".join(statement.split())
+        for statement in statements
+        for query in (
+            "SELECT performer_id FROM scene_performer WHERE scene_id=",
+            "SELECT studio_id FROM source_scene WHERE scene_id=",
+            "SELECT occurred_at_ms FROM feedback WHERE scene_id=",
+        )
+    )
     assert scores["old-good"].direct_confidence == pytest.approx(0.7135, abs=0.001)
     assert scores["old-good"].current_fit > scores["recent-good"].current_fit
     assert scores["disliked"].current_fit == pytest.approx(scores["disliked"].appeal)
@@ -199,6 +212,17 @@ def test_model_build_reports_stage_progress(tmp_path: Path) -> None:
 
     assert {(50, 1_000), (100, 1_000), (200, 1_000), (1_000, 1_000)} <= set(progress)
     assert progress[-1] == (1_000, 1_000)
+
+
+def test_model_compares_known_performer_pairs_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    counted = Mock(wraps=builder_module.performer_similarity)
+    monkeypatch.setattr(builder_module, "performer_similarity", counted)
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+
+    assert counted.call_count == 3
 
 
 def test_wrong_metadata_is_not_reused_but_direct_scene_evidence_remains(tmp_path: Path) -> None:

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -131,6 +132,25 @@ def test_backend_module_loads_without_starting(tmp_path: Path) -> None:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     assert module.SCHEMA_VERSION == 1
+
+
+def test_reused_model_keeps_existing_lane_classifications(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
+    spec = importlib.util.spec_from_file_location("curator_plugin_lanes", backend)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(
+        module.LanePolicy,
+        "classify",
+        lambda *_args: (_ for _ in ()).throw(AssertionError("reclassified")),
+    )
+    cursor = SimpleNamespace(fetchone=lambda: (3,))
+    connection = SimpleNamespace(execute=lambda *_args: cursor)
+
+    assert module._classify_lanes(connection, SimpleNamespace(model_id="model", reused=True)) == 3
 
 
 def test_plugin_settings_are_applied_to_sidecar_config(tmp_path: Path) -> None:

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -106,6 +106,16 @@ def test_curator_tabs_update_browser_history() -> None:
     assert "onClick: () => openView(option.value)" in source
 
 
+def test_curator_prefetches_only_the_intended_lane() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
+    assert "function prefetchLanes" not in source
+    assert "if (!laneByValue.has(lane)) return;" in source
+    assert "loadSlate(lane).then(" in source
+    assert "loadSlate(lane, true).catch(" in source
+    assert "onMouseEnter: () => prefetchLane(option.value)" in source
+    assert "onFocus: () => prefetchLane(option.value)" in source
+
+
 def test_plugin_ignores_repeated_script_evaluation() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
     guard = "if (window.__stashCuratorPluginLoaded) return;"

--- a/tests/storage/test_cli_db.py
+++ b/tests/storage/test_cli_db.py
@@ -15,7 +15,7 @@ def test_database_cli_migrate_status_and_backup(
 
     assert run(["--db", str(database), "db", "migrate", "--json"]) == 0
     migrated = json.loads(capsys.readouterr().out)
-    assert migrated["current_version"] == migrated["latest_version"] == 13
+    assert migrated["current_version"] == migrated["latest_version"] == 14
 
     assert run(["--db", str(database), "db", "status", "--json"]) == 0
     status = json.loads(capsys.readouterr().out)

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -11,10 +11,10 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
         runner = MigrationRunner(connection)
         before = runner.status()
         assert before.current_version == 0
-        assert before.pending_versions == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13)
+        assert before.pending_versions == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
 
         after = runner.migrate(applied_at_ms=1234)
-        assert after.current_version == 13
+        assert after.current_version == 14
         assert after.pending_versions == ()
         assert runner.migrate(applied_at_ms=5678) == after
 
@@ -39,6 +39,9 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
             "model_lane_candidate_cache",
         } <= tables
         assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+        assert connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='index' AND name='model_scene_score_prune_idx'"
+        ).fetchone()
     finally:
         connection.close()
 
@@ -80,7 +83,7 @@ def test_status_stays_read_only_after_migrations(tmp_path: Path) -> None:
     reader.execute("PRAGMA busy_timeout=1")
     try:
         writer.execute("BEGIN IMMEDIATE")
-        assert MigrationRunner(reader).status().current_version == 13
+        assert MigrationRunner(reader).status().current_version == 14
     finally:
         writer.rollback()
         reader.close()
@@ -106,7 +109,7 @@ def test_stale_concurrent_migrator_rechecks_after_writer_lock(
 
     monkeypatch.setattr(second_runner, "status", status)
     try:
-        assert second_runner.migrate(applied_at_ms=2).current_version == 13
+        assert second_runner.migrate(applied_at_ms=2).current_version == 14
     finally:
         second.close()
         first.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,7 @@ import pytest
 from curator.api import CuratorAPI
 from curator.features import FeatureStore
 from curator.model import ModelUpdateCoordinator, PreferenceModelBuilder
+from curator.similarity import SimilarityService
 from curator.storage import connect_database
 from tests.model.test_builder import REFERENCE_MS, _database
 
@@ -91,7 +92,16 @@ def test_similar_scenes_blend_similarity_with_appeal_and_explain_relationships(
         assert scene_ids is not None
         return original(self, feature_version, scene_ids)
 
+    studio_scans = 0
+    original_studios = SimilarityService._studios
+
+    def counted_studios(self):
+        nonlocal studio_scans
+        studio_scans += 1
+        return original_studios(self)
+
     monkeypatch.setattr(FeatureStore, "scene_content_vectors", bounded_vectors)
+    monkeypatch.setattr(SimilarityService, "_studios", counted_studios)
 
     result = CuratorAPI(connection).similar(
         "scene", "old-good", 5, impression_id="similar-impression", now_ms=REFERENCE_MS
@@ -106,6 +116,7 @@ def test_similar_scenes_blend_similarity_with_appeal_and_explain_relationships(
     )
     assert any("shared_content" in item["relationships"] for item in result["items"])
     assert all(item["label"] for item in result["items"])
+    assert studio_scans == 1
     impression = connection.execute(
         "SELECT lane, request_context_json FROM impression WHERE impression_id='similar-impression'"
     ).fetchone()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_doctor_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
     assert result["status"] == "ok"
     assert result["stash"] == "not_configured"
     assert result["schema_current"] == 0
-    assert result["schema_latest"] == 13
+    assert result["schema_latest"] == 14
 
 
 def test_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 from curator.config import DEFAULT_CONFIG
 from curator.expand import ExpandService
+from curator.features import FeatureStore
 from curator.model import PreferenceModelBuilder
 from tests.model.test_builder import REFERENCE_MS, _database
 
@@ -375,7 +376,9 @@ def test_external_content_similarity_normalizes_candidate_mapped_tags(tmp_path: 
     assert result["items"][0]["similarity"] > result["items"][1]["similarity"]
 
 
-def test_external_similarity_sends_only_raw_stashdb_tag_ids(tmp_path: Path) -> None:
+def test_external_similarity_loads_only_positive_anchor_profiles(
+    tmp_path: Path, monkeypatch
+) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
     connection.execute(
@@ -383,6 +386,14 @@ def test_external_similarity_sends_only_raw_stashdb_tag_ids(tmp_path: Path) -> N
         ("good", "https://stashdb.org/graphql", "external-tag"),
     )
     client = FakeStashDB()
+    requested: list[object] = []
+    performer_profiles = FeatureStore.performer_profiles
+
+    def capture_profiles(store, feature_version, performer_ids=None):
+        requested.append(performer_ids)
+        return performer_profiles(store, feature_version, performer_ids)
+
+    monkeypatch.setattr(FeatureStore, "performer_profiles", capture_profiles)
 
     ExpandService(connection).targeted_similar(
         client,
@@ -393,6 +404,7 @@ def test_external_similarity_sends_only_raw_stashdb_tag_ids(tmp_path: Path) -> N
 
     tag_query = next(value for value in client.inputs if "tags" in value)
     assert tag_query["tags"] == {"value": ["external-tag"], "modifier": "INCLUDES"}
+    assert {"p1"} in requested
 
 
 def test_sparse_external_performer_profile_has_low_confidence() -> None:

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -109,3 +109,17 @@ def test_profile_limit_is_validated(tmp_path: Path) -> None:
             get_trace(connection, "missing")
     finally:
         connection.close()
+
+
+def test_truncated_trace_keeps_high_level_spans(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(profiling, "MAX_EVENTS", 5)
+    trace, token = begin_trace("update-model", "task")
+    try:
+        for index in range(4):
+            trace.record("sqlite", f"query-{index}", time.perf_counter_ns(), 1_000)
+        trace.record("python", "model.scores", time.perf_counter_ns(), 1_000)
+    finally:
+        end_trace(trace, token)
+
+    assert "model.scores" in {event["name"] for event in trace.events}
+    assert trace.dropped_events == 2


### PR DESCRIPTION
## Summary

- add a covering prune-score index and split the candidate query so SQLite uses it
- batch per-scene scoring reads, reuse symmetric performer comparisons and cosine norms, and retain useful high-level spans in capped traces
- reuse persisted lane classifications when an immutable model is reused

## Measured impact

- steady-state Prune: 12.0–12.3 s to 126–157 ms (about 87x faster)
- no-change rebuild: 37.09 s to 11.01 s
- fresh sync-build: 411.8 s before batching, 217.5 s after batching, then 161.7 s after symmetric performer comparison reuse
- live-data cosine benchmark: 47.928 s to 23.181 s with identical results

## Verification

- `scripts/verify full`
- 157 tests passed
- plugin archive built successfully