### PR TITLE
Polish Curator explanation labels

### DIFF
--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -56,7 +56,7 @@
       value: "expand",
       label: "Expand",
       icon: faCompass,
-      description: "External metadata candidates scored locally; a Wildcard was selected outside preference-derived seeds.",
+      description: "External metadata candidates scored locally. Wildcard items are selected outside preference-derived seeds.",
     },
     {
       value: "prune",
@@ -277,6 +277,15 @@
     );
   }
 
+  function reasonLabel(code) {
+    const labels = {
+      "appeal.performer_identity": "Performer match",
+      "appeal.content_neighbor": "Similar content",
+    };
+    const fallback = code.split(".").at(-1).replaceAll("_", " ");
+    return labels[code] || fallback.charAt(0).toUpperCase() + fallback.slice(1);
+  }
+
   function ExternalCard({ item, kind, gender, onShortlist, onShowScenes, onWhisparr }) {
     const [copied, setCopied] = React.useState(false);
     const [whisparr, setWhisparr] = React.useState(null);
@@ -448,7 +457,7 @@
                 React.createElement(
                   "li",
                   { key: `${reason.code}-${index}` },
-                  `${reason.code.replaceAll(".", " · ")} (${reason.magnitude.toFixed(2)})`
+                  `${reasonLabel(reason.code)} (${reason.magnitude.toFixed(2)})`
                 )
               )
             )

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -119,6 +119,9 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     assert 'className: "card-section-title"' in source
     assert "Curator never deletes media; tagging is reversible" in source
     assert "Score is ranking utility, not a probability" in source
+    assert '"appeal.performer_identity": "Performer match"' in source
+    assert '"appeal.content_neighbor": "Similar content"' in source
+    assert "Wildcard items are selected outside preference-derived seeds" in source
 
 
 def test_backend_module_loads_without_starting(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- replace raw reason codes with concise display labels, including Performer match and Similar content
- clarify that Expand wildcard items may be selected outside preference-derived seeds

## Verification
- scripts/verify changed tests/plugin/test_runtime.py: 8 passed
- pre-push verification: 153 passed