### PR TITLE
Fix Pages artifact permissions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,12 +27,12 @@ jobs:
           version: "0.11.21"
           python-version: "3.12"
       - uses: actions/configure-pages@v6
+      - run: uv run --frozen python scripts/build_plugin.py
+      - run: cp dist/stash-curator.zip dist/index.yml docs/
       - uses: actions/jekyll-build-pages@v1
         with:
           source: ./docs
           destination: ./_site
-      - run: uv run --frozen python scripts/build_plugin.py
-      - run: cp dist/stash-curator.zip dist/index.yml _site/
       - uses: actions/upload-pages-artifact@v4
         with:
           path: _site


### PR DESCRIPTION
## Root cause

The native Jekyll action runs in Docker and leaves `_site` owned by root. The
following runner step could build the plugin but failed when copying
`stash-curator.zip` and `index.yml` into `_site` with `Permission denied`.

## Fix

Build the plugin first and place both artifacts in the Jekyll source directory.
Jekyll copies them into `_site` as static files, preserving the atomic documentation
and plugin-source deployment without sudo or another build system.

## Verification

- `scripts/verify changed`
- package archive built successfully
- `dist/index.yml` checksum matches `dist/stash-curator.zip`
- pre-push full suite: 153 passed
