### PR TITLE
Give utility tabs distinct icons

### DIFF
--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -210,9 +210,9 @@
 .curator-lane-revisit { --lane-color: #b197fc; }
 .curator-lane-discover { --lane-color: #ffd43b; }
 .curator-lane-adventure { --lane-color: #ff922b; }
-.curator-lane-similar { --lane-color: #4dabf7; }
-.curator-lane-expand { --lane-color: #ff922b; }
-.curator-lane-prune { --lane-color: #fa5252; }
+.curator-lane-similar { --lane-color: #66d9e8; }
+.curator-lane-expand { --lane-color: #f783ac; }
+.curator-lane-prune { --lane-color: #ff6b6b; }
 
 .curator-tabs .nav-link svg,
 .curator-source-badge svg {

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -11,7 +11,7 @@
   const { NavLink, useHistory, useLocation } = libraries.ReactRouterDOM;
   const { FontAwesomeIcon } = libraries.ReactFontAwesome;
   const { faDev } = libraries.FontAwesomeBrands;
-  const { faBullseye, faCheckCircle, faClock, faCog, faCompass, faCopy, faDatabase, faDownload, faExternalLinkAlt, faFilm, faFilter, faHeart, faHistory, faList, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSync, faThumbsDown, faThumbsUp, faUser, faVenus, faWrench } = libraries.FontAwesomeSolid;
+  const { faBroom, faBullseye, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faDatabase, faDownload, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSync, faThumbsDown, faThumbsUp, faUser, faVenus, faWrench } = libraries.FontAwesomeSolid;
   const LANES = [
     {
       value: "for_you",
@@ -49,19 +49,19 @@
     {
       value: "similar",
       label: "Similar",
-      icon: faSearch,
+      icon: faClone,
       description: "Choose a scene or performer, then compare preference-aware matches from your Library or StashDB.",
     },
     {
       value: "expand",
       label: "Expand",
-      icon: faCompass,
+      icon: faGlobe,
       description: "External metadata candidates scored locally. Wildcard items are selected outside preference-derived seeds.",
     },
     {
       value: "prune",
       label: "Prune",
-      icon: faWrench,
+      icon: faBroom,
       description: "Curator never deletes media; tagging is reversible, and Candidates, Explicit dislikes, and Model suspects are separate review queues.",
     },
   ];
@@ -753,7 +753,7 @@
           return React.createElement(
             "article",
             { key: item.scene_id, className: "curator-card" },
-            item.tagged && React.createElement("span", { className: "curator-prune-badge", title: `Tagged ${data.tag_name}`, "aria-label": `Tagged ${data.tag_name}` }, React.createElement(FontAwesomeIcon, { icon: faWrench })),
+            item.tagged && React.createElement("span", { className: "curator-prune-badge", title: `Tagged ${data.tag_name}`, "aria-label": `Tagged ${data.tag_name}` }, React.createElement(FontAwesomeIcon, { icon: faBroom })),
             React.createElement(SceneCard, { scene }),
             React.createElement("div", { className: "curator-card-body" }, React.createElement("p", { className: "curator-similarity-reason" }, item.evidence.join(" · ")), item.appeal !== null && React.createElement("small", null, `Appeal ${item.appeal.toFixed(2)} · confidence ${item.confidence.toFixed(2)}`)),
             React.createElement("div", { className: "curator-prune-actions" }, React.createElement(Button, { size: "sm", variant: item.tagged ? "secondary" : "danger", onClick: () => tag([item.scene_id], !item.tagged) }, item.tagged ? `Undo ${data.tag_name}` : `Tag ${data.tag_name}`), !item.tagged && item.suspect && !item.explicit && React.createElement(Button, { size: "sm", variant: "link", onClick: () => dismiss(item.scene_id) }, "Dismiss"))


### PR DESCRIPTION
## Summary
- replace Similar and Expand icons that duplicated recommendation lanes
- use a broom consistently for Prune navigation and tagged-state badges
- add distinct icon colors for the three utility tabs

## Verification
- `scripts/verify changed`
- `scripts/verify full` (150 passed)
- installed and inspected locally