### PR TITLE
Add paged, materialized recommendations

### DIFF
--- a/curator/api.py
+++ b/curator/api.py
@@ -24,6 +24,7 @@ from curator.storage import transaction
 API_SCHEMA_VERSION = 1
 DEFAULT_PLUGIN_CONFIG: dict[str, object] = {
     "page_size": 20,
+    "diversity_enabled": True,
     "sync_page_size": 250,
     "debounce_ms": 2_000,
     "model_update_event_threshold": 5,
@@ -45,12 +46,15 @@ class CuratorAPI:
         lane: str,
         count: int,
         *,
+        page: int = 1,
         impression_id: str | None = None,
         context: dict[str, object] | None = None,
         now_ms: int | None = None,
         exclude_scene_ids: set[str] | None = None,
         exploration: float = 0,
     ) -> dict[str, object]:
+        if page < 1 or not 1 <= count <= 500:
+            raise ValueError("invalid recommendation page")
         started = time.perf_counter()
         timings: dict[str, int] = {}
         config = self.config()["config"]
@@ -64,14 +68,37 @@ class CuratorAPI:
         record_duration("python", "slate.model_update", timings["model_update"])
         stage_started = time.perf_counter()
         excluded = exclude_scene_ids or set()
-        built = SlateBuilder(self.connection).recommend(
-            lane, count + len(excluded), exploration=exploration
-        )
-        selected = tuple(item for item in built.items if item.scene_id not in excluded)[:count]
+        start = (page - 1) * count
+        end = page * count
+        built = SlateBuilder(
+            self.connection, diversity_enabled=bool(config["diversity_enabled"])
+        ).recommend(lane, end + len(excluded), exploration=exploration)
+        available = tuple(item for item in built.items if item.scene_id not in excluded)
+        selected = available[start:end]
+        if lane == "for_you":
+            candidate_count = int(
+                self.connection.execute(
+                    "SELECT count(DISTINCT scene_id) FROM model_scene_lane WHERE model_id=?",
+                    (built.model_id,),
+                ).fetchone()[0]
+            )
+        else:
+            candidate_count = int(
+                self.connection.execute(
+                    """
+                    SELECT count(DISTINCT scene_id) FROM model_scene_lane
+                    WHERE model_id=? AND lane=?
+                    """,
+                    (built.model_id, lane),
+                ).fetchone()[0]
+            )
         slate = Slate(
             built.model_id,
             built.lane,
-            tuple(replace(item, position=position) for position, item in enumerate(selected)),
+            tuple(
+                replace(item, position=position)
+                for position, item in enumerate(selected, start=start)
+            ),
             built.diagnostics,
             built.timings_ms,
         )
@@ -123,6 +150,10 @@ class CuratorAPI:
             is not None,
             "impression_id": impression_id,
             "lane": lane,
+            "page": page,
+            "page_size": count,
+            # ponytail: candidate count is an optimistic bound; exact lookahead reranks a card.
+            "has_more": len(available) >= end and candidate_count > end + len(excluded),
             "items": items,
             "diagnostics": list(slate.diagnostics),
             "timings_ms": timings,
@@ -183,6 +214,7 @@ class CuratorAPI:
         entity_id: str,
         count: int = 20,
         *,
+        page: int = 1,
         impression_id: str | None = None,
         now_ms: int | None = None,
         gender: str = "",
@@ -192,16 +224,21 @@ class CuratorAPI:
         studio_ids: tuple[str, ...] = (),
         favorite_only: bool = False,
         minimum_similarity: float = 0.18,
+        exclude_scene_ids: set[str] | None = None,
     ) -> dict[str, object]:
-        if not 1 <= count <= 100:
-            raise ValueError("count must be between 1 and 100")
+        if page < 1 or not 1 <= count <= 500:
+            raise ValueError("invalid Similar page")
         if not 0 <= minimum_similarity <= 1:
             raise ValueError("minimum_similarity must be between 0 and 1")
+        start = (page - 1) * count
+        end = page * count
+        excluded = exclude_scene_ids or set()
+        requested = end + 1 + len(excluded)
         service = SimilarityService(self.connection)
         if entity_type == "scene":
             results = service.scenes(
                 entity_id,
-                count,
+                requested,
                 gender,
                 include_tags=include_tags,
                 exclude_tags=exclude_tags,
@@ -212,10 +249,12 @@ class CuratorAPI:
             )
             table, id_column, label_column = "source_scene", "scene_id", "title"
         elif entity_type == "performer":
-            results = service.performers(entity_id, count, gender)
+            results = service.performers(entity_id, requested, gender)
             table, id_column, label_column = "source_performer", "performer_id", "name"
         else:
             raise ValueError(f"unsupported similar entity type: {entity_type}")
+        available = tuple(item for item in results if item.entity_id not in excluded)
+        results = available[start:end]
         labels = {
             str(row[id_column]): str(row[label_column] or "")
             for row in self.connection.execute(f"SELECT {id_column}, {label_column} FROM {table}")
@@ -230,7 +269,7 @@ class CuratorAPI:
                     service.model_id,
                     (
                         (item.entity_id, position, item.rank_score, item.relationships)
-                        for position, item in enumerate(results)
+                        for position, item in enumerate(results, start=start)
                     ),
                     now_ms if now_ms is not None else time.time_ns() // 1_000_000,
                     {"provenance": "similar", "source_scene_id": entity_id},
@@ -247,9 +286,17 @@ class CuratorAPI:
             "entity_type": entity_type,
             "entity_id": entity_id,
             "impression_id": impression_id if entity_type == "scene" else None,
+            "page": page,
+            "page_size": count,
+            "has_more": len(available) > end,
             "timings_ms": service.timings_ms,
             "items": [
-                {**asdict(item), "label": labels.get(item.entity_id, "")} for item in results
+                {
+                    **asdict(item),
+                    "label": labels.get(item.entity_id, ""),
+                    "position": position,
+                }
+                for position, item in enumerate(results, start=start)
             ],
         }
 
@@ -270,6 +317,7 @@ class CuratorAPI:
         self,
         entity_type: str,
         *,
+        page: int = 1,
         sort: str = "match",
         performer_id: str | None = None,
         favorite_only: bool = False,
@@ -285,6 +333,7 @@ class CuratorAPI:
     ) -> dict[str, object]:
         return ExpandService(self.connection).results(
             entity_type,
+            page=page,
             sort=sort,
             performer_id=performer_id,
             favorite_only=favorite_only,
@@ -611,6 +660,7 @@ class CuratorAPI:
     ) -> dict[str, object]:
         allowed = {
             "page_size",
+            "diversity_enabled",
             "sync_page_size",
             "debounce_ms",
             "model_update_event_threshold",
@@ -640,6 +690,9 @@ class CuratorAPI:
 
     @staticmethod
     def _validate_config(values: dict[str, object]) -> None:
+        diversity = values.get("diversity_enabled")
+        if diversity is not None and not isinstance(diversity, bool):
+            raise ValueError("diversity_enabled must be true or false")
         for key in ("page_size", "sync_page_size"):
             value = values.get(key)
             if value is not None and (not isinstance(value, int) or not 1 <= value <= 500):

--- a/curator/config.py
+++ b/curator/config.py
@@ -75,7 +75,7 @@ class FeatureConfig:
 
 @dataclass(frozen=True)
 class ModelConfig:
-    algorithm_version: int = 3
+    algorithm_version: int = 4
     affinity_prior: float = 1.0
     affinity_confidence_scale: float = 3.0
     direct_confidence_scale: float = 0.8

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -190,6 +190,7 @@ class ExpandService:
         self,
         entity_type: str,
         *,
+        page: int = 1,
         sort: str = "match",
         performer_id: str | None = None,
         favorite_only: bool = False,
@@ -205,11 +206,19 @@ class ExpandService:
     ) -> dict[str, object]:
         if entity_type not in {"scene", "performer"} or sort not in {"match", "newest"}:
             raise ValueError("invalid Expand query")
+        if page < 1 or not 1 <= count <= 500:
+            raise ValueError("invalid Expand page")
         if not -1 <= minimum_score <= 1:
             raise ValueError("minimum_score must be between -1 and 1")
         cache = self.connection.execute("SELECT * FROM expand_cache WHERE singleton=1").fetchone()
         if cache is None:
-            return {"ready": False, "items": []}
+            return {
+                "ready": False,
+                "page": page,
+                "page_size": count,
+                "has_more": False,
+                "items": [],
+            }
         shortlisted = {
             str(row[0])
             for row in self.connection.execute(
@@ -274,11 +283,16 @@ class ExpandService:
             rows.sort(key=lambda item: (-item["score"], item["id"]))
             if entity_type == "scene":
                 rows = self._diverse_scenes(rows)
+        start = (page - 1) * count
+        end = page * count
         return {
             "ready": True,
             "fetched_at_ms": int(cache["fetched_at_ms"]),
             "expires_at_ms": int(cache["expires_at_ms"]),
-            "items": rows[:count],
+            "page": page,
+            "page_size": count,
+            "has_more": len(rows) > end,
+            "items": rows[start:end],
         }
 
     @staticmethod

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -1132,6 +1132,12 @@ class PreferenceModelBuilder:
                 for score in scores
             ),
         )
+        # Lane orders are immutable model artifacts: finish them before the atomic
+        # status flip so requests never observe a half-published recommendation model.
+        from curator.ranking import LanePolicy, SlateBuilder
+
+        LanePolicy(self.connection, self.config).classify(model_id)
+        SlateBuilder(self.connection, self.config).materialize(model_id, force=True)
         with transaction(self.connection):
             self.connection.execute(
                 "UPDATE model_version SET status='superseded' WHERE status='published'"

--- a/curator/ranking/policy.py
+++ b/curator/ranking/policy.py
@@ -281,9 +281,7 @@ class LanePolicy:
         if limit_per_lane is not None and limit_per_lane < 1:
             raise ValueError("limit_per_lane must be positive")
         rows: list[sqlite3.Row] = []
-        selected_lanes: tuple[str | None, ...] = (
-            tuple(lanes or LANES) if limit_per_lane else (None,)
-        )
+        selected_lanes: tuple[str | None, ...] = tuple(lanes) if lanes else (None,)
         for lane in selected_lanes:
             where = "model_id=?"
             parameters: list[object] = [model_id]

--- a/curator/ranking/slate.py
+++ b/curator/ranking/slate.py
@@ -6,8 +6,9 @@ import json
 import math
 import sqlite3
 import time
+from collections import defaultdict
 from dataclasses import asdict, dataclass, field, replace
-from heapq import nsmallest
+from heapq import heappop, heappush
 from typing import Any
 
 from curator.config import DEFAULT_CONFIG, CuratorConfig
@@ -88,9 +89,12 @@ class SlateBuilder:
         self,
         connection: sqlite3.Connection,
         config: CuratorConfig = DEFAULT_CONFIG,
+        *,
+        diversity_enabled: bool = True,
     ) -> None:
         self.connection = connection
         self.config = config
+        self.diversity_enabled = diversity_enabled
         self._cached_model_id: str | None = None
         self._cached_source_lanes: frozenset[str] = frozenset()
         self._cached_candidates: tuple[_Candidate, ...] = ()
@@ -100,47 +104,264 @@ class SlateBuilder:
         self._live_fit: dict[str, float] = {}
         self._live_cooldown: dict[str, float] = {}
 
-    def prepare(
-        self, model_id: str, *, limit_per_lane: int = 500, slate_size: int = 60
-    ) -> dict[str, int]:
+    def prepare(self, model_id: str, *, slate_size: int = 60) -> dict[str, int]:
         policy = LanePolicy(self.connection, self.config)
-        prepared: list[tuple[str, str, int]] = []
+        prepared: list[_Candidate] = []
+        counts: dict[str, int] = {}
         for lane in LANES:
-            classifications = policy.load(model_id, lanes={lane}, limit_per_lane=limit_per_lane)
+            classifications = policy.load(model_id, lanes={lane})
             candidates = self._candidates(model_id, classifications)
-            payload = [
-                {
-                    "scene_id": item.classification.scene_id,
-                    "lane": item.classification.lane,
-                    "subtype": item.classification.subtype,
-                    "lane_value": item.classification.lane_value,
-                    "qualification": item.classification.qualification,
-                    "performers": item.performers,
-                    "studio_group": item.studio_group,
-                    "content": item.content,
-                }
-                for item in candidates
-            ]
-            prepared.append((lane, json.dumps(payload, separators=(",", ":")), len(payload)))
+            prepared.extend(candidates)
+            counts[lane] = len(candidates)
         with transaction(self.connection):
             self.connection.execute(
                 "DELETE FROM model_lane_candidate_cache WHERE model_id=?", (model_id,)
             )
             self.connection.execute("DELETE FROM application_meta WHERE key LIKE 'slate:%'")
-            self.connection.executemany(
-                """
-                INSERT INTO model_lane_candidate_cache(
-                    model_id, lane, candidates_json, candidate_count, created_at_ms
-                ) VALUES (?, ?, ?, ?, ?)
-                """,
-                (
-                    (model_id, lane, payload, count, time.time_ns() // 1_000_000)
-                    for lane, payload, count in prepared
-                ),
-            )
+        self._save_prepared_candidates(model_id, set(LANES), tuple(prepared))
         for lane in (*LANES, "for_you"):
             self.recommend(lane, slate_size)
-        return {lane: count for lane, _, count in prepared}
+        return counts
+
+    def materialize(self, model_id: str, *, force: bool = False) -> dict[str, int]:
+        if (
+            not force
+            and self.connection.execute(
+                "SELECT 1 FROM model_lane_order_state WHERE model_id=?", (model_id,)
+            ).fetchone()
+        ):
+            return {
+                str(row["lane"]): int(row["candidate_count"])
+                for row in self.connection.execute(
+                    """
+                    SELECT lane, count(*) AS candidate_count FROM model_scene_lane
+                    WHERE model_id=? GROUP BY lane
+                    """,
+                    (model_id,),
+                )
+            }
+        classifications = LanePolicy(self.connection, self.config).load(model_id)
+        candidates = self._candidates(model_id, classifications)
+        counts = {
+            lane: sum(candidate.classification.lane == lane for candidate in candidates)
+            for lane in LANES
+        }
+        with transaction(self.connection):
+            self.connection.execute(
+                "DELETE FROM model_lane_order_state WHERE model_id=?", (model_id,)
+            )
+            self.connection.execute("DELETE FROM model_lane_order WHERE model_id=?", (model_id,))
+        for lane in (*LANES, "for_you"):
+            lane_candidates = tuple(
+                candidate
+                for candidate in candidates
+                if lane == "for_you" or candidate.classification.lane == lane
+            )
+            for ordering, varied in (("score_first", False), ("varied", True)):
+                ordered = self._build_order(lane, lane_candidates, varied=varied)
+                with transaction(self.connection):
+                    self.connection.executemany(
+                        """
+                        INSERT INTO model_lane_order(
+                            model_id, lane, ordering, position, scene_id,
+                            source_lane, utility, ranking_json
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            (
+                                model_id,
+                                lane,
+                                ordering,
+                                position,
+                                candidate.classification.scene_id,
+                                candidate.classification.lane,
+                                utility,
+                                json.dumps(
+                                    {"penalties": penalties, "bonuses": bonuses},
+                                    separators=(",", ":"),
+                                ),
+                            )
+                            for position, (candidate, utility, penalties, bonuses) in enumerate(
+                                ordered
+                            )
+                        ),
+                    )
+        with transaction(self.connection):
+            self.connection.execute(
+                """
+                INSERT INTO model_lane_order_state(model_id, created_at_ms) VALUES (?, ?)
+                """,
+                (model_id, time.time_ns() // 1_000_000),
+            )
+        return counts
+
+    def _build_order(
+        self, lane: str, candidates: tuple[_Candidate, ...], *, varied: bool
+    ) -> list[tuple[_Candidate, float, dict[str, float], dict[str, float]]]:
+        by_key = {
+            (candidate.classification.scene_id, candidate.classification.lane): candidate
+            for candidate in candidates
+        }
+        utilities = {
+            key: candidate.classification.lane_value
+            + (self.config.ranking.uncovered_content_bonus if varied and candidate.content else 0.0)
+            for key, candidate in by_key.items()
+        }
+        versions = dict.fromkeys(by_key, 0)
+        heaps: dict[tuple[str, str], list[tuple[float, str, str, int]]] = defaultdict(list)
+
+        def selectors(candidate: _Candidate) -> tuple[tuple[str, str], ...]:
+            result = [("all", "")]
+            if lane == "for_you":
+                result.append(("lane", candidate.classification.lane))
+            elif lane == "adventure" and candidate.classification.subtype:
+                result.append(("subtype", candidate.classification.subtype))
+            return tuple(result)
+
+        def push(key: tuple[str, str]) -> None:
+            candidate = by_key[key]
+            entry = (
+                -utilities[key],
+                candidate.classification.scene_id,
+                candidate.classification.lane,
+                versions[key],
+            )
+            for selector in selectors(candidate):
+                heappush(heaps[selector], entry)
+
+        for key in by_key:
+            push(key)
+
+        selected_scene_ids: set[str] = set()
+        seen_performers: set[str] = set()
+        seen_studios: set[str] = set()
+        covered_features: set[str] = set()
+        performer_penalized: set[tuple[str, str]] = set()
+        studio_penalized: set[tuple[str, str]] = set()
+        covered_share = dict.fromkeys(by_key, 0.0)
+        content_totals = {
+            key: sum(abs(value) for value in candidate.content.values())
+            for key, candidate in by_key.items()
+        }
+        performer_index: dict[str, set[tuple[str, str]]] = defaultdict(set)
+        studio_index: dict[str, set[tuple[str, str]]] = defaultdict(set)
+        feature_index: dict[str, list[tuple[tuple[str, str], float]]] = defaultdict(list)
+        if varied:
+            for key, candidate in by_key.items():
+                for performer in candidate.performers:
+                    performer_index[performer].add(key)
+                if candidate.studio_group:
+                    studio_index[candidate.studio_group].add(key)
+                total = content_totals[key]
+                if total:
+                    for feature, value in candidate.content.items():
+                        feature_index[feature].append((key, abs(value) / total))
+
+        def pop(
+            selector: tuple[str, str],
+            previous: _Candidate | None,
+            *,
+            allow_adjacent: bool = False,
+        ) -> _Candidate | None:
+            deferred: list[tuple[float, str, str, int]] = []
+            heap = heaps[selector]
+            chosen = None
+            while heap:
+                entry = heappop(heap)
+                key = (entry[1], entry[2])
+                if (
+                    key not in by_key
+                    or entry[3] != versions[key]
+                    or by_key[key].classification.scene_id in selected_scene_ids
+                ):
+                    continue
+                candidate = by_key[key]
+                if (
+                    varied
+                    and previous
+                    and not allow_adjacent
+                    and not self.config.ranking.adjacent_shared_performers
+                    and set(candidate.performers) & set(previous.performers)
+                ):
+                    deferred.append(entry)
+                    continue
+                chosen = candidate
+                break
+            for entry in deferred:
+                heappush(heap, entry)
+            return chosen
+
+        ordered: list[tuple[_Candidate, float, dict[str, float], dict[str, float]]] = []
+        previous: _Candidate | None = None
+        scene_count = len({candidate.classification.scene_id for candidate in candidates})
+        while len(selected_scene_ids) < scene_count:
+            target_lane, target_subtype = self._target(lane, len(ordered), 0)
+            wanted = (
+                ("subtype", target_subtype)
+                if lane == "adventure" and target_subtype
+                else ("lane", target_lane)
+                if lane == "for_you"
+                else ("all", "")
+            )
+            chosen = pop(wanted, previous) or pop(("all", ""), previous)
+            if chosen is None:
+                chosen = pop(("all", ""), previous, allow_adjacent=True)
+            if chosen is None:
+                break
+            key = (chosen.classification.scene_id, chosen.classification.lane)
+            penalties = {
+                "performer": (
+                    self.config.ranking.performer_repeat_penalty
+                    if key in performer_penalized
+                    else 0.0
+                ),
+                "studio": (self.config.ranking.studio_penalty if key in studio_penalized else 0.0),
+                "content": (
+                    self.config.ranking.content_penalty * covered_share[key] if varied else 0.0
+                ),
+                "history": 0.0,
+                "live_cooldown": 0.0,
+            }
+            bonuses = {
+                "uncovered_content": (
+                    self.config.ranking.uncovered_content_bonus * (1 - covered_share[key])
+                    if varied and chosen.content
+                    else 0.0
+                )
+            }
+            ordered.append((chosen, utilities[key], penalties, bonuses))
+            selected_scene_ids.add(chosen.classification.scene_id)
+            previous = chosen
+            if not varied:
+                continue
+            changed: set[tuple[str, str]] = set()
+            for performer in set(chosen.performers) - seen_performers:
+                seen_performers.add(performer)
+                for affected in performer_index[performer] - performer_penalized:
+                    performer_penalized.add(affected)
+                    utilities[affected] -= self.config.ranking.performer_repeat_penalty
+                    changed.add(affected)
+            if chosen.studio_group and chosen.studio_group not in seen_studios:
+                seen_studios.add(chosen.studio_group)
+                for affected in studio_index[chosen.studio_group] - studio_penalized:
+                    studio_penalized.add(affected)
+                    utilities[affected] -= self.config.ranking.studio_penalty
+                    changed.add(affected)
+            for feature in set(chosen.content) - covered_features:
+                covered_features.add(feature)
+                for affected, share in feature_index[feature]:
+                    covered_share[affected] += share
+                    utilities[affected] -= (
+                        self.config.ranking.content_penalty
+                        + self.config.ranking.uncovered_content_bonus
+                    ) * share
+                    changed.add(affected)
+            for affected in changed:
+                if by_key[affected].classification.scene_id in selected_scene_ids:
+                    continue
+                versions[affected] += 1
+                push(affected)
+        return ordered
 
     def recommend(self, lane: str, count: int, *, exploration: float = 0) -> Slate:
         started = time.perf_counter()
@@ -155,8 +376,13 @@ class SlateBuilder:
         if model_id is None:
             raise RuntimeError("no published model; run build-model first")
         if exploration == 0:
+            materialized = self._load_materialized_slate(model_id, lane, count)
+            if materialized is not None:
+                return materialized
+        prepared_slate = None
+        if exploration == 0:
             prepared_slate = self._load_prepared_slate(model_id, lane, count)
-            if prepared_slate is not None:
+            if prepared_slate is not None and len(prepared_slate.items) >= count:
                 return prepared_slate
         source_lanes = {lane}
         if lane == "for_you":
@@ -169,17 +395,18 @@ class SlateBuilder:
             prepared = self._load_prepared(model_id, source_lanes)
             classifications: tuple[LaneClassification, ...] = ()
             if not prepared:
-                classifications = policy.load(
-                    model_id,
-                    lanes=source_lanes,
-                    limit_per_lane=max(500, count * 20),
-                ) or policy.classify(model_id)
+                classifications = policy.load(model_id, lanes=source_lanes)
+                if not classifications:
+                    policy.classify(model_id)
+                    classifications = policy.load(model_id, lanes=source_lanes)
             timings["classifications"] = round((time.perf_counter() - started) * 1000)
             record_duration("python", "ranking.classifications", timings["classifications"])
             stage_started = time.perf_counter()
             self._cached_model_id = model_id
             self._cached_source_lanes = source_lane_key
             self._cached_candidates = prepared or tuple(self._candidates(model_id, classifications))
+            if not prepared:
+                self._save_prepared_candidates(model_id, source_lanes, self._cached_candidates)
             timings["candidates"] = round((time.perf_counter() - stage_started) * 1000)
             record_duration("python", "ranking.candidates", timings["candidates"])
         stage_started = time.perf_counter()
@@ -224,23 +451,51 @@ class SlateBuilder:
         timings["eligibility"] = round((time.perf_counter() - stage_started) * 1000)
         record_duration("python", "ranking.eligibility", timings["eligibility"])
         stage_started = time.perf_counter()
-        selected: list[_Candidate] = []
+        candidate_lookup = {
+            (item.classification.scene_id, item.classification.lane): item for item in candidates
+        }
+        prefix_items = tuple(
+            item
+            for item in (prepared_slate.items if prepared_slate else ())
+            if (item.scene_id, item.source_lane) in candidate_lookup
+        )
+        selected = [candidate_lookup[(item.scene_id, item.source_lane)] for item in prefix_items]
         selected_utilities: list[tuple[float, dict[str, float], dict[str, float]]] = []
         diagnostics: list[str] = []
-        history = self._history_context(model_id)
+        history = self._history_context(model_id) if self.diversity_enabled else (set(), set(), ())
         self._pair_similarities.clear()
-        self._history_similarities = {
-            candidate.classification.scene_id: max(
-                (self._cosine(candidate.content, vector) for vector in history[2]), default=0.0
-            )
-            for candidate in candidates
-        }
+        self._history_similarities = (
+            {
+                candidate.classification.scene_id: max(
+                    (self._cosine(candidate.content, vector) for vector in history[2]), default=0.0
+                )
+                for candidate in candidates
+            }
+            if self.diversity_enabled
+            else {}
+        )
         timings["history"] = round((time.perf_counter() - stage_started) * 1000)
         record_duration("python", "ranking.history", timings["history"])
         stage_started = time.perf_counter()
-        for position in range(count):
+        selected_scene_ids = {candidate.classification.scene_id for candidate in selected}
+        seen_performers = {
+            performer for candidate in selected for performer in candidate.performers
+        }
+        seen_studios = {candidate.studio_group for candidate in selected if candidate.studio_group}
+        covered_content = {name for candidate in selected for name in candidate.content}
+        content_similarities = (
+            {
+                candidate.classification.scene_id: max(
+                    (self._candidate_similarity(candidate, previous) for previous in selected),
+                    default=0.0,
+                )
+                for candidate in candidates
+            }
+            if self.diversity_enabled
+            else {}
+        )
+        for position in range(len(selected), count):
             target_lane, target_subtype = self._target(lane, position, exploration)
-            selected_scene_ids = {candidate.classification.scene_id for candidate in selected}
             remaining = [
                 candidate
                 for candidate in candidates
@@ -260,25 +515,33 @@ class SlateBuilder:
                 ]
                 or remaining
             )
-            # ponytail: 500 leaves broad diversity room; raise only if real slates exhaust it.
-            pool = nsmallest(
-                max(500, count * 20),
-                pool,
-                key=lambda candidate: (
-                    -candidate.classification.lane_value,
-                    candidate.classification.scene_id,
-                ),
-            )
             ranked = []
             for candidate in pool:
-                utility = self._utility(candidate, selected, history)
+                utility = self._utility(
+                    candidate,
+                    selected[-1] if selected else None,
+                    history,
+                    seen_performers,
+                    seen_studios,
+                    covered_content,
+                    content_similarities.get(candidate.classification.scene_id, 0.0),
+                )
                 if utility is None:
                     continue
                 ranked.append((utility[0], candidate.classification.scene_id, candidate, utility))
             if not ranked and self.config.ranking.relax_adjacent_when_exhausted:
                 diagnostics.append(f"position {position}: relaxed adjacent performer constraint")
                 for candidate in pool:
-                    utility = self._utility(candidate, selected, history, relax_adjacent=True)
+                    utility = self._utility(
+                        candidate,
+                        selected[-1] if selected else None,
+                        history,
+                        seen_performers,
+                        seen_studios,
+                        covered_content,
+                        content_similarities.get(candidate.classification.scene_id, 0.0),
+                        relax_adjacent=True,
+                    )
                     if utility:
                         ranked.append(
                             (utility[0], candidate.classification.scene_id, candidate, utility)
@@ -288,17 +551,32 @@ class SlateBuilder:
                 break
             _, _, chosen, utility = min(ranked, key=lambda item: (-item[0], item[1]))
             selected.append(chosen)
+            selected_scene_ids.add(chosen.classification.scene_id)
             selected_utilities.append(utility)
+            if self.diversity_enabled:
+                seen_performers.update(chosen.performers)
+                if chosen.studio_group:
+                    seen_studios.add(chosen.studio_group)
+                covered_content.update(chosen.content)
+                for candidate in remaining:
+                    scene_id = candidate.classification.scene_id
+                    if scene_id in selected_scene_ids:
+                        continue
+                    content_similarities[scene_id] = max(
+                        content_similarities[scene_id],
+                        self._candidate_similarity(candidate, chosen),
+                    )
 
         timings["selection"] = round((time.perf_counter() - stage_started) * 1000)
         record_duration("python", "ranking.selection", timings["selection"])
         stage_started = time.perf_counter()
+        new_selected = selected[len(prefix_items) :]
         scores = RecommendationModelStore(self.connection).scores(
-            model_id, {candidate.classification.scene_id for candidate in selected}
+            model_id, {candidate.classification.scene_id for candidate in new_selected}
         )
-        items: list[RecommendationItem] = []
-        selected_items = zip(selected, selected_utilities, strict=True)
-        for position, (chosen, utility) in enumerate(selected_items):
+        items = list(prefix_items)
+        selected_items = zip(new_selected, selected_utilities, strict=True)
+        for position, (chosen, utility) in enumerate(selected_items, start=len(prefix_items)):
             score = scores[chosen.classification.scene_id]
             reasons = ["eligibility.lane"]
             reasons.extend(f"diversity.{name}" for name, value in utility[1].items() if value > 0)
@@ -331,6 +609,140 @@ class SlateBuilder:
             self._save_prepared_slate(slate)
         return slate
 
+    def _load_materialized_slate(self, model_id: str, lane: str, count: int) -> Slate | None:
+        started = time.perf_counter()
+        if not self.connection.execute(
+            "SELECT 1 FROM model_lane_order_state WHERE model_id=?", (model_id,)
+        ).fetchone():
+            return None
+        ordering = "varied" if self.diversity_enabled else "score_first"
+        direct_plays = {
+            str(row["scene_id"]): int(row["last_played"])
+            for row in self.connection.execute(
+                """
+                SELECT scene_id, max(ended_at_ms) AS last_played FROM play_session
+                WHERE provenance='direct_player' GROUP BY scene_id
+                """
+            )
+        }
+        now_ms = time.time_ns() // 1_000_000
+        unrecovered_direct_plays = {
+            scene_id
+            for scene_id, played_at_ms in direct_plays.items()
+            if scene_recovery(
+                max(0.0, (now_ms - played_at_ms) / 86_400_000), config=self.config.model
+            )
+            < 0.10
+        }
+        selected_rows: list[sqlite3.Row] = []
+        offset = 0
+        chunk_size = max(100, count)
+        while len(selected_rows) < count:
+            rows = self.connection.execute(
+                """
+                SELECT position, scene_id, source_lane, utility, ranking_json
+                FROM model_lane_order
+                WHERE model_id=? AND lane=? AND ordering=?
+                ORDER BY position LIMIT ? OFFSET ?
+                """,
+                (model_id, lane, ordering, chunk_size, offset),
+            ).fetchall()
+            if not rows:
+                break
+            offset += len(rows)
+            scene_ids = {str(row["scene_id"]) for row in rows}
+            eligibility = scene_eligibility(
+                self.connection, now_ms, self.config, scene_ids=scene_ids
+            )
+            selected_rows.extend(
+                row
+                for row in rows
+                if bool(eligibility.get(str(row["scene_id"]), {}).get("eligible", False))
+                and not (
+                    str(row["source_lane"]) == "best_bets" and str(row["scene_id"]) in direct_plays
+                )
+                and not (
+                    str(row["source_lane"]) == "revisit"
+                    and str(row["scene_id"]) in unrecovered_direct_plays
+                )
+            )
+            if len(rows) < chunk_size:
+                break
+        selected_rows = selected_rows[:count]
+        scene_ids = {str(row["scene_id"]) for row in selected_rows}
+        scores = RecommendationModelStore(self.connection).scores(model_id, scene_ids)
+        classifications: dict[tuple[str, str], LaneClassification] = {}
+        if scene_ids:
+            placeholders = ",".join("?" for _ in scene_ids)
+            for row in self.connection.execute(
+                f"""
+                SELECT scene_id, lane, subtype, lane_value, qualification_json
+                FROM model_scene_lane
+                WHERE model_id=? AND scene_id IN ({placeholders})
+                """,
+                (model_id, *scene_ids),
+            ):
+                classification = LaneClassification(
+                    str(row["scene_id"]),
+                    str(row["lane"]),
+                    str(row["subtype"]) if row["subtype"] else None,
+                    float(row["lane_value"]),
+                    json.loads(str(row["qualification_json"])),
+                )
+                classifications[(classification.scene_id, classification.lane)] = classification
+        self._live_fit, self._live_cooldown = self._live_current_fit(model_id, direct_plays, now_ms)
+        items = []
+        for position, row in enumerate(selected_rows):
+            scene_id = str(row["scene_id"])
+            source_lane = str(row["source_lane"])
+            classification = classifications[(scene_id, source_lane)]
+            score = scores[scene_id]
+            ranking = json.loads(str(row["ranking_json"]))
+            penalties = {
+                str(name): float(value)
+                for name, value in dict(ranking.get("penalties", {})).items()
+            }
+            penalties["live_cooldown"] = self._live_cooldown.get(scene_id, 0.0)
+            bonuses = {
+                str(name): float(value) for name, value in dict(ranking.get("bonuses", {})).items()
+            }
+            reasons = ["eligibility.lane"]
+            reasons.extend(
+                f"diversity.{name}"
+                for name, value in penalties.items()
+                if name != "live_cooldown" and value > 0
+            )
+            items.append(
+                RecommendationItem(
+                    scene_id,
+                    lane,
+                    source_lane,
+                    classification.subtype,
+                    position,
+                    score.appeal,
+                    self._live_fit.get(scene_id, score.current_fit),
+                    score.confidence,
+                    classification.lane_value,
+                    float(row["utility"]) - penalties["live_cooldown"],
+                    penalties,
+                    bonuses,
+                    score.components,
+                    score.neighbors,
+                    score.eligibility,
+                    classification.qualification,
+                    tuple(reasons),
+                )
+            )
+        elapsed = round((time.perf_counter() - started) * 1_000)
+        record_duration("python", "ranking.materialized", elapsed)
+        return Slate(
+            model_id,
+            lane,
+            tuple(items),
+            (),
+            {"materialized": 1, "selection": elapsed, "total": elapsed},
+        )
+
     def _save_prepared_slate(self, slate: Slate) -> None:
         with transaction(self.connection):
             self.connection.execute(
@@ -339,7 +751,7 @@ class SlateBuilder:
                 ON CONFLICT(key) DO UPDATE SET value=excluded.value
                 """,
                 (
-                    f"slate:{slate.model_id}:{slate.lane}",
+                    self._slate_key(slate.model_id, slate.lane),
                     json.dumps(
                         {
                             "created_at_ms": time.time_ns() // 1_000_000,
@@ -354,7 +766,7 @@ class SlateBuilder:
         started = time.perf_counter()
         row = self.connection.execute(
             "SELECT value FROM application_meta WHERE key=?",
-            (f"slate:{model_id}:{lane}",),
+            (self._slate_key(model_id, lane),),
         ).fetchone()
         if row is None:
             return None
@@ -363,8 +775,6 @@ class SlateBuilder:
         if time.time_ns() // 1_000_000 - created_at_ms > 3_600_000:
             return None
         items = tuple(self._recommendation_item(item) for item in payload["items"])
-        if len(items) < count:
-            return None
         if not items:
             return Slate(model_id, lane, (), (), {"precomputed": 1, "total": 0})
         scene_ids = {item.scene_id for item in items}
@@ -394,8 +804,6 @@ class SlateBuilder:
                 and bool(eligibility.get(item.scene_id, {}).get("eligible", False))
             )
         )[:count]
-        if len(selected) < count:
-            return None
         elapsed = round((time.perf_counter() - started) * 1_000)
         return Slate(model_id, lane, selected, (), {"precomputed": 1, "total": elapsed})
 
@@ -425,12 +833,24 @@ class SlateBuilder:
         placeholders = ",".join("?" for _ in lanes)
         rows = self.connection.execute(
             f"""
-            SELECT lane, candidates_json FROM model_lane_candidate_cache
+            SELECT lane, candidates_json, candidate_count FROM model_lane_candidate_cache
             WHERE model_id=? AND lane IN ({placeholders})
             """,
             (model_id, *lanes),
         ).fetchall()
         if {str(row["lane"]) for row in rows} != lanes:
+            return ()
+        expected = {
+            str(row["lane"]): int(row["candidate_count"])
+            for row in self.connection.execute(
+                f"""
+                SELECT lane, count(*) AS candidate_count FROM model_scene_lane
+                WHERE model_id=? AND lane IN ({placeholders}) GROUP BY lane
+                """,
+                (model_id, *lanes),
+            )
+        }
+        if any(int(row["candidate_count"]) != expected.get(str(row["lane"]), 0) for row in rows):
             return ()
         candidates = tuple(
             _Candidate(
@@ -452,6 +872,48 @@ class SlateBuilder:
             candidate.classification.scene_id: candidate.content for candidate in candidates
         }
         return candidates
+
+    def _save_prepared_candidates(
+        self, model_id: str, lanes: set[str], candidates: tuple[_Candidate, ...]
+    ) -> None:
+        rows = []
+        for lane in lanes:
+            payload = [
+                {
+                    "scene_id": item.classification.scene_id,
+                    "lane": item.classification.lane,
+                    "subtype": item.classification.subtype,
+                    "lane_value": item.classification.lane_value,
+                    "qualification": item.classification.qualification,
+                    "performers": item.performers,
+                    "studio_group": item.studio_group,
+                    "content": item.content,
+                }
+                for item in candidates
+                if item.classification.lane == lane
+            ]
+            rows.append(
+                (
+                    model_id,
+                    lane,
+                    json.dumps(payload, separators=(",", ":")),
+                    len(payload),
+                    time.time_ns() // 1_000_000,
+                )
+            )
+        with transaction(self.connection):
+            self.connection.executemany(
+                """
+                INSERT INTO model_lane_candidate_cache(
+                    model_id, lane, candidates_json, candidate_count, created_at_ms
+                ) VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(model_id, lane) DO UPDATE SET
+                    candidates_json=excluded.candidates_json,
+                    candidate_count=excluded.candidate_count,
+                    created_at_ms=excluded.created_at_ms
+                """,
+                rows,
+            )
 
     def _target(self, lane: str, position: int, exploration: float) -> tuple[str, str | None]:
         if lane == "for_you":
@@ -519,16 +981,21 @@ class SlateBuilder:
     def _utility(
         self,
         candidate: _Candidate,
-        selected: list[_Candidate],
+        previous: _Candidate | None,
         history: tuple[set[str], set[str], tuple[dict[str, float], ...]],
+        seen_performers: set[str],
+        seen_studios: set[str],
+        covered_content: set[str],
+        content_similarity: float,
         *,
         relax_adjacent: bool = False,
     ) -> tuple[float, dict[str, float], dict[str, float]] | None:
         if (
-            selected
+            self.diversity_enabled
+            and previous
             and not self.config.ranking.adjacent_shared_performers
             and not relax_adjacent
-            and set(candidate.performers) & set(selected[-1].performers)
+            and set(candidate.performers) & set(previous.performers)
         ):
             return None
         penalties = {
@@ -539,34 +1006,28 @@ class SlateBuilder:
             "live_cooldown": 0.0,
         }
         penalties["live_cooldown"] = self._live_cooldown.get(candidate.classification.scene_id, 0.0)
-        for previous in selected:
-            if set(candidate.performers) & set(previous.performers):
-                penalties["performer"] = max(
-                    penalties["performer"], self.config.ranking.performer_repeat_penalty
+        uncovered_share = 0.0
+        if self.diversity_enabled:
+            if set(candidate.performers) & seen_performers:
+                penalties["performer"] = self.config.ranking.performer_repeat_penalty
+            if candidate.studio_group and candidate.studio_group in seen_studios:
+                penalties["studio"] = self.config.ranking.studio_penalty
+            penalties["content"] = self.config.ranking.content_penalty * content_similarity
+            history_performers, history_studios, history_vectors = history
+            if set(candidate.performers) & history_performers:
+                penalties["history"] += self.config.ranking.history_performer_penalty
+            if candidate.studio_group and candidate.studio_group in history_studios:
+                penalties["history"] += self.config.ranking.history_studio_penalty
+            if history_vectors:
+                penalties["history"] += (
+                    self.config.ranking.history_content_penalty
+                    * self._history_similarities[candidate.classification.scene_id]
                 )
-            if candidate.studio_group and candidate.studio_group == previous.studio_group:
-                penalties["studio"] = max(penalties["studio"], self.config.ranking.studio_penalty)
-            penalties["content"] = max(
-                penalties["content"],
-                self.config.ranking.content_penalty
-                * self._candidate_similarity(candidate, previous),
+            uncovered_share = (
+                len(set(candidate.content) - covered_content) / len(candidate.content)
+                if candidate.content
+                else 0.0
             )
-        history_performers, history_studios, history_vectors = history
-        if set(candidate.performers) & history_performers:
-            penalties["history"] += self.config.ranking.history_performer_penalty
-        if candidate.studio_group and candidate.studio_group in history_studios:
-            penalties["history"] += self.config.ranking.history_studio_penalty
-        if history_vectors:
-            penalties["history"] += (
-                self.config.ranking.history_content_penalty
-                * self._history_similarities[candidate.classification.scene_id]
-            )
-        covered = {name for previous in selected for name in previous.content}
-        uncovered_share = (
-            len(set(candidate.content) - covered) / len(candidate.content)
-            if candidate.content
-            else 0.0
-        )
         bonuses = {
             "uncovered_content": self.config.ranking.uncovered_content_bonus * uncovered_share
         }
@@ -574,6 +1035,10 @@ class SlateBuilder:
             candidate.classification.lane_value + sum(bonuses.values()) - sum(penalties.values())
         )
         return final, penalties, bonuses
+
+    def _slate_key(self, model_id: str, lane: str) -> str:
+        suffix = "" if self.diversity_enabled else ":unshuffled"
+        return f"slate:{model_id}:{lane}{suffix}"
 
     def _live_current_fit(
         self, model_id: str, direct_plays: dict[str, int], now_ms: int

--- a/curator/storage/sql/0015_materialized_lane_orders.sql
+++ b/curator/storage/sql/0015_materialized_lane_orders.sql
@@ -1,0 +1,24 @@
+CREATE TABLE model_lane_order (
+    model_id TEXT NOT NULL REFERENCES model_version(model_id) ON DELETE CASCADE,
+    lane TEXT NOT NULL CHECK (
+        lane IN ('for_you', 'best_bets', 'revisit', 'discover', 'adventure')
+    ),
+    ordering TEXT NOT NULL CHECK (ordering IN ('score_first', 'varied')),
+    position INTEGER NOT NULL CHECK (position >= 0),
+    scene_id TEXT NOT NULL REFERENCES source_scene(scene_id) ON DELETE CASCADE,
+    source_lane TEXT NOT NULL CHECK (
+        source_lane IN ('best_bets', 'revisit', 'discover', 'adventure')
+    ),
+    utility REAL NOT NULL,
+    ranking_json TEXT NOT NULL DEFAULT '{}',
+    PRIMARY KEY (model_id, lane, ordering, position),
+    UNIQUE (model_id, lane, ordering, scene_id)
+) STRICT, WITHOUT ROWID;
+
+CREATE INDEX model_lane_order_scene_idx
+ON model_lane_order(model_id, scene_id);
+
+CREATE TABLE model_lane_order_state (
+    model_id TEXT PRIMARY KEY REFERENCES model_version(model_id) ON DELETE CASCADE,
+    created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0)
+) STRICT, WITHOUT ROWID;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ source cache ──► normalized events                  StashDB
         Appeal + Current Fit + confidence
                      │
                      ▼
-        lane policy + diversity slate
+       lane policy + published lane orders
                      │
                      ▼
        cards, Similar, and explanations
@@ -37,7 +37,7 @@ source cache ──► normalized events                  StashDB
 - `curator/graphql/` and `curator/sync/` incrementally copy the required Stash facts.
 - `curator/events/` conservatively reconstructs history and stores direct outcomes.
 - `curator/features/`, `curator/model/`, and `curator/ranking/` publish immutable
-  feature/model versions and construct slates.
+  feature/model versions with indexed score-first and varied lane orders.
 - `curator/similarity.py`, `curator/expand.py`, and `curator/explanations/` serve
   Similar, StashDB discovery, and factual reasons.
 - `curator/storage/sql/` contains ordered, checksummed, transactional migrations.
@@ -45,8 +45,9 @@ source cache ──► normalized events                  StashDB
 ## Data flow and failure boundaries
 
 Sync writes normalized source tables, then event and feature builders create a new
-version. Model publication is atomic: readers see the old complete model or the new
-complete model, never a partial build. Interactive lane and Similar requests use
+version. Lane classifications and both page orders are built before model publication:
+readers see the old complete model or the new complete model, never a partial build.
+Interactive lane and Similar requests use
 compact SQLite indexes and return stable IDs; the browser fetches current display
 metadata from Stash.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -23,8 +23,8 @@ to open it.
 
 Select **Sync library** in Curator's toolbar. The corresponding Stash task is named
 **Sync and build recommendations**. It incrementally reads metadata and history,
-normalizes evidence, and publishes the first model. Progress and errors appear in
-Curator and on Stash's Tasks page.
+normalizes evidence, and publishes the first model with indexed recommendation
+orders. Progress and errors appear in Curator and on Stash's Tasks page.
 
 A full reconciliation is available as **Full sync and build recommendations** on the
 Tasks page. Use it when source records were deleted or an incremental sync appears
@@ -36,7 +36,9 @@ Curator's settings live with Stash's plugin settings. Useful early choices are:
 
 - **Sidecar database path:** set this before first use if plugin updates or removal
   may replace the plugin data directory.
-- **Scenes per lane:** defaults to 20.
+- **Results per page:** defaults to 20 for recommendations, Similar, and Expand.
+- **Disable recommendation variety:** leave unchecked to avoid repeating performers,
+  studios, and similar content; check it for score-first ordering.
 - **Prune tag:** defaults to `[Prune]`.
 - **Expand settings:** optional StashDB and Whisparr behavior.
 - **Enable profiling:** keep off unless diagnosing performance.

--- a/docs/using-curator.md
+++ b/docs/using-curator.md
@@ -17,6 +17,11 @@ permalink: /using-curator/
 
 Cards are arranged as a slate. Curator avoids adjacent performer repetition and
 softly varies studios and content, so the page is not merely the top 20 scores.
+Previous and Next continue through that same ranked sequence, preserving earlier
+variety decisions. Use the **Balanced** button beside a recommendation lane's
+description to switch between varied and score-first order. This also updates
+**Disable recommendation variety** in Curator's plugin settings. Both orders are
+published with the model, so later pages do not rerank the library.
 
 ## Inspect and teach
 
@@ -35,13 +40,16 @@ Open Similar from Curator or the compass action on a Stash scene or performer.
 Library results use content overlap and preference-aware performer profiles. Switch
 to StashDB only when you want external candidates; local and remote results remain
 separate and the reference entity stays visible.
+Local matches use the configured page size. StashDB Similar keeps up to 100 matches
+from one remote search and pages that stable result locally.
 
 ## Expand
 
 Expand is optional StashDB discovery. Refresh its cache from Curator or with the
 **Refresh Expand cache** task, then browse scenes and performers, save filters, or
 shortlist candidates. External results are metadata leads, not proof that a scene is
-available locally. Optional Whisparr actions require separate settings.
+available locally. Filters and ordering are applied before paging. Optional Whisparr
+actions require separate settings.
 
 ## Prune
 

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -212,6 +212,8 @@ def _apply_plugin_settings(connection: Any, settings: dict[str, Any]) -> None:
         for source, (key, convert) in mapping.items()
         if settings.get(source) not in (None, "")
     }
+    if "diversityDisabled" in settings:
+        overrides["diversity_enabled"] = not bool(settings["diversityDisabled"])
     if not overrides:
         return
     row = connection.execute("SELECT config_json FROM curator_config WHERE singleton=1").fetchone()
@@ -373,6 +375,9 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
         api = CuratorAPI(connection)
         if operation == "get_slate":
             config = api.config()["config"]
+            excluded = args.get("exclude_scene_ids", [])
+            if not isinstance(excluded, list):
+                raise ValueError("exclude_scene_ids must be a list")
             count = int(
                 args.get("count")
                 or (config.get("page_size", 20) if isinstance(config, dict) else 20)
@@ -380,8 +385,10 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
             return api.get_slate(
                 str(args.get("lane") or "for_you"),
                 count,
+                page=int(args.get("page") or 1),
                 impression_id=str(args["impression_id"]) if args.get("impression_id") else None,
                 context=args.get("context") if isinstance(args.get("context"), dict) else None,
+                exclude_scene_ids={str(value) for value in excluded},
                 exploration=float(args.get("exploration") or 0),
             )
         if operation == "replace_item":
@@ -402,6 +409,7 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
             assert isinstance(config, dict)
             return api.expand(
                 str(args.get("entity_type") or "scene"),
+                page=int(args.get("page") or 1),
                 sort=str(args.get("sort") or "match"),
                 performer_id=str(args["performer_id"]) if args.get("performer_id") else None,
                 favorite_only=bool(args.get("favorite_only")),
@@ -415,7 +423,7 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
                 minimum_score=(
                     float(args["minimum_score"]) if args.get("minimum_score") is not None else -1
                 ),
-                count=int(args.get("count") or 50),
+                count=int(args.get("count") or config["page_size"]),
             )
         if operation == "get_shortlist":
             return api.expand_shortlist()
@@ -427,6 +435,7 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
                 _external_links(payload),
                 str(args.get("entity_type") or ""),
                 str(args.get("entity_id") or ""),
+                count=100,
                 gender=str(args.get("gender", config["expand_gender"])),
                 include_tags=_string_list(args.get("include_tags")),
                 exclude_tags=_string_list(args.get("exclude_tags")),
@@ -586,10 +595,16 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
                 str(args.get("entity_type") or ""), str(args.get("entity_id") or "")
             )
         if operation == "get_similar":
+            config = api.config()["config"]
+            assert isinstance(config, dict)
+            excluded = args.get("exclude_scene_ids", [])
+            if not isinstance(excluded, list):
+                raise ValueError("exclude_scene_ids must be a list")
             return api.similar(
                 str(args.get("entity_type") or ""),
                 str(args.get("entity_id") or ""),
-                int(args.get("count") or 20),
+                int(args.get("count") or config["page_size"]),
+                page=int(args.get("page") or 1),
                 impression_id=(str(args["impression_id"]) if args.get("impression_id") else None),
                 gender=str(args.get("gender") or ""),
                 include_tags=_string_list(args.get("include_tags")),
@@ -602,6 +617,7 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
                     if args.get("minimum_similarity") is not None
                     else 0.18
                 ),
+                exclude_scene_ids={str(value) for value in excluded},
             )
         raise ValueError(f"unknown Curator API operation: {operation}")
     finally:
@@ -626,15 +642,18 @@ def _job_status(connection: Any) -> dict[str, object]:
 
 
 def _classify_lanes(connection: Any, model: Any) -> int:
-    if model.reused:
-        count = int(
-            connection.execute(
-                "SELECT count(*) FROM model_scene_lane WHERE model_id=?", (model.model_id,)
-            ).fetchone()[0]
-        )
-        if count:
-            return count
+    count = int(
+        connection.execute(
+            "SELECT count(*) FROM model_scene_lane WHERE model_id=?", (model.model_id,)
+        ).fetchone()[0]
+    )
+    if count:
+        return count
     return len(LanePolicy(connection).classify(model.model_id))
+
+
+def _prepare_lanes(connection: Any, model_id: str) -> dict[str, int]:
+    return SlateBuilder(connection).materialize(model_id)
 
 
 def _run_task_body(
@@ -733,6 +752,10 @@ def _run_task_body(
             _log("i", "Organizing scenes into recommendation lanes")
             with span("python", "task.lane_classification"):
                 lane_count = _classify_lanes(connection, model)
+            _progress(0.96)
+            _log("i", "Preparing recommendation pages")
+            with span("python", "task.prepare_pages"):
+                lane_caches = _prepare_lanes(connection, model.model_id)
             _progress(0.98)
             _log("i", f"Published recommendation model {model.model_id}")
             summary: dict[str, object] = {
@@ -741,6 +764,7 @@ def _run_task_body(
                 "historical_scenes": historical.scene_count,
                 "model_id": model.model_id,
                 "lane_classifications": lane_count,
+                "lane_candidate_caches": lane_caches,
                 "stage_timings_ms": model.stage_timings_ms,
             }
         elif mode in {"build", "update-model"}:
@@ -772,11 +796,16 @@ def _run_task_body(
                 _log("i", "Organizing scenes into recommendation lanes")
                 with span("python", "task.lane_classification"):
                     lane_count = _classify_lanes(connection, model)
+                _progress(0.96)
+                _log("i", "Preparing recommendation pages")
+                with span("python", "task.prepare_pages"):
+                    lane_caches = _prepare_lanes(connection, model.model_id)
                 _progress(0.98)
                 summary = {
                     "updated": True,
                     "model_id": model.model_id,
                     "lane_classifications": lane_count,
+                    "lane_candidate_caches": lane_caches,
                     "stage_timings_ms": model.stage_timings_ms,
                 }
         elif mode == "prepare":
@@ -784,13 +813,9 @@ def _run_task_body(
             model_id = RecommendationModelStore(connection).current_model_id()
             if model_id is None:
                 raise RuntimeError("no published model; build recommendations first")
-            config = CuratorAPI(connection).config()["config"]
-            assert isinstance(config, dict)
             _log("i", "Preparing recommendation pages")
             with span("python", "task.prepare_pages"):
-                lane_caches = SlateBuilder(connection).prepare(
-                    model_id, slate_size=max(60, int(config["page_size"]) * 3)
-                )
+                lane_caches = _prepare_lanes(connection, model_id)
             _progress(0.98)
             summary = {"model_id": model_id, "lane_candidate_caches": lane_caches}
         elif mode == "backup":

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -59,18 +59,31 @@
 }
 
 .curator-view-guidance {
+  align-items: center;
   color: var(--text-muted, #adb5bd);
+  display: flex;
   font-size: 0.82rem;
+  gap: 0.75rem;
+  justify-content: space-between;
   margin: 0.35rem 0 0.8rem;
 }
 
-.curator-view-guidance p {
+.curator-view-copy {
+  min-width: 0;
+}
+
+.curator-view-copy p {
   display: inline;
   margin: 0;
 }
 
-.curator-view-guidance p + p::before {
+.curator-view-copy p + p::before {
   content: " ";
+}
+
+.curator-diversity-toggle {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 .curator-tabs {
@@ -564,14 +577,14 @@
 
 .curator-prune-toolbar,
 .curator-prune-actions,
-.curator-prune-pager {
+.curator-pager {
   align-items: center;
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
 }
 
-.curator-prune-pager {
+.curator-pager {
   justify-content: center;
   margin-top: 0.8rem;
 }
@@ -1124,6 +1137,11 @@
 }
 
 @media (max-width: 36rem) {
+  .curator-view-guidance {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
   .curator-tabs .nav-link {
     justify-content: center;
     padding-inline: 0.45rem;

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -11,7 +11,7 @@
   const { NavLink, useHistory, useLocation } = libraries.ReactRouterDOM;
   const { FontAwesomeIcon } = libraries.ReactFontAwesome;
   const { faDev } = libraries.FontAwesomeBrands;
-  const { faBroom, faBullseye, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faDatabase, faDownload, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSync, faTag, faThumbsDown, faThumbsUp, faUser, faVenus, faWrench } = libraries.FontAwesomeSolid;
+  const { faBalanceScale, faBroom, faBullseye, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faDatabase, faDownload, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSync, faTag, faThumbsDown, faThumbsUp, faUser, faVenus, faWrench } = libraries.FontAwesomeSolid;
   const componentTransforms = window.StashCuratorComponentTransforms ||= {};
 
   function transformComponentProps(name, props) {
@@ -78,9 +78,11 @@
   const WHISPARR_LOGO = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAAyAAAAMgFOp+RzAAAAGXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAAxZJREFUOI1tk0tMXHUYxX///713HjDMXB4zpdBBgVKSVobWQY10WGCsSVsTJxqbNF1pNy5cSWJ07cYmbeLapUl9JCbqommiLvoAKZA2pdQSmcnQQQp1nlCY6czc/73XRYXQxLM+38n3fecckUwm2YsHd5YTVsO6aFluTBOGBgLbbdiGIeallBNDrx78Yy9f7AikUilPtcgNlDfe1zqmD4ZO49WCAFTtEumNq6TLk0p6G7fa9vveiEaj1q5AKpXyVApkw97B8PHOCU0Ijf+D41pMrV+y8/WlfO/hSNQ0TSUBqkVuhL2D4cT+TzUhNBwUj6ozpDaucL/w/a6AFAZjXZ9pHd5D4Wy68DuA5lS9CadmfH6i5wtdCMHy1jUqao3uptfwG+3k64t0Nh19bpOeltfl6tbtrkwmm5HKUhf62hK6cqsslL6ju2mEaPMYQmgsln/msPkua5UZpta+wsV59jg0cByPYfCRtCyOvRBIsFD8kSOtZ/BoLQAsb/1GtOUVstvXmX18mWORcwgkAKuVafpD4yjLjUuJ0BZLvxBrP4sUOgCl+hK2bbNZ/xvbUYx2nadJDwNQUTkeby/QF3wT15YeiXSc7sBRNGmQq91jW62T3ZxESJdoYBQERPzDACjnKfO5b4mFz/13Cq4UQlil2gq56n1Mo5f5/A+EfAfoD54kvfkrh8y3AbDdOnfzl4nv+wCPbKaqyqA7DSkk92wsIv4h5v75mg5/L33Bt6jZRVp9vUh0LGeLu4VveCn8Hl4tBED6yVV0XdzR0fjkYXlmSrpSN309DJrvAPDEWiWgR1itTFO3N3i540N2Aua4ikx5Ugk/E3J4ZGBW91uT5UbGPtL2/q7XEV8MhGCff4j+4En2pnNq/ZItjPqtWHxgTgJEBzpOlOorheuPvrRdV+3UhJDxIoYM7A66KG6uXbBztb8KmfU/xwF0ANM01Ur+2gHZKW/+lP54pL/tuH4wdIpmvf1ZmVSRpc0rPNyYVsJozKzkH4wnk0n1XBt3sDCbHrUd96KtGBauMAAX4SrN4LbQmYjFB+b28v8FOo1CLH194s4AAAAASUVORK5CYII=";
   const similarityCache = new Map();
   const restoredCache = readSlateCache();
+  const laneExclusions = new Map(restoredCache.exclusions.map(([lane, ids]) => [lane, new Set(ids)]));
   const slateCache = new Map(restoredCache.entries);
   const slateRequests = new Map();
   let cachedModelId = restoredCache.modelId;
+  let cachedConfigUpdatedAtMs = restoredCache.configUpdatedAtMs;
   let cacheGeneration = 0;
   let modelUpdateTimer = null;
 
@@ -117,18 +119,23 @@
     }
   }
 
-  function slateKey(lane) {
-    return `${lane}:0`;
+  function slateKey(lane, page = 1) {
+    return `${cachedConfigUpdatedAtMs || 0}:${lane}:${page}`;
   }
 
   function readSlateCache() {
     try {
       const value = JSON.parse(sessionStorage.getItem(SLATE_CACHE_KEY) || "null");
       return value && Array.isArray(value.entries)
-        ? { modelId: value.modelId || null, entries: value.entries.filter((entry) => Array.isArray(entry) && entry.length === 2) }
-        : { modelId: null, entries: [] };
+        ? {
+            modelId: value.modelId || null,
+            configUpdatedAtMs: Number.isFinite(value.configUpdatedAtMs) ? value.configUpdatedAtMs : null,
+            entries: value.entries.filter((entry) => Array.isArray(entry) && entry.length === 2),
+            exclusions: Array.isArray(value.exclusions) ? value.exclusions.filter((entry) => Array.isArray(entry) && Array.isArray(entry[1])) : [],
+          }
+        : { modelId: null, configUpdatedAtMs: null, entries: [], exclusions: [] };
     } catch (_) {
-      return { modelId: null, entries: [] };
+      return { modelId: null, configUpdatedAtMs: null, entries: [], exclusions: [] };
     }
   }
 
@@ -136,7 +143,7 @@
     try {
       sessionStorage.setItem(
         SLATE_CACHE_KEY,
-        JSON.stringify({ modelId: cachedModelId, entries: [...slateCache.entries()] })
+        JSON.stringify({ modelId: cachedModelId, configUpdatedAtMs: cachedConfigUpdatedAtMs, entries: [...slateCache.entries()], exclusions: [...laneExclusions].map(([lane, ids]) => [lane, [...ids]]) })
       );
     } catch (_) {
       // The in-memory cache still works if browser storage is unavailable or full.
@@ -147,9 +154,21 @@
     slateCache.clear();
     slateRequests.clear();
     cachedModelId = null;
+    cachedConfigUpdatedAtMs = null;
     sessionStorage.removeItem(SLATE_CACHE_KEY);
     cacheGeneration += 1;
     similarityCache.clear();
+  }
+
+  function Pager({ page, hasMore, loading, onPage, label }) {
+    if (page === 1 && !hasMore) return null;
+    return React.createElement(
+      "nav",
+      { className: "curator-pager", "aria-label": label },
+      React.createElement(Button, { size: "sm", disabled: loading || page === 1, onClick: () => onPage(page - 1) }, "Previous"),
+      React.createElement("span", null, `Page ${page}`),
+      React.createElement(Button, { size: "sm", disabled: loading || !hasMore, onClick: () => onPage(page + 1) }, "Next")
+    );
   }
 
   function readFilterPresets() {
@@ -175,22 +194,30 @@
     if (!copied) throw new Error("Copy failed");
   }
 
-  function loadSlate(lane, prefetched = false) {
-    const key = slateKey(lane);
+  function loadSlate(lane, page = 1, prefetched = false) {
+    const key = slateKey(lane, page);
     if (slateCache.has(key)) return Promise.resolve(slateCache.get(key));
     if (slateRequests.has(key)) return slateRequests.get(key);
     const generation = cacheGeneration;
     const request = operation({
       operation: "get_slate",
       lane,
+      page,
+      exclude_scene_ids: [...(laneExclusions.get(lane) || [])],
       exploration: 0,
       context: { route: location.pathname, prefetched },
     })
       .then((data) => {
         if (generation !== cacheGeneration) return data;
-        if (cachedModelId && cachedModelId !== data.model_id) clearSlateCache();
+        const modelChanged = cachedModelId && cachedModelId !== data.model_id;
+        const configChanged = cachedConfigUpdatedAtMs !== null && cachedConfigUpdatedAtMs !== data.config_updated_at_ms;
+        if (modelChanged || configChanged) {
+          clearSlateCache();
+          if (modelChanged) laneExclusions.clear();
+        }
         cachedModelId = data.model_id;
-        slateCache.set(key, data);
+        cachedConfigUpdatedAtMs = data.config_updated_at_ms;
+        slateCache.set(slateKey(lane, page), data);
         persistSlateCache();
         return data;
       })
@@ -200,10 +227,27 @@
   }
 
   function prefetchLane(lane) {
-    if (!laneByValue.has(lane)) return;
-    loadSlate(lane, true).catch(() => {
+    if (!laneByValue.has(lane) || cachedConfigUpdatedAtMs === null) return;
+    loadSlate(lane, 1, true).catch(() => {
       // Opening the lane will retry and show any error in context.
     });
+  }
+
+  async function configurePlugin(values) {
+    const response = await fetch("/graphql", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: 'mutation ConfigureCurator($input: Map!) { configurePlugin(plugin_id: "stash-curator", input: $input) }',
+        variables: { input: values },
+      }),
+    });
+    const payload = await response.json();
+    if (!response.ok || payload.errors) {
+      throw new Error(payload.errors?.[0]?.message || `HTTP ${response.status}`);
+    }
+    return payload.data.configurePlugin;
   }
 
   async function runTask(taskName) {
@@ -562,6 +606,9 @@
     const [result, setResult] = React.useState(null);
     const [error, setError] = React.useState("");
     const [loading, setLoading] = React.useState(false);
+    const [page, setPage] = React.useState(1);
+    const [pageSize, setPageSize] = React.useState(20);
+    const [excludedIds, setExcludedIds] = React.useState([]);
     const [gender, setGender] = React.useState(initialFilters.gender ?? "FEMALE");
     const [favoriteOnly, setFavoriteOnly] = React.useState(Boolean(initialFilters.favoriteOnly));
     const [includeTags, setIncludeTags] = React.useState(initialFilters.includeTags || []);
@@ -579,7 +626,10 @@
       variables: { filter: { q: search, per_page: 8 } },
       skip: entityType !== "performer" || !search,
     });
-    const items = result?.items || [];
+    const externalItems = result?.items || [];
+    const items = source === "stashdb"
+      ? externalItems.slice((page - 1) * pageSize, page * pageSize)
+      : externalItems;
     const ids = source === "library" ? items.map((item) => item.entity_id) : [];
     const similarScenes = GQL.useFindScenesQuery({
       variables: { filter: { per_page: Math.max(1, ids.length) }, scene_filter: idFilter(ids) },
@@ -602,15 +652,19 @@
     const sourcePerformer = GQL.useFindPerformerQuery({ variables: { id: selected?.id || "0" }, skip: entityType !== "performer" || !selected });
     const sourceEntity = entityType === "scene" ? sourceScene.data?.findScene : sourcePerformer.data?.findPerformer;
 
-    function load(id, label, type = entityType, nextSource = source, nextGender = gender) {
+    function load(id, label, type = entityType, nextSource = source, nextGender = gender, nextPage = 1, nextExcluded = excludedIds) {
       setSelected({ id: String(id), label: label || `#${id}` });
       setError("");
       const request = { operation: nextSource === "library" ? "get_similar" : "get_external_similar", entity_type: type, entity_id: String(id), gender: nextGender, favorite_only: favoriteOnly, include_tags: includeTags.map((item) => item.name), exclude_tags: excludeTags.map((item) => item.name), performer_ids: filterPerformers.map((item) => String(item.id)), performer_names: filterPerformers.map((item) => item.name), studio_ids: filterStudios.map((item) => String(item.id)), studio_names: filterStudios.map((item) => item.name), minimum_similarity: minimumSimilarity };
+      if (nextSource === "library") {
+        request.page = nextPage;
+        request.exclude_scene_ids = nextExcluded;
+      }
       const cacheKey = JSON.stringify(request);
-      if (similarityCache.has(cacheKey)) { setResult(similarityCache.get(cacheKey)); setLoading(false); return; }
+      if (similarityCache.has(cacheKey)) { setResult(similarityCache.get(cacheKey)); setPage(nextPage); setLoading(false); return; }
       setLoading(true);
       operation(request, nextSource === "stashdb" ? 60000 : 30000).then(
-        (data) => { similarityCache.set(cacheKey, data); if (similarityCache.size > 10) similarityCache.delete(similarityCache.keys().next().value); setResult(data); setLoading(false); },
+        (data) => { similarityCache.set(cacheKey, data); if (similarityCache.size > 10) similarityCache.delete(similarityCache.keys().next().value); setResult(data); setPage(nextPage); setLoading(false); },
         (failure) => (setError(failure.message), setLoading(false))
       );
     }
@@ -624,7 +678,8 @@
       setMinimumSimilarity(value.minimum ?? 0.18);
     }
     function choose(entity) {
-      load(entity.id, entity.title || entity.name || `#${entity.id}`);
+      setExcludedIds([]);
+      load(entity.id, entity.title || entity.name || `#${entity.id}`, entityType, source, gender, 1, []);
     }
     React.useEffect(() => {
       if (initialId) load(initialId, initialLabel, initialType, "library");
@@ -632,6 +687,7 @@
     React.useEffect(() => {
       operation({ operation: "get_config" }).then((data) => {
         if (initialFilters.gender === undefined) setGender(data.config.expand_gender || "");
+        setPageSize(data.config.page_size || 20);
         setWhisparrEnabled(data.whisparr_enabled);
       }, () => {});
     }, []);
@@ -641,11 +697,25 @@
       setSelected(null);
       setResult(null);
       setSource("library");
+      setPage(1);
+      setExcludedIds([]);
     }
     function switchSource(value) {
       setSource(value);
       setResult(null);
-      if (selected) load(selected.id, selected.label, entityType, value);
+      setPage(1);
+      setExcludedIds([]);
+      if (selected) load(selected.id, selected.label, entityType, value, gender, 1, []);
+    }
+    function changePage(nextPage) {
+      if (source === "stashdb") return setPage(nextPage);
+      load(selected.id, selected.label, entityType, source, gender, nextPage);
+    }
+    function removeSimilar(sceneId) {
+      const nextExcluded = [...new Set([...excludedIds, sceneId])];
+      setExcludedIds(nextExcluded);
+      similarityCache.clear();
+      load(selected.id, selected.label, entityType, source, gender, page, nextExcluded);
     }
     async function shortlistExternal(item, kind) {
       try {
@@ -686,7 +756,7 @@
         selected && React.createElement("div", { className: "btn-group curator-similar-source-tabs", role: "group", "aria-label": "Similarity source" }, [["library", "Library", faDatabase], ["stashdb", "StashDB", faCompass]].map(([value, label, icon]) => React.createElement(Button, { key: value, size: "sm", variant: source === value ? "primary" : "secondary", onClick: () => switchSource(value) }, React.createElement(FontAwesomeIcon, { icon }), ` ${label}`))),
         React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters")
       ),
-      filtersOpen && React.createElement("div", { className: "curator-expand-filters curator-filter-panel" }, React.createElement("div", null, entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Include tags", values: includeTags, onChange: setIncludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: setExcludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "performer", label: "Performers", values: filterPerformers, onChange: setFilterPerformers }), entityType === "scene" && React.createElement(FilterTokens, { kind: "studio", label: "Studios", values: filterStudios, onChange: setFilterStudios }), entityType === "scene" && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", onClick: () => setFavoriteOnly((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"), React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: (event) => setGender(event.target.value), "aria-label": "Performer gender" }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))), entityType === "scene" && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimumSimilarity.toFixed(2)}`), React.createElement("input", { type: "range", min: "0", max: "0.8", step: "0.05", value: minimumSimilarity, onChange: (event) => setMinimumSimilarity(Number(event.target.value)) })), entityType === "scene" && React.createElement(SavedFilters, { scope: "similar", current: { gender, favoriteOnly, includeTags, excludeTags, performers: filterPerformers, studios: filterStudios, minimum: minimumSimilarity }, onApply: applySaved }), selected && React.createElement(Button, { size: "sm", variant: "primary", onClick: () => load(selected.id, selected.label) }, "Apply"))),
+      filtersOpen && React.createElement("div", { className: "curator-expand-filters curator-filter-panel" }, React.createElement("div", null, entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Include tags", values: includeTags, onChange: setIncludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: setExcludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "performer", label: "Performers", values: filterPerformers, onChange: setFilterPerformers }), entityType === "scene" && React.createElement(FilterTokens, { kind: "studio", label: "Studios", values: filterStudios, onChange: setFilterStudios }), entityType === "scene" && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", onClick: () => setFavoriteOnly((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"), React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: (event) => setGender(event.target.value), "aria-label": "Performer gender" }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))), entityType === "scene" && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimumSimilarity.toFixed(2)}`), React.createElement("input", { type: "range", min: "0", max: "0.8", step: "0.05", value: minimumSimilarity, onChange: (event) => setMinimumSimilarity(Number(event.target.value)) })), entityType === "scene" && React.createElement(SavedFilters, { scope: "similar", current: { gender, favoriteOnly, includeTags, excludeTags, performers: filterPerformers, studios: filterStudios, minimum: minimumSimilarity }, onApply: applySaved }), selected && React.createElement(Button, { size: "sm", variant: "primary", onClick: () => (setExcludedIds([]), load(selected.id, selected.label, entityType, source, gender, 1, [])) }, "Apply"))),
       search && !selected && React.createElement(
         "div",
         { className: "curator-similar-candidates" },
@@ -699,7 +769,7 @@
       result && source === "library" && React.createElement(
         "div",
         { className: "curator-grid" },
-        items.map((item, position) => {
+        items.map((item) => {
           const entity = entities.get(String(item.entity_id));
           if (!entity) return null;
           const body = React.createElement("div", { className: "curator-card-body" }, React.createElement("div", { className: "curator-card-details" }, React.createElement("details", { className: "curator-evidence" }, React.createElement("summary", null, "Why this?"), React.createElement("p", { className: "curator-explanation" }, relationshipText(item))), React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, `Score · ${item.rank_score.toFixed(2)}`), React.createElement("p", null, `Similarity ${item.similarity.toFixed(2)} · predicted appeal ${item.appeal.toFixed(2)}`))));
@@ -707,16 +777,17 @@
           const feedbackItem = { ...item, scene_id: item.entity_id, impression_id: result.impression_id };
           function rememberOrigin(event) {
             if (!event.target.closest("a")) return;
-            sessionStorage.setItem(ORIGIN_KEY, JSON.stringify({ scene_id: item.entity_id, impression_id: result.impression_id, lane: "similar", impression_position: position, model_id: result.model_id }));
+            sessionStorage.setItem(ORIGIN_KEY, JSON.stringify({ scene_id: item.entity_id, impression_id: result.impression_id, lane: "similar", impression_position: item.position, model_id: result.model_id }));
           }
-          return React.createElement("article", { key: item.entity_id, className: "curator-card", onClickCapture: rememberOrigin }, React.createElement(SceneCard, { scene: entity }), body, React.createElement("div", { className: "curator-similar-feedback" }, React.createElement(Feedback, { item: feedbackItem, onRemove: () => setResult((current) => ({ ...current, items: current.items.filter((value) => value.entity_id !== item.entity_id) })) })));
+          return React.createElement("article", { key: item.entity_id, className: "curator-card", onClickCapture: rememberOrigin }, React.createElement(SceneCard, { scene: entity }), body, React.createElement("div", { className: "curator-similar-feedback" }, React.createElement(Feedback, { item: feedbackItem, onRemove: removeSimilar })));
         })
       ),
       result && source === "stashdb" && React.createElement(
         "div",
         { className: "curator-grid curator-external-grid" },
         items.map((item) => React.createElement(ExternalCard, { key: item.id, item, kind: entityType, gender, onShortlist: shortlistExternal, onShowScenes: (id) => location.assign(`/plugins/stash-curator?view=expand&performer=${id}`), onWhisparr: sendWhisparr, whisparrEnabled }))
-      )
+      ),
+      result && React.createElement(Pager, { page, hasMore: source === "stashdb" ? page * pageSize < externalItems.length : result.has_more, loading, onPage: changePage, label: "Similar pages" })
     );
   }
 
@@ -794,7 +865,7 @@
           );
         })
       ),
-      data && data.total > data.page_size && React.createElement("nav", { className: "curator-prune-pager", "aria-label": "Prune pages" }, React.createElement(Button, { size: "sm", disabled: page === 1, onClick: () => setPage((value) => value - 1) }, "Previous"), React.createElement("span", null, `Page ${page} of ${Math.ceil(data.total / data.page_size)}`), React.createElement(Button, { size: "sm", disabled: page * data.page_size >= data.total, onClick: () => setPage((value) => value + 1) }, "Next"))
+      data && data.total > data.page_size && React.createElement("nav", { className: "curator-pager", "aria-label": "Prune pages" }, React.createElement(Button, { size: "sm", disabled: page === 1, onClick: () => setPage((value) => value - 1) }, "Previous"), React.createElement("span", null, `Page ${page} of ${Math.ceil(data.total / data.page_size)}`), React.createElement(Button, { size: "sm", disabled: page * data.page_size >= data.total, onClick: () => setPage((value) => value + 1) }, "Next"))
     );
   }
 
@@ -814,6 +885,7 @@
     const [filterVersion, setFilterVersion] = React.useState(0);
     const [data, setData] = React.useState(null);
     const [loading, setLoading] = React.useState(true);
+    const [page, setPage] = React.useState(1);
     const [error, setError] = React.useState("");
     const [message, setMessage] = React.useState("");
     const [version, setVersion] = React.useState(0);
@@ -821,12 +893,12 @@
     React.useEffect(() => {
       let active = true;
       setLoading(true);
-      operation(entityType === "shortlist" ? { operation: "get_shortlist" } : { operation: "get_expand", entity_type: entityType, sort, performer_id: performerId, favorite_only: favoriteOnly, gender, include_tags: includeTags.map((item) => item.name), exclude_tags: excludeTags.map((item) => item.name), performer_names: performers.map((item) => item.name), studio_names: studios.map((item) => item.name), minimum_score: minimumScore }).then(
+      operation(entityType === "shortlist" ? { operation: "get_shortlist" } : { operation: "get_expand", page, entity_type: entityType, sort, performer_id: performerId, favorite_only: favoriteOnly, gender, include_tags: includeTags.map((item) => item.name), exclude_tags: excludeTags.map((item) => item.name), performer_names: performers.map((item) => item.name), studio_names: studios.map((item) => item.name), minimum_score: minimumScore }).then(
         (result) => active && (setData(result), setLoading(false)),
         (failure) => active && (setError(failure.message), setLoading(false))
       );
       return () => { active = false; };
-    }, [entityType, sort, performerId, favoriteOnly, gender, filterVersion, version]);
+    }, [entityType, sort, performerId, favoriteOnly, gender, filterVersion, version, page]);
     React.useEffect(() => {
       operation({ operation: "get_config" }).then((data) => {
         if (initialFilters.gender === undefined) setGender(data.config.expand_gender || "");
@@ -834,6 +906,7 @@
       }, () => {});
     }, []);
     function applySaved(value) {
+      setPage(1);
       setGender(value.gender ?? "FEMALE");
       setFavoriteOnly(Boolean(value.favoriteOnly));
       setIncludeTags(value.includeTags || []);
@@ -849,6 +922,7 @@
       } catch (failure) { setError(failure.message); }
     }
     function showPerformerScenes(id) {
+      setPage(1);
       setEntityType("scene");
       setPerformerId(id);
     }
@@ -865,15 +939,15 @@
       React.createElement(
         "div",
         { className: "curator-expand-toolbar" },
-        React.createElement("div", { className: "btn-group", role: "group", "aria-label": "Explore external content" }, [["scene", "Scenes", faPlayCircle], ["performer", "Performers", faUser]].map(([value, label, icon]) => React.createElement(Button, { key: value, size: "sm", variant: entityType === value ? "primary" : "secondary", onClick: () => (setEntityType(value), setPerformerId(null)) }, React.createElement(FontAwesomeIcon, { icon }), ` ${label}`))),
-        React.createElement(Button, { className: "curator-shortlist-tab", size: "sm", variant: entityType === "shortlist" ? "primary" : "secondary", onClick: () => (setEntityType("shortlist"), setPerformerId(null)) }, React.createElement(FontAwesomeIcon, { icon: faList }), " Shortlist"),
-        entityType === "scene" && React.createElement("label", { className: "curator-toolbar-select" }, React.createElement(FontAwesomeIcon, { icon: faSortAmountDown }), React.createElement("select", { value: sort, onChange: (event) => setSort(event.target.value), "aria-label": "Sort Expand results" }, React.createElement("option", { value: "match" }, "Best match"), React.createElement("option", { value: "newest" }, "Newest"))),
+        React.createElement("div", { className: "btn-group", role: "group", "aria-label": "Explore external content" }, [["scene", "Scenes", faPlayCircle], ["performer", "Performers", faUser]].map(([value, label, icon]) => React.createElement(Button, { key: value, size: "sm", variant: entityType === value ? "primary" : "secondary", onClick: () => (setPage(1), setEntityType(value), setPerformerId(null)) }, React.createElement(FontAwesomeIcon, { icon }), ` ${label}`))),
+        React.createElement(Button, { className: "curator-shortlist-tab", size: "sm", variant: entityType === "shortlist" ? "primary" : "secondary", onClick: () => (setPage(1), setEntityType("shortlist"), setPerformerId(null)) }, React.createElement(FontAwesomeIcon, { icon: faList }), " Shortlist"),
+        entityType === "scene" && React.createElement("label", { className: "curator-toolbar-select" }, React.createElement(FontAwesomeIcon, { icon: faSortAmountDown }), React.createElement("select", { value: sort, onChange: (event) => (setPage(1), setSort(event.target.value)), "aria-label": "Sort Expand results" }, React.createElement("option", { value: "match" }, "Best match"), React.createElement("option", { value: "newest" }, "Newest"))),
         entityType !== "shortlist" && React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters"),
-        performerId && React.createElement(Button, { size: "sm", variant: "link", onClick: () => setPerformerId(null) }, "Clear performer filter"),
+        performerId && React.createElement(Button, { size: "sm", variant: "link", onClick: () => (setPage(1), setPerformerId(null)) }, "Clear performer filter"),
         React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Refresh the bounded StashDB candidate cache in a background task.", "aria-label": "Refresh Expand cache", onClick: refresh }, React.createElement(FontAwesomeIcon, { icon: faSync })),
         data?.fetched_at_ms && React.createElement("small", null, `${Date.now() > data.expires_at_ms ? "Stale · " : ""}Updated ${new Date(data.fetched_at_ms).toLocaleString()}`)
       ),
-      entityType !== "shortlist" && filtersOpen && React.createElement("div", { className: "curator-expand-filters curator-filter-panel" }, React.createElement("div", null, entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Include tags", values: includeTags, onChange: setIncludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: setExcludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "performer", label: "Performers", values: performers, onChange: setPerformers }), entityType === "scene" && React.createElement(FilterTokens, { kind: "studio", label: "Studios", values: studios, onChange: setStudios }), entityType === "scene" && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", title: "Show only scenes containing a performer favorited in your local library", "aria-pressed": favoriteOnly, onClick: () => setFavoriteOnly((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"), React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: (event) => setGender(event.target.value), "aria-label": "External performer gender" }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))), entityType === "scene" && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimumScore.toFixed(2)}`), React.createElement("input", { type: "range", min: "-0.2", max: "0.8", step: "0.05", value: minimumScore, onChange: (event) => setMinimumScore(Number(event.target.value)) })), entityType === "scene" && React.createElement(SavedFilters, { scope: "expand", current: { gender, favoriteOnly, includeTags, excludeTags, performers, studios, minimum: minimumScore }, onApply: applySaved }), React.createElement(Button, { size: "sm", variant: "primary", onClick: () => setFilterVersion((value) => value + 1) }, "Apply"))),
+      entityType !== "shortlist" && filtersOpen && React.createElement("div", { className: "curator-expand-filters curator-filter-panel" }, React.createElement("div", null, entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Include tags", values: includeTags, onChange: setIncludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: setExcludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "performer", label: "Performers", values: performers, onChange: setPerformers }), entityType === "scene" && React.createElement(FilterTokens, { kind: "studio", label: "Studios", values: studios, onChange: setStudios }), entityType === "scene" && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", title: "Show only scenes containing a performer favorited in your local library", "aria-pressed": favoriteOnly, onClick: () => (setPage(1), setFavoriteOnly((value) => !value)) }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"), React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: (event) => (setPage(1), setGender(event.target.value)), "aria-label": "External performer gender" }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))), entityType === "scene" && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimumScore.toFixed(2)}`), React.createElement("input", { type: "range", min: "-0.2", max: "0.8", step: "0.05", value: minimumScore, onChange: (event) => setMinimumScore(Number(event.target.value)) })), entityType === "scene" && React.createElement(SavedFilters, { scope: "expand", current: { gender, favoriteOnly, includeTags, excludeTags, performers, studios, minimum: minimumScore }, onApply: applySaved }), React.createElement(Button, { size: "sm", variant: "primary", onClick: () => (setPage(1), setFilterVersion((value) => value + 1)) }, "Apply"))),
       loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Loading Expand cache…"), React.createElement("div", { className: "curator-progress", "aria-hidden": "true" })),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
       message && React.createElement("p", { role: "status" }, message),
@@ -886,7 +960,8 @@
           const kind = entityType === "shortlist" ? item.entity_type : entityType;
           return React.createElement(ExternalCard, { key: `${kind}-${item.id}`, item, kind, gender, onShortlist: shortlist, onShowScenes: showPerformerScenes, onWhisparr: sendWhisparr, whisparrEnabled });
         })
-      )
+      ),
+      entityType !== "shortlist" && data?.ready && React.createElement(Pager, { page, hasMore: data.has_more, loading, onPage: setPage, label: "Expand pages" })
     );
   }
 
@@ -1078,20 +1153,41 @@
     const [error, setError] = React.useState("");
     const [loading, setLoading] = React.useState(true);
     const [refreshKey, setRefreshKey] = React.useState(0);
+    const [page, setPage] = React.useState(1);
+    const [configReady, setConfigReady] = React.useState(false);
+    const [diversityEnabled, setDiversityEnabled] = React.useState(null);
+    const [diversitySaving, setDiversitySaving] = React.useState(false);
 
     React.useEffect(() => {
       let active = true;
+      operation({ operation: "get_config" }).then(
+        (data) => {
+          if (!active) return;
+          if (cachedConfigUpdatedAtMs !== data.updated_at_ms) clearSlateCache();
+          cachedConfigUpdatedAtMs = data.updated_at_ms;
+          setDiversityEnabled(Boolean(data.config.diversity_enabled));
+          persistSlateCache();
+          setConfigReady(true);
+        },
+        () => active && setConfigReady(true)
+      );
+      return () => { active = false; };
+    }, []);
+
+    React.useEffect(() => {
+      let active = true;
+      if (!configReady) return () => { active = false; };
       if (!laneByValue.has(lane)) {
         setSlate(null);
         setLoading(false);
         setError("");
         return () => { active = false; };
       }
-      const cached = slateCache.get(slateKey(lane));
+      const cached = slateCache.get(slateKey(lane, page));
       setSlate(cached || null);
       setLoading(!cached);
       setError("");
-      loadSlate(lane).then(
+      loadSlate(lane, page).then(
         (data) => {
           if (!active) return;
           setSlate(data);
@@ -1102,7 +1198,7 @@
       return () => {
         active = false;
       };
-    }, [lane, refreshKey]);
+    }, [lane, page, refreshKey, configReady]);
 
     const laneOption = NAV_ITEMS.find((option) => option.value === lane);
 
@@ -1118,31 +1214,45 @@
       (scenesQuery.data?.findScenes?.scenes || []).map((scene) => [String(scene.id), scene])
     );
     function remove(sceneId) {
-      const excluded = slate.items.map((item) => item.scene_id);
       clearSlateCache();
-      setSlate((current) => ({ ...current, items: current.items.filter((item) => item.scene_id !== sceneId) }));
-      operation({ operation: "replace_item", lane, exploration: 0, exclude_scene_ids: excluded }).then(
-        (replacement) =>
-          setSlate((current) => ({
-            ...current,
-            items: [
-              ...current.items,
-              ...replacement.items.filter(
-                (candidate) => !current.items.some((item) => item.scene_id === candidate.scene_id)
-              ),
-            ],
-          })),
-        () => {}
-      );
+      const excluded = laneExclusions.get(lane) || new Set();
+      excluded.add(sceneId);
+      laneExclusions.set(lane, excluded);
+      persistSlateCache();
+      setLoading(true);
+      setRefreshKey((value) => value + 1);
     }
     function refresh() {
       clearSlateCache();
+      laneExclusions.clear();
+      setPage(1);
       setRefreshKey((value) => value + 1);
     }
     function openView(view) {
       if (view === lane) return;
+      setPage(1);
       route.set("view", view);
       history.push({ pathname: routeLocation.pathname, search: route.toString() });
+    }
+    async function toggleDiversity() {
+      const nextEnabled = !diversityEnabled;
+      setDiversitySaving(true);
+      setError("");
+      try {
+        await configurePlugin({ diversityDisabled: !nextEnabled });
+        const data = await operation({ operation: "get_config" });
+        clearSlateCache();
+        cachedConfigUpdatedAtMs = data.updated_at_ms;
+        setDiversityEnabled(Boolean(data.config.diversity_enabled));
+        persistSlateCache();
+        setPage(1);
+        setLoading(true);
+        setRefreshKey((value) => value + 1);
+      } catch (failure) {
+        setError(failure.message);
+      } finally {
+        setDiversitySaving(false);
+      }
     }
 
     return React.createElement(
@@ -1169,8 +1279,27 @@
       laneOption && React.createElement(
         "div",
         { className: "curator-view-guidance" },
-        React.createElement("p", null, laneOption.description),
-        laneByValue.has(lane) && React.createElement("p", null, "The colored corner icon identifies the source lane; Score is ranking utility, not a probability.")
+        React.createElement(
+          "div",
+          { className: "curator-view-copy" },
+          React.createElement("p", null, laneOption.description),
+          laneByValue.has(lane) && React.createElement("p", null, "The colored corner icon identifies the source lane; Score is ranking utility, not a probability.")
+        ),
+        laneByValue.has(lane) && diversityEnabled !== null && React.createElement(
+          Button,
+          {
+            className: "curator-diversity-toggle",
+            size: "sm",
+            variant: diversityEnabled ? "primary" : "secondary",
+            disabled: diversitySaving,
+            "aria-pressed": diversityEnabled,
+            "aria-label": diversityEnabled ? "Disable recommendation variety" : "Enable recommendation variety",
+            title: diversityEnabled ? "Switch to the model's score-first order" : "Vary performers, studios, and similar content",
+            onClick: toggleDiversity,
+          },
+          React.createElement(FontAwesomeIcon, { icon: faBalanceScale }),
+          diversityEnabled ? " Balanced" : " Score-first"
+        )
       ),
       lane === "similar" && !loadingComponents && React.createElement(SimilarityPanel, { initialType: route.get("type") || "scene", initialId: route.get("id"), initialLabel: route.get("label") }),
       lane === "prune" && !loadingComponents && React.createElement(PrunePanel),
@@ -1194,7 +1323,8 @@
             "section",
             { className: "curator-grid", role: "tabpanel", "aria-live": "polite" },
             slate.items.map((item) => React.createElement(RecommendationCard, { key: item.scene_id, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove }))
-          )
+          ),
+          React.createElement(Pager, { page, hasMore: slate.has_more, loading, onPage: setPage, label: `${laneOption.label} pages` })
         )
     );
   }

--- a/plugin/stash-curator.yml
+++ b/plugin/stash-curator.yml
@@ -26,9 +26,13 @@ settings:
     description: Leave empty to store data in the plugin's data directory.
     type: STRING
   pageSize:
-    displayName: Scenes per lane
-    description: Number of recommendations shown on each Curator lane. Default 20.
+    displayName: Results per page
+    description: Number of results shown on Curator recommendation, Similar, and Expand pages. Default 20.
     type: NUMBER
+  diversityDisabled:
+    displayName: Disable recommendation variety
+    description: Use score-first ordering instead of avoiding repeated performers, studios, and similar content.
+    type: BOOLEAN
   syncPageSize:
     displayName: Sync page size
     description: Number of Stash records fetched per synchronization request. Default 250.

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -165,6 +165,37 @@ def test_complete_model_is_bounded_reproducible_and_applies_cooldown(tmp_path: P
     assert isinstance(exclusion_reasons, list)
     assert "current_thumb_down" in exclusion_reasons
     assert connection.execute("SELECT count(*) FROM feature_affinity").fetchone()[0] > 0
+    assert connection.execute(
+        "SELECT 1 FROM model_lane_order_state WHERE model_id=?", (first.model_id,)
+    ).fetchone()
+    assert {
+        str(row[0])
+        for row in connection.execute(
+            "SELECT DISTINCT ordering FROM model_lane_order WHERE model_id=?",
+            (first.model_id,),
+        )
+    } == {"score_first", "varied"}
+    assert [
+        str(row[0])
+        for row in connection.execute(
+            """
+            SELECT scene_id FROM model_lane_order
+            WHERE model_id=? AND lane='for_you' AND ordering='varied'
+            ORDER BY position
+            """,
+            (first.model_id,),
+        )
+    ] != [
+        str(row[0])
+        for row in connection.execute(
+            """
+            SELECT scene_id FROM model_lane_order
+            WHERE model_id=? AND lane='for_you' AND ordering='score_first'
+            ORDER BY position
+            """,
+            (first.model_id,),
+        )
+    ]
     assert scores["unseen-good"].neighbors
     assert all("scene_id" in neighbor for neighbor in scores["unseen-good"].neighbors)
     assert {str(neighbor["scene_id"]) for neighbor in scores["unseen-good"].neighbors} <= {
@@ -279,6 +310,32 @@ def test_failed_rebuild_cannot_replace_published_model(
     ]
     assert "published" in statuses
     assert "failed" in statuses
+
+
+def test_failed_lane_order_build_cannot_replace_published_model(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    published = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    connection.execute(
+        """
+        INSERT INTO behavior_event(
+            event_id, event_type, scene_id, occurred_at_ms, outcome, confidence,
+            provenance, payload_json
+        ) VALUES ('new-order-event', 'occasion_outcome', 'unlabeled', ?, 0.4, 1,
+                  'synthetic', '{"primary_signal":"view"}')
+        """,
+        (REFERENCE_MS,),
+    )
+    monkeypatch.setattr(
+        "curator.ranking.SlateBuilder.materialize",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("synthetic order failure")),
+    )
+
+    with pytest.raises(RuntimeError, match="synthetic order failure"):
+        PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+
+    assert RecommendationModelStore(connection).current_model_id() == published.model_id
 
 
 def test_all_positive_cold_start_learns_relative_lift_without_saturating(

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -124,11 +124,33 @@ def test_whisparr_button_is_disabled_until_configured() -> None:
 def test_curator_prefetches_only_the_intended_lane() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
     assert "function prefetchLanes" not in source
-    assert "if (!laneByValue.has(lane)) return;" in source
-    assert "loadSlate(lane).then(" in source
-    assert "loadSlate(lane, true).catch(" in source
+    assert "if (!laneByValue.has(lane) || cachedConfigUpdatedAtMs === null) return;" in source
+    assert "loadSlate(lane, page).then(" in source
+    assert "loadSlate(lane, 1, true).catch(" in source
     assert "onMouseEnter: () => prefetchLane(option.value)" in source
     assert "onFocus: () => prefetchLane(option.value)" in source
+
+
+def test_plugin_pages_generated_results_without_repeating_external_searches() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
+
+    assert "function Pager({ page, hasMore, loading, onPage, label })" in source
+    assert "return `${cachedConfigUpdatedAtMs || 0}:${lane}:${page}`" in source
+    assert "externalItems.slice((page - 1) * pageSize, page * pageSize)" in source
+    assert 'operation: "get_expand", page' in source
+
+
+def test_recommendation_variety_toggle_updates_native_setting_and_cache() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
+
+    assert 'configurePlugin(plugin_id: "stash-curator", input: $input)' in source
+    assert "await configurePlugin({ diversityDisabled: !nextEnabled });" in source
+    assert "configUpdatedAtMs: cachedConfigUpdatedAtMs" in source
+    assert "laneByValue.has(lane) && diversityEnabled !== null" in source
+    assert '"aria-pressed": diversityEnabled' in source
+    assert "icon: faBalanceScale" in source
+    assert "faRandom" not in source
+    assert 'diversityEnabled ? " Balanced" : " Score-first"' in source
 
 
 def test_plugin_ignores_repeated_script_evaluation() -> None:
@@ -208,6 +230,7 @@ def test_plugin_settings_are_applied_to_sidecar_config(tmp_path: Path) -> None:
         {
             "databasePath": str(tmp_path / "curator.sqlite3"),
             "pageSize": 12,
+            "diversityDisabled": True,
             "modelUpdateEventThreshold": 7,
         },
     )
@@ -218,6 +241,7 @@ def test_plugin_settings_are_applied_to_sidecar_config(tmp_path: Path) -> None:
             ).fetchone()[0]
         )
         assert config["page_size"] == 12
+        assert config["diversity_enabled"] is False
         assert config["model_update_event_threshold"] == 7
     finally:
         connection.close()
@@ -237,6 +261,13 @@ def test_plugin_settings_are_applied_to_sidecar_config(tmp_path: Path) -> None:
         )["whisparr_enabled"]
         is False
     )
+
+
+def test_model_tasks_prepare_recommendation_pages() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "backend.py").read_text(encoding="utf-8")
+
+    assert source.count("_prepare_lanes(connection, model.model_id)") == 2
+    assert '"lane_candidate_caches": lane_caches' in source
 
 
 def test_backend_profiles_only_when_enabled_and_exposes_profile_api(

--- a/tests/ranking/test_slate.py
+++ b/tests/ranking/test_slate.py
@@ -279,10 +279,30 @@ def test_new_slate_builder_reuses_persisted_lane_classifications(
 
     builder = SlateBuilder(connection)
     assert builder.recommend("best_bets", 1).items
-    assert connection.execute("SELECT count(*) FROM model_lane_candidate_cache").fetchone()[0] == 0
+    assert connection.execute("SELECT count(*) FROM model_lane_candidate_cache").fetchone()[0] == 1
     assert connection.execute(
         "SELECT 1 FROM application_meta WHERE key='slate:model:best_bets'"
     ).fetchone()
+
+
+def test_longer_slate_extends_the_saved_prefix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    first = SlateBuilder(connection).recommend("best_bets", 2)
+    builder = SlateBuilder(connection)
+    positions = []
+    target = builder._target
+
+    def counted_target(lane: str, position: int, exploration: float):
+        positions.append(position)
+        return target(lane, position, exploration)
+
+    monkeypatch.setattr(builder, "_target", counted_target)
+    extended = builder.recommend("best_bets", 4)
+
+    assert extended.items[:2] == first.items
+    assert positions == [2, 3]
 
 
 def test_prepared_lane_candidates_avoid_rehydrating_model_features(
@@ -364,7 +384,18 @@ def test_direct_play_updates_prebuilt_lanes_without_rebuilding(
 
 def test_greedy_slate_enforces_adjacency_and_soft_penalties_only_reorder(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
-    slate = SlateBuilder(connection).recommend("best_bets", 4)
+    builder = SlateBuilder(connection)
+    compared_pairs: list[tuple[str, str]] = []
+    similarity = builder._candidate_similarity
+
+    def counted_similarity(left, right):  # type: ignore[no-untyped-def]
+        compared_pairs.append(
+            tuple(sorted((left.classification.scene_id, right.classification.scene_id)))
+        )
+        return similarity(left, right)
+
+    builder._candidate_similarity = counted_similarity  # type: ignore[method-assign]
+    slate = builder.recommend("best_bets", 4)
 
     assert [item.scene_id for item in slate.items] == [
         "a-best",
@@ -379,6 +410,38 @@ def test_greedy_slate_enforces_adjacency_and_soft_penalties_only_reorder(tmp_pat
     assert slate.items[2].penalties["content"] > 0
     assert all(item.final_utility <= item.lane_value + 0.03 for item in slate.items)
     assert all(item.eligibility["eligible"] is True for item in slate.items)
+    assert len(compared_pairs) == len(set(compared_pairs))
+
+
+def test_diversity_can_be_disabled_without_reusing_diverse_slate(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    diverse = SlateBuilder(connection).recommend("best_bets", 4)
+    score_first = SlateBuilder(connection, diversity_enabled=False).recommend("best_bets", 4)
+
+    assert [item.scene_id for item in diverse.items[:2]] == ["a-best", "l-varied"]
+    assert [item.scene_id for item in score_first.items[:2]] == ["a-best", "b-best"]
+    assert all(
+        not any(item.penalties[name] for name in ("performer", "studio", "content", "history"))
+        and item.bonuses["uncovered_content"] == 0
+        for item in score_first.items
+    )
+
+
+def test_slate_loads_all_lane_candidates(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    LanePolicy(connection).classify("model")
+    limits: list[int | None] = []
+    load = LanePolicy.load
+
+    def counted_load(self, model_id, *, lanes=None, limit_per_lane=None):  # type: ignore[no-untyped-def]
+        limits.append(limit_per_lane)
+        return load(self, model_id, lanes=lanes, limit_per_lane=limit_per_lane)
+
+    monkeypatch.setattr(LanePolicy, "load", counted_load)
+
+    SlateBuilder(connection).recommend("best_bets", 2)
+
+    assert limits == [None]
 
 
 def test_slate_applies_feedback_added_after_model_publication(tmp_path: Path) -> None:

--- a/tests/storage/test_cli_db.py
+++ b/tests/storage/test_cli_db.py
@@ -15,7 +15,7 @@ def test_database_cli_migrate_status_and_backup(
 
     assert run(["--db", str(database), "db", "migrate", "--json"]) == 0
     migrated = json.loads(capsys.readouterr().out)
-    assert migrated["current_version"] == migrated["latest_version"] == 14
+    assert migrated["current_version"] == migrated["latest_version"] == 15
 
     assert run(["--db", str(database), "db", "status", "--json"]) == 0
     status = json.loads(capsys.readouterr().out)

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -11,10 +11,10 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
         runner = MigrationRunner(connection)
         before = runner.status()
         assert before.current_version == 0
-        assert before.pending_versions == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14)
+        assert before.pending_versions == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
 
         after = runner.migrate(applied_at_ms=1234)
-        assert after.current_version == 14
+        assert after.current_version == 15
         assert after.pending_versions == ()
         assert runner.migrate(applied_at_ms=5678) == after
 
@@ -37,6 +37,8 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
             "curator_config",
             "curator_job",
             "model_lane_candidate_cache",
+            "model_lane_order",
+            "model_lane_order_state",
         } <= tables
         assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
         assert connection.execute(
@@ -83,7 +85,7 @@ def test_status_stays_read_only_after_migrations(tmp_path: Path) -> None:
     reader.execute("PRAGMA busy_timeout=1")
     try:
         writer.execute("BEGIN IMMEDIATE")
-        assert MigrationRunner(reader).status().current_version == 14
+        assert MigrationRunner(reader).status().current_version == 15
     finally:
         writer.rollback()
         reader.close()
@@ -109,7 +111,7 @@ def test_stale_concurrent_migrator_rechecks_after_writer_lock(
 
     monkeypatch.setattr(second_runner, "status", status)
     try:
-        assert second_runner.migrate(applied_at_ms=2).current_version == 14
+        assert second_runner.migrate(applied_at_ms=2).current_version == 15
     finally:
         second.close()
         first.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -70,6 +70,42 @@ def test_slate_api_never_builds_a_pending_model_inline(
     assert result["items"]
 
 
+def test_slate_api_pages_one_ranked_prefix_with_global_positions(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    api = CuratorAPI(connection)
+    fail = lambda *_args, **_kwargs: (_ for _ in ()).throw(  # noqa: E731
+        AssertionError("materialized requests must not hydrate candidates")
+    )
+    monkeypatch.setattr("curator.ranking.slate.SlateBuilder._load_prepared", fail)
+    monkeypatch.setattr("curator.ranking.slate.SlateBuilder._candidates", fail)
+    assert api.get_slate("best_bets", 1, now_ms=REFERENCE_MS)["items"] == []
+
+    whole = api.get_slate("for_you", 2, now_ms=REFERENCE_MS)
+    first = api.get_slate("for_you", 1, page=1, impression_id="page-1", now_ms=REFERENCE_MS)
+    second = api.get_slate("for_you", 1, page=2, impression_id="page-2", now_ms=REFERENCE_MS)
+
+    assert first["has_more"] is True
+    assert first["ranking_timings_ms"]["materialized"] == 1
+    assert [first["items"][0]["scene_id"], second["items"][0]["scene_id"]] == [
+        item["scene_id"] for item in whole["items"]
+    ]
+    assert [first["items"][0]["position"], second["items"][0]["position"]] == [0, 1]
+    assert (
+        connection.execute(
+            "SELECT position FROM impression_item WHERE impression_id='page-2'"
+        ).fetchone()[0]
+        == 1
+    )
+    assert api.get_slate("for_you", 20, page=20, now_ms=REFERENCE_MS)["has_more"] is False
+    api.update_config({"diversity_enabled": False}, now_ms=REFERENCE_MS)
+    assert (
+        api.get_slate("for_you", 2, now_ms=REFERENCE_MS)["ranking_timings_ms"]["materialized"] == 1
+    )
+
+
 def test_scene_inspector_returns_complete_score_state(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
@@ -135,6 +171,22 @@ def test_similar_performers_are_preference_aware_and_inspectable(tmp_path: Path)
     assert result["items"][0]["details"]["blocks"]
 
 
+def test_local_similarity_pages_one_ranked_prefix(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    api = CuratorAPI(connection)
+
+    whole = api.similar("scene", "old-good", 2)
+    first = api.similar("scene", "old-good", 1, page=1)
+    second = api.similar("scene", "old-good", 1, page=2)
+
+    assert first["has_more"] is True
+    assert [first["items"][0]["entity_id"], second["items"][0]["entity_id"]] == [
+        item["entity_id"] for item in whole["items"]
+    ]
+    assert [first["items"][0]["position"], second["items"][0]["position"]] == [0, 1]
+
+
 def test_local_similarity_filters_gender(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     connection.execute("UPDATE source_performer SET gender='FEMALE' WHERE performer_id='p3'")
@@ -169,9 +221,10 @@ def test_local_scene_similarity_filters_candidates(tmp_path: Path) -> None:
         "unlabeled",
         "unseen-good",
     ]
-    assert api.similar("scene", "old-good", exclude_tags=("Familiar Scenario",))["items"] == [
-        item for item in api.similar("scene", "old-good")["items"] if item["entity_id"] == "unusual"
-    ]
+    assert [
+        item["entity_id"]
+        for item in api.similar("scene", "old-good", exclude_tags=("Familiar Scenario",))["items"]
+    ] == ["unusual"]
     assert "recent-good" not in {
         item["entity_id"]
         for item in api.similar("scene", "old-good", exclude_tags=("Big Ass",))["items"]
@@ -209,10 +262,13 @@ def test_sidecar_configuration_is_validated(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     api = CuratorAPI(connection)
 
-    config = api.update_config({"page_size": 30}, now_ms=10)["config"]
+    config = api.update_config({"page_size": 30, "diversity_enabled": False}, now_ms=10)["config"]
     assert config["page_size"] == 30
+    assert config["diversity_enabled"] is False
     with pytest.raises(ValueError, match="page_size"):
         api.update_config({"page_size": 0})
+    with pytest.raises(ValueError, match="diversity_enabled"):
+        api.update_config({"diversity_enabled": 0})
     with pytest.raises(ValueError, match="unknown"):
         api.update_config({"mystery": True})
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_doctor_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
     assert result["status"] == "ok"
     assert result["stash"] == "not_configured"
     assert result["schema_current"] == 0
-    assert result["schema_latest"] == 14
+    assert result["schema_latest"] == 15
 
 
 def test_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -216,6 +216,14 @@ def test_expand_pages_and_preserves_cache_during_outage(tmp_path: Path) -> None:
         "external-scene-1",
         "external-scene-2",
     ]
+    first = service.results("scene", count=1)
+    second = service.results("scene", page=2, count=1)
+    assert first["has_more"] is True
+    assert [first["items"][0]["id"], second["items"][0]["id"]] == [
+        "external-scene-1",
+        "external-scene-2",
+    ]
+    assert second["has_more"] is False
     assert len(client.inputs) == 2
 
     try:


### PR DESCRIPTION
## Summary

- add paging across recommendation, Similar, and Expand results
- materialize score-first and balanced lane orders so later pages have consistent latency
- add an on-page Balanced / Score-first control synchronized with plugin settings
- version browser caches by model configuration to prevent stale ordering
- include the lane-order migration, performance instrumentation, documentation, and regression coverage

## Verification

- scripts/verify full
- 170 tests passed
- pre-push verification passed