### PR TITLE
Add Performer Hunt for StashDB scenes

### DIFF
--- a/curator/api.py
+++ b/curator/api.py
@@ -328,6 +328,7 @@ class CuratorAPI:
         studio_query: str = "",
         performer_names: tuple[str, ...] = (),
         studio_names: tuple[str, ...] = (),
+        hide_phash_matches: bool = True,
         minimum_score: float = -1.0,
         count: int = 50,
     ) -> dict[str, object]:
@@ -344,6 +345,7 @@ class CuratorAPI:
             studio_query=studio_query,
             performer_names=performer_names,
             studio_names=studio_names,
+            hide_phash_matches=hide_phash_matches,
             minimum_score=minimum_score,
             count=count,
         )

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -30,6 +30,7 @@ from curator.taxonomy import (
 )
 
 STASHDB = "https://stashdb.org/graphql"
+PERFORMER_HUNT_LIMIT = 1_000
 SCENES = """
 query CuratorExpandScenes($input: SceneQueryInput!) {
   queryScenes(input: $input) {
@@ -39,6 +40,7 @@ query CuratorExpandScenes($input: SceneQueryInput!) {
       studio { id name }
       tags { id name }
       images { url width height }
+      fingerprints { hash algorithm duration }
       performers { performer {
         id name gender birth_date ethnicity eye_color hair_color height cup_size band_size
         waist_size hip_size breast_type tattoos { location } piercings { location }
@@ -59,6 +61,17 @@ query CuratorSimilarPerformers($input: PerformerQueryInput!) {
   }
 }
 """
+
+
+def normalize_phash(value: object) -> str | None:
+    normalized = str(value or "").strip().casefold()
+    if len(normalized) != 16:
+        return None
+    try:
+        int(normalized, 16)
+    except ValueError:
+        return None
+    return normalized
 
 
 class ExpandService:
@@ -133,14 +146,16 @@ class ExpandService:
         if wildcard:
             self._fetch(client, rows, sources, "wildcard", [], min(100, per_source))
         cutoff = date.today() - timedelta(days=horizon_days)
-        owned = set(links["scenes"].values())
-        candidates = [
-            row
-            for identifier, row in rows.items()
-            if identifier not in owned
-            and self._recent(row, cutoff)
-            and self._matches_gender(row, gender)
-        ]
+        candidates = []
+        for row in rows.values():
+            candidate = self._annotate_local_match(row, links)
+            match = candidate.get("curator_local_match") or {}
+            if (
+                match.get("type") != "stashdb_id"
+                and self._recent(candidate, cutoff)
+                and self._matches_gender(candidate, gender)
+            ):
+                candidates.append(candidate)
         scenes, performers = self._score(candidates, sources, model_id, feature_version, links)
         with transaction(self.connection):
             self.connection.execute("DELETE FROM external_entity")
@@ -186,6 +201,88 @@ class ExpandService:
             "taxonomy_refreshed": taxonomy_refreshed,
         }
 
+    def performer_hunt(
+        self,
+        client: GraphQLClient,
+        links: dict[str, dict[str, str]],
+        performer_id: str,
+        *,
+        limit: int = PERFORMER_HUNT_LIMIT,
+    ) -> dict[str, object]:
+        performer = self.connection.execute(
+            "SELECT name FROM source_performer WHERE performer_id=?", (performer_id,)
+        ).fetchone()
+        if performer is None:
+            raise ValueError(f"unknown performer: {performer_id}")
+        external_performer_id = links["performers"].get(performer_id)
+        if not external_performer_id:
+            raise ValueError("selected performer is not linked to StashDB")
+        model_id = RecommendationModelStore(self.connection).current_model_id()
+        feature_version = FeatureStore(self.connection).current_version()
+        if model_id is None or feature_version is None:
+            raise RuntimeError("no published model")
+
+        rows: dict[str, dict[str, Any]] = {}
+        sources: dict[str, set[str]] = defaultdict(set)
+        total_count, truncated = self._fetch(
+            client,
+            rows,
+            sources,
+            "performers",
+            [external_performer_id],
+            limit,
+        )
+        scenes, _ = self._score(
+            [self._annotate_local_match(row, links) for row in rows.values()],
+            sources,
+            model_id,
+            feature_version,
+            links,
+        )
+        self._merge_external("scene", scenes)
+        shortlisted = {
+            str(row[0])
+            for row in self.connection.execute(
+                "SELECT external_id FROM external_shortlist WHERE entity_type='scene'"
+            )
+        }
+        items = [
+            {
+                **scene,
+                "linked_locally": bool(scene["payload"].get("curator_local_match")),
+                "local_scene_id": (scene["payload"].get("curator_local_match") or {}).get(
+                    "local_scene_id"
+                ),
+                "match_type": (scene["payload"].get("curator_local_match") or {}).get("type"),
+                "shortlisted": scene["id"] in shortlisted,
+            }
+            for scene in scenes
+        ]
+        items.sort(
+            key=lambda item: (
+                str(
+                    item["payload"].get("release_date")
+                    or item["payload"].get("production_date")
+                    or ""
+                ),
+                item["id"],
+            ),
+            reverse=True,
+        )
+        linked_count = sum(bool(item["linked_locally"]) for item in items)
+        return {
+            "ready": True,
+            "performer_id": performer_id,
+            "performer_name": str(performer["name"] or performer_id),
+            "stashdb_total": total_count,
+            "fetched_count": len(items),
+            "linked_count": linked_count,
+            "not_linked_count": len(items) - linked_count,
+            "truncated": truncated,
+            "limit": limit,
+            "items": items,
+        }
+
     def results(
         self,
         entity_type: str,
@@ -201,6 +298,7 @@ class ExpandService:
         studio_query: str = "",
         performer_names: tuple[str, ...] = (),
         studio_names: tuple[str, ...] = (),
+        hide_phash_matches: bool = True,
         minimum_score: float = -1.0,
         count: int = 50,
     ) -> dict[str, object]:
@@ -235,6 +333,12 @@ class ExpandService:
             if float(row["score"]) < minimum_score:
                 continue
             payload = json.loads(row["payload_json"])
+            if (
+                hide_phash_matches
+                and entity_type == "scene"
+                and (payload.get("curator_local_match") or {}).get("type") == "phash"
+            ):
+                continue
             if (
                 performer_id
                 and entity_type == "scene"
@@ -651,6 +755,7 @@ class ExpandService:
         performer_names: tuple[str, ...] = (),
         studio_names: tuple[str, ...] = (),
         favorite_only: bool = False,
+        hide_phash_matches: bool = True,
         minimum_similarity: float = 0.15,
     ) -> dict[str, object]:
         model_id = RecommendationModelStore(self.connection).current_model_id()
@@ -696,11 +801,16 @@ class ExpandService:
             timings["retrieval"] = round((time.perf_counter() - started) * 1000)
             record_duration("python", "external_similar.retrieval", timings["retrieval"])
             stage_started = time.perf_counter()
-            candidates = [
-                value
-                for key, value in rows.items()
-                if key not in set(links["scenes"].values()) and self._matches_gender(value, gender)
-            ]
+            candidates = []
+            for value in rows.values():
+                candidate = self._annotate_local_match(value, links)
+                match_type = (candidate.get("curator_local_match") or {}).get("type")
+                if (
+                    match_type != "stashdb_id"
+                    and (not hide_phash_matches or match_type != "phash")
+                    and self._matches_gender(candidate, gender)
+                ):
+                    candidates.append(candidate)
             candidate_ids = {str(value["id"]) for value in candidates}
             scenes, _ = self._score(candidates, sources, model_id, feature_version, links)
             self._merge_external("scene", scenes)
@@ -784,6 +894,43 @@ class ExpandService:
         timings["total"] = round((time.perf_counter() - started) * 1000)
         result["timings_ms"] = timings
         return result
+
+    @staticmethod
+    def _annotate_local_match(
+        scene: dict[str, Any], links: dict[str, dict[str, str]]
+    ) -> dict[str, Any]:
+        external_id = str(scene["id"])
+        local_scene_id = links.get("scene_ids", {}).get(external_id)
+        if local_scene_id is None:
+            local_scene_id = next(
+                (
+                    local
+                    for local, external in links.get("scenes", {}).items()
+                    if external == external_id
+                ),
+                None,
+            )
+        match_type = "stashdb_id" if local_scene_id else None
+        if local_scene_id is None:
+            for fingerprint in scene.get("fingerprints", []):
+                if str(fingerprint.get("algorithm") or "").casefold() != "phash":
+                    continue
+                value = normalize_phash(fingerprint.get("hash"))
+                if value is None:
+                    continue
+                local_scene_id = links.get("scene_phashes", {}).get(value)
+                if local_scene_id:
+                    match_type = "phash"
+                    break
+        if local_scene_id is None:
+            return scene
+        return {
+            **scene,
+            "curator_local_match": {
+                "type": match_type,
+                "local_scene_id": local_scene_id,
+            },
+        }
 
     def _fetch_probes(
         self,
@@ -1032,11 +1179,12 @@ class ExpandService:
         values: list[str],
         limit: int,
         modifier: str = "INCLUDES",
-    ) -> None:
+    ) -> tuple[int, bool]:
         fetched = 0
         page = 1
+        total = 0
+        page_size = min(250, limit)
         while fetched < limit:
-            page_size = min(250, limit - fetched)
             query: dict[str, object] = {
                 "page": page,
                 "per_page": page_size,
@@ -1046,15 +1194,18 @@ class ExpandService:
             if source != "wildcard":
                 query[source] = {"value": values, "modifier": modifier}
             data = client.execute(SCENES, {"input": query})["queryScenes"]
+            total = int(data["count"])
             batch = data["scenes"]
-            for scene in batch:
+            accepted = batch[: limit - fetched]
+            for scene in accepted:
                 identifier = str(scene["id"])
                 rows.setdefault(identifier, scene)
                 sources[identifier].add(source)
-            fetched += len(batch)
-            if not batch or fetched >= int(data["count"]):
+            fetched += len(accepted)
+            if not batch or fetched >= total:
                 break
             page += 1
+        return total, fetched < total
 
     @staticmethod
     def _recent(scene: dict[str, Any], cutoff: date) -> bool:

--- a/docs/using-curator.md
+++ b/docs/using-curator.md
@@ -51,6 +51,17 @@ shortlist candidates. External results are metadata leads, not proof that a scen
 available locally. Filters and ordering are applied before paging. Optional Whisparr
 actions require separate settings.
 
+The top-level Performer Hunt view queries StashDB directly for scenes listed for a selected local
+performer with a StashDB identity. It compares exact StashDB scene links and separates
+All, In library, and Not linked locally results; unlinked does not mean definitively
+missing because local scenes without StashDB identities cannot be matched. Queries
+follow StashDB pagination up to 1,000 scenes and disclose when that cap truncates the
+result. Include and exclude tag filters apply to the fetched result.
+The **Hide exact PHash matches** filter is enabled by default. It also applies to
+Expand and StashDB Similar scenes. Disable it to inspect candidates marked
+**Likely local · exact PHash**; a matching PHash is strong evidence, not guaranteed
+identity.
+
 ## Prune
 
 Prune groups explicit dislikes, suspected poor fits, and candidates surfaced during

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -19,7 +19,12 @@ for package_root in (PLUGIN_DIR, PLUGIN_DIR.parent):
 from curator import __version__  # noqa: E402
 from curator.api import CuratorAPI  # noqa: E402
 from curator.events import HistoricalEventStore  # noqa: E402
-from curator.expand import STASHDB, ExpandService  # noqa: E402
+from curator.expand import (  # noqa: E402
+    PERFORMER_HUNT_LIMIT,
+    STASHDB,
+    ExpandService,
+    normalize_phash,
+)
 from curator.graphql import GraphQLClient  # noqa: E402
 from curator.model import ModelUpdateCoordinator, RecommendationModelStore  # noqa: E402
 from curator.profiling import (  # noqa: E402
@@ -64,7 +69,13 @@ query CuratorExternalLinks($page: Int!, $perPage: Int!) {
   scenes: findScenes(
     scene_filter: {stash_id_endpoint: {endpoint: "https://stashdb.org/graphql", modifier: NOT_NULL}}
     filter: {page: $page, per_page: $perPage, sort: "id", direction: ASC}
-  ) { count scenes { id stash_ids { endpoint stash_id } } }
+  ) {
+    count
+    scenes {
+      id stash_ids { endpoint stash_id }
+      files { fingerprints { type value } }
+    }
+  }
   performers: findPerformers(
     performer_filter: {stash_id_endpoint: {
       endpoint: "https://stashdb.org/graphql", modifier: NOT_NULL
@@ -142,12 +153,18 @@ def _stashdb(payload: dict[str, Any]) -> GraphQLClient:
 
 
 def _external_links(payload: dict[str, Any]) -> dict[str, dict[str, str]]:
-    result: dict[str, dict[str, str]] = {"scenes": {}, "performers": {}, "studios": {}}
+    result: dict[str, dict[str, str]] = {
+        "scenes": {},
+        "scene_ids": {},
+        "scene_phashes": {},
+        "performers": {},
+        "studios": {},
+    }
     page = 1
     while True:
         data = _client(payload).execute(EXTERNAL_LINKS_QUERY, {"page": page, "perPage": 500})
         more = False
-        for kind in result:
+        for kind in ("scenes", "performers", "studios"):
             collection = data[kind]
             for row in collection[kind]:
                 external = next(
@@ -161,6 +178,15 @@ def _external_links(payload: dict[str, Any]) -> dict[str, dict[str, str]]:
                 )
                 if external:
                     result[kind][str(row["id"])] = external
+                    if kind == "scenes":
+                        result["scene_ids"][external] = str(row["id"])
+                if kind == "scenes":
+                    for file in row.get("files", []):
+                        for fingerprint in file.get("fingerprints", []):
+                            if str(fingerprint.get("type") or "").casefold() == "phash":
+                                value = normalize_phash(fingerprint.get("value"))
+                                if value:
+                                    result["scene_phashes"].setdefault(value, str(row["id"]))
             more |= page * 500 < int(collection["count"])
         if not more:
             return result
@@ -420,10 +446,18 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
                 studio_query=str(args.get("studio_query") or ""),
                 performer_names=_string_list(args.get("performer_names")),
                 studio_names=_string_list(args.get("studio_names")),
+                hide_phash_matches=bool(args.get("hide_phash_matches", True)),
                 minimum_score=(
                     float(args["minimum_score"]) if args.get("minimum_score") is not None else -1
                 ),
                 count=int(args.get("count") or config["page_size"]),
+            )
+        if operation == "get_performer_hunt":
+            return ExpandService(connection).performer_hunt(
+                _stashdb(payload),
+                _external_links(payload),
+                str(args.get("performer_id") or ""),
+                limit=PERFORMER_HUNT_LIMIT,
             )
         if operation == "get_shortlist":
             return api.expand_shortlist()
@@ -442,6 +476,7 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
                 performer_names=_string_list(args.get("performer_names")),
                 studio_names=_string_list(args.get("studio_names")),
                 favorite_only=bool(args.get("favorite_only", False)),
+                hide_phash_matches=bool(args.get("hide_phash_matches", True)),
                 minimum_similarity=(
                     float(args["minimum_similarity"])
                     if args.get("minimum_similarity") is not None

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -23,6 +23,18 @@
   max-width: 100%;
 }
 
+.curator-hunt-controls {
+  align-items: end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.4rem 0 0.8rem;
+}
+
+.curator-hunt-controls .curator-token-filter {
+  flex: 1 1 18rem;
+}
+
 .curator-brand {
   align-items: center;
   display: flex;
@@ -225,6 +237,7 @@
 .curator-lane-adventure { --lane-color: #ff922b; }
 .curator-lane-similar { --lane-color: #66d9e8; }
 .curator-lane-expand { --lane-color: #f783ac; }
+.curator-lane-hunt { --lane-color: #69db7c; }
 .curator-lane-prune { --lane-color: #ff6b6b; }
 
 .curator-tabs .nav-link svg,
@@ -392,10 +405,12 @@
 
 .curator-similar { --surface-color: #4dabf7; }
 .curator-expand { --surface-color: #ff922b; }
+.curator-hunt { --surface-color: #69db7c; }
 .curator-prune-page { --surface-color: #fa5252; }
 
 .curator-similar .curator-card,
 .curator-expand .curator-card,
+.curator-hunt .curator-card,
 .curator-prune-page .curator-card {
   border-left: 3px solid var(--surface-color);
 }
@@ -1036,6 +1051,17 @@
   padding: 0.25rem 0.4rem;
   position: absolute;
   right: 0.5rem;
+  top: 0.5rem;
+  z-index: 3;
+}
+
+.curator-phash-badge {
+  background: #2b8a3e;
+  border-radius: 0.3rem;
+  font-size: 0.75rem;
+  left: 0.5rem;
+  padding: 0.25rem 0.4rem;
+  position: absolute;
   top: 0.5rem;
   z-index: 3;
 }

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -11,7 +11,7 @@
   const { NavLink, useHistory, useLocation } = libraries.ReactRouterDOM;
   const { FontAwesomeIcon } = libraries.ReactFontAwesome;
   const { faDev } = libraries.FontAwesomeBrands;
-  const { faBalanceScale, faBroom, faBullseye, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faDatabase, faDownload, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSync, faTag, faThumbsDown, faThumbsUp, faUser, faVenus, faWrench } = libraries.FontAwesomeSolid;
+  const { faBalanceScale, faBroom, faBullseye, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faCrosshairs, faDatabase, faDownload, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSync, faTag, faThumbsDown, faThumbsUp, faUser, faVenus, faWrench } = libraries.FontAwesomeSolid;
   const componentTransforms = window.StashCuratorComponentTransforms ||= {};
 
   function transformComponentProps(name, props) {
@@ -62,6 +62,12 @@
       label: "Expand",
       icon: faGlobe,
       description: "External metadata candidates scored locally. Wildcard items are selected outside preference-derived seeds.",
+    },
+    {
+      value: "hunt",
+      label: "Performer Hunt",
+      icon: faCrosshairs,
+      description: "Find scenes listed for a performer on StashDB and compare them with exact links in your library.",
     },
     {
       value: "prune",
@@ -374,6 +380,7 @@
       "article",
       { className: `curator-card curator-external-card curator-external-${kind} grid-card ${kind}-card` },
       item.sources?.includes("wildcard") && React.createElement("span", { className: "curator-wildcard-badge", title: "Popularity wildcard: selected outside preference-derived seeds." }, "Wildcard"),
+      payload.curator_local_match?.type === "phash" && React.createElement("span", { className: "curator-phash-badge", title: "A local scene has the same exact PHash. This is strong matching evidence, not guaranteed identity." }, "Likely local · exact PHash"),
       React.createElement("div", { className: `curator-external-thumbnail thumbnail-section ${kind === "scene" ? "video-section" : ""}` }, React.createElement("a", { className: `${kind}-card-link`, href, target: "_blank", rel: "noreferrer" }, image && React.createElement("img", { className: `${kind}-card-image`, src: image, loading: "lazy", alt: "" })), kind === "scene" && payload.studio?.name && React.createElement("span", { className: "curator-external-studio-overlay" }, payload.studio.name)),
       React.createElement("div", { className: "card-section" }, React.createElement("a", { href, target: "_blank", rel: "noreferrer" }, React.createElement("h5", { className: "card-section-title flex-aligned" }, title)), React.createElement("div", { className: kind === "scene" ? "scene-card__details" : "curator-external-details" }, React.createElement("span", null, payload.release_date || payload.birth_date || ""), metadataControls)),
       React.createElement("div", { className: "curator-card-body" }, React.createElement("div", { className: "curator-card-details" }, payload.why?.length && React.createElement("details", { className: "curator-evidence" }, React.createElement("summary", null, "Why this?"), React.createElement("p", { className: "curator-explanation" }, payload.why.join(" · "))), React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, `Score · ${item.score.toFixed(2)}`), React.createElement("p", null, item.similarity === undefined ? `Match ${item.score.toFixed(2)} · found via ${item.sources.join(", ")}` : `Similarity ${item.similarity.toFixed(2)} · rank ${item.score.toFixed(2)}`)))),
@@ -616,6 +623,7 @@
     const [filterPerformers, setFilterPerformers] = React.useState(initialFilters.performers || []);
     const [filterStudios, setFilterStudios] = React.useState(initialFilters.studios || []);
     const [minimumSimilarity, setMinimumSimilarity] = React.useState(initialFilters.minimum ?? 0.18);
+    const [hidePhashMatches, setHidePhashMatches] = React.useState(initialFilters.hidePhashMatches !== false);
     const [filtersOpen, setFiltersOpen] = React.useState(false);
     const [whisparrEnabled, setWhisparrEnabled] = React.useState(false);
     const sceneSearch = GQL.useFindScenesQuery({
@@ -655,7 +663,7 @@
     function load(id, label, type = entityType, nextSource = source, nextGender = gender, nextPage = 1, nextExcluded = excludedIds) {
       setSelected({ id: String(id), label: label || `#${id}` });
       setError("");
-      const request = { operation: nextSource === "library" ? "get_similar" : "get_external_similar", entity_type: type, entity_id: String(id), gender: nextGender, favorite_only: favoriteOnly, include_tags: includeTags.map((item) => item.name), exclude_tags: excludeTags.map((item) => item.name), performer_ids: filterPerformers.map((item) => String(item.id)), performer_names: filterPerformers.map((item) => item.name), studio_ids: filterStudios.map((item) => String(item.id)), studio_names: filterStudios.map((item) => item.name), minimum_similarity: minimumSimilarity };
+      const request = { operation: nextSource === "library" ? "get_similar" : "get_external_similar", entity_type: type, entity_id: String(id), gender: nextGender, favorite_only: favoriteOnly, hide_phash_matches: hidePhashMatches, include_tags: includeTags.map((item) => item.name), exclude_tags: excludeTags.map((item) => item.name), performer_ids: filterPerformers.map((item) => String(item.id)), performer_names: filterPerformers.map((item) => item.name), studio_ids: filterStudios.map((item) => String(item.id)), studio_names: filterStudios.map((item) => item.name), minimum_similarity: minimumSimilarity };
       if (nextSource === "library") {
         request.page = nextPage;
         request.exclude_scene_ids = nextExcluded;
@@ -675,6 +683,7 @@
       setExcludeTags(value.excludeTags || []);
       setFilterPerformers(value.performers || []);
       setFilterStudios(value.studios || []);
+      setHidePhashMatches(value.hidePhashMatches !== false);
       setMinimumSimilarity(value.minimum ?? 0.18);
     }
     function choose(entity) {
@@ -756,7 +765,7 @@
         selected && React.createElement("div", { className: "btn-group curator-similar-source-tabs", role: "group", "aria-label": "Similarity source" }, [["library", "Library", faDatabase], ["stashdb", "StashDB", faCompass]].map(([value, label, icon]) => React.createElement(Button, { key: value, size: "sm", variant: source === value ? "primary" : "secondary", onClick: () => switchSource(value) }, React.createElement(FontAwesomeIcon, { icon }), ` ${label}`))),
         React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters")
       ),
-      filtersOpen && React.createElement("div", { className: "curator-expand-filters curator-filter-panel" }, React.createElement("div", null, entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Include tags", values: includeTags, onChange: setIncludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: setExcludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "performer", label: "Performers", values: filterPerformers, onChange: setFilterPerformers }), entityType === "scene" && React.createElement(FilterTokens, { kind: "studio", label: "Studios", values: filterStudios, onChange: setFilterStudios }), entityType === "scene" && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", onClick: () => setFavoriteOnly((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"), React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: (event) => setGender(event.target.value), "aria-label": "Performer gender" }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))), entityType === "scene" && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimumSimilarity.toFixed(2)}`), React.createElement("input", { type: "range", min: "0", max: "0.8", step: "0.05", value: minimumSimilarity, onChange: (event) => setMinimumSimilarity(Number(event.target.value)) })), entityType === "scene" && React.createElement(SavedFilters, { scope: "similar", current: { gender, favoriteOnly, includeTags, excludeTags, performers: filterPerformers, studios: filterStudios, minimum: minimumSimilarity }, onApply: applySaved }), selected && React.createElement(Button, { size: "sm", variant: "primary", onClick: () => (setExcludedIds([]), load(selected.id, selected.label, entityType, source, gender, 1, [])) }, "Apply"))),
+      filtersOpen && React.createElement("div", { className: "curator-expand-filters curator-filter-panel" }, React.createElement("div", null, entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Include tags", values: includeTags, onChange: setIncludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: setExcludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "performer", label: "Performers", values: filterPerformers, onChange: setFilterPerformers }), entityType === "scene" && React.createElement(FilterTokens, { kind: "studio", label: "Studios", values: filterStudios, onChange: setFilterStudios }), entityType === "scene" && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", onClick: () => setFavoriteOnly((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"), entityType === "scene" && React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: () => setHidePhashMatches((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faClone }), " Hide exact PHash matches"), React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: (event) => setGender(event.target.value), "aria-label": "Performer gender" }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))), entityType === "scene" && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimumSimilarity.toFixed(2)}`), React.createElement("input", { type: "range", min: "0", max: "0.8", step: "0.05", value: minimumSimilarity, onChange: (event) => setMinimumSimilarity(Number(event.target.value)) })), entityType === "scene" && React.createElement(SavedFilters, { scope: "similar", current: { gender, favoriteOnly, hidePhashMatches, includeTags, excludeTags, performers: filterPerformers, studios: filterStudios, minimum: minimumSimilarity }, onApply: applySaved }), selected && React.createElement(Button, { size: "sm", variant: "primary", onClick: () => (setExcludedIds([]), load(selected.id, selected.label, entityType, source, gender, 1, [])) }, "Apply"))),
       search && !selected && React.createElement(
         "div",
         { className: "curator-similar-candidates" },
@@ -869,9 +878,9 @@
     );
   }
 
-  function ExpandPanel({ initialPerformerId = null }) {
-    const initialFilters = React.useMemo(() => defaultFilters("expand"), []);
-    const [entityType, setEntityType] = React.useState("scene");
+  function ExpandPanel({ initialPerformerId = null, initialType = "scene", huntOnly = false }) {
+    const initialFilters = React.useMemo(() => defaultFilters(huntOnly ? "hunt" : "expand"), []);
+    const [entityType, setEntityType] = React.useState(initialType);
     const [sort, setSort] = React.useState("match");
     const [performerId, setPerformerId] = React.useState(initialPerformerId);
     const [favoriteOnly, setFavoriteOnly] = React.useState(Boolean(initialFilters.favoriteOnly));
@@ -881,6 +890,7 @@
     const [performers, setPerformers] = React.useState(initialFilters.performers || []);
     const [studios, setStudios] = React.useState(initialFilters.studios || []);
     const [minimumScore, setMinimumScore] = React.useState(initialFilters.minimum ?? 0);
+    const [hidePhashMatches, setHidePhashMatches] = React.useState(initialFilters.hidePhashMatches !== false);
     const [filtersOpen, setFiltersOpen] = React.useState(false);
     const [filterVersion, setFilterVersion] = React.useState(0);
     const [data, setData] = React.useState(null);
@@ -890,19 +900,36 @@
     const [message, setMessage] = React.useState("");
     const [version, setVersion] = React.useState(0);
     const [whisparrEnabled, setWhisparrEnabled] = React.useState(false);
+    const [pageSize, setPageSize] = React.useState(20);
+    const [huntPerformer, setHuntPerformer] = React.useState(null);
+    const [huntView, setHuntView] = React.useState("unlinked");
+    const [huntSort, setHuntSort] = React.useState("date");
     React.useEffect(() => {
       let active = true;
+      if (entityType === "hunt" && !huntPerformer) {
+        setData(null);
+        setLoading(false);
+        setError("");
+        return () => { active = false; };
+      }
       setLoading(true);
-      operation(entityType === "shortlist" ? { operation: "get_shortlist" } : { operation: "get_expand", page, entity_type: entityType, sort, performer_id: performerId, favorite_only: favoriteOnly, gender, include_tags: includeTags.map((item) => item.name), exclude_tags: excludeTags.map((item) => item.name), performer_names: performers.map((item) => item.name), studio_names: studios.map((item) => item.name), minimum_score: minimumScore }).then(
+      setError("");
+      const request = entityType === "shortlist"
+        ? { operation: "get_shortlist" }
+        : entityType === "hunt"
+          ? { operation: "get_performer_hunt", performer_id: String(huntPerformer.id) }
+          : { operation: "get_expand", page, entity_type: entityType, sort, performer_id: performerId, favorite_only: favoriteOnly, hide_phash_matches: hidePhashMatches, gender, include_tags: includeTags.map((item) => item.name), exclude_tags: excludeTags.map((item) => item.name), performer_names: performers.map((item) => item.name), studio_names: studios.map((item) => item.name), minimum_score: minimumScore };
+      operation(request, entityType === "hunt" ? 60000 : 30000).then(
         (result) => active && (setData(result), setLoading(false)),
         (failure) => active && (setError(failure.message), setLoading(false))
       );
       return () => { active = false; };
-    }, [entityType, sort, performerId, favoriteOnly, gender, filterVersion, version, page]);
+    }, [entityType, sort, performerId, favoriteOnly, hidePhashMatches, gender, filterVersion, version, page, huntPerformer?.id]);
     React.useEffect(() => {
       operation({ operation: "get_config" }).then((data) => {
         if (initialFilters.gender === undefined) setGender(data.config.expand_gender || "");
         setWhisparrEnabled(data.whisparr_enabled);
+        setPageSize(data.config.page_size || 20);
       }, () => {});
     }, []);
     function applySaved(value) {
@@ -913,13 +940,23 @@
       setExcludeTags(value.excludeTags || []);
       setPerformers(value.performers || []);
       setStudios(value.studios || []);
+      setHidePhashMatches(value.hidePhashMatches !== false);
       setMinimumScore(value.minimum ?? 0);
     }
     async function refresh() {
+      if (entityType === "hunt") {
+        setVersion((value) => value + 1);
+        return;
+      }
       try {
         const id = await runTask("Refresh Expand cache");
         setMessage(`Started Stash job ${id}. Progress is available in Tasks.`);
       } catch (failure) { setError(failure.message); }
+    }
+    function selectHuntPerformer(values) {
+      setPage(1);
+      setData(null);
+      setHuntPerformer(values.at(-1) || null);
     }
     function showPerformerScenes(id) {
       setPage(1);
@@ -929,39 +966,77 @@
     async function shortlist(item, kind) {
       try {
         await operation({ operation: "update_shortlist", entity_type: kind, external_id: item.id, selected: !item.shortlisted });
-        setVersion((value) => value + 1);
+        if (entityType === "hunt") {
+          setData((current) => ({ ...current, items: current.items.map((value) => value.id === item.id ? { ...value, shortlisted: !item.shortlisted } : value) }));
+        } else {
+          setVersion((value) => value + 1);
+        }
       } catch (failure) { setError(failure.message); }
     }
     const sendWhisparr = (id) => operation({ operation: "send_whisparr", external_id: id });
+    const tagFilteredHuntItems = entityType === "hunt"
+      ? (data?.items || []).filter((item) => {
+        const tags = new Set((item.payload.tags || []).map((tag) => String(tag.name || "").toLocaleLowerCase()));
+        return (!hidePhashMatches || item.match_type !== "phash")
+          && includeTags.every((tag) => tags.has(tag.name.toLocaleLowerCase()))
+          && excludeTags.every((tag) => !tags.has(tag.name.toLocaleLowerCase()));
+      })
+      : [];
+    const huntCounts = {
+      all: tagFilteredHuntItems.length,
+      linked: tagFilteredHuntItems.filter((item) => item.linked_locally).length,
+      unlinked: tagFilteredHuntItems.filter((item) => !item.linked_locally).length,
+    };
+    const huntItems = entityType === "hunt"
+      ? tagFilteredHuntItems
+        .filter((item) => huntView === "all" || item.linked_locally === (huntView === "linked"))
+        .sort((left, right) => huntSort === "score"
+          ? right.score - left.score || left.id.localeCompare(right.id)
+          : String(right.payload.release_date || right.payload.production_date || "").localeCompare(String(left.payload.release_date || left.payload.production_date || "")) || left.id.localeCompare(right.id))
+      : [];
+    const visibleItems = entityType === "hunt"
+      ? huntItems.slice((page - 1) * pageSize, page * pageSize)
+      : data?.items || [];
+    const huntHasMore = entityType === "hunt" && page * pageSize < huntItems.length;
     return React.createElement(
       "section",
-      { className: "curator-expand" },
+      { className: huntOnly ? "curator-hunt" : "curator-expand" },
       React.createElement(
         "div",
         { className: "curator-expand-toolbar" },
-        React.createElement("div", { className: "btn-group", role: "group", "aria-label": "Explore external content" }, [["scene", "Scenes", faPlayCircle], ["performer", "Performers", faUser]].map(([value, label, icon]) => React.createElement(Button, { key: value, size: "sm", variant: entityType === value ? "primary" : "secondary", onClick: () => (setPage(1), setEntityType(value), setPerformerId(null)) }, React.createElement(FontAwesomeIcon, { icon }), ` ${label}`))),
-        React.createElement(Button, { className: "curator-shortlist-tab", size: "sm", variant: entityType === "shortlist" ? "primary" : "secondary", onClick: () => (setPage(1), setEntityType("shortlist"), setPerformerId(null)) }, React.createElement(FontAwesomeIcon, { icon: faList }), " Shortlist"),
+        !huntOnly && React.createElement("div", { className: "btn-group", role: "group", "aria-label": "Explore external content" }, [["scene", "Scenes", faPlayCircle], ["performer", "Performers", faUser]].map(([value, label, icon]) => React.createElement(Button, { key: value, size: "sm", variant: entityType === value ? "primary" : "secondary", onClick: () => (setPage(1), setEntityType(value), setPerformerId(null)) }, React.createElement(FontAwesomeIcon, { icon }), ` ${label}`))),
+        !huntOnly && React.createElement(Button, { className: "curator-shortlist-tab", size: "sm", variant: entityType === "shortlist" ? "primary" : "secondary", onClick: () => (setPage(1), setEntityType("shortlist"), setPerformerId(null)) }, React.createElement(FontAwesomeIcon, { icon: faList }), " Shortlist"),
         entityType === "scene" && React.createElement("label", { className: "curator-toolbar-select" }, React.createElement(FontAwesomeIcon, { icon: faSortAmountDown }), React.createElement("select", { value: sort, onChange: (event) => (setPage(1), setSort(event.target.value)), "aria-label": "Sort Expand results" }, React.createElement("option", { value: "match" }, "Best match"), React.createElement("option", { value: "newest" }, "Newest"))),
         entityType !== "shortlist" && React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters"),
         performerId && React.createElement(Button, { size: "sm", variant: "link", onClick: () => (setPage(1), setPerformerId(null)) }, "Clear performer filter"),
-        React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Refresh the bounded StashDB candidate cache in a background task.", "aria-label": "Refresh Expand cache", onClick: refresh }, React.createElement(FontAwesomeIcon, { icon: faSync })),
+        React.createElement(Button, { className: "curator-icon-button", size: "sm", disabled: entityType === "hunt" && !huntPerformer, title: entityType === "hunt" ? "Refresh this performer's scenes directly from StashDB." : "Refresh the bounded StashDB candidate cache in a background task.", "aria-label": entityType === "hunt" ? "Refresh Performer Hunt" : "Refresh Expand cache", onClick: refresh }, React.createElement(FontAwesomeIcon, { icon: faSync })),
         data?.fetched_at_ms && React.createElement("small", null, `${Date.now() > data.expires_at_ms ? "Stale · " : ""}Updated ${new Date(data.fetched_at_ms).toLocaleString()}`)
       ),
-      entityType !== "shortlist" && filtersOpen && React.createElement("div", { className: "curator-expand-filters curator-filter-panel" }, React.createElement("div", null, entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Include tags", values: includeTags, onChange: setIncludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: setExcludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "performer", label: "Performers", values: performers, onChange: setPerformers }), entityType === "scene" && React.createElement(FilterTokens, { kind: "studio", label: "Studios", values: studios, onChange: setStudios }), entityType === "scene" && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", title: "Show only scenes containing a performer favorited in your local library", "aria-pressed": favoriteOnly, onClick: () => (setPage(1), setFavoriteOnly((value) => !value)) }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"), React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: (event) => (setPage(1), setGender(event.target.value)), "aria-label": "External performer gender" }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))), entityType === "scene" && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimumScore.toFixed(2)}`), React.createElement("input", { type: "range", min: "-0.2", max: "0.8", step: "0.05", value: minimumScore, onChange: (event) => setMinimumScore(Number(event.target.value)) })), entityType === "scene" && React.createElement(SavedFilters, { scope: "expand", current: { gender, favoriteOnly, includeTags, excludeTags, performers, studios, minimum: minimumScore }, onApply: applySaved }), React.createElement(Button, { size: "sm", variant: "primary", onClick: () => (setPage(1), setFilterVersion((value) => value + 1)) }, "Apply"))),
-      loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Loading Expand cache…"), React.createElement("div", { className: "curator-progress", "aria-hidden": "true" })),
+      entityType === "hunt" && React.createElement(
+        "div",
+        { className: "curator-hunt-controls" },
+        React.createElement(FilterTokens, { kind: "performer", label: "Local performer with a StashDB link", values: huntPerformer ? [huntPerformer] : [], onChange: selectHuntPerformer }),
+        data?.ready && React.createElement("div", { className: "btn-group", role: "group", "aria-label": "Performer Hunt view" }, [["all", `All ${huntCounts.all}`], ["linked", `In library ${huntCounts.linked}`], ["unlinked", `Not linked locally ${huntCounts.unlinked}`]].map(([value, label]) => React.createElement(Button, { key: value, size: "sm", variant: huntView === value ? "primary" : "secondary", onClick: () => (setPage(1), setHuntView(value)) }, label))),
+        data?.ready && React.createElement("label", { className: "curator-toolbar-select" }, React.createElement(FontAwesomeIcon, { icon: faSortAmountDown }), React.createElement("select", { value: huntSort, onChange: (event) => (setPage(1), setHuntSort(event.target.value)), "aria-label": "Sort Performer Hunt results" }, React.createElement("option", { value: "date" }, "Release date"), React.createElement("option", { value: "score" }, "Preference score")))
+      ),
+      entityType === "hunt" && data?.truncated && React.createElement("div", { className: "alert alert-warning" }, `Showing the first ${data.fetched_count.toLocaleString()} of ${data.stashdb_total.toLocaleString()} StashDB scenes; the safety cap is ${data.limit.toLocaleString()}. Counts below apply to the fetched scenes.`),
+      entityType === "hunt" && filtersOpen && React.createElement("div", { className: "curator-expand-filters curator-filter-panel" }, React.createElement("div", null, React.createElement(FilterTokens, { kind: "tag", label: "Include tags", values: includeTags, onChange: setIncludeTags }), React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: setExcludeTags }), React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: () => setHidePhashMatches((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faClone }), " Hide exact PHash matches"), React.createElement(SavedFilters, { scope: "hunt", current: { hidePhashMatches, includeTags, excludeTags }, onApply: (value) => (setPage(1), setHidePhashMatches(value.hidePhashMatches !== false), setIncludeTags(value.includeTags || []), setExcludeTags(value.excludeTags || [])) }), React.createElement(Button, { size: "sm", variant: "primary", onClick: () => (setPage(1), setFiltersOpen(false)) }, "Apply"))),
+      entityType !== "shortlist" && entityType !== "hunt" && filtersOpen && React.createElement("div", { className: "curator-expand-filters curator-filter-panel" }, React.createElement("div", null, entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Include tags", values: includeTags, onChange: setIncludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: setExcludeTags }), entityType === "scene" && React.createElement(FilterTokens, { kind: "performer", label: "Performers", values: performers, onChange: setPerformers }), entityType === "scene" && React.createElement(FilterTokens, { kind: "studio", label: "Studios", values: studios, onChange: setStudios }), entityType === "scene" && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", title: "Show only scenes containing a performer favorited in your local library", "aria-pressed": favoriteOnly, onClick: () => (setPage(1), setFavoriteOnly((value) => !value)) }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"), entityType === "scene" && React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: () => (setPage(1), setHidePhashMatches((value) => !value)) }, React.createElement(FontAwesomeIcon, { icon: faClone }), " Hide exact PHash matches"), React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: (event) => (setPage(1), setGender(event.target.value)), "aria-label": "External performer gender" }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))), entityType === "scene" && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimumScore.toFixed(2)}`), React.createElement("input", { type: "range", min: "-0.2", max: "0.8", step: "0.05", value: minimumScore, onChange: (event) => setMinimumScore(Number(event.target.value)) })), entityType === "scene" && React.createElement(SavedFilters, { scope: "expand", current: { gender, favoriteOnly, hidePhashMatches, includeTags, excludeTags, performers, studios, minimum: minimumScore }, onApply: applySaved }), React.createElement(Button, { size: "sm", variant: "primary", onClick: () => (setPage(1), setFilterVersion((value) => value + 1)) }, "Apply"))),
+      loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, entityType === "hunt" ? "Querying StashDB…" : "Loading Expand cache…"), React.createElement("div", { className: "curator-progress", "aria-hidden": "true" })),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
       message && React.createElement("p", { role: "status" }, message),
+      entityType === "hunt" && !huntPerformer && React.createElement("div", { className: "alert alert-info" }, "Select a local performer linked to StashDB."),
       data && !data.ready && React.createElement("div", { className: "alert alert-info" }, "Expand has not been prepared yet. Use refresh to collect candidates from StashDB."),
-      data?.ready && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No external candidates match these filters."),
+      data?.ready && visibleItems.length === 0 && React.createElement("div", { className: "alert alert-info" }, entityType === "hunt" ? "No scenes match this view." : "No external candidates match these filters."),
       data?.ready && React.createElement(
         "div",
         { className: "curator-grid curator-external-grid" },
-        data.items.map((item) => {
-          const kind = entityType === "shortlist" ? item.entity_type : entityType;
+        visibleItems.map((item) => {
+          const kind = entityType === "shortlist" ? item.entity_type : entityType === "hunt" ? "scene" : entityType;
           return React.createElement(ExternalCard, { key: `${kind}-${item.id}`, item, kind, gender, onShortlist: shortlist, onShowScenes: showPerformerScenes, onWhisparr: sendWhisparr, whisparrEnabled });
         })
       ),
-      entityType !== "shortlist" && data?.ready && React.createElement(Pager, { page, hasMore: data.has_more, loading, onPage: setPage, label: "Expand pages" })
+      entityType !== "shortlist" && data?.ready && React.createElement(Pager, { page, hasMore: entityType === "hunt" ? huntHasMore : data.has_more, loading, onPage: setPage, label: entityType === "hunt" ? "Performer Hunt pages" : "Expand pages" })
     );
   }
 
@@ -1303,7 +1378,8 @@
       ),
       lane === "similar" && !loadingComponents && React.createElement(SimilarityPanel, { initialType: route.get("type") || "scene", initialId: route.get("id"), initialLabel: route.get("label") }),
       lane === "prune" && !loadingComponents && React.createElement(PrunePanel),
-      lane === "expand" && React.createElement(ExpandPanel, { initialPerformerId: route.get("performer") }),
+      lane === "expand" && React.createElement(ExpandPanel, { key: "expand", initialPerformerId: route.get("performer") }),
+      lane === "hunt" && React.createElement(ExpandPanel, { key: "hunt", initialType: "hunt", huntOnly: true }),
       lane === "profiling" && React.createElement(ProfilingPanel),
       (loading || loadingComponents || scenesQuery.loading) &&
         React.createElement(

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -153,6 +153,36 @@ def test_recommendation_variety_toggle_updates_native_setting_and_cache() -> Non
     assert 'diversityEnabled ? " Balanced" : " Score-first"' in source
 
 
+def test_plugin_performer_hunt_keeps_results_and_reuses_external_cards() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
+
+    assert 'operation: "get_performer_hunt"' in source
+    assert 'value: "hunt"' in source
+    assert "icon: faCrosshairs" in source
+    assert 'initialType: "hunt", huntOnly: true' in source
+    assert '["all", `All ${huntCounts.all}`]' in source
+    assert '["linked", `In library ${huntCounts.linked}`]' in source
+    assert '["unlinked", `Not linked locally ${huntCounts.unlinked}`]' in source
+    assert 'kind: "tag", label: "Include tags"' in source
+    assert 'kind: "tag", label: "Exclude tags"' in source
+    assert source.count('" Hide exact PHash matches"') == 3
+    assert "hide_phash_matches: hidePhashMatches" in source
+    assert '"Likely local · exact PHash"' in source
+    assert '"Release date"' in source
+    assert '"Preference score"' in source
+    assert "data?.truncated" in source
+    assert "(failure) => active && (setError(failure.message), setLoading(false))" in source
+    assert 'entityType === "hunt" ? "scene" : entityType' in source
+
+
+def test_plugin_reads_local_file_phashes_for_external_matching() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "backend.py").read_text(encoding="utf-8")
+
+    assert "files { fingerprints { type value } }" in source
+    assert '"scene_phashes": {}' in source
+    assert 'casefold() == "phash"' in source
+
+
 def test_plugin_ignores_repeated_script_evaluation() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
     guard = "if (window.__stashCuratorPluginLoaded) return;"
@@ -198,6 +228,52 @@ def test_backend_module_loads_without_starting(tmp_path: Path) -> None:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     assert module.SCHEMA_VERSION == 1
+
+
+def test_external_links_collect_normalized_local_phashes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
+    spec = importlib.util.spec_from_file_location("curator_plugin_links", backend)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    data = {
+        "scenes": {
+            "count": 1,
+            "scenes": [
+                {
+                    "id": "local-scene",
+                    "stash_ids": [
+                        {
+                            "endpoint": "https://stashdb.org/graphql",
+                            "stash_id": "external-scene",
+                        }
+                    ],
+                    "files": [
+                        {
+                            "fingerprints": [
+                                {"type": "phash", "value": "D8BC7554C5A178AA"},
+                                {"type": "phash", "value": "not-a-phash"},
+                            ]
+                        }
+                    ],
+                }
+            ],
+        },
+        "performers": {"count": 0, "performers": []},
+        "studios": {"count": 0, "studios": []},
+    }
+    monkeypatch.setattr(
+        module,
+        "_client",
+        lambda _payload: SimpleNamespace(execute=lambda *_args: data),
+    )
+
+    links = module._external_links({})
+
+    assert links["scene_ids"] == {"external-scene": "local-scene"}
+    assert links["scene_phashes"] == {"d8bc7554c5a178aa": "local-scene"}
 
 
 def test_reused_model_keeps_existing_lane_classifications(

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -3,7 +3,7 @@ from datetime import date
 from pathlib import Path
 
 from curator.config import DEFAULT_CONFIG
-from curator.expand import ExpandService
+from curator.expand import ExpandService, normalize_phash
 from curator.features import FeatureStore
 from curator.model import PreferenceModelBuilder
 from tests.model.test_builder import REFERENCE_MS, _database
@@ -49,6 +49,9 @@ class FakeStashDB:
                 "id": "new-external-scene",
                 "title": "A new candidate",
                 "release_date": date.today().isoformat(),
+                "fingerprints": [
+                    {"hash": "d8bc7554c5a178aa", "algorithm": "PHASH", "duration": 120}
+                ],
                 "studio": {"id": "external-studio", "name": "Studio"},
                 "tags": [{"id": "external-tag", "name": "Useful"}],
                 "images": [{"url": "https://example.test/scene.jpg"}],
@@ -74,6 +77,48 @@ class OfflineStashDB:
         raise RuntimeError("offline")
 
 
+class PerformerHuntStashDB(FakeStashDB):
+    def execute(self, _document: str, variables: dict[str, object]):
+        input_data = variables["input"]
+        assert isinstance(input_data, dict)
+        self.inputs.append(input_data)
+        page = int(input_data["page"])
+        scenes = [
+            {
+                "id": identifier,
+                "title": identifier,
+                "release_date": release_date,
+                "fingerprints": (
+                    [{"hash": "0123456789abcdef", "algorithm": "PHASH", "duration": 120}]
+                    if identifier == "hunt-new"
+                    else []
+                ),
+                "studio": None,
+                "tags": [],
+                "images": [],
+                "performers": [
+                    {
+                        "performer": {
+                            "id": "known-external-performer",
+                            "name": "Known",
+                            "gender": "FEMALE",
+                            "tattoos": [],
+                            "piercings": [],
+                            "images": [],
+                        }
+                    }
+                ],
+            }
+            for identifier, release_date in (
+                ("hunt-old", "2024-01-01"),
+                ("hunt-linked", "2025-01-01"),
+                ("hunt-new", "2026-01-01"),
+            )
+        ]
+        start = (page - 1) * 2
+        return {"queryScenes": {"count": len(scenes), "scenes": scenes[start : start + 2]}}
+
+
 class TaxonomyStashDB(FakeStashDB):
     url = "https://stashdb.org/graphql"
 
@@ -95,6 +140,12 @@ class TaxonomyStashDB(FakeStashDB):
                 }
             }
         return super().execute(document, variables or {})
+
+
+def test_phash_normalization_accepts_only_exact_64_bit_hex() -> None:
+    assert normalize_phash(" D8BC7554C5A178AA ") == "d8bc7554c5a178aa"
+    assert normalize_phash("shared-phash") is None
+    assert normalize_phash("") is None
 
 
 def test_expand_refresh_is_bounded_owned_filtered_and_cached(tmp_path: Path) -> None:
@@ -182,6 +233,28 @@ def test_refresh_resolves_local_tag_names_from_stashdb_taxonomy(tmp_path: Path) 
     assert "id:external-tag" in service._external_content("old-good")
 
 
+def test_expand_hides_exact_local_phash_matches_by_default(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    service = ExpandService(connection)
+    links = {
+        "scenes": {"old-good": "owned-external-scene"},
+        "scene_phashes": {"d8bc7554c5a178aa": "old-good"},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {},
+    }
+
+    service.refresh(FakeStashDB(), links, now_ms=REFERENCE_MS, candidate_limit=10)
+
+    assert service.results("scene")["items"] == []
+    visible = service.results("scene", hide_phash_matches=False)["items"]
+    assert [item["id"] for item in visible] == ["new-external-scene"]
+    assert visible[0]["payload"]["curator_local_match"] == {
+        "type": "phash",
+        "local_scene_id": "old-good",
+    }
+
+
 def test_expand_wildcard_is_opt_in_and_bad_queries_are_rejected(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
@@ -236,6 +309,61 @@ def test_expand_pages_and_preserves_cache_during_outage(tmp_path: Path) -> None:
         "external-scene-1",
         "external-scene-2",
     ]
+
+
+def test_performer_hunt_pages_classifies_exact_links_and_discloses_cap(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    links = {
+        "scenes": {"old-good": "hunt-linked"},
+        "scene_phashes": {"0123456789abcdef": "old-good"},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {},
+    }
+    client = PerformerHuntStashDB()
+    service = ExpandService(connection)
+
+    result = service.performer_hunt(client, links, "p1", limit=10)
+
+    assert [item["id"] for item in result["items"]] == [
+        "hunt-new",
+        "hunt-linked",
+        "hunt-old",
+    ]
+    assert result["stashdb_total"] == result["fetched_count"] == 3
+    assert result["linked_count"] == 2
+    assert result["not_linked_count"] == 1
+    assert result["truncated"] is False
+    assert [item["id"] for item in result["items"] if not item["linked_locally"]] == ["hunt-old"]
+    assert result["items"][0]["match_type"] == "phash"
+    assert result["items"][1]["local_scene_id"] == "old-good"
+    assert len(client.inputs) == 2
+    assert all(
+        request["performers"] == {"value": ["known-external-performer"], "modifier": "INCLUDES"}
+        for request in client.inputs
+    )
+
+    capped = service.performer_hunt(PerformerHuntStashDB(), links, "p1", limit=2)
+    assert capped["stashdb_total"] == 3
+    assert capped["fetched_count"] == capped["limit"] == 2
+    assert capped["truncated"] is True
+    assert [item["id"] for item in capped["items"] if not item["linked_locally"]] == ["hunt-old"]
+
+
+def test_performer_hunt_requires_a_stashdb_link(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+
+    try:
+        ExpandService(connection).performer_hunt(
+            PerformerHuntStashDB(),
+            {"scenes": {}, "performers": {}, "studios": {}},
+            "p1",
+        )
+    except ValueError as error:
+        assert str(error) == "selected performer is not linked to StashDB"
+    else:
+        raise AssertionError("unlinked performers must be rejected")
 
 
 def test_expand_avoids_adjacent_repeated_performers() -> None:
@@ -403,13 +531,32 @@ def test_external_similarity_loads_only_positive_anchor_profiles(
 
     monkeypatch.setattr(FeatureStore, "performer_profiles", capture_profiles)
 
-    ExpandService(connection).targeted_similar(
+    hidden = ExpandService(connection).targeted_similar(
         client,
-        {"scenes": {}, "performers": {"p1": "known-external-performer"}, "studios": {}},
+        {
+            "scenes": {"old-good": "owned-external-scene"},
+            "scene_phashes": {"d8bc7554c5a178aa": "old-good"},
+            "performers": {"p1": "known-external-performer"},
+            "studios": {},
+        },
         "scene",
         "old-good",
     )
+    visible = ExpandService(connection).targeted_similar(
+        client,
+        {
+            "scenes": {"old-good": "owned-external-scene"},
+            "scene_phashes": {"d8bc7554c5a178aa": "old-good"},
+            "performers": {"p1": "known-external-performer"},
+            "studios": {},
+        },
+        "scene",
+        "old-good",
+        hide_phash_matches=False,
+    )
 
+    assert hidden["items"] == []
+    assert [item["id"] for item in visible["items"]] == ["new-external-scene"]
     tag_query = next(value for value in client.inputs if "tags" in value)
     assert tag_query["tags"] == {"value": ["external-tag"], "modifier": "INCLUDES"}
     assert {"p1"} in requested


### PR DESCRIPTION
## Summary
- add a top-level Performer Hunt for a selected StashDB-linked performer
- add saved include/exclude tag filters and date/preference sorting
- suppress exact PHash matches across Hunt, Expand, and StashDB Similar by default

## Testing
- scripts/verify full (168 passed)

Closes #22