### PR TITLE
Add direct tag sentiment and thumbs-down follow-up

### DIFF
--- a/curator/api.py
+++ b/curator/api.py
@@ -363,6 +363,72 @@ class CuratorAPI:
         inserted = InteractionStore(self.connection).submit_feedback(entries)
         return {"schema_version": API_SCHEMA_VERSION, "accepted": inserted}
 
+    def submit_tag_preferences(self, entries: list[dict[str, Any]]) -> dict[str, object]:
+        inserted = InteractionStore(self.connection).submit_tag_preferences(entries)
+        return {"schema_version": API_SCHEMA_VERSION, "accepted": inserted}
+
+    def taste_profile(self) -> dict[str, object]:
+        model_id = RecommendationModelStore(self.connection).current_model_id()
+        if model_id is None:
+            raise RuntimeError("no published model")
+        feature_version = str(
+            self.connection.execute(
+                "SELECT feature_version FROM model_version WHERE model_id=?", (model_id,)
+            ).fetchone()[0]
+        )
+        direct = {
+            str(row["tag_id"]): float(row["value"])
+            for row in self.connection.execute("SELECT tag_id, value FROM direct_tag_preference")
+        }
+        items: list[dict[str, object]] = []
+        for row in self.connection.execute(
+            """
+            SELECT d.name, d.metadata_json, a.affinity, a.confidence,
+                   a.effective_support
+            FROM feature_definition d
+            LEFT JOIN feature_affinity a
+              ON a.feature_id=d.feature_id AND a.model_id=?
+            WHERE d.feature_version=? AND d.family='content'
+            ORDER BY d.name
+            """,
+            (model_id, feature_version),
+        ):
+            metadata = json.loads(str(row["metadata_json"]))
+            tag_id = str(metadata.get("tag_id") or str(row["name"]).removeprefix("tag:"))
+            scene_count = int(metadata.get("document_frequency") or 0)
+            affinity = float(row["affinity"] or 0)
+            confidence = float(row["confidence"] or 0)
+            direct_value = direct.get(tag_id)
+            prompt = None
+            if direct_value is None and scene_count >= 2:
+                prompt = "belief" if confidence >= 0.35 and abs(affinity) >= 0.15 else "uncertain"
+            items.append(
+                {
+                    "tag_id": tag_id,
+                    "name": str(metadata.get("tag_name") or tag_id),
+                    "inferred_value": affinity,
+                    "confidence": confidence,
+                    "support": float(row["effective_support"] or 0),
+                    "scene_count": scene_count,
+                    "direct_value": direct_value,
+                    "prompt": prompt,
+                }
+            )
+        items.sort(
+            key=lambda item: (
+                item["prompt"] is None,
+                item["prompt"] == "uncertain",
+                -abs(float(str(item["inferred_value"]))),
+                str(item["name"]).casefold(),
+                str(item["tag_id"]),
+            )
+        )
+        return {
+            "schema_version": API_SCHEMA_VERSION,
+            "model_id": model_id,
+            "items": items,
+        }
+
     def submit_events(self, entries: list[dict[str, Any]]) -> dict[str, object]:
         store = InteractionStore(self.connection)
         impressions = [

--- a/curator/api.py
+++ b/curator/api.py
@@ -429,6 +429,64 @@ class CuratorAPI:
             "items": items,
         }
 
+    def tag_sentiment_follow_up(self, scene_id: str, limit: int = 3) -> dict[str, object]:
+        if not scene_id or not 1 <= limit <= 3:
+            raise ValueError("scene_id and a limit from 1 to 3 are required")
+        scene_tags = {
+            str(row[0])
+            for row in self.connection.execute(
+                """
+                SELECT tag_id FROM scene_tag
+                WHERE scene_id=? AND provenance='scene'
+                """,
+                (scene_id,),
+            )
+        }
+        if (
+            not scene_tags
+            and self.connection.execute(
+                "SELECT 1 FROM source_scene WHERE scene_id=?", (scene_id,)
+            ).fetchone()
+            is None
+        ):
+            raise ValueError(f"unknown scene: {scene_id}")
+        total_scenes = int(
+            self.connection.execute("SELECT count(*) FROM source_scene").fetchone()[0]
+        )
+        profile_items = self.taste_profile()["items"]
+        assert isinstance(profile_items, list)
+        candidates = [
+            item
+            for item in profile_items
+            if isinstance(item, dict)
+            and str(item["tag_id"]) in scene_tags
+            and item["direct_value"] is None
+            # ponytail: library-wide prevalence is the existing cheap generic-tag signal.
+            and not (
+                int(item["scene_count"]) >= 5 and int(item["scene_count"]) >= 0.8 * total_scenes
+            )
+        ]
+        candidates.sort(
+            key=lambda item: (
+                0
+                if float(str(item["inferred_value"])) > 0.05
+                else (
+                    1
+                    if float(str(item["confidence"])) < 0.35
+                    or abs(float(str(item["inferred_value"]))) < 0.15
+                    else 2
+                ),
+                -abs(float(str(item["inferred_value"]))),
+                str(item["name"]).casefold(),
+                str(item["tag_id"]),
+            )
+        )
+        return {
+            "schema_version": API_SCHEMA_VERSION,
+            "scene_id": scene_id,
+            "items": candidates[:limit],
+        }
+
     def submit_events(self, entries: list[dict[str, Any]]) -> dict[str, object]:
         store = InteractionStore(self.connection)
         impressions = [

--- a/curator/explanations/planner.py
+++ b/curator/explanations/planner.py
@@ -46,6 +46,7 @@ class Microplanner:
         "direct.positive": 7,
         "appeal.performer_identity": 6,
         "appeal.content_neighbor": 5,
+        "appeal.tag_declared_positive": 5,
         "appeal.tag_positive": 4,
         "appeal.studio": 3,
         "appeal.performer_similar": 2,
@@ -113,7 +114,13 @@ class Microplanner:
                 self._unit(reason)
                 for reason in reasons
                 if reason.direction == "negative"
-                and reason.code in {"appeal.tag_negative", "fit.cooldown", "fit.not_now"}
+                and reason.code
+                in {
+                    "appeal.tag_declared_negative",
+                    "appeal.tag_negative",
+                    "fit.cooldown",
+                    "fit.not_now",
+                }
             ),
             key=lambda unit: (-unit.strength, unit.reason.code),
         )
@@ -125,10 +132,11 @@ class Microplanner:
             return False
         # A neighbor clause already names the content features creating the
         # relationship, so a separate tag clause normally repeats the same evidence.
-        return {primary.reason.code, candidate.reason.code} != {
-            "appeal.content_neighbor",
-            "appeal.tag_positive",
-        }
+        codes = {primary.reason.code, candidate.reason.code}
+        return not (
+            "appeal.content_neighbor" in codes
+            and bool(codes & {"appeal.tag_positive", "appeal.tag_declared_positive"})
+        )
 
     @staticmethod
     def _narratable(reason: Reason) -> bool:

--- a/curator/explanations/realizations.json
+++ b/curator/explanations/realizations.json
@@ -17,6 +17,10 @@
       "lead": ["scenes with {tags} have tended to suit you", "your history is positive around {tags}", "{tags} are a recurring positive pattern for you"],
       "support": ["{tags} provide additional support", "your past choices also favour {tags}", "{tags} are another positive signal"]
     },
+    "appeal.tag_declared_positive": {
+      "lead": ["you said you like {tags}", "your declared preference for {tags} is positive", "you explicitly marked {tags} as appealing"],
+      "support": ["you said you like {tags}", "your declared preference also supports {tags}", "{tags} match a preference you set"]
+    },
     "appeal.studio": {
       "lead": ["your history with {studio} is positive", "scenes from {studio} have often suited you", "{studio} has been a reliable source in your library"],
       "support": ["{studio} adds a positive studio signal", "your history with {studio} provides additional support", "{studio} is another familiar source"]
@@ -27,6 +31,9 @@
     },
     "appeal.tag_negative": {
       "boundary": ["your history with {tags} is mixed", "the pattern around {tags} has been less consistent for you", "there is some friction around {tags}"]
+    },
+    "appeal.tag_declared_negative": {
+      "boundary": ["you said you dislike {tags}", "your declared preference for {tags} is negative", "you explicitly marked {tags} as unappealing"]
     },
     "fit.cooldown": {
       "boundary": ["you watched this relatively recently", "it may need a little more time to feel fresh", "recency is holding this back for now"]

--- a/curator/explanations/reasons.py
+++ b/curator/explanations/reasons.py
@@ -266,21 +266,32 @@ class ReasonGraphStore:
                 continue
             metadata = item.get("metadata", {})
             metadata = metadata if isinstance(metadata, dict) else {}
+            affinity_metadata = item.get("affinity_metadata", {})
+            affinity_metadata = affinity_metadata if isinstance(affinity_metadata, dict) else {}
+            declared = affinity_metadata.get("declared_preference")
+            code = (
+                ("appeal.tag_declared_positive" if value > 0 else "appeal.tag_declared_negative")
+                if declared is not None
+                else ("appeal.tag_positive" if value > 0 else "appeal.tag_negative")
+            )
             reasons.append(
                 self._reason(
                     score,
                     feature_version,
-                    "appeal.tag_positive" if value > 0 else "appeal.tag_negative",
+                    code,
                     value,
                     _number(item.get("confidence")),
                     "tag",
                     str(metadata.get("tag_id")) if metadata.get("tag_id") else None,
-                    "learned_feature_affinity",
+                    "declared_tag_preference"
+                    if declared is not None
+                    else "learned_feature_affinity",
                     {
                         "name": str(metadata.get("tag_name", "this content pattern")),
                         "related_names": related_names[_direction(value)][:3],
                         "contribution": value,
                         "support": metadata.get("document_frequency"),
+                        "declared_preference": declared,
                     },
                 )
             )

--- a/curator/interactions.py
+++ b/curator/interactions.py
@@ -15,6 +15,7 @@ from curator.events import (
     quick_replacement_outcome,
     viewing_outcome,
 )
+from curator.features import FeatureStore
 from curator.model import ModelUpdateCoordinator
 from curator.ranking import Slate
 from curator.storage import transaction
@@ -27,6 +28,7 @@ FEEDBACK_TYPES = {
     "prune",
     "metadata_wrong",
 }
+TAG_SENTIMENT_VALUES = {-1.0, -0.5, 0.0, 0.5, 1.0}
 
 
 class InteractionStore:
@@ -161,6 +163,80 @@ class InteractionStore:
                 self._apply_feedback(entry)
             if inserted:
                 ModelUpdateCoordinator(self.connection).request("direct_feedback")
+        return inserted
+
+    def submit_tag_preferences(self, entries: list[dict[str, Any]]) -> int:
+        normalized = [self._tag_preference_entry(entry) for entry in entries]
+        inserted = 0
+        with transaction(self.connection):
+            for entry in normalized:
+                current = self.connection.execute(
+                    """
+                    SELECT preference_id, occurred_at_ms FROM direct_tag_preference
+                    WHERE tag_id=?
+                    """,
+                    (entry["tag_id"],),
+                ).fetchone()
+                cursor = self.connection.execute(
+                    """
+                    INSERT OR IGNORE INTO direct_tag_preference_history(
+                        preference_id, tag_id, value, occurred_at_ms
+                    ) VALUES (?, ?, ?, ?)
+                    """,
+                    (
+                        entry["preference_id"],
+                        entry["tag_id"],
+                        entry["value"],
+                        entry["occurred_at_ms"],
+                    ),
+                )
+                if not cursor.rowcount:
+                    continue
+                inserted += 1
+                if current and (
+                    int(current["occurred_at_ms"]),
+                    str(current["preference_id"]),
+                ) >= (entry["occurred_at_ms"], entry["preference_id"]):
+                    self.connection.execute(
+                        """
+                        UPDATE direct_tag_preference_history SET replaced_by_id=?
+                        WHERE preference_id=?
+                        """,
+                        (current["preference_id"], entry["preference_id"]),
+                    )
+                    continue
+                if current:
+                    self.connection.execute(
+                        """
+                        UPDATE direct_tag_preference_history SET replaced_by_id=?
+                        WHERE preference_id=?
+                        """,
+                        (entry["preference_id"], current["preference_id"]),
+                    )
+                if entry["value"] is None:
+                    self.connection.execute(
+                        "DELETE FROM direct_tag_preference WHERE tag_id=?", (entry["tag_id"],)
+                    )
+                else:
+                    self.connection.execute(
+                        """
+                        INSERT INTO direct_tag_preference(
+                            tag_id, preference_id, value, occurred_at_ms
+                        ) VALUES (?, ?, ?, ?)
+                        ON CONFLICT(tag_id) DO UPDATE SET
+                            preference_id=excluded.preference_id,
+                            value=excluded.value,
+                            occurred_at_ms=excluded.occurred_at_ms
+                        """,
+                        (
+                            entry["tag_id"],
+                            entry["preference_id"],
+                            entry["value"],
+                            entry["occurred_at_ms"],
+                        ),
+                    )
+            if inserted:
+                ModelUpdateCoordinator(self.connection).request("direct_tag_preference")
         return inserted
 
     def submit_sessions(self, entries: list[dict[str, Any]]) -> int:
@@ -327,6 +403,39 @@ class InteractionStore:
             "occurred_at_ms": occurred_at_ms,
             "impression_id": (str(entry["impression_id"]) if entry.get("impression_id") else None),
             "payload": entry.get("payload") if isinstance(entry.get("payload"), dict) else {},
+        }
+
+    def _tag_preference_entry(self, entry: dict[str, Any]) -> dict[str, Any]:
+        preference_id = str(entry.get("preference_id") or "")
+        tag_id = str(entry.get("tag_id") or "")
+        occurred_at_ms = int(entry.get("occurred_at_ms", -1))
+        value = entry.get("value")
+        if value is not None:
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError("tag sentiment must be numeric or null")
+            value = float(value)
+            if value not in TAG_SENTIMENT_VALUES:
+                raise ValueError("tag sentiment must use the fixed five-point scale")
+        if not preference_id or not tag_id or occurred_at_ms < 0:
+            raise ValueError("preference_id, tag_id, and occurred_at_ms are required")
+        feature_version = FeatureStore(self.connection).current_version()
+        if (
+            feature_version is None
+            or self.connection.execute(
+                """
+            SELECT 1 FROM feature_definition
+            WHERE feature_version=? AND family='content' AND name='tag:' || ?
+            """,
+                (feature_version, tag_id),
+            ).fetchone()
+            is None
+        ):
+            raise ValueError(f"unknown or unsupported content tag: {tag_id}")
+        return {
+            "preference_id": preference_id,
+            "tag_id": tag_id,
+            "value": value,
+            "occurred_at_ms": occurred_at_ms,
         }
 
     @staticmethod

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -49,7 +49,7 @@ class _Affinity:
     confidence: float
     support: float
     scene_count: int
-    contexts: dict[str, int]
+    contexts: dict[str, object]
 
 
 @dataclass(frozen=True)
@@ -314,6 +314,15 @@ class PreferenceModelBuilder:
             tuple(row)
             for row in self.connection.execute("SELECT * FROM pruning_candidate ORDER BY scene_id")
         ]
+        tag_preferences = [
+            tuple(row)
+            for row in self.connection.execute(
+                """
+                SELECT tag_id, preference_id, value, occurred_at_ms
+                FROM direct_tag_preference ORDER BY tag_id
+                """
+            )
+        ]
         return hashlib.sha256(
             json.dumps(
                 {
@@ -321,6 +330,7 @@ class PreferenceModelBuilder:
                     "feedback": feedback_state,
                     "exclusions": exclusions,
                     "pruning": pruning,
+                    "tag_preferences": tag_preferences,
                 },
                 sort_keys=True,
                 separators=(",", ":"),
@@ -373,6 +383,39 @@ class PreferenceModelBuilder:
                 support,
                 len({scene_id for scene_id, _, _ in values}),
                 {"studios": len(studios), "performers": len(performers)},
+            )
+        tag_features = {
+            str(feature.metadata["tag_id"]): feature.feature_id
+            for features in scene_features.values()
+            for feature in features
+            if feature.family == "content" and feature.metadata.get("tag_id")
+        }
+        for row in self.connection.execute(
+            "SELECT tag_id, value FROM direct_tag_preference ORDER BY tag_id"
+        ):
+            direct_feature_id = tag_features.get(str(row["tag_id"]))
+            if direct_feature_id is None:
+                continue
+            learned = result.get(
+                direct_feature_id,
+                _Affinity(direct_feature_id, 0.0, 0.0, 0.0, 0, {}),
+            )
+            direct_support = 8.0
+            direct_value = float(row["value"])
+            result[direct_feature_id] = _Affinity(
+                direct_feature_id,
+                _clamp(
+                    (learned.affinity * learned.support + direct_value * direct_support)
+                    / (learned.support + direct_support)
+                ),
+                max(learned.confidence, 0.9),
+                learned.support + direct_support,
+                learned.scene_count,
+                {
+                    **learned.contexts,
+                    "declared_preference": direct_value,
+                    "learned_affinity": learned.affinity,
+                },
             )
         return result
 
@@ -483,6 +526,7 @@ class PreferenceModelBuilder:
                             "affinity": affinity.affinity,
                             "confidence": affinity.confidence,
                             "metadata": feature.metadata,
+                            "affinity_metadata": affinity.contexts,
                         }
                     )
                 raw = sum(_number(item["value"]) for item in contributions)

--- a/curator/storage/sql/0016_direct_tag_preferences.sql
+++ b/curator/storage/sql/0016_direct_tag_preferences.sql
@@ -1,0 +1,18 @@
+CREATE TABLE direct_tag_preference_history (
+    preference_id TEXT PRIMARY KEY,
+    tag_id TEXT NOT NULL REFERENCES source_tag(tag_id) ON DELETE CASCADE,
+    value REAL CHECK (value IS NULL OR value IN (-1, -0.5, 0, 0.5, 1)),
+    occurred_at_ms INTEGER NOT NULL CHECK (occurred_at_ms >= 0),
+    replaced_by_id TEXT REFERENCES direct_tag_preference_history(preference_id)
+) STRICT;
+
+CREATE INDEX direct_tag_preference_history_tag_idx
+ON direct_tag_preference_history(tag_id, occurred_at_ms);
+
+CREATE TABLE direct_tag_preference (
+    tag_id TEXT PRIMARY KEY REFERENCES source_tag(tag_id) ON DELETE CASCADE,
+    preference_id TEXT NOT NULL UNIQUE
+        REFERENCES direct_tag_preference_history(preference_id) ON DELETE CASCADE,
+    value REAL NOT NULL CHECK (value IN (-1, -0.5, 0, 0.5, 1)),
+    occurred_at_ms INTEGER NOT NULL CHECK (occurred_at_ms >= 0)
+) STRICT, WITHOUT ROWID;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -56,6 +56,10 @@ preference rebuild after a short debounce. They do not rerun library sync. Full
 sync/build and Expand refresh remain one-shot tasks because Stash provides no plugin
 background scheduler/startup hook.
 
+Direct tag sentiments keep append-only replacement history plus one current value per
+tag. Model publication blends that value into the shared content affinity, so local
+recommendations, Similar, Expand, and factual explanations consume the same result.
+
 The only mutation path into Stash is isolated Prune tag application/removal.
 StashDB failures affect external discovery only; cached Expand results and local
 recommendations remain available.

--- a/docs/using-curator.md
+++ b/docs/using-curator.md
@@ -40,6 +40,11 @@ hard exclusion; **Neutral** is an explicit near-zero preference, while **Clear
 answer** returns the tag to behavior-derived inference. Answers are queued locally
 during transient failures.
 
+After an accepted thumbs down, Curator may offer an optional, dismissible follow-up
+with up to three relevant content tags. Answer only the tags that contributed to the
+problem, or choose a scene-specific or metadata explanation; the original thumbs down
+remains independent.
+
 ## Similar
 
 Open Similar from Curator or the compass action on a Stash scene or performer.

--- a/docs/using-curator.md
+++ b/docs/using-curator.md
@@ -34,6 +34,12 @@ Use thumbs up or down for direct feedback. The detail menu also supports **Not n
 queued durably in the browser during transient failures and applied in a small model
 update. A later explicit action can reverse earlier feedback.
 
+Open **Taste Profile** to review content-tag beliefs and answer with a fixed sentiment
+from strong dislike to strong like. A direct answer is strong evidence rather than a
+hard exclusion; **Neutral** is an explicit near-zero preference, while **Clear
+answer** returns the tag to behavior-derived inference. Answers are queued locally
+during transient failures.
+
 ## Similar
 
 Open Similar from Curator or the compass action on a Stash scene or performer.

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -532,6 +532,11 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
             return api.submit_tag_preferences(entries)
         if operation == "get_taste_profile":
             return api.taste_profile()
+        if operation == "get_tag_sentiment_follow_up":
+            return api.tag_sentiment_follow_up(
+                str(args.get("scene_id") or ""),
+                min(3, int(args.get("limit") or 3)),
+            )
         if operation == "submit_events":
             entries = args.get("entries")
             if not isinstance(entries, list):

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -525,6 +525,13 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
             if not isinstance(entries, list):
                 raise ValueError("entries must be a list")
             return api.submit_feedback(entries)
+        if operation == "submit_tag_preferences":
+            entries = args.get("entries")
+            if not isinstance(entries, list):
+                raise ValueError("entries must be a list")
+            return api.submit_tag_preferences(entries)
+        if operation == "get_taste_profile":
+            return api.taste_profile()
         if operation == "submit_events":
             entries = args.get("entries")
             if not isinstance(entries, list):

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -187,6 +187,31 @@
   gap: 0.25rem;
 }
 
+.curator-tag-follow-up {
+  margin: 0.5rem 0;
+}
+
+.curator-tag-follow-up-heading,
+.curator-tag-follow-up-item,
+.curator-tag-follow-up-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.curator-tag-follow-up-heading {
+  justify-content: space-between;
+}
+
+.curator-tag-follow-up p {
+  margin: 0.25rem 0 0.5rem;
+}
+
+.curator-tag-follow-up-item {
+  margin-bottom: 0.35rem;
+}
+
 .curator-profiling-toolbar {
   align-items: center;
   display: flex;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -143,6 +143,50 @@
   margin-top: 1rem;
 }
 
+.curator-taste {
+  margin-top: 1rem;
+}
+
+.curator-taste > h2 {
+  font-size: 1.2rem;
+}
+
+.curator-taste-list {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.curator-taste-item {
+  align-items: center;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: 0.4rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem 1rem;
+  justify-content: space-between;
+  padding: 0.65rem;
+}
+
+.curator-taste-item strong,
+.curator-taste-item small {
+  display: block;
+}
+
+.curator-taste-item .badge {
+  margin-left: 0.5rem;
+}
+
+.curator-taste-item small {
+  color: var(--text-muted, #adb5bd);
+}
+
+.curator-sentiment {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
 .curator-profiling-toolbar {
   align-items: center;
   display: flex;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -156,6 +156,20 @@
   gap: 0.6rem;
 }
 
+.curator-taste-toolbar {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.6rem;
+}
+
+.curator-taste-toolbar input {
+  flex: 1 1 16rem;
+}
+
+.curator-taste-toolbar select {
+  flex: 0 1 9rem;
+}
+
 .curator-taste-item {
   align-items: center;
   background: rgba(255, 255, 255, 0.04);

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -399,6 +399,9 @@
   function TasteProfilePanel() {
     const [data, setData] = React.useState(null);
     const [error, setError] = React.useState("");
+    const [query, setQuery] = React.useState("");
+    const [sort, setSort] = React.useState("suggested");
+    const [status, setStatus] = React.useState("all");
     React.useEffect(() => {
       let active = true;
       operation({ operation: "get_taste_profile" }).then(
@@ -411,18 +414,49 @@
       submitTagPreference(tagId, value);
       setData((current) => ({ ...current, items: current.items.map((item) => item.tag_id === tagId ? { ...item, direct_value: value, prompt: null } : item) }));
     }
+    const visibleItems = data
+      ? data.items
+          .filter((item) =>
+            item.name.toLocaleLowerCase().includes(query.trim().toLocaleLowerCase())
+            && (status === "all" || (status === "answered") === (item.direct_value !== null))
+          )
+      : [];
+    if (sort !== "suggested") {
+      visibleItems.sort((left, right) => {
+        const difference = sort === "confidence"
+          ? right.confidence - left.confidence
+          : right.scene_count - left.scene_count;
+        return difference || left.name.localeCompare(right.name);
+      });
+    }
     return React.createElement(
       "section",
       { className: "curator-taste", "aria-labelledby": "curator-taste-title" },
       React.createElement("h2", { id: "curator-taste-title" }, "Taste Profile"),
       React.createElement("p", null, "Declared answers are strong evidence, not hard exclusions. Clear an answer to return to behavior-derived inference."),
+      React.createElement(
+        "div",
+        { className: "curator-taste-toolbar" },
+        React.createElement("input", { className: "form-control form-control-sm", type: "search", value: query, onChange: (event) => setQuery(event.target.value), placeholder: "Search tags…", "aria-label": "Search taste profile tags" }),
+        React.createElement("select", { className: "form-control form-control-sm", value: status, onChange: (event) => setStatus(event.target.value), "aria-label": "Filter taste profile tags" },
+          React.createElement("option", { value: "all" }, "All tags"),
+          React.createElement("option", { value: "unanswered" }, "Needs answer"),
+          React.createElement("option", { value: "answered" }, "Answered")
+        ),
+        React.createElement("select", { className: "form-control form-control-sm", value: sort, onChange: (event) => setSort(event.target.value), "aria-label": "Sort taste profile" },
+          React.createElement("option", { value: "suggested" }, "Suggested"),
+          React.createElement("option", { value: "confidence" }, "Confidence"),
+          React.createElement("option", { value: "scenes" }, "Scene count")
+        )
+      ),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
       !data && !error && React.createElement("div", { role: "status" }, "Loading taste profile…"),
       data && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No supported content tags are available yet."),
+      data && data.items.length > 0 && visibleItems.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No tags match that search."),
       data && React.createElement(
         "div",
         { className: "curator-taste-list" },
-        data.items.map((item) =>
+        visibleItems.map((item) =>
           React.createElement(
             "article",
             { key: item.tag_id, className: "curator-taste-item" },

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -75,9 +75,16 @@
       icon: faBroom,
       description: "Curator never deletes media; tagging is reversible, and Candidates, Explicit dislikes, and Model suspects are separate review queues.",
     },
+    {
+      value: "taste",
+      label: "Taste Profile",
+      icon: faTag,
+      description: "Review what Curator has inferred and directly teach it how you feel about content tags.",
+    },
   ];
   const laneByValue = new Map(LANES.map((lane) => [lane.value, lane]));
   const EVENT_QUEUE_KEY = "stash-curator:event-queue:v1";
+  const TAG_PREFERENCE_QUEUE_KEY = "stash-curator:tag-preference-queue:v1";
   const ORIGIN_KEY = "stash-curator:origin:v1";
   const SLATE_CACHE_KEY = "stash-curator:slates:v1";
   const FILTER_PRESETS_KEY = "stash-curator:filter-presets:v1";
@@ -333,6 +340,102 @@
     };
     const fallback = code.split(".").at(-1).replaceAll("_", " ");
     return labels[code] || fallback.charAt(0).toUpperCase() + fallback.slice(1);
+  }
+
+  const SENTIMENTS = [
+    [-1, "Strong dislike"],
+    [-0.5, "Slight dislike"],
+    [0, "Neutral"],
+    [0.5, "Slight like"],
+    [1, "Strong like"],
+  ];
+
+  function TagSentimentControl({ tag, value, onChange }) {
+    return React.createElement(
+      "div",
+      { className: "curator-sentiment", role: "group", "aria-label": `Sentiment for ${tag.name}` },
+      SENTIMENTS.map(([score, label]) =>
+        React.createElement(Button, { key: score, size: "sm", variant: value === score ? "primary" : "secondary", "aria-pressed": value === score, title: label, onClick: () => onChange(score) }, label)
+      ),
+      value !== null && value !== undefined && React.createElement(Button, { size: "sm", variant: "link", onClick: () => onChange(null) }, "Clear answer")
+    );
+  }
+
+  function readTagPreferenceQueue() {
+    try {
+      const value = JSON.parse(localStorage.getItem(TAG_PREFERENCE_QUEUE_KEY) || "[]");
+      return Array.isArray(value) ? value : [];
+    } catch (_) {
+      return [];
+    }
+  }
+
+  let flushingTagPreferences = false;
+  async function flushTagPreferenceQueue() {
+    if (flushingTagPreferences) return;
+    const entries = readTagPreferenceQueue();
+    if (!entries.length) return;
+    flushingTagPreferences = true;
+    try {
+      await operation({ operation: "submit_tag_preferences", entries });
+      const sent = new Set(entries.map((entry) => entry.preference_id));
+      localStorage.setItem(TAG_PREFERENCE_QUEUE_KEY, JSON.stringify(readTagPreferenceQueue().filter((entry) => !sent.has(entry.preference_id))));
+      clearSlateCache();
+      scheduleModelUpdate();
+    } catch (_) {
+      // Retry on the next route, online event, or plugin page load.
+    } finally {
+      flushingTagPreferences = false;
+    }
+  }
+
+  function submitTagPreference(tagId, value) {
+    const queue = readTagPreferenceQueue();
+    queue.push({ preference_id: uuid(), tag_id: tagId, value, occurred_at_ms: Date.now() });
+    localStorage.setItem(TAG_PREFERENCE_QUEUE_KEY, JSON.stringify(queue));
+    flushTagPreferenceQueue();
+  }
+
+  function TasteProfilePanel() {
+    const [data, setData] = React.useState(null);
+    const [error, setError] = React.useState("");
+    React.useEffect(() => {
+      let active = true;
+      operation({ operation: "get_taste_profile" }).then(
+        (value) => active && setData(value),
+        (failure) => active && setError(failure.message)
+      );
+      return () => { active = false; };
+    }, []);
+    function answer(tagId, value) {
+      submitTagPreference(tagId, value);
+      setData((current) => ({ ...current, items: current.items.map((item) => item.tag_id === tagId ? { ...item, direct_value: value, prompt: null } : item) }));
+    }
+    return React.createElement(
+      "section",
+      { className: "curator-taste", "aria-labelledby": "curator-taste-title" },
+      React.createElement("h2", { id: "curator-taste-title" }, "Taste Profile"),
+      React.createElement("p", null, "Declared answers are strong evidence, not hard exclusions. Clear an answer to return to behavior-derived inference."),
+      error && React.createElement("div", { className: "alert alert-danger" }, error),
+      !data && !error && React.createElement("div", { role: "status" }, "Loading taste profile…"),
+      data && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No supported content tags are available yet."),
+      data && React.createElement(
+        "div",
+        { className: "curator-taste-list" },
+        data.items.map((item) =>
+          React.createElement(
+            "article",
+            { key: item.tag_id, className: "curator-taste-item" },
+            React.createElement("div", null,
+              React.createElement("strong", null, item.name),
+              item.prompt && React.createElement("span", { className: "badge badge-info" }, item.prompt === "belief" ? `I think you ${item.inferred_value >= 0 ? "like" : "dislike"} this` : "I'm unsure"),
+              React.createElement("small", null, `Inferred ${item.inferred_value.toFixed(2)} · confidence ${item.confidence.toFixed(2)} · support ${item.support.toFixed(1)} · ${item.scene_count} local scene${item.scene_count === 1 ? "" : "s"}`)
+            ),
+            React.createElement(TagSentimentControl, { tag: item, value: item.direct_value, onChange: (value) => answer(item.tag_id, value) })
+          )
+        )
+      )
+    );
   }
 
   const ExternalCard = Api.register.component("stash-curator.ExternalCard", function ExternalCard(props) {
@@ -1378,6 +1481,7 @@
       ),
       lane === "similar" && !loadingComponents && React.createElement(SimilarityPanel, { initialType: route.get("type") || "scene", initialId: route.get("id"), initialLabel: route.get("label") }),
       lane === "prune" && !loadingComponents && React.createElement(PrunePanel),
+      lane === "taste" && React.createElement(TasteProfilePanel),
       lane === "expand" && React.createElement(ExpandPanel, { key: "expand", initialPerformerId: route.get("performer") }),
       lane === "hunt" && React.createElement(ExpandPanel, { key: "hunt", initialType: "hunt", huntOnly: true }),
       lane === "profiling" && React.createElement(ProfilingPanel),
@@ -1572,9 +1676,11 @@
     flushQueue();
   });
   window.addEventListener("online", flushQueue);
+  window.addEventListener("online", flushTagPreferenceQueue);
   window.addEventListener("pagehide", () => finishTracker(false));
   attachPlayer(location.pathname);
   flushQueue();
+  flushTagPreferenceQueue();
   function scheduleModelMaintenance() {
     operation({ operation: "health" })
       .then((health) => {

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -438,6 +438,67 @@
     );
   }
 
+  function TagSentimentFollowUp({ followUp, onDismiss }) {
+    const [selected, setSelected] = React.useState(null);
+    const [answers, setAnswers] = React.useState({});
+    const [status, setStatus] = React.useState("");
+    const [busy, setBusy] = React.useState(false);
+    function answer(tag, value) {
+      submitTagPreference(tag.tag_id, value);
+      setAnswers((current) => ({ ...current, [tag.tag_id]: value }));
+      setSelected(null);
+      setStatus(`${tag.name} answer queued`);
+    }
+    async function metadataWrong() {
+      setBusy(true);
+      try {
+        await operation({
+          operation: "submit_feedback",
+          entries: [{
+            feedback_id: uuid(),
+            scene_id: followUp.scene_id,
+            feedback_type: "metadata_wrong",
+            value: "Do not train from this metadata",
+            occurred_at_ms: Date.now(),
+          }],
+        });
+        scheduleModelUpdate();
+        onDismiss();
+      } catch (error) {
+        setStatus(error.message);
+      } finally {
+        setBusy(false);
+      }
+    }
+    return React.createElement(
+      "aside",
+      { className: "curator-tag-follow-up alert alert-secondary", "aria-label": "Help Curator understand why" },
+      React.createElement("div", { className: "curator-tag-follow-up-heading" },
+        React.createElement("strong", null, "Help Curator understand why"),
+        React.createElement(Button, { size: "sm", variant: "link", onClick: onDismiss, "aria-label": "Dismiss tag follow-up" }, "×")
+      ),
+      React.createElement("p", null, "Was a content tag part of the problem? This is optional."),
+      followUp.items.map((tag) =>
+        React.createElement(
+          "div",
+          { key: tag.tag_id, className: "curator-tag-follow-up-item" },
+          React.createElement(Button, { size: "sm", variant: selected === tag.tag_id ? "primary" : "secondary", onClick: () => setSelected(selected === tag.tag_id ? null : tag.tag_id) }, tag.name),
+          Object.hasOwn(answers, tag.tag_id) && React.createElement("small", null, `Answered: ${SENTIMENTS.find(([value]) => value === answers[tag.tag_id])?.[1]}`),
+          selected === tag.tag_id && React.createElement(TagSentimentControl, { tag, value: answers[tag.tag_id], onChange: (value) => answer(tag, value) })
+        )
+      ),
+      React.createElement(
+        "div",
+        { className: "curator-tag-follow-up-actions" },
+        React.createElement(Button, { size: "sm", variant: "link", onClick: onDismiss }, "None of these"),
+        React.createElement(Button, { size: "sm", variant: "link", onClick: onDismiss }, "Something scene-specific"),
+        React.createElement(Button, { size: "sm", variant: "link", disabled: busy, onClick: metadataWrong }, "Metadata is wrong"),
+        React.createElement(Button, { size: "sm", variant: "link", onClick: onDismiss }, "Skip")
+      ),
+      status && React.createElement("small", { role: "status" }, status)
+    );
+  }
+
   const ExternalCard = Api.register.component("stash-curator.ExternalCard", function ExternalCard(props) {
     const { HoverPopover } = Api.components;
     const { item, kind, gender, onShortlist, onShowScenes, onWhisparr, whisparrEnabled } = transformComponentProps("stash-curator.ExternalCard", props);
@@ -509,7 +570,7 @@
     );
   });
 
-  function Feedback({ item, onRemove }) {
+  function Feedback({ item, onRemove, onThumbDown }) {
     const [saved, setSaved] = React.useState("");
     const [busy, setBusy] = React.useState(false);
     async function send(feedbackType, value) {
@@ -529,6 +590,14 @@
           ],
         });
         scheduleModelUpdate();
+        if (feedbackType === "thumb_down" && onThumbDown) {
+          const followUp = await operation({
+            operation: "get_tag_sentiment_follow_up",
+            scene_id: item.scene_id,
+            limit: 3,
+          }).catch(() => ({ scene_id: item.scene_id, items: [] }));
+          onThumbDown(followUp);
+        }
         setSaved(feedbackType === "thumb_up" ? "Saved" : "Removed from this view");
         if (feedbackType !== "thumb_up") onRemove(item.scene_id);
       } catch (error) {
@@ -559,7 +628,7 @@
     );
   }
 
-  function RecommendationCard({ item, scene, slate, onRemove }) {
+  function RecommendationCard({ item, scene, slate, onRemove, onThumbDown }) {
     const { SceneCard } = Api.components;
     const card = React.useRef(null);
     React.useEffect(() => {
@@ -651,7 +720,7 @@
             React.createElement(ScoreNode, { name: "diversity_penalties", value: item.penalties }),
             React.createElement(ScoreNode, { name: "diversity_bonuses", value: item.bonuses })
           ),
-          React.createElement(Feedback, { item, onRemove })
+          React.createElement(Feedback, { item, onRemove, onThumbDown })
         )
       )
     );
@@ -729,6 +798,7 @@
     const [hidePhashMatches, setHidePhashMatches] = React.useState(initialFilters.hidePhashMatches !== false);
     const [filtersOpen, setFiltersOpen] = React.useState(false);
     const [whisparrEnabled, setWhisparrEnabled] = React.useState(false);
+    const [followUps, setFollowUps] = React.useState([]);
     const sceneSearch = GQL.useFindScenesQuery({
       variables: { filter: { q: search, per_page: 8 } },
       skip: entityType !== "scene" || !search,
@@ -790,6 +860,7 @@
       setMinimumSimilarity(value.minimum ?? 0.18);
     }
     function choose(entity) {
+      setFollowUps([]);
       setExcludedIds([]);
       load(entity.id, entity.title || entity.name || `#${entity.id}`, entityType, source, gender, 1, []);
     }
@@ -804,6 +875,7 @@
       }, () => {});
     }, []);
     function switchType(value) {
+      setFollowUps([]);
       setEntityType(value);
       setSearch("");
       setSelected(null);
@@ -813,6 +885,7 @@
       setExcludedIds([]);
     }
     function switchSource(value) {
+      setFollowUps([]);
       setSource(value);
       setResult(null);
       setPage(1);
@@ -828,6 +901,9 @@
       setExcludedIds(nextExcluded);
       similarityCache.clear();
       load(selected.id, selected.label, entityType, source, gender, page, nextExcluded);
+    }
+    function showFollowUp(followUp) {
+      setFollowUps((current) => [...current.filter((item) => item.scene_id !== followUp.scene_id), followUp]);
     }
     async function shortlistExternal(item, kind) {
       try {
@@ -878,6 +954,7 @@
       selected && React.createElement("div", { className: "curator-similar-reference" }, React.createElement("strong", null, "Comparing from"), React.createElement(SourceReference, { entity: sourceEntity, type: entityType, fallback: selected })),
       loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Finding close matches…"), React.createElement("div", { className: "curator-progress", "aria-hidden": "true" })),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
+      followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),
       result && source === "library" && React.createElement(
         "div",
         { className: "curator-grid" },
@@ -891,7 +968,7 @@
             if (!event.target.closest("a")) return;
             sessionStorage.setItem(ORIGIN_KEY, JSON.stringify({ scene_id: item.entity_id, impression_id: result.impression_id, lane: "similar", impression_position: item.position, model_id: result.model_id }));
           }
-          return React.createElement("article", { key: item.entity_id, className: "curator-card", onClickCapture: rememberOrigin }, React.createElement(SceneCard, { scene: entity }), body, React.createElement("div", { className: "curator-similar-feedback" }, React.createElement(Feedback, { item: feedbackItem, onRemove: removeSimilar })));
+          return React.createElement("article", { key: item.entity_id, className: "curator-card", onClickCapture: rememberOrigin }, React.createElement(SceneCard, { scene: entity }), body, React.createElement("div", { className: "curator-similar-feedback" }, React.createElement(Feedback, { item: feedbackItem, onRemove: removeSimilar, onThumbDown: showFollowUp })));
         })
       ),
       result && source === "stashdb" && React.createElement(
@@ -1335,6 +1412,9 @@
     const [configReady, setConfigReady] = React.useState(false);
     const [diversityEnabled, setDiversityEnabled] = React.useState(null);
     const [diversitySaving, setDiversitySaving] = React.useState(false);
+    const [followUps, setFollowUps] = React.useState([]);
+
+    React.useEffect(() => setFollowUps([]), [lane]);
 
     React.useEffect(() => {
       let active = true;
@@ -1400,6 +1480,9 @@
       setLoading(true);
       setRefreshKey((value) => value + 1);
     }
+    function showFollowUp(followUp) {
+      setFollowUps((current) => [...current.filter((item) => item.scene_id !== followUp.scene_id), followUp]);
+    }
     function refresh() {
       clearSlateCache();
       laneExclusions.clear();
@@ -1408,6 +1491,7 @@
     }
     function openView(view) {
       if (view === lane) return;
+      setFollowUps([]);
       setPage(1);
       route.set("view", view);
       history.push({ pathname: routeLocation.pathname, search: route.toString() });
@@ -1479,6 +1563,7 @@
           diversityEnabled ? " Balanced" : " Score-first"
         )
       ),
+      followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),
       lane === "similar" && !loadingComponents && React.createElement(SimilarityPanel, { initialType: route.get("type") || "scene", initialId: route.get("id"), initialLabel: route.get("label") }),
       lane === "prune" && !loadingComponents && React.createElement(PrunePanel),
       lane === "taste" && React.createElement(TasteProfilePanel),
@@ -1502,7 +1587,7 @@
           React.createElement(
             "section",
             { className: "curator-grid", role: "tabpanel", "aria-live": "polite" },
-            slate.items.map((item) => React.createElement(RecommendationCard, { key: item.scene_id, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove }))
+            slate.items.map((item) => React.createElement(RecommendationCard, { key: item.scene_id, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp }))
           ),
           React.createElement(Pager, { page, hasMore: slate.has_more, loading, onPage: setPage, label: `${laneOption.label} pages` })
         )

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -9,6 +9,7 @@ import pytest
 import curator.model.builder as builder_module
 from curator.cli import run
 from curator.config import DEFAULT_CONFIG
+from curator.interactions import InteractionStore
 from curator.model import PreferenceModelBuilder, RecommendationModelStore
 from curator.storage import MigrationRunner, connect_database
 
@@ -229,6 +230,51 @@ def test_complete_model_is_bounded_reproducible_and_applies_cooldown(tmp_path: P
             component = score.components[family]
             assert isinstance(component, dict)
             assert abs(float(component["value"])) <= bound
+
+
+def test_direct_tag_sentiment_overrides_and_clear_restores_inference(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    builder = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS)
+    baseline = builder.build()
+
+    def affinity(model_id: str) -> tuple[float, dict[str, object]]:
+        row = connection.execute(
+            """
+            SELECT a.affinity, a.metadata_json FROM feature_affinity a
+            JOIN feature_definition d USING(feature_id)
+            WHERE a.model_id=? AND d.name='tag:good'
+            """,
+            (model_id,),
+        ).fetchone()
+        return float(row[0]), json.loads(row[1])
+
+    inferred, _ = affinity(baseline.model_id)
+    store = InteractionStore(connection)
+    store.submit_tag_preferences(
+        [{"preference_id": "negative", "tag_id": "good", "value": -1, "occurred_at_ms": 10}]
+    )
+    negative = builder.build()
+    negative_value, metadata = affinity(negative.model_id)
+    assert negative_value < inferred
+    assert metadata["declared_preference"] == -1
+
+    store.submit_tag_preferences(
+        [{"preference_id": "neutral", "tag_id": "good", "value": 0, "occurred_at_ms": 20}]
+    )
+    neutral = builder.build()
+    assert abs(affinity(neutral.model_id)[0]) < abs(inferred)
+
+    store.submit_tag_preferences(
+        [{"preference_id": "positive", "tag_id": "good", "value": 1, "occurred_at_ms": 30}]
+    )
+    positive = builder.build()
+    assert affinity(positive.model_id)[0] > inferred
+
+    store.submit_tag_preferences(
+        [{"preference_id": "clear", "tag_id": "good", "value": None, "occurred_at_ms": 40}]
+    )
+    restored = builder.build()
+    assert affinity(restored.model_id)[0] == pytest.approx(inferred)
 
 
 def test_model_build_reports_stage_progress(tmp_path: Path) -> None:

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -116,6 +116,14 @@ def test_taste_profile_uses_fixed_durable_tag_sentiment_control() -> None:
     assert '[-1, "Strong dislike"]' in source
     assert '[1, "Strong like"]' in source
     assert '"Clear answer"' in source
+    assert '"Search taste profile tags"' in source
+    assert '"Filter taste profile tags"' in source
+    assert 'value: "answered"' in source
+    assert '"Needs answer"' in source
+    assert '"Sort taste profile"' in source
+    assert 'value: "confidence"' in source
+    assert 'value: "scenes"' in source
+    assert 'if (sort !== "suggested")' in source
 
 
 def test_thumb_down_follow_up_is_optional_and_survives_card_removal() -> None:

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -106,6 +106,18 @@ def test_curator_tabs_update_browser_history() -> None:
     assert "onClick: () => openView(option.value)" in source
 
 
+def test_taste_profile_uses_fixed_durable_tag_sentiment_control() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
+
+    assert 'value: "taste"' in source
+    assert 'operation: "get_taste_profile"' in source
+    assert 'operation: "submit_tag_preferences"' in source
+    assert "TAG_PREFERENCE_QUEUE_KEY" in source
+    assert '[-1, "Strong dislike"]' in source
+    assert '[1, "Strong like"]' in source
+    assert '"Clear answer"' in source
+
+
 def test_curator_external_components_are_public_and_patchable() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
     assert 'Api.register.component("stash-curator.ExternalCard"' in source

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -118,6 +118,22 @@ def test_taste_profile_uses_fixed_durable_tag_sentiment_control() -> None:
     assert '"Clear answer"' in source
 
 
+def test_thumb_down_follow_up_is_optional_and_survives_card_removal() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
+
+    assert 'operation: "get_tag_sentiment_follow_up"' in source
+    assert 'if (feedbackType === "thumb_down" && onThumbDown)' in source
+    assert "onThumbDown(followUp);" in source
+    assert "onRemove(item.scene_id);" in source
+    assert "TagSentimentFollowUp" in source
+    assert '"None of these"' in source
+    assert '"Something scene-specific"' in source
+    assert '"Metadata is wrong"' in source
+    assert '"Skip"' in source
+    assert "onClick: onDismiss" in source
+    assert "submitTagPreference(tag.tag_id, value);" in source
+
+
 def test_curator_external_components_are_public_and_patchable() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
     assert 'Api.register.component("stash-curator.ExternalCard"' in source

--- a/tests/storage/test_cli_db.py
+++ b/tests/storage/test_cli_db.py
@@ -15,7 +15,7 @@ def test_database_cli_migrate_status_and_backup(
 
     assert run(["--db", str(database), "db", "migrate", "--json"]) == 0
     migrated = json.loads(capsys.readouterr().out)
-    assert migrated["current_version"] == migrated["latest_version"] == 15
+    assert migrated["current_version"] == migrated["latest_version"] == 16
 
     assert run(["--db", str(database), "db", "status", "--json"]) == 0
     status = json.loads(capsys.readouterr().out)

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -11,10 +11,10 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
         runner = MigrationRunner(connection)
         before = runner.status()
         assert before.current_version == 0
-        assert before.pending_versions == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15)
+        assert before.pending_versions == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
 
         after = runner.migrate(applied_at_ms=1234)
-        assert after.current_version == 15
+        assert after.current_version == 16
         assert after.pending_versions == ()
         assert runner.migrate(applied_at_ms=5678) == after
 
@@ -39,6 +39,8 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
             "model_lane_candidate_cache",
             "model_lane_order",
             "model_lane_order_state",
+            "direct_tag_preference",
+            "direct_tag_preference_history",
         } <= tables
         assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
         assert connection.execute(
@@ -85,7 +87,7 @@ def test_status_stays_read_only_after_migrations(tmp_path: Path) -> None:
     reader.execute("PRAGMA busy_timeout=1")
     try:
         writer.execute("BEGIN IMMEDIATE")
-        assert MigrationRunner(reader).status().current_version == 15
+        assert MigrationRunner(reader).status().current_version == 16
     finally:
         writer.rollback()
         reader.close()
@@ -111,7 +113,7 @@ def test_stale_concurrent_migrator_rechecks_after_writer_lock(
 
     monkeypatch.setattr(second_runner, "status", status)
     try:
-        assert second_runner.migrate(applied_at_ms=2).current_version == 15
+        assert second_runner.migrate(applied_at_ms=2).current_version == 16
     finally:
         second.close()
         first.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -140,6 +140,89 @@ def test_taste_profile_exposes_inference_and_direct_answer(tmp_path: Path) -> No
     assert good["prompt"] is None
 
 
+def test_thumb_down_follow_up_filters_caps_and_keeps_scene_feedback_independent(
+    tmp_path: Path,
+) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    extra_tags = (
+        ("candidate-a", "Candidate A", "a"),
+        ("candidate-b", "Candidate B", "b"),
+        ("candidate-c", "Candidate C", "c"),
+        ("candidate-d", "Candidate D", "d"),
+        ("generic", "Generic", "g"),
+        ("workflow", "[Workflow]", "w"),
+    )
+    connection.executemany(
+        "INSERT INTO source_tag(tag_id, name, source_hash) VALUES (?, ?, ?)", extra_tags
+    )
+    connection.executemany(
+        "INSERT INTO scene_tag(scene_id, tag_id, provenance) VALUES ('disliked', ?, 'scene')",
+        ((tag_id,) for tag_id, _, _ in extra_tags),
+    )
+    connection.executemany(
+        "INSERT INTO scene_tag(scene_id, tag_id, provenance) VALUES (?, 'generic', 'scene')",
+        (
+            ("old-good",),
+            ("recent-good",),
+            ("unseen-good",),
+            ("unlabeled",),
+            ("unusual",),
+        ),
+    )
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    api = CuratorAPI(connection)
+    api.submit_tag_preferences(
+        [
+            {
+                "preference_id": "answered",
+                "tag_id": "candidate-a",
+                "value": 0.5,
+                "occurred_at_ms": 10,
+            }
+        ]
+    )
+
+    follow_up = api.tag_sentiment_follow_up("disliked")
+
+    assert len(follow_up["items"]) == 3
+    assert {"candidate-a", "generic", "workflow"}.isdisjoint(
+        {item["tag_id"] for item in follow_up["items"]}
+    )
+
+    api.submit_feedback(
+        [
+            {
+                "feedback_id": "follow-up-down",
+                "scene_id": "unusual",
+                "feedback_type": "thumb_down",
+                "occurred_at_ms": 20,
+            }
+        ]
+    )
+    api.submit_tag_preferences(
+        [
+            {
+                "preference_id": "follow-up-tag",
+                "tag_id": "unusual",
+                "value": -1,
+                "occurred_at_ms": 21,
+            }
+        ]
+    )
+    assert (
+        connection.execute(
+            "SELECT feedback_type FROM feedback WHERE feedback_id='follow-up-down'"
+        ).fetchone()[0]
+        == "thumb_down"
+    )
+    assert (
+        connection.execute(
+            "SELECT value FROM direct_tag_preference WHERE preference_id='follow-up-tag'"
+        ).fetchone()[0]
+        == -1
+    )
+
+
 def test_similar_scenes_blend_similarity_with_appeal_and_explain_relationships(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -117,6 +117,29 @@ def test_scene_inspector_returns_complete_score_state(tmp_path: Path) -> None:
     assert inspected["explanation"]["summary"]
 
 
+def test_taste_profile_exposes_inference_and_direct_answer(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    api = CuratorAPI(connection)
+
+    profile = api.taste_profile()
+    good = next(item for item in profile["items"] if item["tag_id"] == "good")
+    assert good["name"] == "Familiar Scenario"
+    assert good["scene_count"] == 4
+    assert good["direct_value"] is None
+    assert good["prompt"] in {"belief", "uncertain"}
+
+    assert (
+        api.submit_tag_preferences(
+            [{"preference_id": "direct", "tag_id": "good", "value": 0.5, "occurred_at_ms": 10}]
+        )["accepted"]
+        == 1
+    )
+    good = next(item for item in api.taste_profile()["items"] if item["tag_id"] == "good")
+    assert good["direct_value"] == 0.5
+    assert good["prompt"] is None
+
+
 def test_similar_scenes_blend_similarity_with_appeal_and_explain_relationships(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_doctor_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
     assert result["status"] == "ok"
     assert result["stash"] == "not_configured"
     assert result["schema_current"] == 0
-    assert result["schema_latest"] == 15
+    assert result["schema_latest"] == 16
 
 
 def test_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+import pytest
+
 from curator.interactions import InteractionStore
 from curator.model import PreferenceModelBuilder
 from curator.ranking import SlateBuilder
@@ -40,6 +42,46 @@ def test_impressions_and_feedback_are_idempotent(tmp_path: Path) -> None:
         ]
         == 1
     )
+
+
+def test_tag_preferences_validate_replace_clear_and_ignore_stale_retries(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    store = InteractionStore(connection)
+    positive = {
+        "preference_id": "positive",
+        "tag_id": "good",
+        "value": 1,
+        "occurred_at_ms": 20,
+    }
+    stale = {**positive, "preference_id": "stale", "value": -1, "occurred_at_ms": 10}
+    clear = {**positive, "preference_id": "clear", "value": None, "occurred_at_ms": 30}
+
+    assert store.submit_tag_preferences([positive]) == 1
+    assert store.submit_tag_preferences([positive]) == 0
+    assert store.submit_tag_preferences([stale]) == 1
+    assert (
+        connection.execute(
+            "SELECT value FROM direct_tag_preference WHERE tag_id='good'"
+        ).fetchone()[0]
+        == 1
+    )
+    assert store.submit_tag_preferences([clear]) == 1
+    assert (
+        connection.execute("SELECT 1 FROM direct_tag_preference WHERE tag_id='good'").fetchone()
+        is None
+    )
+    assert (
+        connection.execute(
+            "SELECT count(*) FROM direct_tag_preference_history WHERE tag_id='good'"
+        ).fetchone()[0]
+        == 3
+    )
+
+    with pytest.raises(ValueError, match="five-point"):
+        store.submit_tag_preferences([{**positive, "preference_id": "bad", "value": 0.25}])
+    with pytest.raises(ValueError, match="unsupported"):
+        store.submit_tag_preferences([{**positive, "preference_id": "unknown", "tag_id": "x"}])
 
 
 def test_direct_sessions_record_views_and_quick_replacement(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add durable five-point direct tag sentiment and a searchable Taste Profile
- blend declared sentiment into shared recommendation, Similar, Expand, and explanation evidence
- offer an optional multi-tag follow-up after accepted thumbs-down feedback

## Verification

- `scripts/verify full`
- 183 tests passed

Closes #23
Closes #24
