### PR TITLE
Keep owned scenes out of Expand

### DIFF
--- a/curator/expand.py
+++ b/curator/expand.py
@@ -333,10 +333,9 @@ class ExpandService:
             if float(row["score"]) < minimum_score:
                 continue
             payload = json.loads(row["payload_json"])
-            if (
-                hide_phash_matches
-                and entity_type == "scene"
-                and (payload.get("curator_local_match") or {}).get("type") == "phash"
+            match_type = (payload.get("curator_local_match") or {}).get("type")
+            if entity_type == "scene" and (
+                match_type == "stashdb_id" or (hide_phash_matches and match_type == "phash")
             ):
                 continue
             if (

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -367,6 +367,28 @@ def test_performer_hunt_requires_a_stashdb_link(tmp_path: Path) -> None:
         raise AssertionError("unlinked performers must be rejected")
 
 
+def test_performer_hunt_does_not_leak_owned_scenes_into_expand(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    links = {
+        "scenes": {
+            "old-good": "owned-external-scene",
+            "old-bad": "hunt-linked",
+        },
+        "scene_phashes": {"0123456789abcdef": "old-good"},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {},
+    }
+    service = ExpandService(connection)
+
+    service.refresh(FakeStashDB(), links, now_ms=REFERENCE_MS, candidate_limit=10)
+    service.performer_hunt(PerformerHuntStashDB(), links, "p1", limit=10)
+
+    identifiers = {item["id"] for item in service.results("scene")["items"]}
+    assert "hunt-linked" not in identifiers
+    assert "hunt-old" in identifiers
+
+
 def test_expand_avoids_adjacent_repeated_performers() -> None:
     def row(identifier: str, performer: str):
         return {


### PR DESCRIPTION
## Summary
- always exclude exact StashDB-ID matches from Expand results
- preserve the optional pHash visibility toggle
- cover Performer Hunt cache population with a regression test

## Verification
- `scripts/verify full` (186 passed)