### PR TITLE
Keep tag sentiment out of neighbor corroboration

### DIFF
--- a/curator/config.py
+++ b/curator/config.py
@@ -75,7 +75,7 @@ class FeatureConfig:
 
 @dataclass(frozen=True)
 class ModelConfig:
-    algorithm_version: int = 4
+    algorithm_version: int = 5
     affinity_prior: float = 1.0
     affinity_confidence_scale: float = 3.0
     direct_confidence_scale: float = 0.8

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -415,6 +415,7 @@ class PreferenceModelBuilder:
                     **learned.contexts,
                     "declared_preference": direct_value,
                     "learned_affinity": learned.affinity,
+                    "learned_confidence": learned.confidence,
                 },
             )
         return result
@@ -769,9 +770,17 @@ class PreferenceModelBuilder:
                 if feature.family != "content" or feature.name in strengths:
                     continue
                 affinity = affinities.get(feature.feature_id)
-                strengths[feature.name] = (
-                    max(0.0, affinity.affinity) * affinity.confidence if affinity else 0.0
+                learned_affinity = (
+                    _number(affinity.contexts.get("learned_affinity", affinity.affinity))
+                    if affinity
+                    else 0.0
                 )
+                learned_confidence = (
+                    _number(affinity.contexts.get("learned_confidence", affinity.confidence))
+                    if affinity
+                    else 0.0
+                )
+                strengths[feature.name] = max(0.0, learned_affinity) * learned_confidence
         maximum = max(strengths.values(), default=0.0)
         generic = self.config.model.neighbor_generic_weight
         weighted: dict[str, dict[str, float]] = {}

--- a/docs/using-curator.md
+++ b/docs/using-curator.md
@@ -38,9 +38,10 @@ Open **Taste Profile** to review tag beliefs and answer with a fixed sentiment
 from strong dislike to strong like. A direct answer is strong evidence rather than a
 hard exclusion; **Neutral** is an explicit near-zero preference, while **Clear
 answer** returns the tag to behavior-derived inference. Answers are queued locally
-during transient failures. Search includes classified local tags, including performer
-attributes and tags that currently appear on zero scenes, so preferences can be
-declared before that content enters the library.
+during transient failures. Direct answers affect tag fit but do not count as separate
+behavioral corroboration. Search includes classified local tags, including performer
+attributes and tags that currently appear on zero scenes, so preferences can be declared
+before that content enters the library.
 
 After an accepted thumbs down, Curator may offer an optional, dismissible follow-up
 with up to three relevant content tags. Answer only the tags that contributed to the

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -277,6 +277,29 @@ def test_direct_tag_sentiment_overrides_and_clear_restores_inference(tmp_path: P
     assert affinity(restored.model_id)[0] == pytest.approx(inferred)
 
 
+def test_direct_tag_sentiment_does_not_rewrite_behavioral_neighbors(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    connection.execute(
+        """
+        INSERT INTO scene_tag(scene_id, tag_id, provenance)
+        VALUES ('unseen-good', 'unusual', 'scene')
+        """
+    )
+    builder = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS)
+    baseline = RecommendationModelStore(connection).scores(builder.build().model_id)["unseen-good"]
+
+    InteractionStore(connection).submit_tag_preferences(
+        [{"preference_id": "unusual", "tag_id": "unusual", "value": 1, "occurred_at_ms": 10}]
+    )
+    rated = RecommendationModelStore(connection).scores(builder.build().model_id)["unseen-good"]
+
+    assert float(rated.components["content"]["value"]) > float(
+        baseline.components["content"]["value"]
+    )
+    assert rated.components["content_neighbor"] == baseline.components["content_neighbor"]
+    assert rated.neighbors == baseline.neighbors
+
+
 def test_model_build_reports_stage_progress(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     progress: list[tuple[int, int]] = []


### PR DESCRIPTION
## Summary
- keep declared tag sentiment as strong direct content evidence
- preserve behavior-derived affinities for content-neighbor similarity
- rebuild existing models with algorithm version 5

## Verification
- scripts/verify full (187 passed)