### PR TITLE
Add correctable feedback history

### DIFF
--- a/curator/api.py
+++ b/curator/api.py
@@ -363,6 +363,51 @@ class CuratorAPI:
         inserted = InteractionStore(self.connection).submit_feedback(entries)
         return {"schema_version": API_SCHEMA_VERSION, "accepted": inserted}
 
+    def feedback_history(self, page: int = 1, page_size: int = 20) -> dict[str, object]:
+        if page < 1 or not 1 <= page_size <= 100:
+            raise ValueError("invalid feedback history page")
+        where = "feedback_type <> 'reversal'"
+        total = int(
+            self.connection.execute(f"SELECT count(*) FROM feedback WHERE {where}").fetchone()[0]
+        )
+        rows = self.connection.execute(
+            f"""
+            SELECT feedback_id, scene_id, feedback_type, value, occurred_at_ms,
+                   reversed_by_id
+            FROM feedback WHERE {where}
+            ORDER BY occurred_at_ms DESC, feedback_id DESC LIMIT ? OFFSET ?
+            """,
+            (page_size, (page - 1) * page_size),
+        )
+        return {
+            "schema_version": API_SCHEMA_VERSION,
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+            "items": [dict(row) for row in rows],
+        }
+
+    def correct_feedback(
+        self,
+        feedback_id: str,
+        correction_id: str,
+        feedback_type: str | None,
+        *,
+        now_ms: int | None = None,
+    ) -> dict[str, object]:
+        InteractionStore(self.connection).correct_feedback(
+            feedback_id,
+            correction_id,
+            feedback_type,
+            now_ms if now_ms is not None else time.time_ns() // 1_000_000,
+        )
+        return {
+            "schema_version": API_SCHEMA_VERSION,
+            "feedback_id": feedback_id,
+            "correction_id": correction_id,
+            "feedback_type": feedback_type,
+        }
+
     def submit_tag_preferences(self, entries: list[dict[str, Any]]) -> dict[str, object]:
         inserted = InteractionStore(self.connection).submit_tag_preferences(entries)
         return {"schema_version": API_SCHEMA_VERSION, "accepted": inserted}

--- a/curator/interactions.py
+++ b/curator/interactions.py
@@ -165,6 +165,95 @@ class InteractionStore:
                 ModelUpdateCoordinator(self.connection).request("direct_feedback")
         return inserted
 
+    def correct_feedback(
+        self,
+        feedback_id: str,
+        correction_id: str,
+        feedback_type: str | None,
+        occurred_at_ms: int,
+    ) -> None:
+        if feedback_type is not None and feedback_type not in FEEDBACK_TYPES:
+            raise ValueError(f"unknown feedback type: {feedback_type}")
+        if not feedback_id or not correction_id or occurred_at_ms < 0:
+            raise ValueError("feedback_id, correction_id, and occurred_at_ms are required")
+        with transaction(self.connection):
+            original = self.connection.execute(
+                """
+                SELECT scene_id, feedback_type, occurred_at_ms, reversed_by_id
+                FROM feedback WHERE feedback_id=?
+                """,
+                (feedback_id,),
+            ).fetchone()
+            if original is None:
+                raise ValueError("unknown feedback")
+            if original["reversed_by_id"] is not None:
+                raise ValueError("feedback was already corrected")
+            if occurred_at_ms < int(original["occurred_at_ms"]):
+                raise ValueError("correction cannot predate feedback")
+            scene_id = str(original["scene_id"])
+            correction = {
+                "feedback_id": correction_id,
+                "scene_id": scene_id,
+                "feedback_type": feedback_type or "reversal",
+                "value": None,
+                "occurred_at_ms": occurred_at_ms,
+                "impression_id": None,
+                "payload": {"replaces_feedback_id": feedback_id},
+            }
+            self.connection.execute(
+                """
+                INSERT INTO feedback(
+                    feedback_id, scene_id, feedback_type, value, occurred_at_ms,
+                    impression_id, payload_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    correction_id,
+                    scene_id,
+                    correction["feedback_type"],
+                    correction["value"],
+                    occurred_at_ms,
+                    correction["impression_id"],
+                    json.dumps(correction["payload"], separators=(",", ":")),
+                ),
+            )
+            self.connection.execute(
+                "UPDATE feedback SET reversed_by_id=? WHERE feedback_id=?",
+                (correction_id, feedback_id),
+            )
+            if feedback_type is not None:
+                self._apply_feedback(correction)
+            if not self.connection.execute(
+                """
+                SELECT 1 FROM feedback
+                WHERE scene_id=? AND feedback_type='never_show' AND reversed_by_id IS NULL
+                """,
+                (scene_id,),
+            ).fetchone():
+                self.connection.execute(
+                    """
+                    UPDATE exclusion SET reversed_at_ms=?
+                    WHERE entity_type='scene' AND entity_id=? AND exclusion_type='never_show'
+                    AND reversed_at_ms IS NULL
+                    """,
+                    (occurred_at_ms, scene_id),
+                )
+            if str(original["feedback_type"]) in {"thumb_down", "never_show", "prune"} and not (
+                self.connection.execute(
+                    """
+                    SELECT 1 FROM feedback
+                    WHERE scene_id=? AND feedback_type IN ('thumb_down', 'never_show', 'prune')
+                    AND reversed_by_id IS NULL
+                    """,
+                    (scene_id,),
+                ).fetchone()
+            ):
+                self.connection.execute(
+                    "DELETE FROM pruning_candidate WHERE scene_id=? AND state='review'",
+                    (scene_id,),
+                )
+            ModelUpdateCoordinator(self.connection).request("feedback_correction")
+
     def submit_tag_preferences(self, entries: list[dict[str, Any]]) -> int:
         normalized = [self._tag_preference_entry(entry) for entry in entries]
         inserted = 0

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -525,6 +525,17 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
             if not isinstance(entries, list):
                 raise ValueError("entries must be a list")
             return api.submit_feedback(entries)
+        if operation == "get_feedback_history":
+            return api.feedback_history(
+                int(args.get("page") or 1),
+                int(args.get("page_size") or 20),
+            )
+        if operation == "correct_feedback":
+            return api.correct_feedback(
+                str(args.get("feedback_id") or ""),
+                str(args.get("correction_id") or ""),
+                str(args["feedback_type"]) if args.get("feedback_type") else None,
+            )
         if operation == "submit_tag_preferences":
             entries = args.get("entries")
             if not isinstance(entries, list):

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -52,6 +52,13 @@
   const NAV_ITEMS = [
     ...LANES,
     {
+      value: "feedback",
+      label: "Feedback history",
+      icon: faThumbsUp,
+      maintenance: true,
+      description: "Review recent feedback, undo mistakes, or replace an action without rewriting history.",
+    },
+    {
       value: "similar",
       label: "Similar",
       icon: faClone,
@@ -684,6 +691,113 @@
         )
       ),
       saved && React.createElement("small", { role: "status" }, saved)
+    );
+  }
+
+  const FEEDBACK_LABELS = {
+    thumb_up: "Thumbs Up",
+    thumb_down: "Thumbs Down",
+    not_now: "Not Now",
+    never_show: "Never Show",
+    metadata_wrong: "Metadata Wrong",
+    prune: "Prune",
+  };
+
+  function FeedbackHistoryRow({ item, scene, onCorrect }) {
+    const [replacement, setReplacement] = React.useState("");
+    const [busy, setBusy] = React.useState(false);
+    const [error, setError] = React.useState("");
+    async function correct(feedbackType) {
+      setBusy(true);
+      setError("");
+      try {
+        await operation({
+          operation: "correct_feedback",
+          feedback_id: item.feedback_id,
+          correction_id: uuid(),
+          feedback_type: feedbackType || null,
+        });
+        scheduleModelUpdate();
+        onCorrect();
+      } catch (failure) {
+        setError(failure.message);
+      } finally {
+        setBusy(false);
+      }
+    }
+    return React.createElement(
+      "tr",
+      null,
+      React.createElement(
+        "td",
+        null,
+        scene
+          ? React.createElement(NavLink, { to: `/scenes/${item.scene_id}` }, scene.title || `Scene ${item.scene_id}`)
+          : React.createElement("span", { className: "text-muted" }, "Scene removed from Stash")
+      ),
+      React.createElement("td", null, FEEDBACK_LABELS[item.feedback_type] || item.feedback_type),
+      React.createElement("td", null, new Date(item.occurred_at_ms).toLocaleString()),
+      React.createElement(
+        "td",
+        null,
+        item.reversed_by_id
+          ? React.createElement("span", { className: "text-muted" }, "Corrected")
+          : React.createElement(
+              "div",
+              { className: "curator-feedback-correction" },
+              React.createElement(Button, { size: "sm", variant: "link", disabled: busy, onClick: () => correct(null) }, "Undo"),
+              React.createElement(
+                "select",
+                { className: "form-control form-control-sm", value: replacement, disabled: busy, onChange: (event) => setReplacement(event.target.value), "aria-label": "Replacement feedback" },
+                React.createElement("option", { value: "" }, "Replace with…"),
+                Object.entries(FEEDBACK_LABELS).map(([value, label]) => React.createElement("option", { key: value, value }, label))
+              ),
+              React.createElement(Button, { size: "sm", disabled: busy || !replacement, onClick: () => correct(replacement) }, "Save"),
+              error && React.createElement("small", { className: "text-danger" }, error)
+            )
+      )
+    );
+  }
+
+  function FeedbackHistoryPanel() {
+    const [page, setPage] = React.useState(1);
+    const [data, setData] = React.useState(null);
+    const [loading, setLoading] = React.useState(true);
+    const [error, setError] = React.useState("");
+    const [version, setVersion] = React.useState(0);
+    React.useEffect(() => {
+      let active = true;
+      setLoading(true);
+      setError("");
+      operation({ operation: "get_feedback_history", page }).then(
+        (result) => active && (setData(result), setLoading(false)),
+        (failure) => active && (setError(failure.message), setLoading(false))
+      );
+      return () => { active = false; };
+    }, [page, version]);
+    const ids = [...new Set(data?.items.map((item) => item.scene_id) || [])];
+    const scenesQuery = GQL.useFindScenesQuery({
+      variables: { filter: { per_page: Math.max(1, ids.length) }, scene_filter: idFilter(ids) },
+      skip: ids.length === 0,
+    });
+    const scenes = new Map((scenesQuery.data?.findScenes?.scenes || []).map((scene) => [String(scene.id), scene]));
+    return React.createElement(
+      "section",
+      { className: "curator-history-page" },
+      loading && React.createElement("div", { role: "status" }, "Loading feedback history…"),
+      error && React.createElement("div", { className: "alert alert-danger" }, error),
+      data && !loading && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No feedback has been recorded yet."),
+      data && data.items.length > 0 && React.createElement(
+        "div",
+        { className: "table-responsive" },
+        React.createElement(
+          "table",
+          { className: "table" },
+          React.createElement("thead", null, React.createElement("tr", null, ["Scene", "Action", "Time", "Correction"].map((label) => React.createElement("th", { key: label, scope: "col" }, label)))),
+          React.createElement("tbody", null, data.items.map((item) => React.createElement(FeedbackHistoryRow, { key: item.feedback_id, item, scene: scenes.get(String(item.scene_id)), onCorrect: () => setVersion((value) => value + 1) })))
+        )
+      ),
+      data && React.createElement(Pager, { page, hasMore: page * data.page_size < data.total, loading, onPage: setPage, label: "Feedback history pages" })
     );
   }
 
@@ -1623,6 +1737,7 @@
         )
       ),
       followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),
+      lane === "feedback" && React.createElement(FeedbackHistoryPanel),
       lane === "similar" && !loadingComponents && React.createElement(SimilarityPanel, { initialType: route.get("type") || "scene", initialId: route.get("id"), initialLabel: route.get("label") }),
       lane === "prune" && !loadingComponents && React.createElement(PrunePanel),
       lane === "taste" && React.createElement(TasteProfilePanel),

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -142,6 +142,20 @@ def test_thumb_down_follow_up_is_optional_and_survives_card_removal() -> None:
     assert "submitTagPreference(tag.tag_id, value);" in source
 
 
+def test_feedback_history_can_undo_or_replace_append_only_actions() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
+
+    assert 'value: "feedback"' in source
+    assert 'label: "Feedback history"' in source
+    assert 'operation: "get_feedback_history"' in source
+    assert 'operation: "correct_feedback"' in source
+    assert '"Scene removed from Stash"' in source
+    assert '"Replacement feedback"' in source
+    assert 'className: "form-control form-control-sm", value: replacement' in source
+    assert "icon: faThumbsUp,\n      maintenance: true" in source
+    assert "scheduleModelUpdate();" in source
+
+
 def test_external_scene_cards_can_rate_matching_local_tags() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -70,6 +70,35 @@ def test_slate_api_never_builds_a_pending_model_inline(
     assert result["items"]
 
 
+def test_feedback_history_is_newest_first_paginated_and_correctable(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    api = CuratorAPI(connection)
+    existing = int(api.feedback_history()["total"])
+    for feedback_id, feedback_type, occurred_at_ms in (
+        ("older", "thumb_down", REFERENCE_MS + 10),
+        ("newer", "not_now", REFERENCE_MS + 20),
+    ):
+        api.submit_feedback(
+            [
+                {
+                    "feedback_id": feedback_id,
+                    "scene_id": "old-good",
+                    "feedback_type": feedback_type,
+                    "occurred_at_ms": occurred_at_ms,
+                }
+            ]
+        )
+
+    first = api.feedback_history(page=1, page_size=1)
+    second = api.feedback_history(page=2, page_size=1)
+    assert first["total"] == existing + 2
+    assert first["items"][0]["feedback_id"] == "newer"
+    assert second["items"][0]["feedback_id"] == "older"
+
+    api.correct_feedback("newer", "undo", None, now_ms=REFERENCE_MS + 30)
+    assert api.feedback_history()["items"][0]["reversed_by_id"] == "undo"
+
+
 def test_slate_api_pages_one_ranked_prefix_with_global_positions(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -160,6 +160,53 @@ def test_never_show_and_pruning_apply_operational_state(tmp_path: Path) -> None:
     )
 
 
+def test_feedback_corrections_preserve_history_and_reconcile_state(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    store = InteractionStore(connection)
+    assert (
+        store.submit_feedback(
+            [
+                {
+                    "feedback_id": "never",
+                    "scene_id": "old-good",
+                    "feedback_type": "never_show",
+                    "occurred_at_ms": 10,
+                }
+            ]
+        )
+        == 1
+    )
+
+    store.correct_feedback("never", "replacement", "thumb_up", 20)
+
+    rows = connection.execute(
+        """
+        SELECT feedback_id, feedback_type, reversed_by_id
+        FROM feedback WHERE scene_id='old-good' ORDER BY occurred_at_ms
+        """
+    ).fetchall()
+    assert [tuple(row) for row in rows] == [
+        ("never", "never_show", "replacement"),
+        ("replacement", "thumb_up", None),
+    ]
+    assert (
+        connection.execute(
+            "SELECT reversed_at_ms FROM exclusion WHERE entity_id='old-good'"
+        ).fetchone()[0]
+        == 20
+    )
+    assert (
+        connection.execute("SELECT 1 FROM pruning_candidate WHERE scene_id='old-good'").fetchone()
+        is None
+    )
+    assert (
+        connection.execute(
+            "SELECT last_cause FROM model_update_state WHERE singleton=1"
+        ).fetchone()[0]
+        == "feedback_correction"
+    )
+
+
 def test_short_curator_session_followed_by_another_scene_records_replacement(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- add newest-first paginated feedback history
- support append-only undo and replacement while reconciling exclusions
- place Feedback history under Maintenance with themed controls

## Verification
- focused plugin regression: 22 passed
- combined five-issue suite: 198 passed
- clean sequential integration with #18-#21

Closes #17