### PR TITLE
Add first-run setup checklist

### DIFF
--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -52,6 +52,7 @@ RUNTIME_QUERY = """
 query CuratorPluginRuntime {
   version { version }
   jobQueue { id status description progress startTime }
+  configuration { general { stashBoxes { endpoint api_key } } }
 }
 """
 SETTINGS_QUERY = """
@@ -358,8 +359,16 @@ def _health(payload: dict[str, Any]) -> dict[str, object]:
         "stash_version": stash["version"]["version"],
         "database": str(_database_path(payload, settings)),
         "database_schema": migration.current_version,
+        "database_schema_latest": migration.latest_version,
+        "sidecar_ready": not migration.pending_versions,
         "model_id": str(current[0]) if current else None,
         "ready": current is not None,
+        "sync_ready": last_sync is not None,
+        "stashdb_available": any(
+            str(box.get("endpoint") or "").rstrip("/").casefold() == STASHDB.rstrip("/").casefold()
+            and bool(box.get("api_key"))
+            for box in stash["configuration"]["general"]["stashBoxes"]
+        ),
         "capture": capture,
         "model_pending": model_update.pending,
         "model_pending_events": model_update.pending_count,

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -403,6 +403,28 @@
   order: 3;
 }
 
+.curator-setup-checklist {
+  grid-column: 1 / -1;
+  order: 2;
+}
+
+.curator-setup-checklist h2 {
+  font-size: 1.1rem;
+}
+
+.curator-setup-checklist ul {
+  display: grid;
+  gap: 0.3rem;
+  list-style: none;
+  padding: 0;
+}
+
+.curator-setup-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
 .curator-job-progress {
   background: rgba(255, 255, 255, 0.12);
   border-radius: 999px;

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -1426,6 +1426,26 @@
           : "Not built";
     const activeJob = health?.active_job;
     const progress = typeof activeJob?.progress === "number" ? activeJob.progress : null;
+    const setupChecklist = health && !health.ready && React.createElement(
+      "section",
+      { className: "curator-setup-checklist", "aria-labelledby": "curator-setup-heading" },
+      React.createElement("h2", { id: "curator-setup-heading" }, "Finish Curator setup"),
+      React.createElement(
+        "ul",
+        null,
+        React.createElement("li", null, React.createElement(FontAwesomeIcon, { icon: health.sidecar_ready ? faCheckCircle : faWrench }), ` Sidecar and migrations: ${health.sidecar_ready ? `ready (schema ${health.database_schema})` : "needs attention"}`),
+        React.createElement("li", null, React.createElement(FontAwesomeIcon, { icon: health.sync_ready ? faCheckCircle : faClock }), ` Library sync: ${health.sync_ready ? "complete" : activeJob ? "running" : "not started"}`),
+        React.createElement("li", null, React.createElement(FontAwesomeIcon, { icon: health.ready ? faCheckCircle : faClock }), ` Recommendation model: ${health.model_rebuilding ? "building" : "not built"}`),
+        React.createElement("li", null, React.createElement(FontAwesomeIcon, { icon: health.stashdb_available ? faCheckCircle : faGlobe }), ` StashDB: ${health.stashdb_available ? "available" : "optional — not configured"}`)
+      ),
+      lastError && React.createElement("div", { className: "alert alert-danger" }, React.createElement("strong", null, "Initial sync failed: "), lastError.error, " Open Tasks for the full log, correct the problem, then retry."),
+      React.createElement(
+        "div",
+        { className: "curator-setup-actions" },
+        React.createElement(Button, { size: "sm", disabled: Boolean(activeJob), onClick: () => start("Sync and build recommendations") }, activeJob ? "Setup task running…" : "Sync and build recommendations"),
+        React.createElement(NavLink, { className: "btn btn-secondary btn-sm", to: "/settings?tab=plugins" }, "Open plugin settings")
+      )
+    );
 
     return React.createElement(
       React.Fragment,
@@ -1450,6 +1470,7 @@
           React.createElement(NavLink, { className: "btn btn-secondary btn-sm curator-icon-button", title: "Open Curator's plugin settings.", "aria-label": "Plugin settings", to: "/settings?tab=plugins" }, React.createElement(FontAwesomeIcon, { icon: faCog }))
         )
       ),
+      setupChecklist,
       activeJob && React.createElement("div", { className: "curator-active-job" }, React.createElement("span", null, activeJob.description), progress !== null && React.createElement("strong", null, `${Math.round(progress * 100)}%`), React.createElement("div", { className: "curator-job-progress" }, React.createElement("span", { style: { width: `${Math.round((progress || 0) * 100)}%` } })), React.createElement(NavLink, { to: "/settings?tab=tasks" }, "View tasks")),
       lastError && React.createElement("small", { className: "curator-header-message text-danger" }, lastError.error),
       message && React.createElement("p", { className: "curator-header-message", role: "status" }, message)

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -321,6 +321,50 @@ def test_external_links_collect_normalized_local_phashes(
     assert links["scene_phashes"] == {"d8bc7554c5a178aa": "local-scene"}
 
 
+def test_first_run_health_reports_setup_states(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
+    spec = importlib.util.spec_from_file_location("curator_plugin_health", backend)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    runtime = {
+        "version": {"version": "0.31.0"},
+        "jobQueue": [],
+        "configuration": {
+            "general": {
+                "stashBoxes": [{"endpoint": "https://stashdb.org/graphql", "api_key": "configured"}]
+            }
+        },
+    }
+    monkeypatch.setattr(module, "_settings", lambda _payload: {})
+    monkeypatch.setattr(
+        module,
+        "_client",
+        lambda _payload: SimpleNamespace(execute=lambda *_args: runtime),
+    )
+
+    health = module._health({"args": {"database_path": str(tmp_path / "curator.sqlite3")}})
+
+    assert health["sidecar_ready"] is True
+    assert health["database_schema"] == health["database_schema_latest"]
+    assert health["sync_ready"] is False
+    assert health["ready"] is False
+    assert health["stashdb_available"] is True
+
+
+def test_first_run_checklist_starts_setup_and_shows_actionable_errors() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
+
+    assert "health && !health.ready" in source
+    assert "Sidecar and migrations:" in source
+    assert '"optional — not configured"' in source
+    assert 'start("Sync and build recommendations")' in source
+    assert '"Initial sync failed: "' in source
+    assert 'to: "/settings?tab=plugins"' in source
+
+
 def test_reused_model_keeps_existing_lane_classifications(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- expose schema, sidecar, sync, and optional StashDB readiness
- show a compact actionable setup checklist only while Curator is not ready
- provide direct sync and settings actions with recent-error guidance

## Verification
- focused plugin regression: 22 passed
- combined five-issue suite: 198 passed
- clean sequential integration with #17 and #19-#21

Closes #18