### PR TITLE
Add recommendation history

### DIFF
--- a/curator/api.py
+++ b/curator/api.py
@@ -313,6 +313,57 @@ class CuratorAPI:
             "reasons": [asdict(reason) for reason in explanation.all_reasons],
         }
 
+    def recommendation_history(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        *,
+        lane: str | None = None,
+    ) -> dict[str, object]:
+        if page < 1 or not 1 <= page_size <= 100:
+            raise ValueError("invalid recommendation history page")
+        if lane and lane not in {"for_you", "best_bets", "revisit", "discover", "adventure"}:
+            raise ValueError("unknown recommendation lane")
+        where = "WHERE h.lane=?" if lane else ""
+        parameters: tuple[object, ...] = (lane,) if lane else ()
+        total = int(
+            self.connection.execute(
+                f"SELECT count(*) FROM recommendation_history h {where}",
+                parameters,
+            ).fetchone()[0]
+        )
+        rows = self.connection.execute(
+            f"""
+            SELECT h.history_id, h.scene_id, h.impression_id, h.lane, h.shown_at_ms,
+                   i.reason_snapshot_json,
+                   EXISTS(
+                     SELECT 1 FROM model_scene_score score
+                     JOIN model_version model USING(model_id)
+                     WHERE model.status='published' AND score.scene_id=h.scene_id
+                   ) AS current_model
+            FROM recommendation_history h
+            LEFT JOIN impression_item i
+              ON i.impression_id=h.impression_id AND i.scene_id=h.scene_id
+            {where}
+            ORDER BY h.shown_at_ms DESC, h.history_id DESC LIMIT ? OFFSET ?
+            """,
+            (*parameters, page_size, (page - 1) * page_size),
+        )
+        items = []
+        for row in rows:
+            item = dict(row)
+            snapshot = item.pop("reason_snapshot_json")
+            item["reason_snapshot"] = json.loads(str(snapshot)) if snapshot else []
+            items.append(item)
+        return {
+            "schema_version": API_SCHEMA_VERSION,
+            "page": page,
+            "page_size": page_size,
+            "total": total,
+            "lane": lane,
+            "items": items,
+        }
+
     def expand(
         self,
         entity_type: str,

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -430,6 +430,12 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
             )
         if operation == "get_explanation":
             return api.explanation(str(args.get("scene_id") or ""))
+        if operation == "get_recommendation_history":
+            return api.recommendation_history(
+                int(args.get("page") or 1),
+                int(args.get("page_size") or 20),
+                lane=str(args["lane"]) if args.get("lane") else None,
+            )
         if operation == "get_expand":
             config = api.config()["config"]
             assert isinstance(config, dict)

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -58,6 +58,13 @@
       description: "Choose a scene or performer, then compare preference-aware matches from your Library or StashDB.",
     },
     {
+      value: "history",
+      label: "Recently recommended",
+      icon: faHistory,
+      maintenance: true,
+      description: "Revisit qualified recommendations with the reasons recorded when each card appeared.",
+    },
+    {
       value: "expand",
       label: "Expand",
       icon: faGlobe,
@@ -782,6 +789,108 @@
           React.createElement(Feedback, { item, onRemove, onThumbDown })
         )
       )
+    );
+  }
+
+  function RecommendationHistoryRow({ item, scene }) {
+    const [explanation, setExplanation] = React.useState(null);
+    const [error, setError] = React.useState("");
+    async function explain() {
+      setError("");
+      try {
+        setExplanation(await operation({ operation: "get_explanation", scene_id: item.scene_id }));
+      } catch (failure) {
+        setError(failure.message);
+      }
+    }
+    return React.createElement(
+      "tr",
+      null,
+      React.createElement(
+        "td",
+        null,
+        scene
+          ? React.createElement(NavLink, { to: `/scenes/${item.scene_id}` }, scene.title || `Scene ${item.scene_id}`)
+          : React.createElement("span", { className: "text-muted" }, "Scene removed from Stash")
+      ),
+      React.createElement("td", null, laneByValue.get(item.lane)?.label || item.lane),
+      React.createElement(
+        "td",
+        null,
+        item.reason_snapshot.length
+          ? item.reason_snapshot.map(reasonLabel).join(" · ")
+          : "No reason snapshot recorded"
+      ),
+      React.createElement(
+        "td",
+        null,
+        item.current_model && scene && !explanation && React.createElement(Button, { size: "sm", variant: "link", onClick: explain }, "Why this now?"),
+        explanation && React.createElement("span", null, explanation.summary),
+        error && React.createElement("small", { className: "text-danger" }, error)
+      )
+    );
+  }
+
+  function RecommendationHistoryPanel() {
+    const [page, setPage] = React.useState(1);
+    const [laneFilter, setLaneFilter] = React.useState("");
+    const [data, setData] = React.useState(null);
+    const [loading, setLoading] = React.useState(true);
+    const [error, setError] = React.useState("");
+    React.useEffect(() => {
+      let active = true;
+      setLoading(true);
+      setError("");
+      operation({ operation: "get_recommendation_history", page, lane: laneFilter || null }).then(
+        (result) => active && (setData(result), setLoading(false)),
+        (failure) => active && (setError(failure.message), setLoading(false))
+      );
+      return () => { active = false; };
+    }, [page, laneFilter]);
+    const ids = [...new Set(data?.items.map((item) => item.scene_id) || [])];
+    const scenesQuery = GQL.useFindScenesQuery({
+      variables: { filter: { per_page: Math.max(1, ids.length) }, scene_filter: idFilter(ids) },
+      skip: ids.length === 0,
+    });
+    const scenes = new Map((scenesQuery.data?.findScenes?.scenes || []).map((scene) => [String(scene.id), scene]));
+    const groups = (data?.items || []).reduce((result, item) => {
+      const date = new Date(item.shown_at_ms).toLocaleDateString();
+      (result[date] ||= []).push(item);
+      return result;
+    }, {});
+    return React.createElement(
+      "section",
+      { className: "curator-history-page" },
+      React.createElement(
+        "label",
+        null,
+        "Lane ",
+        React.createElement(
+          "select",
+          { className: "form-control form-control-sm", value: laneFilter, onChange: (event) => (setLaneFilter(event.target.value), setPage(1)), "aria-label": "Filter recommendation history by lane" },
+          React.createElement("option", { value: "" }, "All lanes"),
+          LANES.map((lane) => React.createElement("option", { key: lane.value, value: lane.value }, lane.label))
+        )
+      ),
+      loading && React.createElement("div", { role: "status" }, "Loading recommendation history…"),
+      error && React.createElement("div", { className: "alert alert-danger" }, error),
+      data && !loading && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No qualified recommendations have been recorded yet."),
+      Object.entries(groups).map(([date, items]) => React.createElement(
+        "section",
+        { key: date },
+        React.createElement("h3", null, date),
+        React.createElement(
+          "div",
+          { className: "table-responsive" },
+          React.createElement(
+            "table",
+            { className: "table" },
+            React.createElement("thead", null, React.createElement("tr", null, ["Scene", "Lane", "Reason shown", "Current explanation"].map((label) => React.createElement("th", { key: label, scope: "col" }, label)))),
+            React.createElement("tbody", null, items.map((item) => React.createElement(RecommendationHistoryRow, { key: item.history_id, item, scene: scenes.get(String(item.scene_id)) })))
+          )
+        )
+      )),
+      data && React.createElement(Pager, { page, hasMore: page * data.page_size < data.total, loading, onPage: setPage, label: "Recommendation history pages" })
     );
   }
 
@@ -1624,6 +1733,7 @@
       ),
       followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),
       lane === "similar" && !loadingComponents && React.createElement(SimilarityPanel, { initialType: route.get("type") || "scene", initialId: route.get("id"), initialLabel: route.get("label") }),
+      lane === "history" && React.createElement(RecommendationHistoryPanel),
       lane === "prune" && !loadingComponents && React.createElement(PrunePanel),
       lane === "taste" && React.createElement(TasteProfilePanel),
       lane === "expand" && React.createElement(ExpandPanel, { key: "expand", initialPerformerId: route.get("performer") }),

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -106,6 +106,19 @@ def test_curator_tabs_update_browser_history() -> None:
     assert "onClick: () => openView(option.value)" in source
 
 
+def test_recent_recommendations_reuse_qualified_impression_history() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
+
+    assert 'value: "history"' in source
+    assert "icon: faHistory,\n      maintenance: true" in source
+    assert 'operation: "get_recommendation_history"' in source
+    assert '"Filter recommendation history by lane"' in source
+    assert 'className: "form-control form-control-sm", value: laneFilter' in source
+    assert '"Scene removed from Stash"' in source
+    assert "item.reason_snapshot.map(reasonLabel)" in source
+    assert '"Why this now?"' in source
+
+
 def test_taste_profile_uses_fixed_durable_tag_sentiment_control() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -506,3 +506,38 @@ def test_never_show_can_be_reversed_explicitly(tmp_path: Path) -> None:
     assert api.exclusions()["items"][0]["scene_id"] == "old-good"
     assert api.reverse_exclusion("old-good", now_ms=2)["reversed"] is True
     assert api.exclusions()["items"] == []
+
+
+def test_recommendation_history_uses_qualified_impressions_without_new_tracking(
+    tmp_path: Path,
+) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    api = CuratorAPI(connection)
+    for impression_id, lane, shown_at_ms in (
+        ("older", "best_bets", REFERENCE_MS + 10),
+        ("newer", "discover", REFERENCE_MS + 20),
+    ):
+        slate = api.get_slate("for_you", 1, impression_id=impression_id, now_ms=shown_at_ms - 1)
+        connection.execute(
+            "UPDATE impression SET lane=? WHERE impression_id=?",
+            (lane, impression_id),
+        )
+        api.submit_events(
+            [
+                {
+                    "event_id": f"qualified:{impression_id}",
+                    "event_type": "qualified_impression",
+                    "impression_id": impression_id,
+                    "scene_id": slate["items"][0]["scene_id"],
+                    "occurred_at_ms": shown_at_ms,
+                }
+            ]
+        )
+
+    history = api.recommendation_history(page_size=1)
+    assert history["total"] == 2
+    assert history["items"][0]["impression_id"] == "newer"
+    assert history["items"][0]["reason_snapshot"]
+    assert history["items"][0]["current_model"] == 1
+    assert api.recommendation_history(lane="best_bets")["items"][0]["impression_id"] == "older"


### PR DESCRIPTION
## Summary
- reuse qualified impression history for newest-first recommendation history
- group entries by date with lane filtering and recorded reason snapshots
- place Recently recommended under Maintenance with a dark-theme-safe filter

## Verification
- focused plugin regression: 22 passed
- combined five-issue suite: 198 passed
- clean sequential integration with #17-#18 and #20-#21

Closes #19