### PR TITLE
Add safe backup restore controls

### DIFF
--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sys
 import time
 from collections.abc import Callable
@@ -219,6 +220,115 @@ def _database_path(payload: dict[str, Any], settings: dict[str, Any] | None = No
     if not configured:
         configured = str((settings or {}).get("databasePath") or "").strip()
     return Path(configured).expanduser() if configured else PLUGIN_DIR / "data" / "curator.sqlite3"
+
+
+BACKUP_NAME = re.compile(r"curator-(?:before-restore-)?(?P<created>\d+)\.sqlite3\.backup")
+
+
+def _backup_directory(payload: dict[str, Any], settings: dict[str, Any]) -> Path:
+    configured = str(settings.get("backupPath") or "").strip()
+    return (
+        Path(configured).expanduser().resolve()
+        if configured
+        else _database_path(payload, settings).expanduser().resolve().parent
+    )
+
+
+def _list_backups(payload: dict[str, Any], settings: dict[str, Any]) -> list[dict[str, object]]:
+    directory = _backup_directory(payload, settings)
+    if not directory.is_dir():
+        return []
+    items = []
+    for path in directory.iterdir():
+        match = BACKUP_NAME.fullmatch(path.name)
+        if match and path.is_file() and not path.is_symlink():
+            items.append(
+                {
+                    "id": path.name,
+                    "created_at_ms": int(match.group("created")),
+                    "size_bytes": path.stat().st_size,
+                    "path": str(path.resolve()),
+                }
+            )
+    return sorted(items, key=lambda item: int(str(item["created_at_ms"])), reverse=True)
+
+
+def _validate_backup(path: Path) -> None:
+    connection = connect_database(path, readonly=True)
+    try:
+        if str(connection.execute("PRAGMA quick_check").fetchone()[0]) != "ok":
+            raise ValueError("backup failed SQLite integrity validation")
+        if not connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='schema_migration'"
+        ).fetchone():
+            raise ValueError("backup is not a Curator database")
+        MigrationRunner(connection).status()
+    except Exception as error:
+        raise ValueError(f"incompatible Curator backup: {error}") from error
+    finally:
+        connection.close()
+
+
+def _backup_control(
+    payload: dict[str, Any], operation: str, settings: dict[str, Any]
+) -> dict[str, object]:
+    args = payload.get("args") or {}
+    database = _database_path(payload, settings).expanduser().resolve()
+    directory = _backup_directory(payload, settings)
+    if operation == "list_backups":
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "backup_directory": str(directory),
+            "items": _list_backups(payload, settings),
+        }
+    connection = _open(payload, settings)
+    try:
+        if connection.execute("SELECT 1 FROM curator_job WHERE state='running' LIMIT 1").fetchone():
+            raise RuntimeError("cannot change backups while a Curator job is running")
+        now_ms = time.time_ns() // 1_000_000
+        if operation == "create_backup":
+            backup = backup_database(
+                connection,
+                directory / f"curator-{now_ms}.sqlite3.backup",
+            )
+            return {
+                "schema_version": SCHEMA_VERSION,
+                "backup_path": str(backup),
+                "items": _list_backups(payload, settings),
+            }
+        backup_id = str(args.get("backup_id") or "")
+        match = BACKUP_NAME.fullmatch(backup_id)
+        backup = directory / backup_id
+        if (
+            not match
+            or backup.parent.resolve() != directory
+            or not backup.is_file()
+            or backup.is_symlink()
+        ):
+            raise ValueError("select a recognized Curator backup")
+        if str(args.get("confirmation") or "") != f"RESTORE {backup_id}":
+            raise ValueError("restore requires explicit confirmation")
+        _validate_backup(backup)
+        safety = backup_database(
+            connection,
+            directory / f"curator-before-restore-{now_ms}.sqlite3.backup",
+        )
+    finally:
+        connection.close()
+    for suffix in ("-wal", "-shm"):
+        Path(f"{database}{suffix}").unlink(missing_ok=True)
+    source = connect_database(backup, readonly=True)
+    try:
+        backup_database(source, database, overwrite=True)
+    finally:
+        source.close()
+    restored = _open(payload, settings)
+    restored.close()
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "restored_from": str(backup.resolve()),
+        "safety_backup": str(safety),
+    }
 
 
 def _apply_plugin_settings(connection: Any, settings: dict[str, Any]) -> None:
@@ -872,7 +982,9 @@ def _run_task_body(
             summary = {"model_id": model_id, "lane_candidate_caches": lane_caches}
         elif mode == "backup":
             _progress(0.1)
-            destination = PLUGIN_DIR / "data" / f"curator-{started_at_ms}.sqlite3.backup"
+            destination = (
+                _backup_directory(payload, settings) / f"curator-{started_at_ms}.sqlite3.backup"
+            )
             with span("python", "task.backup"):
                 backup_database(connection, destination)
             _progress(0.98)
@@ -967,6 +1079,8 @@ def dispatch(payload: dict[str, Any]) -> dict[str, object]:
         return _health(payload)
     if operation == "round_trip":
         return _round_trip(payload)
+    if operation in {"list_backups", "create_backup", "restore_backup"}:
+        return _backup_control(payload, operation, _settings(payload))
     if operation == "reset":
         if str((payload.get("args") or {}).get("confirmation") or "") != "RESET":
             raise ValueError("reset requires confirmation")

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -64,6 +64,13 @@
       description: "External metadata candidates scored locally. Wildcard items are selected outside preference-derived seeds.",
     },
     {
+      value: "backups",
+      label: "Backups",
+      icon: faDatabase,
+      maintenance: true,
+      description: "Create, inspect, and safely restore Curator sidecar backups.",
+    },
+    {
       value: "hunt",
       label: "Performer Hunt",
       icon: faCrosshairs,
@@ -1279,6 +1286,79 @@
     );
   }
 
+  function BackupPanel() {
+    const [data, setData] = React.useState(null);
+    const [busy, setBusy] = React.useState(false);
+    const [message, setMessage] = React.useState("");
+    const [error, setError] = React.useState("");
+    async function load() {
+      try {
+        setData(await operation({ operation: "list_backups" }));
+      } catch (failure) {
+        setError(failure.message);
+      }
+    }
+    React.useEffect(() => { load(); }, []);
+    async function create() {
+      setBusy(true);
+      setError("");
+      try {
+        const result = await operation({ operation: "create_backup" }, 120000);
+        setMessage(`Backup created: ${result.backup_path}`);
+        setData((current) => ({ ...current, items: result.items }));
+      } catch (failure) {
+        setError(failure.message);
+      } finally {
+        setBusy(false);
+      }
+    }
+    async function restore(item) {
+      if (!window.confirm(`Restore ${item.id}? Curator will first back up the current sidecar.`)) return;
+      setBusy(true);
+      setError("");
+      try {
+        const result = await operation({
+          operation: "restore_backup",
+          backup_id: item.id,
+          confirmation: `RESTORE ${item.id}`,
+        }, 120000);
+        clearSlateCache();
+        setMessage(`Restored from ${result.restored_from}. Safety backup: ${result.safety_backup}`);
+        await load();
+      } catch (failure) {
+        setError(failure.message);
+      } finally {
+        setBusy(false);
+      }
+    }
+    return React.createElement(
+      "section",
+      { className: "curator-backup-page" },
+      React.createElement(Button, { size: "sm", disabled: busy, onClick: create }, busy ? "Working…" : "Create backup"),
+      data && React.createElement("p", null, `Backup directory: ${data.backup_directory}`),
+      message && React.createElement("div", { className: "alert alert-success", role: "status" }, message),
+      error && React.createElement("div", { className: "alert alert-danger" }, error),
+      data && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No Curator backups found."),
+      data && data.items.length > 0 && React.createElement(
+        "div",
+        { className: "table-responsive" },
+        React.createElement(
+          "table",
+          { className: "table" },
+          React.createElement("thead", null, React.createElement("tr", null, ["Created", "Size", "File", "Action"].map((label) => React.createElement("th", { key: label, scope: "col" }, label)))),
+          React.createElement("tbody", null, data.items.map((item) => React.createElement(
+            "tr",
+            { key: item.id },
+            React.createElement("td", null, new Date(item.created_at_ms).toLocaleString()),
+            React.createElement("td", null, `${(item.size_bytes / 1048576).toFixed(1)} MB`),
+            React.createElement("td", null, item.id),
+            React.createElement("td", null, React.createElement(Button, { size: "sm", variant: "danger", disabled: busy, onClick: () => restore(item) }, "Restore"))
+          )))
+        )
+      )
+    );
+  }
+
   function ProfilingPanel() {
     const [profiles, setProfiles] = React.useState(null);
     const [selected, setSelected] = React.useState(null);
@@ -1627,6 +1707,7 @@
       lane === "prune" && !loadingComponents && React.createElement(PrunePanel),
       lane === "taste" && React.createElement(TasteProfilePanel),
       lane === "expand" && React.createElement(ExpandPanel, { key: "expand", initialPerformerId: route.get("performer") }),
+      lane === "backups" && React.createElement(BackupPanel),
       lane === "hunt" && React.createElement(ExpandPanel, { key: "hunt", initialType: "hunt", huntOnly: true }),
       lane === "profiling" && React.createElement(ProfilingPanel),
       (loading || loadingComponents || scenesQuery.loading) &&

--- a/plugin/stash-curator.yml
+++ b/plugin/stash-curator.yml
@@ -25,6 +25,10 @@ settings:
     displayName: Sidecar database path
     description: Leave empty to store data in the plugin's data directory.
     type: STRING
+  backupPath:
+    displayName: Backup directory
+    description: Leave empty to store Curator backups beside the sidecar database.
+    type: STRING
   pageSize:
     displayName: Results per page
     description: Number of results shown on Curator recommendation, Similar, and Expand pages. Default 20.

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -99,6 +99,76 @@ def test_plugin_archive_contains_runtime_and_core(tmp_path: Path) -> None:
         assert connection.execute("SELECT last_error FROM model_update_state").fetchone()[0]
 
 
+def test_backup_management_uses_recognized_ids_and_explicit_confirmation() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
+
+    assert "icon: faDatabase,\n      maintenance: true" in source
+    assert 'value: "backups"' in source
+    assert 'operation: "list_backups"' in source
+    assert 'operation: "create_backup"' in source
+    assert 'operation({ operation: "create_backup" }, 120000)' in source
+    assert 'operation: "restore_backup"' in source
+    assert "backup_id: item.id" in source
+    assert "confirmation: `RESTORE ${item.id}`" in source
+    assert "Safety backup:" in source
+
+
+def test_backup_controls_validate_ids_refuse_jobs_and_restore_with_safety_copy(
+    tmp_path: Path,
+) -> None:
+    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
+    spec = importlib.util.spec_from_file_location("curator_plugin_backups", backend)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    database = tmp_path / "curator.sqlite3"
+    backups = tmp_path / "backups"
+    payload = {"args": {"database_path": str(database)}}
+    settings = {"backupPath": str(backups)}
+    connection = module._open(payload, settings)
+    module.CuratorAPI(connection).update_config({"page_size": 12}, now_ms=1)
+    connection.close()
+
+    created = module._backup_control(payload, "create_backup", settings)
+    backup_id = Path(str(created["backup_path"])).name
+    assert created["items"][0]["id"] == backup_id
+
+    connection = module._open(payload, settings)
+    module.CuratorAPI(connection).update_config({"page_size": 30}, now_ms=2)
+    connection.execute(
+        """
+        INSERT INTO curator_job(job_id, job_type, state, started_at_ms)
+        VALUES ('running', 'build', 'running', 3)
+        """
+    )
+    connection.close()
+    with pytest.raises(RuntimeError, match="job is running"):
+        module._backup_control(payload, "create_backup", settings)
+    connection = module._open(payload, settings)
+    connection.execute("DELETE FROM curator_job WHERE job_id='running'")
+    connection.close()
+
+    payload["args"] = {
+        "database_path": str(database),
+        "backup_id": f"../{backup_id}",
+        "confirmation": f"RESTORE ../{backup_id}",
+    }
+    with pytest.raises(ValueError, match="recognized"):
+        module._backup_control(payload, "restore_backup", settings)
+    payload["args"] = {
+        "database_path": str(database),
+        "backup_id": backup_id,
+        "confirmation": f"RESTORE {backup_id}",
+    }
+    restored = module._backup_control(payload, "restore_backup", settings)
+
+    assert Path(str(restored["restored_from"])).name == backup_id
+    assert Path(str(restored["safety_backup"])).is_file()
+    connection = module._open(payload, settings)
+    assert module.CuratorAPI(connection).config()["config"]["page_size"] == 12
+    connection.close()
+
+
 def test_curator_tabs_update_browser_history() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
     assert "const routeLocation = useLocation();" in source


### PR DESCRIPTION
## Summary
- add configured-directory backup listing and creation with strict path validation
- restore only recognized, integrity-checked backups after explicit confirmation and a safety copy
- allow long-running backup creation to complete instead of using the default 30-second page timeout

## Verification
- focused plugin regression: 23 passed
- combined five-issue suite: 198 passed
- live 1.46 GB backup completed in 33.2 seconds and passed SQLite quick_check
- clean sequential integration with #17-#19 and #21

Closes #20