### PR TITLE
Add privacy-safe diagnostics

### DIFF
--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -624,6 +624,8 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
             return api.update_config(values)
         if operation == "get_job_status":
             return _job_status(connection)
+        if operation == "get_diagnostics":
+            return _diagnostics(connection)
         if operation == "list_profiles":
             return {
                 "schema_version": SCHEMA_VERSION,
@@ -691,6 +693,105 @@ def _job_status(connection: Any) -> dict[str, object]:
         for row in rows
     ]
     return {"schema_version": SCHEMA_VERSION, "jobs": jobs}
+
+
+DIAGNOSTIC_JOB_TYPES = {
+    "sync-build",
+    "full-sync-build",
+    "build",
+    "update-model",
+    "prepare",
+    "backup",
+    "expand-refresh",
+}
+
+
+def _diagnostics(connection: Any) -> dict[str, object]:
+    migration = MigrationRunner(connection).status()
+    model = connection.execute(
+        "SELECT 1 FROM model_version WHERE status='published' LIMIT 1"
+    ).fetchone()
+    sync = connection.execute(
+        """
+        SELECT 1 FROM curator_job
+        WHERE job_type IN ('sync-build', 'full-sync-build') AND state='complete' LIMIT 1
+        """
+    ).fetchone()
+    model_update = connection.execute(
+        """
+        SELECT requested_generation, published_generation, last_duration_ms
+        FROM model_update_state WHERE singleton=1
+        """
+    ).fetchone()
+    rows = [
+        row
+        for row in connection.execute(
+            """
+            SELECT job_type, state, started_at_ms, finished_at_ms
+            FROM curator_job ORDER BY started_at_ms DESC LIMIT 50
+            """
+        )
+        if str(row["job_type"]) in DIAGNOSTIC_JOB_TYPES
+    ]
+    recent_jobs = [
+        {
+            "job_type": str(row["job_type"]),
+            "outcome": str(row["state"]),
+            "started_at_ms": int(row["started_at_ms"]),
+            "finished_at_ms": (
+                int(row["finished_at_ms"]) if row["finished_at_ms"] is not None else None
+            ),
+            "duration_ms": (
+                int(row["finished_at_ms"]) - int(row["started_at_ms"])
+                if row["finished_at_ms"] is not None
+                else None
+            ),
+        }
+        for row in rows[:10]
+    ]
+    durations: dict[str, list[int]] = {}
+    for row in rows:
+        if row["finished_at_ms"] is not None:
+            durations.setdefault(str(row["job_type"]), []).append(
+                int(row["finished_at_ms"]) - int(row["started_at_ms"])
+            )
+    return {
+        "report_version": 1,
+        "generated_at_ms": time.time_ns() // 1_000_000,
+        "curator_version": __version__,
+        "api_schema_version": SCHEMA_VERSION,
+        "migration": {
+            "current_version": migration.current_version,
+            "latest_version": migration.latest_version,
+            "pending_count": len(migration.pending_versions),
+        },
+        "readiness": {
+            "sidecar": not migration.pending_versions,
+            "library_sync": sync is not None,
+            "recommendation_model": model is not None,
+            "model_update_pending": (
+                int(model_update["requested_generation"])
+                > int(model_update["published_generation"])
+            ),
+        },
+        "recent_jobs": recent_jobs,
+        "timing_ms": {
+            "last_model_update": (
+                int(model_update["last_duration_ms"])
+                if model_update["last_duration_ms"] is not None
+                else None
+            ),
+            "jobs": [
+                {
+                    "job_type": job_type,
+                    "count": len(values),
+                    "average": round(sum(values) / len(values)),
+                    "maximum": max(values),
+                }
+                for job_type, values in sorted(durations.items())
+            ],
+        },
+    }
 
 
 def _classify_lanes(connection: Any, model: Any) -> int:

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -98,14 +98,20 @@
   white-space: nowrap;
 }
 
+.curator-navigation {
+  align-items: stretch;
+  display: flex;
+  grid-column: 1 / -1;
+  grid-row: 2;
+  min-width: 0;
+}
+
 .curator-tabs {
   align-items: center;
   align-self: center;
   border-bottom: 0;
   flex: 1 1 34rem;
   flex-wrap: nowrap;
-  grid-column: 1 / -1;
-  grid-row: 2;
   height: 3rem;
   justify-content: flex-start;
   margin-inline: 0;
@@ -137,6 +143,64 @@
 .curator-tabs .curator-lane-prune {
   border-left: 1px solid rgba(255, 255, 255, 0.18);
   margin-left: 0.45rem;
+}
+
+.curator-maintenance-menu {
+  flex: 0 0 auto;
+  position: relative;
+}
+
+.curator-maintenance-menu summary {
+  align-items: center;
+  color: inherit;
+  cursor: pointer;
+  display: flex;
+  gap: 0.4rem;
+  height: 3rem;
+  list-style: none;
+  padding: 0.55rem 0.7rem;
+}
+
+.curator-maintenance-menu summary::-webkit-details-marker {
+  display: none;
+}
+
+.curator-maintenance-menu summary.active,
+.curator-maintenance-menu[open] summary {
+  background: rgba(255, 255, 255, 0.08);
+  color: #fff;
+}
+
+.curator-maintenance-items {
+  background: #343a40;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 0.3rem;
+  box-shadow: 0 0.35rem 1rem rgba(0, 0, 0, 0.35);
+  display: grid;
+  min-width: 13rem;
+  padding: 0.35rem;
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.25rem);
+  z-index: 20;
+}
+
+.curator-maintenance-items button {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-radius: 0.2rem;
+  color: #fff;
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.5rem 0.65rem;
+  text-align: left;
+}
+
+.curator-maintenance-items button:hover,
+.curator-maintenance-items button:focus,
+.curator-maintenance-items button.active {
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .curator-profiling {
@@ -323,6 +387,12 @@
   font-family: monospace;
   max-width: 32rem;
   overflow-wrap: anywhere;
+}
+
+.curator-diagnostics-preview {
+  max-height: 60vh;
+  overflow: auto;
+  white-space: pre-wrap;
 }
 
 .curator-lane-for_you { --lane-color: #4dabf7; }
@@ -1211,10 +1281,13 @@
     grid-template-columns: 1fr;
   }
 
-  .curator-tabs {
-    flex-basis: 100%;
+  .curator-navigation {
     grid-column: 1;
     grid-row: auto;
+  }
+
+  .curator-tabs {
+    flex-basis: 100%;
     overflow-x: auto;
     width: 100%;
   }
@@ -1269,6 +1342,15 @@
   }
 
   .curator-tabs .nav-link span {
+    display: none;
+  }
+
+  .curator-maintenance-menu summary {
+    justify-content: center;
+    padding-inline: 0.45rem;
+  }
+
+  .curator-maintenance-menu summary span {
     display: none;
   }
 

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -70,18 +70,29 @@
       description: "Find scenes listed for a performer on StashDB and compare them with exact links in your library.",
     },
     {
+      value: "diagnostics",
+      label: "Diagnostics",
+      icon: faWrench,
+      maintenance: true,
+      description: "Preview and export a privacy-safe status report for bug reports.",
+    },
+    {
       value: "prune",
       label: "Prune",
       icon: faBroom,
+      maintenance: true,
       description: "Curator never deletes media; tagging is reversible, and Candidates, Explicit dislikes, and Model suspects are separate review queues.",
     },
     {
       value: "taste",
       label: "Taste Profile",
       icon: faTag,
+      maintenance: true,
       description: "Review what Curator has inferred and directly teach it how you feel about tags.",
     },
   ];
+  const PRIMARY_NAV_ITEMS = NAV_ITEMS.filter((item) => !item.maintenance);
+  const MAINTENANCE_ITEMS = NAV_ITEMS.filter((item) => item.maintenance);
   const laneByValue = new Map(LANES.map((lane) => [lane.value, lane]));
   const EVENT_QUEUE_KEY = "stash-curator:event-queue:v1";
   const TAG_PREFERENCE_QUEUE_KEY = "stash-curator:tag-preference-queue:v1";
@@ -1365,6 +1376,53 @@
     );
   }
 
+  function DiagnosticsPanel() {
+    const [report, setReport] = React.useState(null);
+    const [message, setMessage] = React.useState("");
+    const [error, setError] = React.useState("");
+    async function load() {
+      setError("");
+      try {
+        setReport(await operation({ operation: "get_diagnostics" }));
+      } catch (failure) {
+        setError(failure.message);
+      }
+    }
+    React.useEffect(() => { load(); }, []);
+    const preview = report ? JSON.stringify(report, null, 2) : "";
+    async function copy() {
+      try {
+        await copyText(preview);
+        setMessage("Diagnostics copied.");
+      } catch (failure) {
+        setError(failure.message);
+      }
+    }
+    function download() {
+      const url = URL.createObjectURL(new Blob([preview], { type: "application/json" }));
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "stash-curator-diagnostics.json";
+      link.click();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    }
+    return React.createElement(
+      "section",
+      { className: "curator-diagnostics", role: "tabpanel" },
+      React.createElement("p", null, "This allowlisted report excludes library metadata, identifiers, paths, URLs, credentials, preferences, and SQL. Profiling traces are separate and are not included."),
+      React.createElement(
+        "div",
+        { className: "curator-profiling-toolbar" },
+        React.createElement(Button, { size: "sm", onClick: load }, "Refresh"),
+        React.createElement(Button, { size: "sm", disabled: !report, onClick: copy }, React.createElement(FontAwesomeIcon, { icon: faCopy }), " Copy"),
+        React.createElement(Button, { size: "sm", disabled: !report, onClick: download }, React.createElement(FontAwesomeIcon, { icon: faDownload }), " Download JSON")
+      ),
+      message && React.createElement("div", { className: "alert alert-success", role: "status" }, message),
+      error && React.createElement("div", { className: "alert alert-danger" }, error),
+      report && React.createElement("pre", { className: "curator-diagnostics-preview" }, preview)
+    );
+  }
+
   function CuratorControls({ onRefresh, onProfiling, profilingActive }) {
     const [jobs, setJobs] = React.useState([]);
     const [health, setHealth] = React.useState(null);
@@ -1584,14 +1642,40 @@
         { className: "curator-header" },
         React.createElement("div", { className: "curator-brand" }, React.createElement("span", { className: "curator-brand-mark", "aria-hidden": "true" }, React.createElement(FontAwesomeIcon, { icon: faCompass })), React.createElement("div", null, React.createElement("h1", null, "Stash Curator"), React.createElement("p", { className: "curator-tagline" }, "Navigate your library, guided by your taste."))),
         React.createElement(
-          Nav,
-          { variant: "tabs", role: "tablist", className: "curator-tabs" },
-          NAV_ITEMS.map((option) =>
+          "div",
+          { className: "curator-navigation" },
+          React.createElement(
+            Nav,
+            { variant: "tabs", role: "tablist", className: "curator-tabs" },
+            PRIMARY_NAV_ITEMS.map((option) =>
+              React.createElement(
+                Nav.Link,
+                { key: option.value, as: "button", className: `curator-lane-${option.value}`, active: lane === option.value, onClick: () => openView(option.value), onMouseEnter: () => prefetchLane(option.value), onFocus: () => prefetchLane(option.value), role: "tab", title: option.description, "aria-label": `${option.label}: ${option.description}`, "aria-selected": lane === option.value },
+                React.createElement(FontAwesomeIcon, { icon: option.icon }),
+                React.createElement("span", null, option.label)
+              )
+            )
+          ),
+          React.createElement(
+            "details",
+            { className: "curator-maintenance-menu" },
             React.createElement(
-              Nav.Link,
-              { key: option.value, as: "button", className: `curator-lane-${option.value}`, active: lane === option.value, onClick: () => openView(option.value), onMouseEnter: () => prefetchLane(option.value), onFocus: () => prefetchLane(option.value), role: "tab", title: option.description, "aria-label": `${option.label}: ${option.description}`, "aria-selected": lane === option.value },
-              React.createElement(FontAwesomeIcon, { icon: option.icon }),
-              React.createElement("span", null, option.label)
+              "summary",
+              { className: `nav-link ${laneOption?.maintenance ? "active" : ""}`, title: "Maintenance", "aria-label": laneOption?.maintenance ? `Maintenance: ${laneOption.label}` : "Maintenance" },
+              React.createElement(FontAwesomeIcon, { icon: faWrench }),
+              React.createElement("span", null, "Maintenance")
+            ),
+            React.createElement(
+              "div",
+              { className: "curator-maintenance-items" },
+              MAINTENANCE_ITEMS.map((option) =>
+                React.createElement(
+                  "button",
+                  { key: option.value, type: "button", className: lane === option.value ? "active" : "", onClick: (event) => { event.currentTarget.closest("details")?.removeAttribute("open"); openView(option.value); }, title: option.description, "aria-current": lane === option.value ? "page" : undefined },
+                  React.createElement(FontAwesomeIcon, { icon: option.icon }),
+                  React.createElement("span", null, option.label)
+                )
+              )
             )
           )
         ),
@@ -1628,6 +1712,7 @@
       lane === "taste" && React.createElement(TasteProfilePanel),
       lane === "expand" && React.createElement(ExpandPanel, { key: "expand", initialPerformerId: route.get("performer") }),
       lane === "hunt" && React.createElement(ExpandPanel, { key: "hunt", initialType: "hunt", huntOnly: true }),
+      lane === "diagnostics" && React.createElement(DiagnosticsPanel),
       lane === "profiling" && React.createElement(ProfilingPanel),
       (loading || loadingComponents || scenesQuery.loading) &&
         React.createElement(

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -126,6 +126,23 @@ def test_taste_profile_uses_fixed_durable_tag_sentiment_control() -> None:
     assert 'if (sort !== "suggested")' in source
 
 
+def test_diagnostics_can_be_previewed_copied_and_downloaded_separately_from_traces() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
+
+    assert 'value: "diagnostics"' in source
+    assert "icon: faWrench,\n      maintenance: true" in source
+    assert "const PRIMARY_NAV_ITEMS = NAV_ITEMS.filter((item) => !item.maintenance);" in source
+    assert "const MAINTENANCE_ITEMS = NAV_ITEMS.filter((item) => item.maintenance);" in source
+    assert "icon: faBroom,\n      maintenance: true" in source
+    assert "icon: faTag,\n      maintenance: true" in source
+    assert 'className: "curator-maintenance-menu"' in source
+    assert 'React.createElement("span", null, "Maintenance")' in source
+    assert 'operation: "get_diagnostics"' in source
+    assert '"Diagnostics copied."' in source
+    assert 'link.download = "stash-curator-diagnostics.json"' in source
+    assert "Profiling traces are separate and are not included." in source
+
+
 def test_thumb_down_follow_up_is_optional_and_survives_card_removal() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
 
@@ -273,6 +290,105 @@ def test_backend_module_loads_without_starting(tmp_path: Path) -> None:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     assert module.SCHEMA_VERSION == 1
+
+
+def test_diagnostics_allowlist_cannot_emit_representative_private_fields(
+    tmp_path: Path,
+) -> None:
+    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
+    spec = importlib.util.spec_from_file_location("curator_plugin_diagnostics", backend)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    database = tmp_path / "PRIVATE_DATABASE.sqlite3"
+    payload = {"args": {"database_path": str(database)}}
+    connection = module._open(payload, {})
+    connection.execute(
+        "UPDATE curator_config SET config_json=? WHERE singleton=1",
+        (
+            json.dumps(
+                {
+                    "url": "PRIVATE_URL",
+                    "api_key": "PRIVATE_KEY",
+                    "preference": "PRIVATE_PREFERENCE",
+                }
+            ),
+        ),
+    )
+    connection.execute(
+        """
+        INSERT INTO source_scene(scene_id, title, source_hash)
+        VALUES ('PRIVATE_ENTITY_ID', 'PRIVATE_TITLE', 'private')
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO source_performer(performer_id, name, source_hash)
+        VALUES ('private-performer', 'PRIVATE_PERFORMER', 'private')
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO source_tag(tag_id, name, source_hash)
+        VALUES ('private-tag', 'PRIVATE_TAG', 'private')
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO curator_job(
+            job_id, job_type, state, started_at_ms, finished_at_ms, summary_json, error
+        ) VALUES (
+            'PRIVATE_JOB_ID', 'sync-build', 'failed', 100, 250,
+            '{"entity":"PRIVATE_ENTITY_ID"}',
+            'PRIVATE_SQL SELECT * FROM feedback at PRIVATE_URL'
+        )
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO profile_trace(
+            trace_id, kind, operation, started_at_ms, duration_us, status,
+            span_count, truncated, trace_json
+        ) VALUES (
+            'PRIVATE_TRACE_ID', 'operation', 'test', 1, 1, 'ok', 1, 0,
+            '{"traceEvents":[{"args":{"statement":"PRIVATE_SQL"}}]}'
+        )
+        """
+    )
+    connection.close()
+
+    report = module._api(
+        payload,
+        "get_diagnostics",
+        {"whisparrUrl": "PRIVATE_URL", "whisparrApiKey": "PRIVATE_KEY"},
+    )
+    serialized = json.dumps(report, sort_keys=True)
+
+    assert set(report) == {
+        "report_version",
+        "generated_at_ms",
+        "curator_version",
+        "api_schema_version",
+        "migration",
+        "readiness",
+        "recent_jobs",
+        "timing_ms",
+    }
+    assert report["recent_jobs"][0]["outcome"] == "failed"
+    for private in (
+        str(database),
+        "PRIVATE_URL",
+        "PRIVATE_KEY",
+        "PRIVATE_PREFERENCE",
+        "PRIVATE_ENTITY_ID",
+        "PRIVATE_TITLE",
+        "PRIVATE_PERFORMER",
+        "PRIVATE_TAG",
+        "PRIVATE_JOB_ID",
+        "PRIVATE_TRACE_ID",
+        "PRIVATE_SQL",
+    ):
+        assert private not in serialized
 
 
 def test_external_links_collect_normalized_local_phashes(


### PR DESCRIPTION
## Summary
- generate diagnostics strictly from a fixed privacy-safe allowlist
- preview, copy, and download diagnostics separately from profiling traces
- group utility, Prune, and Taste Profile views under a responsive Maintenance menu

## Verification
- focused plugin regression: 23 passed
- combined five-issue suite: 198 passed
- representative private values are excluded by regression coverage
- clean sequential integration with #17-#20

Closes #21