### PR TITLE
Keep Best Bets out of Discover

### DIFF
--- a/curator/config.py
+++ b/curator/config.py
@@ -75,7 +75,7 @@ class FeatureConfig:
 
 @dataclass(frozen=True)
 class ModelConfig:
-    algorithm_version: int = 5
+    algorithm_version: int = 6
     affinity_prior: float = 1.0
     affinity_confidence_scale: float = 3.0
     direct_confidence_scale: float = 0.8

--- a/curator/ranking/policy.py
+++ b/curator/ranking/policy.py
@@ -149,14 +149,15 @@ class LanePolicy:
                 >= self.config.ranking.best_bet_anchor_percentile
             )
             direct_reliable = score.direct_appeal > 0.10 and score.direct_confidence >= 0.50
-            if (
+            best_bet = (
                 score.current_fit >= self.config.ranking.best_bet_fit
                 and score.confidence >= self.config.ranking.best_bet_confidence
                 and score.metadata_confidence >= self.config.ranking.best_bet_metadata_confidence
                 and relevance >= self.config.ranking.best_bet_relevance
                 and (corroborated or direct_reliable)
                 and scene_id not in played_scene_ids
-            ):
+            )
+            if best_bet:
                 classifications.append(
                     LaneClassification(
                         scene_id,
@@ -208,7 +209,8 @@ class LanePolicy:
                     )
                 )
             if (
-                score.direct_confidence < self.config.ranking.revisit_direct_confidence
+                not best_bet
+                and score.direct_confidence < self.config.ranking.revisit_direct_confidence
                 and strongest_anchor >= self.config.ranking.discover_anchor
             ):
                 if len(negatives) == 1:

--- a/tests/ranking/test_slate.py
+++ b/tests/ranking/test_slate.py
@@ -249,6 +249,7 @@ def test_lane_policy_assigns_expected_subtypes_and_excludes_hard_failures(tmp_pa
     lookup = {(item.scene_id, item.lane): item for item in classifications}
 
     assert ("a-best", "best_bets") in lookup
+    assert ("a-best", "discover") not in lookup
     assert ("d-revisit", "revisit") in lookup
     assert lookup[("e-frontier", "discover")].subtype == "frontier"
     assert lookup[("f-stretch", "discover")].subtype == "stretch"


### PR DESCRIPTION
## Summary
- prevent Best Bets candidates from also qualifying for Discover
- bump the model algorithm version so rebuilt recommendations cannot reuse pre-fix lane artifacts
- add a focused lane-policy regression assertion

## Verification
- scripts/verify full (198 passed)
- installed locally with scripts/install-local.sh