### PR TITLE
Add generation storage and speed up background tasks

### DIFF
--- a/curator/api.py
+++ b/curator/api.py
@@ -326,6 +326,7 @@ class CuratorAPI:
             raise ValueError("unknown recommendation lane")
         where = "WHERE h.lane=?" if lane else ""
         parameters: tuple[object, ...] = (lane,) if lane else ()
+        model_id = RecommendationModelStore(self.connection).current_model_id()
         total = int(
             self.connection.execute(
                 f"SELECT count(*) FROM recommendation_history h {where}",
@@ -338,8 +339,7 @@ class CuratorAPI:
                    i.reason_snapshot_json,
                    EXISTS(
                      SELECT 1 FROM model_scene_score score
-                     JOIN model_version model USING(model_id)
-                     WHERE model.status='published' AND score.scene_id=h.scene_id
+                     WHERE score.model_id=? AND score.scene_id=h.scene_id
                    ) AS current_model
             FROM recommendation_history h
             LEFT JOIN impression_item i
@@ -347,7 +347,7 @@ class CuratorAPI:
             {where}
             ORDER BY h.shown_at_ms DESC, h.history_id DESC LIMIT ? OFFSET ?
             """,
-            (*parameters, page_size, (page - 1) * page_size),
+            (model_id, *parameters, page_size, (page - 1) * page_size),
         )
         items = []
         for row in rows:

--- a/curator/api.py
+++ b/curator/api.py
@@ -853,7 +853,7 @@ class CuratorAPI:
                     ((scene_id,) for scene_id in scene_ids),
                 )
 
-    def reconcile_prune_tag(self, tag_name: str) -> None:
+    def reconcile_prune_tag(self, tag_name: str) -> bool:
         tagged = {
             str(row[0])
             for row in self.connection.execute(
@@ -865,17 +865,33 @@ class CuratorAPI:
             )
         }
         now_ms = time.time_ns() // 1_000_000
+        reason = f"Tagged {tag_name}"
         with transaction(self.connection):
-            self.connection.execute("DELETE FROM pruning_candidate WHERE state='remove'")
-            self.connection.executemany(
+            deleted = self.connection.execute(
                 """
+                DELETE FROM pruning_candidate
+                WHERE state='remove' AND scene_id NOT IN (
+                    SELECT st.scene_id FROM scene_tag st JOIN source_tag t USING(tag_id)
+                    WHERE lower(t.name)=lower(?)
+                )
+                """,
+                (tag_name,),
+            ).rowcount
+            changed = deleted > 0
+            for scene_id in tagged:
+                cursor = self.connection.execute(
+                    """
                 INSERT INTO pruning_candidate(scene_id, state, created_at_ms, updated_at_ms, reason)
                 VALUES (?, 'remove', ?, ?, ?)
                 ON CONFLICT(scene_id) DO UPDATE SET state='remove',
                     updated_at_ms=excluded.updated_at_ms, reason=excluded.reason
+                WHERE pruning_candidate.state!='remove'
+                    OR pruning_candidate.reason IS NOT excluded.reason
                 """,
-                ((scene_id, now_ms, now_ms, f"Tagged {tag_name}") for scene_id in tagged),
-            )
+                    (scene_id, now_ms, now_ms, reason),
+                )
+                changed = changed or cursor.rowcount > 0
+        return changed
 
     def update_pruning(
         self, scene_id: str, state: str, now_ms: int | None = None

--- a/curator/cli.py
+++ b/curator/cli.py
@@ -214,7 +214,11 @@ def run(argv: Sequence[str] | None = None) -> int:
             synced_historical = HistoricalEventStore(connection).rebuild(
                 None if args.full or synced.resumed else synced.scene_ids
             )
-            ModelUpdateCoordinator(connection).request("source_sync")
+            model_update_pending = bool(
+                args.full or synced.resumed or any(synced.changed_entity_counts.values())
+            )
+            if model_update_pending:
+                ModelUpdateCoordinator(connection).request("source_sync")
         finally:
             connection.close()
         _print_result(
@@ -224,8 +228,9 @@ def run(argv: Sequence[str] | None = None) -> int:
                 "server_version": synced.server_version,
                 "resumed": synced.resumed,
                 "entity_counts": synced.entity_counts,
+                "changed_entity_counts": synced.changed_entity_counts,
                 "historical_scenes": synced_historical.scene_count,
-                "model_update_pending": True,
+                "model_update_pending": model_update_pending,
             },
             as_json=bool(args.json),
         )

--- a/curator/cli.py
+++ b/curator/cli.py
@@ -361,7 +361,7 @@ def run(argv: Sequence[str] | None = None) -> int:
             model_id = RecommendationModelStore(connection).current_model_id()
             if model_id is None:
                 raise RuntimeError("no published model; run build-model first")
-            ReasonGraphStore(connection).build(model_id)
+            ReasonGraphStore(connection).ensure(model_id)
             explanation = ExplanationService(connection).explain_scene(model_id, str(args.scene_id))
             score = RecommendationModelStore(connection).scores(model_id).get(str(args.scene_id))
             if score is None:

--- a/curator/events/repository.py
+++ b/curator/events/repository.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import sqlite3
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import dataclass
 
 from curator.events.contracts import DEFAULT_CALIBRATION, EventCalibration, NormalizedOutcome
@@ -36,24 +37,35 @@ class HistoricalEventStore:
         self.connection = connection
         self.calibration = calibration
 
-    def rebuild(self, scene_ids: tuple[str, ...] | None = None) -> HistoricalBuildResult:
+    def rebuild(
+        self,
+        scene_ids: tuple[str, ...] | None = None,
+        *,
+        progress: Callable[[int, int], None] | None = None,
+    ) -> HistoricalBuildResult:
         with transaction(self.connection):
             scenes = self._scenes(scene_ids)
             plays = self._plays(scene_ids)
             os = self._os(scene_ids)
-            reconstructions = {
-                scene_id: reconstruct_history(
+            total = max(1, len(scenes) * 2)
+            reconstructions: dict[str, HistoricalReconstruction] = {}
+            for position, (scene_id, duration) in enumerate(scenes, 1):
+                reconstructions[scene_id] = reconstruct_history(
                     scene_id,
                     duration,
                     tuple(plays[scene_id]),
                     tuple(os[scene_id]),
                     calibration=self.calibration,
                 )
-                for scene_id, duration in scenes
-            }
+                if progress and (position == len(scenes) or position % 250 == 0):
+                    progress(position, total)
             self._delete_projection(scene_ids)
-            for reconstruction in reconstructions.values():
+            for position, reconstruction in enumerate(reconstructions.values(), len(scenes) + 1):
                 self._insert_reconstruction(reconstruction)
+                if progress and (position == total or position % 250 == 0):
+                    progress(position, total)
+            if progress and not scenes:
+                progress(1, 1)
         return HistoricalBuildResult(
             scene_count=len(scenes),
             session_count=sum(len(item.sessions) for item in reconstructions.values()),

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -7,7 +7,7 @@ import math
 import sqlite3
 import time
 from collections import defaultdict
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from contextvars import copy_context
 from datetime import date, timedelta
@@ -119,9 +119,12 @@ class ExpandService:
         wildcard: bool = False,
         candidate_limit: int = 1_000,
         now_ms: int | None = None,
+        progress: Callable[[int, int], None] | None = None,
     ) -> dict[str, object]:
         fetched_at_ms = now_ms if now_ms is not None else time.time_ns() // 1_000_000
         taxonomy_refreshed = self._refresh_taxonomy(client, fetched_at_ms)
+        if progress:
+            progress(100, 1_000)
         model_store = RecommendationModelStore(self.connection)
         model_id = model_store.current_model_id()
         if model_id is None:
@@ -131,6 +134,8 @@ class ExpandService:
         ).fetchone()
         feature_version = str(model[0])
         seeds = self._seeds(model_id, feature_version, links)
+        if progress:
+            progress(200, 1_000)
         rows: dict[str, dict[str, Any]] = {}
         sources: dict[str, set[str]] = defaultdict(set)
         filters = (
@@ -140,11 +145,15 @@ class ExpandService:
         )
         active = sum(bool(values) for _, values in filters) + int(wildcard)
         per_source = max(1, math.ceil(candidate_limit / max(1, active)))
-        for source, values in filters:
-            if values:
-                self._fetch(client, rows, sources, source, values, per_source)
+        queries = [(source, values, per_source) for source, values in filters if values]
         if wildcard:
-            self._fetch(client, rows, sources, "wildcard", [], min(100, per_source))
+            queries.append(("wildcard", [], min(100, per_source)))
+        for position, (source, values, limit) in enumerate(queries, 1):
+            self._fetch(client, rows, sources, source, values, limit)
+            if progress:
+                progress(200 + round(450 * position / max(1, len(queries))), 1_000)
+        if progress and not queries:
+            progress(650, 1_000)
         cutoff = date.today() - timedelta(days=horizon_days)
         candidates = []
         for row in rows.values():
@@ -156,7 +165,11 @@ class ExpandService:
                 and self._matches_gender(candidate, gender)
             ):
                 candidates.append(candidate)
+        if progress:
+            progress(750, 1_000)
         scenes, performers = self._score(candidates, sources, model_id, feature_version, links)
+        if progress:
+            progress(900, 1_000)
         with transaction(self.connection):
             self.connection.execute("DELETE FROM external_entity")
             self.connection.executemany(
@@ -195,6 +208,8 @@ class ExpandService:
                     len(performers),
                 ),
             )
+        if progress:
+            progress(1_000, 1_000)
         return {
             "scene_count": len(scenes),
             "performer_count": len(performers),

--- a/curator/explanations/reasons.py
+++ b/curator/explanations/reasons.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from curator.features import FeatureStore
 from curator.model import ModelSceneScore, RecommendationModelStore
 from curator.storage import transaction
+from curator.storage.artifacts import artifact_attached
 
 
 @dataclass(frozen=True)
@@ -99,6 +100,8 @@ class ReasonGraphStore:
             )
 
     def ensure(self, model_id: str, scene_ids: Collection[str] | None = None) -> None:
+        if artifact_attached(self.connection, "model"):
+            return
         if scene_ids is None:
             if (
                 self.connection.execute(
@@ -229,6 +232,26 @@ class ReasonGraphStore:
         self._neighbor_reason(score, feature_version, reasons)
         self._direct_reasons(score, feature_version, reasons)
         self._fit_reasons(score, feature_version, reasons)
+        if not reasons:
+            reasons.append(
+                Reason(
+                    "fallback",
+                    "neutral",
+                    0.0,
+                    score.confidence,
+                    None,
+                    None,
+                    "standard",
+                    "model_baseline",
+                    {
+                        "appeal": score.appeal,
+                        "current_fit": score.current_fit,
+                        "confidence": score.confidence,
+                    },
+                    score.model_id,
+                    feature_version,
+                )
+            )
         return tuple(
             sorted(
                 reasons,

--- a/curator/explanations/render.py
+++ b/curator/explanations/render.py
@@ -9,7 +9,9 @@ from dataclasses import dataclass
 from curator.explanations.catalog import RealizationCatalog
 from curator.explanations.planner import EvidenceUnit, Microplanner
 from curator.explanations.reasons import Reason, ReasonGraphStore
+from curator.model import RecommendationModelStore
 from curator.ranking import RecommendationItem
+from curator.storage.artifacts import artifact_attached
 
 
 @dataclass(frozen=True)
@@ -33,7 +35,11 @@ class ExplanationService:
 
     def explain_scene(self, model_id: str, scene_id: str) -> Explanation:
         reasons = self.store.reasons(model_id, scene_id)
-        if not reasons and scene_id not in self._ensured:
+        if (
+            not reasons
+            and scene_id not in self._ensured
+            and not artifact_attached(self.connection, "model")
+        ):
             self.store.build(model_id, {scene_id})
             self._ensured.add(scene_id)
             reasons = self.store.reasons(model_id, scene_id)
@@ -42,7 +48,11 @@ class ExplanationService:
     def explain_recommendation(self, item: RecommendationItem) -> Explanation:
         model_id = self._current_model_id()
         base = self.store.reasons(model_id, item.scene_id)
-        if not base and item.scene_id not in self._ensured:
+        if (
+            not base
+            and item.scene_id not in self._ensured
+            and not artifact_attached(self.connection, "model")
+        ):
             self.store.build(model_id, {item.scene_id})
             self._ensured.add(item.scene_id)
             base = self.store.reasons(model_id, item.scene_id)
@@ -53,12 +63,10 @@ class ExplanationService:
         )
 
     def _current_model_id(self) -> str:
-        row = self.connection.execute(
-            "SELECT model_id FROM model_version WHERE status='published'"
-        ).fetchone()
-        if row is None:
+        model_id = RecommendationModelStore(self.connection).current_model_id()
+        if model_id is None:
             raise RuntimeError("no published model")
-        return str(row[0])
+        return model_id
 
     def _ranking_reasons(self, model_id: str, item: RecommendationItem) -> tuple[Reason, ...]:
         row = self.connection.execute(

--- a/curator/features/builder.py
+++ b/curator/features/builder.py
@@ -20,6 +20,17 @@ from curator.features.measurements import (
 )
 from curator.features.tag_roles import TagRole, TagRoleResolver, TagRoleResult
 from curator.storage import transaction
+from curator.storage.artifacts import (
+    ARTIFACT_SCHEMA_VERSION,
+    activate_artifact,
+    artifact_path,
+    create_artifact,
+    create_indexes,
+    database_path,
+    discard_artifact,
+    publish_file,
+    validate_artifact,
+)
 from curator.taxonomy import TaxonomyIndex
 from curator.taxonomy.store import CATEGORY_ROLE_FINGERPRINT
 
@@ -35,6 +46,7 @@ class FeatureBuildResult:
     performer_count: int
     feature_count: int
     reused: bool
+    stage_timings_ms: dict[str, int]
 
 
 @dataclass(frozen=True)
@@ -61,16 +73,45 @@ class FeatureBuilder:
         self.clock_ms = clock_ms or (lambda: time.time_ns() // 1_000_000)
 
     def build(self) -> FeatureBuildResult:
+        started = time.perf_counter()
         source_fingerprint = self._source_fingerprint()
         version_hash = hashlib.sha256(
             f"{source_fingerprint}\0{self.config.feature_json()}".encode()
         ).hexdigest()
         feature_version = f"fv-{version_hash[:20]}"
         existing = self.connection.execute(
-            "SELECT status FROM feature_build WHERE feature_version = ?", (feature_version,)
+            """
+            SELECT status, artifact_basename, validation_status FROM feature_build
+            WHERE feature_version = ?
+            """,
+            (feature_version,),
         ).fetchone()
-        if existing and existing["status"] == "published":
-            return self._result(feature_version, reused=True)
+        lookup_ms = round((time.perf_counter() - started) * 1000)
+        if (
+            existing
+            and existing["status"] == "published"
+            and existing["validation_status"] == "valid"
+            and existing["artifact_basename"]
+            and artifact_path(
+                database_path(self.connection), str(existing["artifact_basename"])
+            ).is_file()
+        ):
+            with transaction(self.connection):
+                self.connection.execute(
+                    """
+                    UPDATE feature_build SET reuse_count=reuse_count+1
+                    WHERE feature_version=?
+                    """,
+                    (feature_version,),
+                )
+            return self._result(
+                feature_version,
+                reused=True,
+                timings={
+                    "lookup": lookup_ms,
+                    "total": round((time.perf_counter() - started) * 1000),
+                },
+            )
         now = self.clock_ms()
         with transaction(self.connection):
             self.connection.execute(
@@ -83,14 +124,20 @@ class FeatureBuilder:
                 (feature_version, self.config.feature_json(), source_fingerprint, now),
             )
         try:
+            build_started = time.perf_counter()
             roles = self._resolve_tag_roles()
             scene_features = self._scene_features(roles)
             performer_features = self._performer_features(scene_features)
             if self._source_fingerprint() != source_fingerprint:
                 raise FeatureBuildError("source cache changed during feature construction")
             all_features = (*scene_features, *performer_features)
-            self._publish(feature_version, source_fingerprint, roles, all_features)
-            return self._result(feature_version, reused=False)
+            timings = {
+                "lookup": lookup_ms,
+                "build": round((time.perf_counter() - build_started) * 1000),
+                **self._publish(feature_version, source_fingerprint, roles, all_features),
+            }
+            timings["total"] = round((time.perf_counter() - started) * 1000)
+            return self._result(feature_version, reused=False, timings=timings)
         except Exception as error:
             with transaction(self.connection):
                 self.connection.execute(
@@ -99,46 +146,79 @@ class FeatureBuilder:
                 )
             raise
 
-    def _result(self, feature_version: str, *, reused: bool) -> FeatureBuildResult:
-        scene_count = self.connection.execute(
+    def _result(
+        self, feature_version: str, *, reused: bool, timings: dict[str, int]
+    ) -> FeatureBuildResult:
+        row = self.connection.execute(
             """
-            SELECT count(DISTINCT entity_id) FROM entity_feature
-            WHERE feature_version = ? AND entity_type = 'scene'
+            SELECT scene_count, performer_count, feature_count FROM feature_build
+            WHERE feature_version = ?
             """,
             (feature_version,),
-        ).fetchone()[0]
-        performer_count = self.connection.execute(
-            """
-            SELECT count(DISTINCT entity_id) FROM entity_feature
-            WHERE feature_version = ? AND entity_type = 'performer'
-            """,
-            (feature_version,),
-        ).fetchone()[0]
-        feature_count = self.connection.execute(
-            "SELECT count(*) FROM feature_definition WHERE feature_version = ?",
-            (feature_version,),
-        ).fetchone()[0]
+        ).fetchone()
+        if row is None or any(
+            row[key] is None for key in ("scene_count", "performer_count", "feature_count")
+        ):
+            raise FeatureBuildError(f"feature build counts missing for {feature_version}")
         return FeatureBuildResult(
-            feature_version, int(scene_count), int(performer_count), int(feature_count), reused
+            feature_version,
+            int(row["scene_count"]),
+            int(row["performer_count"]),
+            int(row["feature_count"]),
+            reused,
+            timings,
         )
 
     def _source_fingerprint(self) -> str:
         digest = hashlib.sha256()
-        for table, id_column in (
-            ("source_tag", "tag_id"),
-            ("source_studio", "studio_id"),
-            ("source_performer", "performer_id"),
-            ("source_scene", "scene_id"),
+        for label, statement in (
+            ("source_tag", "SELECT tag_id, name FROM source_tag ORDER BY tag_id"),
+            (
+                "source_performer",
+                """
+                SELECT performer_id, birthdate, ethnicity, eye_color, hair_color,
+                       height_cm, weight_kg, measurements, augmentation, tattoos, piercings
+                FROM source_performer ORDER BY performer_id
+                """,
+            ),
+            (
+                "source_scene",
+                "SELECT scene_id, scene_date, studio_id FROM source_scene ORDER BY scene_id",
+            ),
+            (
+                "scene_performer",
+                "SELECT scene_id, performer_id FROM scene_performer "
+                "ORDER BY scene_id, performer_id",
+            ),
+            (
+                "scene_tag",
+                "SELECT scene_id, tag_id, provenance FROM scene_tag "
+                "ORDER BY scene_id, tag_id, provenance",
+            ),
+            (
+                "scene_marker",
+                "SELECT marker_id, scene_id, primary_tag_id FROM scene_marker ORDER BY marker_id",
+            ),
+            (
+                "marker_tag",
+                "SELECT marker_id, tag_id FROM marker_tag ORDER BY marker_id, tag_id",
+            ),
+            (
+                "tag_parent",
+                "SELECT tag_id, parent_tag_id FROM tag_parent ORDER BY tag_id, parent_tag_id",
+            ),
+            (
+                "source_tag_stash_id",
+                "SELECT tag_id, endpoint, stash_id FROM source_tag_stash_id "
+                "ORDER BY tag_id, endpoint",
+            ),
         ):
-            rows = self.connection.execute(
-                f"SELECT {id_column}, source_hash FROM {table} ORDER BY {id_column}"
-            )
-            for row in rows:
-                digest.update(f"{table}\0{row[0]}\0{row[1]}\n".encode())
-        for row in self.connection.execute(
-            "SELECT tag_id, endpoint, stash_id FROM source_tag_stash_id ORDER BY tag_id, endpoint"
-        ):
-            digest.update(f"source_tag_stash_id\0{row[0]}\0{row[1]}\0{row[2]}\n".encode())
+            digest.update(f"{label}\0".encode())
+            for row in self.connection.execute(statement):
+                digest.update(
+                    json.dumps(tuple(row), separators=(",", ":"), ensure_ascii=False).encode()
+                )
+                digest.update(b"\n")
         row = self.connection.execute(
             "SELECT value FROM application_meta WHERE key='taxonomy_snapshot_id'"
         ).fetchone()
@@ -480,127 +560,203 @@ class FeatureBuilder:
         source_fingerprint: str,
         roles: dict[str, TagRoleResult],
         features: tuple[_Feature, ...],
-    ) -> None:
+    ) -> dict[str, int]:
         config_version = f"cfg-{self.config.feature_fingerprint()[:20]}"
         definitions: dict[tuple[str, str, str], tuple[str, dict[str, object]]] = {}
         for feature in features:
             key = (feature.entity_type, feature.family, feature.name)
             definitions.setdefault(key, (self._feature_id(feature_version, *key), feature.metadata))
-        with transaction(self.connection):
-            self.connection.execute(
-                "DELETE FROM feature_definition WHERE feature_version = ?", (feature_version,)
-            )
-            self.connection.execute(
-                "DELETE FROM tag_role WHERE config_version = ?", (config_version,)
-            )
-            self.connection.executemany(
-                """
-                INSERT INTO tag_role(tag_id, config_version, role, resolution_reason)
-                VALUES (?, ?, ?, ?)
-                """,
-                (
-                    (tag_id, config_version, result.role.value, result.reason)
+        scene_count = len(
+            {feature.entity_id for feature in features if feature.entity_type == "scene"}
+        )
+        performer_count = len(
+            {feature.entity_id for feature in features if feature.entity_type == "performer"}
+        )
+        timings: dict[str, int] = {}
+        writing_started = time.perf_counter()
+        artifact = None
+        temporary = None
+        final = None
+        published = False
+        artifact, temporary, final = create_artifact(self.connection, "feature", feature_version)
+        try:
+            with transaction(self.connection):
+                self.connection.execute(
+                    "DELETE FROM tag_role WHERE config_version = ?", (config_version,)
+                )
+                self.connection.executemany(
+                    """
+                    INSERT INTO tag_role(tag_id, config_version, role, resolution_reason)
+                    VALUES (?, ?, ?, ?)
+                    """,
+                    (
+                        (tag_id, config_version, result.role.value, result.reason)
+                        for tag_id, result in sorted(roles.items())
+                    ),
+                )
+                taxonomy_rows = [
+                    (tag_id, result.taxonomy)
                     for tag_id, result in sorted(roles.items())
-                ),
-            )
-            taxonomy_rows = [
-                (tag_id, result.taxonomy)
-                for tag_id, result in sorted(roles.items())
-                if result.taxonomy is not None
-            ]
-            self.connection.executemany(
-                """
-                INSERT INTO tag_taxonomy_match(
-                    local_tag_id, snapshot_id, external_tag_id, external_category_id,
-                    match_method, confidence, ambiguity_count
-                ) VALUES (?, ?, ?, ?, ?, ?, ?)
-                ON CONFLICT(local_tag_id, snapshot_id) DO UPDATE SET
-                    external_tag_id=excluded.external_tag_id,
-                    external_category_id=excluded.external_category_id,
-                    match_method=excluded.match_method,
-                    confidence=excluded.confidence,
-                    ambiguity_count=excluded.ambiguity_count
-                """,
-                (
+                    if result.taxonomy is not None
+                ]
+                self.connection.executemany(
+                    """
+                    INSERT INTO tag_taxonomy_match(
+                        local_tag_id, snapshot_id, external_tag_id, external_category_id,
+                        match_method, confidence, ambiguity_count
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(local_tag_id, snapshot_id) DO UPDATE SET
+                        external_tag_id=excluded.external_tag_id,
+                        external_category_id=excluded.external_category_id,
+                        match_method=excluded.match_method,
+                        confidence=excluded.confidence,
+                        ambiguity_count=excluded.ambiguity_count
+                    """,
                     (
-                        tag_id,
-                        taxonomy.snapshot_id,
-                        taxonomy.external_tag_id,
-                        taxonomy.external_category_id,
-                        taxonomy.method,
-                        taxonomy.confidence,
-                        taxonomy.ambiguity_count,
-                    )
-                    for tag_id, taxonomy in taxonomy_rows
-                ),
-            )
-            self.connection.executemany(
-                """
-                INSERT INTO feature_definition(
-                    feature_id, feature_version, family, name, provenance, metadata_json
-                ) VALUES (?, ?, ?, ?, 'feature_builder', ?)
-                """,
-                (
+                        (
+                            tag_id,
+                            taxonomy.snapshot_id,
+                            taxonomy.external_tag_id,
+                            taxonomy.external_category_id,
+                            taxonomy.method,
+                            taxonomy.confidence,
+                            taxonomy.ambiguity_count,
+                        )
+                        for tag_id, taxonomy in taxonomy_rows
+                    ),
+                )
+            with transaction(artifact):
+                artifact.executemany(
+                    """
+                    INSERT INTO feature_definition(
+                        feature_id, feature_version, family, name, provenance, metadata_json
+                    ) VALUES (?, ?, ?, ?, 'feature_builder', ?)
+                    """,
                     (
-                        feature_id,
+                        (
+                            feature_id,
+                            feature_version,
+                            family,
+                            name,
+                            json.dumps(metadata, sort_keys=True, separators=(",", ":")),
+                        )
+                        for (entity_type, family, name), (feature_id, metadata) in sorted(
+                            definitions.items()
+                        )
+                    ),
+                )
+                artifact.executemany(
+                    """
+                    INSERT INTO entity_feature(
+                        feature_version, entity_type, entity_id, feature_id, value, confidence
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        (
+                            feature_version,
+                            feature.entity_type,
+                            feature.entity_id,
+                            definitions[(feature.entity_type, feature.family, feature.name)][0],
+                            feature.value,
+                            feature.confidence,
+                        )
+                        for feature in sorted(
+                            features,
+                            key=lambda item: (
+                                item.entity_type,
+                                item.entity_id,
+                                item.family,
+                                item.name,
+                            ),
+                        )
+                    ),
+                )
+                artifact.executemany(
+                    """
+                    INSERT INTO scene_content_search(
+                        feature_version, feature_id, scene_id, value
+                    ) VALUES (?, ?, ?, ?)
+                    """,
+                    (
+                        (
+                            feature_version,
+                            definitions[(feature.entity_type, feature.family, feature.name)][0],
+                            feature.entity_id,
+                            feature.value,
+                        )
+                        for feature in features
+                        if feature.entity_type == "scene" and feature.family == "content"
+                    ),
+                )
+            timings["database_writing"] = round((time.perf_counter() - writing_started) * 1000)
+            indexing_started = time.perf_counter()
+            create_indexes(artifact, "feature")
+            timings["indexing"] = round((time.perf_counter() - indexing_started) * 1000)
+            validation_started = time.perf_counter()
+            stored = artifact.execute(
+                """
+                SELECT
+                    (SELECT count(DISTINCT entity_id) FROM entity_feature
+                     WHERE feature_version=? AND entity_type='scene'),
+                    (SELECT count(DISTINCT entity_id) FROM entity_feature
+                     WHERE feature_version=? AND entity_type='performer'),
+                    (SELECT count(*) FROM feature_definition WHERE feature_version=?)
+                """,
+                (feature_version, feature_version, feature_version),
+            ).fetchone()
+            expected = (scene_count, performer_count, len(definitions))
+            if tuple(stored) != expected:
+                raise FeatureBuildError(
+                    f"feature validation failed: expected {expected}, stored {tuple(stored)}"
+                )
+            summary = validate_artifact(
+                artifact,
+                "feature",
+                {
+                    "scenes": scene_count,
+                    "performers": performer_count,
+                    "features": len(definitions),
+                },
+            )
+            timings["validation"] = round((time.perf_counter() - validation_started) * 1000)
+            publication_started = time.perf_counter()
+            size = publish_file(artifact, temporary, final)
+            artifact = None
+            with transaction(self.connection):
+                self.connection.execute(
+                    "UPDATE feature_build SET status='superseded' WHERE status='published'"
+                )
+                self.connection.execute(
+                    """
+                    UPDATE feature_build SET status='published', source_fingerprint=?,
+                        published_at_ms=?, error=NULL, scene_count=?, performer_count=?,
+                        feature_count=?, artifact_basename=?, artifact_schema_version=?,
+                        artifact_bytes=?, validation_status='valid',
+                        validation_summary_json=?, cleanup_error=NULL
+                    WHERE feature_version=?
+                    """,
+                    (
+                        source_fingerprint,
+                        self.clock_ms(),
+                        scene_count,
+                        performer_count,
+                        len(definitions),
+                        final.name,
+                        ARTIFACT_SCHEMA_VERSION,
+                        size,
+                        json.dumps(summary, sort_keys=True, separators=(",", ":")),
                         feature_version,
-                        family,
-                        name,
-                        json.dumps(metadata, sort_keys=True, separators=(",", ":")),
-                    )
-                    for (entity_type, family, name), (feature_id, metadata) in sorted(
-                        definitions.items()
-                    )
-                ),
-            )
-            self.connection.executemany(
-                """
-                INSERT INTO entity_feature(
-                    feature_version, entity_type, entity_id, feature_id, value, confidence
-                ) VALUES (?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    (
-                        feature_version,
-                        feature.entity_type,
-                        feature.entity_id,
-                        definitions[(feature.entity_type, feature.family, feature.name)][0],
-                        feature.value,
-                        feature.confidence,
-                    )
-                    for feature in sorted(
-                        features,
-                        key=lambda item: (item.entity_type, item.entity_id, item.family, item.name),
-                    )
-                ),
-            )
-            self.connection.execute("DELETE FROM scene_content_search")
-            self.connection.executemany(
-                """
-                INSERT INTO scene_content_search(feature_version, feature_id, scene_id, value)
-                VALUES (?, ?, ?, ?)
-                """,
-                (
-                    (
-                        feature_version,
-                        definitions[(feature.entity_type, feature.family, feature.name)][0],
-                        feature.entity_id,
-                        feature.value,
-                    )
-                    for feature in features
-                    if feature.entity_type == "scene" and feature.family == "content"
-                ),
-            )
-            self.connection.execute(
-                "UPDATE feature_build SET status='superseded' WHERE status='published'"
-            )
-            self.connection.execute(
-                """
-                UPDATE feature_build SET status='published', source_fingerprint=?,
-                    published_at_ms=?, error=NULL WHERE feature_version=?
-                """,
-                (source_fingerprint, self.clock_ms(), feature_version),
-            )
+                    ),
+                )
+            published = True
+            activate_artifact(self.connection, "feature", final)
+            timings["publication"] = round((time.perf_counter() - publication_started) * 1000)
+            return timings
+        finally:
+            if not published:
+                discard_artifact(artifact, temporary)
+                if final is not None and temporary is not None and not temporary.exists():
+                    final.unlink(missing_ok=True)
 
     @staticmethod
     def _feature_id(feature_version: str, entity_type: str, family: str, name: str) -> str:

--- a/curator/features/builder.py
+++ b/curator/features/builder.py
@@ -67,14 +67,17 @@ class FeatureBuilder:
         config: CuratorConfig = DEFAULT_CONFIG,
         *,
         clock_ms: Callable[[], int] | None = None,
+        progress: Callable[[int, int], None] | None = None,
     ) -> None:
         self.connection = connection
         self.config = config
         self.clock_ms = clock_ms or (lambda: time.time_ns() // 1_000_000)
+        self.progress = progress
 
     def build(self) -> FeatureBuildResult:
         started = time.perf_counter()
         source_fingerprint = self._source_fingerprint()
+        self._report(0.05)
         version_hash = hashlib.sha256(
             f"{source_fingerprint}\0{self.config.feature_json()}".encode()
         ).hexdigest()
@@ -104,7 +107,7 @@ class FeatureBuilder:
                     """,
                     (feature_version,),
                 )
-            return self._result(
+            result = self._result(
                 feature_version,
                 reused=True,
                 timings={
@@ -112,6 +115,8 @@ class FeatureBuilder:
                     "total": round((time.perf_counter() - started) * 1000),
                 },
             )
+            self._report(1.0)
+            return result
         now = self.clock_ms()
         with transaction(self.connection):
             self.connection.execute(
@@ -126,8 +131,11 @@ class FeatureBuilder:
         try:
             build_started = time.perf_counter()
             roles = self._resolve_tag_roles()
+            self._report(0.10)
             scene_features = self._scene_features(roles)
+            self._report(0.45)
             performer_features = self._performer_features(scene_features)
+            self._report(0.60)
             if self._source_fingerprint() != source_fingerprint:
                 raise FeatureBuildError("source cache changed during feature construction")
             all_features = (*scene_features, *performer_features)
@@ -137,7 +145,9 @@ class FeatureBuilder:
                 **self._publish(feature_version, source_fingerprint, roles, all_features),
             }
             timings["total"] = round((time.perf_counter() - started) * 1000)
-            return self._result(feature_version, reused=False, timings=timings)
+            result = self._result(feature_version, reused=False, timings=timings)
+            self._report(1.0)
+            return result
         except Exception as error:
             with transaction(self.connection):
                 self.connection.execute(
@@ -145,6 +155,10 @@ class FeatureBuilder:
                     (str(error)[:2000], feature_version),
                 )
             raise
+
+    def _report(self, fraction: float) -> None:
+        if self.progress:
+            self.progress(round(fraction * 1_000), 1_000)
 
     def _result(
         self, feature_version: str, *, reused: bool, timings: dict[str, int]
@@ -307,7 +321,7 @@ class FeatureBuilder:
         }
         features: list[_Feature] = []
         total = max(1, len(scene_ids))
-        for scene_id in scene_ids:
+        for position, scene_id in enumerate(scene_ids, 1):
             weighted: dict[str, float] = {}
             for tag_id, base in base_vectors[scene_id].items():
                 frequency = document_frequency[tag_id]
@@ -335,6 +349,8 @@ class FeatureBuilder:
                         },
                     )
                 )
+            if position == len(scene_ids) or position % 250 == 0:
+                self._report(0.10 + 0.30 * position / max(1, len(scene_ids)))
         for row in self.connection.execute(
             "SELECT scene_id, performer_id FROM scene_performer ORDER BY scene_id, performer_id"
         ):
@@ -452,8 +468,8 @@ class FeatureBuilder:
                    weight_kg, measurements, augmentation, tattoos, piercings
             FROM source_performer ORDER BY performer_id
             """
-        )
-        for row in performer_rows:
+        ).fetchall()
+        for position, row in enumerate(performer_rows, 1):
             performer_id = str(row["performer_id"])
             measurements = parse_measurements(row["measurements"])
             numeric: dict[str, tuple[float, float]] = {}
@@ -552,6 +568,8 @@ class FeatureBuilder:
                         {"provenance": provenance},
                     )
                 )
+            if position == len(performer_rows) or position % 250 == 0:
+                self._report(0.45 + 0.15 * position / max(1, len(performer_rows)))
         return tuple(features)
 
     def _publish(
@@ -689,9 +707,11 @@ class FeatureBuilder:
                     ),
                 )
             timings["database_writing"] = round((time.perf_counter() - writing_started) * 1000)
+            self._report(0.75)
             indexing_started = time.perf_counter()
             create_indexes(artifact, "feature")
             timings["indexing"] = round((time.perf_counter() - indexing_started) * 1000)
+            self._report(0.85)
             validation_started = time.perf_counter()
             stored = artifact.execute(
                 """
@@ -719,6 +739,7 @@ class FeatureBuilder:
                 },
             )
             timings["validation"] = round((time.perf_counter() - validation_started) * 1000)
+            self._report(0.93)
             publication_started = time.perf_counter()
             size = publish_file(artifact, temporary, final)
             artifact = None
@@ -751,6 +772,7 @@ class FeatureBuilder:
             published = True
             activate_artifact(self.connection, "feature", final)
             timings["publication"] = round((time.perf_counter() - publication_started) * 1000)
+            self._report(0.98)
             return timings
         finally:
             if not published:

--- a/curator/features/store.py
+++ b/curator/features/store.py
@@ -13,6 +13,7 @@ from curator.features.profiles import (
     SimilarityResult,
     performer_similarity,
 )
+from curator.storage.artifacts import attached_generation_id
 
 
 @dataclass(frozen=True)
@@ -30,6 +31,8 @@ class FeatureStore:
         self.connection = connection
 
     def current_version(self) -> str | None:
+        if attached := attached_generation_id(self.connection, "feature"):
+            return attached
         row = self.connection.execute(
             "SELECT feature_version FROM feature_build WHERE status = 'published'"
         ).fetchone()

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -10,6 +10,7 @@ import time
 from collections import defaultdict
 from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass
+from heapq import nsmallest
 from itertools import batched
 
 from curator.config import DEFAULT_CONFIG, CuratorConfig
@@ -21,6 +22,18 @@ from curator.model.boundaries import scene_eligibility
 from curator.model.curves import blend_appeal, direct_confidence, scene_recovery
 from curator.profiling import record_duration, span
 from curator.storage import ModelStore, transaction
+from curator.storage.artifacts import (
+    ARTIFACT_SCHEMA_VERSION,
+    activate_artifact,
+    artifact_path,
+    attach_build_sources,
+    create_artifact,
+    create_indexes,
+    database_path,
+    discard_artifact,
+    publish_file,
+    validate_artifact,
+)
 from curator.storage.retention import prune_snapshots
 
 
@@ -114,14 +127,17 @@ class PreferenceModelBuilder:
         # source data nor feature configuration changed. Always ask it for the current
         # version so a feature-only configuration change cannot silently train against
         # stale vectors.
-        feature_version = (
-            FeatureBuilder(self.connection, self.config, clock_ms=self.clock_ms)
-            .build()
-            .feature_version
-        )
+        feature = FeatureBuilder(self.connection, self.config, clock_ms=self.clock_ms).build()
+        feature_version = feature.feature_version
         self._report(0.05)
-        timings["features"] = round((time.perf_counter() - stage_started) * 1000)
-        record_duration("python", "model.features", timings["features"])
+        timings.update(
+            {f"feature_{name}": duration for name, duration in feature.stage_timings_ms.items()}
+        )
+        record_duration(
+            "python",
+            "model.features",
+            round((time.perf_counter() - stage_started) * 1000),
+        )
         stage_started = time.perf_counter()
         reference_at_ms = (self.clock_ms() // 86_400_000) * 86_400_000
         labels = self._scene_labels()
@@ -132,15 +148,32 @@ class PreferenceModelBuilder:
         evidence_fingerprint = self._evidence_fingerprint(labels)
         model_digest = hashlib.sha256(
             (
-                f"{feature_version}\0{evidence_fingerprint}\0"
+                f"{feature_version}\0{evidence_fingerprint}\0{self._source_fingerprint()}\0"
                 f"{self.config.canonical_json()}\0{reference_at_ms}"
             ).encode()
         ).hexdigest()
         model_id = f"model-{model_digest[:20]}"
         existing = self.connection.execute(
-            "SELECT status FROM model_version WHERE model_id=?", (model_id,)
+            """
+            SELECT status, artifact_basename, validation_status FROM model_version
+            WHERE model_id=?
+            """,
+            (model_id,),
         ).fetchone()
-        if existing and existing["status"] == "published":
+        if (
+            existing
+            and existing["status"] == "published"
+            and existing["validation_status"] == "valid"
+            and existing["artifact_basename"]
+            and artifact_path(
+                database_path(self.connection), str(existing["artifact_basename"])
+            ).is_file()
+        ):
+            with transaction(self.connection):
+                self.connection.execute(
+                    "UPDATE model_version SET reuse_count=reuse_count+1 WHERE model_id=?",
+                    (model_id,),
+                )
             self._report(1.0)
             timings["total"] = round((time.perf_counter() - started) * 1000)
             return self._result(
@@ -183,18 +216,25 @@ class PreferenceModelBuilder:
                 training_labels,
                 label_mean,
                 reference_at_ms,
+                timings,
             )
-            timings["scores"] = round((time.perf_counter() - stage_started) * 1000)
-            record_duration("python", "model.scores", timings["scores"])
+            score_total = round((time.perf_counter() - stage_started) * 1000)
+            timings["scoring"] = max(0, score_total - timings["similarity"])
+            record_duration("python", "model.scores", score_total)
             stage_started = time.perf_counter()
-            self._publish(model_id, feature_version, affinities, labels, scores)
+            timings.update(self._publish(model_id, feature_version, affinities, labels, scores))
             self._report(0.97)
-            timings["publish"] = round((time.perf_counter() - stage_started) * 1000)
-            record_duration("python", "model.publish", timings["publish"])
+            record_duration(
+                "python",
+                "model.publish",
+                round((time.perf_counter() - stage_started) * 1000),
+            )
         except Exception:
             model_store.fail(model_id)
             raise
+        stage_started = time.perf_counter()
         prune_snapshots(self.connection)
+        timings["cleanup"] = round((time.perf_counter() - stage_started) * 1000)
         self._report(1.0)
         timings["total"] = round((time.perf_counter() - started) * 1000)
         return self._result(model_id, feature_version, len(labels), reused=False, timings=timings)
@@ -343,6 +383,43 @@ class PreferenceModelBuilder:
         ).fetchone()
         return str(row[0]) if row and row[0] else None
 
+    def _source_fingerprint(self) -> str:
+        digest = hashlib.sha256()
+        for label, statement in (
+            (
+                "source_play",
+                """
+                SELECT scene_id, max(played_at_ms) FROM source_play
+                GROUP BY scene_id ORDER BY scene_id
+                """,
+            ),
+            (
+                "source_performer",
+                """
+                SELECT performer_id, favorite, rating100
+                FROM source_performer ORDER BY performer_id
+                """,
+            ),
+            (
+                "source_studio",
+                "SELECT studio_id, favorite FROM source_studio ORDER BY studio_id",
+            ),
+            (
+                "source_file",
+                """
+                SELECT scene_id, max(available) FROM source_file
+                GROUP BY scene_id ORDER BY scene_id
+                """,
+            ),
+        ):
+            digest.update(f"{label}\0".encode())
+            for row in self.connection.execute(statement):
+                digest.update(
+                    json.dumps(tuple(row), separators=(",", ":"), ensure_ascii=False).encode()
+                )
+                digest.update(b"\n")
+        return digest.hexdigest()
+
     def _affinities(
         self,
         scene_features: dict[str, tuple[StoredFeature, ...]],
@@ -452,6 +529,7 @@ class PreferenceModelBuilder:
         training_labels: dict[str, _SceneLabel],
         label_mean: float,
         reference_at_ms: int,
+        timings: dict[str, int],
     ) -> tuple[_Score, ...]:
         with span("python", "model.score_vectors"):
             vectors = FeatureStore(self.connection).scene_content_vectors(feature_version)
@@ -461,6 +539,7 @@ class PreferenceModelBuilder:
                 "SELECT scene_id FROM source_scene ORDER BY scene_id"
             )
         ]
+        similarity_started = time.perf_counter()
         with span("python", "model.score_neighbors"):
             preference_vectors, discriminative_tag_count = self._preference_content_vectors(
                 vectors, scene_features, affinities
@@ -473,6 +552,7 @@ class PreferenceModelBuilder:
             performer_similarity_scores = self._performer_similarity_scores(
                 feature_version, scene_features, affinities
             )
+        timings["similarity"] = round((time.perf_counter() - similarity_started) * 1000)
         baseline_support = sum(label.confidence for label in training_labels.values())
         baseline = (
             label_mean * baseline_support / (self.config.model.affinity_prior + baseline_support)
@@ -830,8 +910,11 @@ class PreferenceModelBuilder:
                     continue
                 weight = similarity**3 * labels[other_id].confidence
                 evidence.append((other_id, similarity, weight, labels[other_id].outcome))
-            evidence.sort(key=lambda item: (-item[2], item[0]))
-            selected = evidence[: self.config.model.neighbor_count]
+            selected = nsmallest(
+                self.config.model.neighbor_count,
+                evidence,
+                key=lambda item: (-item[2], item[0]),
+            )
             denominator = sum(item[2] for item in selected)
             outcome_mean = (
                 sum(item[2] * item[3] for item in selected) / denominator if denominator else 0.0
@@ -912,8 +995,11 @@ class PreferenceModelBuilder:
                     )
         result: dict[str, dict[str, object]] = {}
         for performer_id, matches in matches_by_performer.items():
-            matches.sort(key=lambda item: (-_number(item["similarity"]), str(item["performer_id"])))
-            selected = matches[:5]
+            selected = nsmallest(
+                5,
+                matches,
+                key=lambda item: (-_number(item["similarity"]), str(item["performer_id"])),
+            )
             denominator = sum(_number(item["similarity"]) ** 3 for item in selected)
             value = (
                 sum(
@@ -1108,103 +1194,193 @@ class PreferenceModelBuilder:
         affinities: dict[str, _Affinity],
         labels: dict[str, _SceneLabel],
         scores: tuple[_Score, ...],
-    ) -> None:
+    ) -> dict[str, int]:
+        timings: dict[str, int] = {}
+        writing_started = time.perf_counter()
         scores_by_scene = {score.scene_id: score for score in scores}
-        with transaction(self.connection):
-            self.connection.execute("DELETE FROM feature_affinity WHERE model_id=?", (model_id,))
-            self.connection.execute("DELETE FROM direct_scene_state WHERE model_id=?", (model_id,))
-            self.connection.execute("DELETE FROM model_scene_score WHERE model_id=?", (model_id,))
+        feature_row = self.connection.execute(
+            """
+            SELECT artifact_basename FROM feature_build
+            WHERE feature_version=? AND validation_status='valid'
+            """,
+            (feature_version,),
+        ).fetchone()
+        if feature_row is None or not feature_row[0]:
+            raise RuntimeError(f"feature artifact missing for {feature_version}")
+        feature_path = artifact_path(database_path(self.connection), str(feature_row[0]))
+        artifact, temporary, final = create_artifact(self.connection, "model", model_id)
+        attach_build_sources(artifact, self.connection, feature_path)
+        published = False
 
         def insert_rows(sql: str, rows: Iterable[tuple[object, ...]]) -> None:
             for batch in batched(rows, 1_000):
-                with transaction(self.connection):
-                    self.connection.executemany(sql, batch)
+                with transaction(artifact):
+                    artifact.executemany(sql, batch)
 
-        insert_rows(
-            """
-            INSERT INTO feature_affinity(
-                model_id, feature_id, affinity, confidence, effective_support,
-                distinct_scene_count, metadata_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                (
-                    model_id,
-                    affinity.feature_id,
-                    affinity.affinity,
-                    affinity.confidence,
-                    affinity.support,
-                    affinity.scene_count,
-                    json.dumps(affinity.contexts, sort_keys=True, separators=(",", ":")),
-                )
-                for affinity in sorted(affinities.values(), key=lambda item: item.feature_id)
-            ),
-        )
-        insert_rows(
-            """
-            INSERT INTO direct_scene_state(
-                model_id, scene_id, direct_appeal, effective_evidence, confidence, residual
-            ) VALUES (?, ?, ?, ?, ?, ?)
-            """,
-            (
-                (
-                    model_id,
-                    scene_id,
-                    label.outcome,
-                    label.effective_evidence,
-                    direct_confidence(label.effective_evidence, config=self.config.model),
-                    _clamp(label.outcome - scores_by_scene[scene_id].general_appeal, -2, 2),
-                )
-                for scene_id, label in sorted(labels.items())
-            ),
-        )
-        insert_rows(
-            """
-            INSERT INTO model_scene_score(
-                model_id, scene_id, general_appeal, direct_appeal, direct_confidence,
-                appeal, current_fit, confidence, metadata_confidence, recovery,
-                components_json, neighbors_json, eligibility_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                (
-                    model_id,
-                    score.scene_id,
-                    score.general_appeal,
-                    score.direct_appeal,
-                    score.direct_confidence,
-                    score.appeal,
-                    score.current_fit,
-                    score.confidence,
-                    score.metadata_confidence,
-                    score.recovery,
-                    json.dumps(score.components, sort_keys=True, separators=(",", ":")),
-                    json.dumps(score.neighbors, sort_keys=True, separators=(",", ":")),
-                    json.dumps(score.eligibility, sort_keys=True, separators=(",", ":")),
-                )
-                for score in scores
-            ),
-        )
-        # Lane orders are immutable model artifacts: finish them before the atomic
-        # status flip so requests never observe a half-published recommendation model.
-        from curator.ranking import LanePolicy, SlateBuilder
-
-        LanePolicy(self.connection, self.config).classify(model_id)
-        SlateBuilder(self.connection, self.config).materialize(model_id, force=True)
-        with transaction(self.connection):
-            self.connection.execute(
-                "UPDATE model_version SET status='superseded' WHERE status='published'"
-            )
-            self.connection.execute(
+        try:
+            insert_rows(
                 """
-                UPDATE model_version SET status='published', published_at_ms=? WHERE model_id=?
+                INSERT INTO feature_affinity(
+                    model_id, feature_id, affinity, confidence, effective_support,
+                    distinct_scene_count, metadata_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
                 """,
-                (self.clock_ms(), model_id),
+                (
+                    (
+                        model_id,
+                        affinity.feature_id,
+                        affinity.affinity,
+                        affinity.confidence,
+                        affinity.support,
+                        affinity.scene_count,
+                        json.dumps(affinity.contexts, sort_keys=True, separators=(",", ":")),
+                    )
+                    for affinity in sorted(affinities.values(), key=lambda item: item.feature_id)
+                ),
             )
-            self.connection.execute(
+            insert_rows(
                 """
-                INSERT INTO application_meta(key, value) VALUES ('current_model_id', ?)
-                ON CONFLICT(key) DO UPDATE SET value=excluded.value
+                INSERT INTO direct_scene_state(
+                    model_id, scene_id, direct_appeal, effective_evidence, confidence, residual
+                ) VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    (
+                        model_id,
+                        scene_id,
+                        label.outcome,
+                        label.effective_evidence,
+                        direct_confidence(label.effective_evidence, config=self.config.model),
+                        _clamp(
+                            label.outcome - scores_by_scene[scene_id].general_appeal,
+                            -2,
+                            2,
+                        ),
+                    )
+                    for scene_id, label in sorted(labels.items())
+                ),
+            )
+            insert_rows(
+                """
+                INSERT INTO model_scene_score(
+                    model_id, scene_id, general_appeal, direct_appeal, direct_confidence,
+                    appeal, current_fit, confidence, metadata_confidence, recovery,
+                    components_json, neighbors_json, eligibility_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    (
+                        model_id,
+                        score.scene_id,
+                        score.general_appeal,
+                        score.direct_appeal,
+                        score.direct_confidence,
+                        score.appeal,
+                        score.current_fit,
+                        score.confidence,
+                        score.metadata_confidence,
+                        score.recovery,
+                        json.dumps(score.components, sort_keys=True, separators=(",", ":")),
+                        json.dumps(score.neighbors, sort_keys=True, separators=(",", ":")),
+                        json.dumps(score.eligibility, sort_keys=True, separators=(",", ":")),
+                    )
+                    for score in scores
+                ),
+            )
+            timings["database_writing"] = round((time.perf_counter() - writing_started) * 1000)
+            from curator.explanations import ReasonGraphStore
+            from curator.ranking import LanePolicy, SlateBuilder
+
+            indexing_started = time.perf_counter()
+            LanePolicy(artifact, self.config).classify(model_id)
+            SlateBuilder(artifact, self.config).materialize(model_id, force=True)
+            ReasonGraphStore(artifact).build(model_id)
+            create_indexes(artifact, "model")
+            timings["indexing"] = round((time.perf_counter() - indexing_started) * 1000)
+            validation_started = time.perf_counter()
+            stored_count = int(
+                artifact.execute(
+                    "SELECT count(*) FROM model_scene_score WHERE model_id=?", (model_id,)
+                ).fetchone()[0]
+            )
+            lane_count = int(
+                artifact.execute(
+                    "SELECT count(*) FROM model_scene_lane WHERE model_id=?", (model_id,)
+                ).fetchone()[0]
+            )
+            reason_scene_count, reason_count = artifact.execute(
+                """
+                SELECT count(DISTINCT scene_id), count(*) FROM model_scene_reason
+                WHERE model_id=?
                 """,
                 (model_id,),
+            ).fetchone()
+            lane_state = artifact.execute(
+                "SELECT 1 FROM model_lane_order_state WHERE model_id=?", (model_id,)
+            ).fetchone()
+            if (
+                stored_count != len(scores)
+                or int(reason_scene_count) != stored_count
+                or lane_state is None
+            ):
+                raise RuntimeError(
+                    "model validation failed: "
+                    f"scores={stored_count}/{len(scores)}, "
+                    f"reason scenes={reason_scene_count}/{stored_count}, "
+                    f"lane state={lane_state is not None}"
+                )
+            summary = validate_artifact(
+                artifact,
+                "model",
+                {
+                    "scenes": stored_count,
+                    "lanes": lane_count,
+                    "reason_scenes": int(reason_scene_count),
+                    "reasons": int(reason_count),
+                },
             )
+            timings["validation"] = round((time.perf_counter() - validation_started) * 1000)
+            publication_started = time.perf_counter()
+            size = publish_file(artifact, temporary, final)
+            with transaction(self.connection):
+                self.connection.execute(
+                    "UPDATE model_version SET status='superseded' WHERE status='published'"
+                )
+                self.connection.execute(
+                    """
+                    UPDATE model_version SET status='published', published_at_ms=?,
+                        artifact_basename=?, artifact_schema_version=?, artifact_bytes=?,
+                        scene_count=?, lane_count=?, reason_scene_count=?, reason_count=?,
+                        validation_status='valid', validation_summary_json=?,
+                        cleanup_error=NULL
+                    WHERE model_id=?
+                    """,
+                    (
+                        self.clock_ms(),
+                        final.name,
+                        ARTIFACT_SCHEMA_VERSION,
+                        size,
+                        stored_count,
+                        lane_count,
+                        int(reason_scene_count),
+                        int(reason_count),
+                        json.dumps(summary, sort_keys=True, separators=(",", ":")),
+                        model_id,
+                    ),
+                )
+                self.connection.execute(
+                    """
+                    INSERT INTO application_meta(key, value) VALUES ('current_model_id', ?)
+                    ON CONFLICT(key) DO UPDATE SET value=excluded.value
+                    """,
+                    (model_id,),
+                )
+            published = True
+            activate_artifact(self.connection, "model", final)
+            timings["publication"] = round((time.perf_counter() - publication_started) * 1000)
+            return timings
+        finally:
+            if not published:
+                discard_artifact(artifact, temporary)
+                if not temporary.exists():
+                    final.unlink(missing_ok=True)

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -127,9 +127,14 @@ class PreferenceModelBuilder:
         # source data nor feature configuration changed. Always ask it for the current
         # version so a feature-only configuration change cannot silently train against
         # stale vectors.
-        feature = FeatureBuilder(self.connection, self.config, clock_ms=self.clock_ms).build()
+        feature = FeatureBuilder(
+            self.connection,
+            self.config,
+            clock_ms=self.clock_ms,
+            progress=lambda processed, total: self._report(0.25 * processed / max(1, total)),
+        ).build()
         feature_version = feature.feature_version
-        self._report(0.05)
+        self._report(0.25)
         timings.update(
             {f"feature_{name}": duration for name, duration in feature.stage_timings_ms.items()}
         )
@@ -142,7 +147,7 @@ class PreferenceModelBuilder:
         reference_at_ms = (self.clock_ms() // 86_400_000) * 86_400_000
         labels = self._scene_labels()
         training_labels = self._training_labels(labels)
-        self._report(0.10)
+        self._report(0.30)
         timings["labels"] = round((time.perf_counter() - stage_started) * 1000)
         record_duration("python", "model.labels", timings["labels"])
         evidence_fingerprint = self._evidence_fingerprint(labels)
@@ -204,7 +209,7 @@ class PreferenceModelBuilder:
             scene_features = FeatureStore(self.connection).entity_features(feature_version, "scene")
             label_mean = self._label_mean(training_labels)
             affinities = self._affinities(scene_features, training_labels, label_mean)
-            self._report(0.20)
+            self._report(0.35)
             timings["affinities"] = round((time.perf_counter() - stage_started) * 1000)
             record_duration("python", "model.affinities", timings["affinities"])
             stage_started = time.perf_counter()
@@ -223,7 +228,7 @@ class PreferenceModelBuilder:
             record_duration("python", "model.scores", score_total)
             stage_started = time.perf_counter()
             timings.update(self._publish(model_id, feature_version, affinities, labels, scores))
-            self._report(0.97)
+            self._report(0.98)
             record_duration(
                 "python",
                 "model.publish",
@@ -835,7 +840,7 @@ class PreferenceModelBuilder:
             )
             progress_index = len(preference_vectors) + scene_index
             if self.progress and (scene_index == total_scenes or scene_index % 250 == 0):
-                self._report(0.20 + 0.70 * progress_index / max(1, progress_total))
+                self._report(0.35 + 0.40 * progress_index / max(1, progress_total))
         return tuple(scores)
 
     def _preference_content_vectors(
@@ -942,7 +947,7 @@ class PreferenceModelBuilder:
                 ),
             )
             if self.progress and (vector_index == vector_count or vector_index % 250 == 0):
-                self._report(0.20 + 0.70 * vector_index / max(1, progress_total))
+                self._report(0.35 + 0.40 * vector_index / max(1, progress_total))
         return result
 
     def _performer_similarity_scores(
@@ -1238,6 +1243,7 @@ class PreferenceModelBuilder:
                     for affinity in sorted(affinities.values(), key=lambda item: item.feature_id)
                 ),
             )
+            self._report(0.78)
             insert_rows(
                 """
                 INSERT INTO direct_scene_state(
@@ -1260,6 +1266,7 @@ class PreferenceModelBuilder:
                     for scene_id, label in sorted(labels.items())
                 ),
             )
+            self._report(0.81)
             insert_rows(
                 """
                 INSERT INTO model_scene_score(
@@ -1287,16 +1294,30 @@ class PreferenceModelBuilder:
                     for score in scores
                 ),
             )
+            self._report(0.85)
             timings["database_writing"] = round((time.perf_counter() - writing_started) * 1000)
             from curator.explanations import ReasonGraphStore
             from curator.ranking import LanePolicy, SlateBuilder
 
             indexing_started = time.perf_counter()
-            LanePolicy(artifact, self.config).classify(model_id)
-            SlateBuilder(artifact, self.config).materialize(model_id, force=True)
+            LanePolicy(artifact, self.config).classify(
+                model_id,
+                progress=lambda processed, total: self._report(
+                    0.85 + 0.02 * processed / max(1, total)
+                ),
+            )
+            SlateBuilder(artifact, self.config).materialize(
+                model_id,
+                force=True,
+                progress=lambda processed, total: self._report(
+                    0.87 + 0.04 * processed / max(1, total)
+                ),
+            )
             ReasonGraphStore(artifact).build(model_id)
+            self._report(0.94)
             create_indexes(artifact, "model")
             timings["indexing"] = round((time.perf_counter() - indexing_started) * 1000)
+            self._report(0.96)
             validation_started = time.perf_counter()
             stored_count = int(
                 artifact.execute(
@@ -1338,8 +1359,12 @@ class PreferenceModelBuilder:
                     "reason_scenes": int(reason_scene_count),
                     "reasons": int(reason_count),
                 },
+                # ponytail: generated models are atomic and rebuildable; restore the
+                # full-file scan if installed evidence ever shows artifact corruption.
+                check_integrity=False,
             )
             timings["validation"] = round((time.perf_counter() - validation_started) * 1000)
+            self._report(0.97)
             publication_started = time.perf_counter()
             size = publish_file(artifact, temporary, final)
             with transaction(self.connection):
@@ -1378,6 +1403,7 @@ class PreferenceModelBuilder:
             published = True
             activate_artifact(self.connection, "model", final)
             timings["publication"] = round((time.perf_counter() - publication_started) * 1000)
+            self._report(0.98)
             return timings
         finally:
             if not published:

--- a/curator/model/store.py
+++ b/curator/model/store.py
@@ -7,6 +7,8 @@ import sqlite3
 from collections.abc import Collection
 from dataclasses import dataclass
 
+from curator.storage.artifacts import attached_generation_id
+
 
 @dataclass(frozen=True)
 class ModelSceneScore:
@@ -30,6 +32,8 @@ class RecommendationModelStore:
         self.connection = connection
 
     def current_model_id(self) -> str | None:
+        if attached := attached_generation_id(self.connection, "model"):
+            return attached
         row = self.connection.execute(
             "SELECT model_id FROM model_version WHERE status='published'"
         ).fetchone()

--- a/curator/model/updates.py
+++ b/curator/model/updates.py
@@ -83,7 +83,7 @@ class ModelUpdateCoordinator:
                         WHEN requested_generation=published_generation THEN ?
                         ELSE requested_at_ms
                     END,
-                    last_cause=?, last_error=NULL
+                    last_cause=?
                 WHERE singleton=1
                 """,
                 (self.clock_ms(), cause),

--- a/curator/ranking/policy.py
+++ b/curator/ranking/policy.py
@@ -423,7 +423,6 @@ class LanePolicy:
             self.connection.execute(
                 "DELETE FROM model_lane_candidate_cache WHERE model_id=?", (model_id,)
             )
-            self.connection.execute("DELETE FROM application_meta WHERE key LIKE 'slate:%'")
             self.connection.executemany(
                 """
                 INSERT INTO model_scene_lane(

--- a/curator/ranking/policy.py
+++ b/curator/ranking/policy.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import math
 import sqlite3
-from collections.abc import Collection
+from collections.abc import Callable, Collection
 from dataclasses import dataclass
 
 from curator.config import DEFAULT_CONFIG, CuratorConfig
@@ -64,7 +64,12 @@ class LanePolicy:
         self.connection = connection
         self.config = config
 
-    def classify(self, model_id: str) -> tuple[LaneClassification, ...]:
+    def classify(
+        self,
+        model_id: str,
+        *,
+        progress: Callable[[int, int], None] | None = None,
+    ) -> tuple[LaneClassification, ...]:
         scores = RecommendationModelStore(self.connection).scores(model_id)
         eligible_scores = {
             scene_id: score
@@ -116,7 +121,8 @@ class LanePolicy:
             model_id, set(eligible_scores)
         )
         classifications: list[LaneClassification] = []
-        for scene_id, score in sorted(eligible_scores.items()):
+        total = len(eligible_scores)
+        for position, (scene_id, score) in enumerate(sorted(eligible_scores.items()), 1):
             reusable = {
                 family: _component_value(score, family)
                 for family in (
@@ -266,6 +272,10 @@ class LanePolicy:
                     },
                 )
             )
+            if progress and (position == total or position % 250 == 0):
+                progress(position, max(1, total))
+        if progress and not total:
+            progress(1, 1)
         self._persist(
             model_id,
             classifications,

--- a/curator/ranking/slate.py
+++ b/curator/ranking/slate.py
@@ -7,6 +7,7 @@ import math
 import sqlite3
 import time
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import asdict, dataclass, field, replace
 from heapq import heappop, heappush
 from typing import Any
@@ -123,14 +124,20 @@ class SlateBuilder:
             self.recommend(lane, slate_size)
         return counts
 
-    def materialize(self, model_id: str, *, force: bool = False) -> dict[str, int]:
+    def materialize(
+        self,
+        model_id: str,
+        *,
+        force: bool = False,
+        progress: Callable[[int, int], None] | None = None,
+    ) -> dict[str, int]:
         if (
             not force
             and self.connection.execute(
                 "SELECT 1 FROM model_lane_order_state WHERE model_id=?", (model_id,)
             ).fetchone()
         ):
-            return {
+            result = {
                 str(row["lane"]): int(row["candidate_count"])
                 for row in self.connection.execute(
                     """
@@ -140,6 +147,9 @@ class SlateBuilder:
                     (model_id,),
                 )
             }
+            if progress:
+                progress(1, 1)
+            return result
         classifications = LanePolicy(self.connection, self.config).load(model_id)
         candidates = self._candidates(model_id, classifications)
         counts = {
@@ -151,6 +161,8 @@ class SlateBuilder:
                 "DELETE FROM model_lane_order_state WHERE model_id=?", (model_id,)
             )
             self.connection.execute("DELETE FROM model_lane_order WHERE model_id=?", (model_id,))
+        completed = 0
+        total = (len(LANES) + 1) * 2
         for lane in (*LANES, "for_you"):
             lane_candidates = tuple(
                 candidate
@@ -186,6 +198,9 @@ class SlateBuilder:
                             )
                         ),
                     )
+                completed += 1
+                if progress:
+                    progress(completed, total)
         with transaction(self.connection):
             self.connection.execute(
                 """

--- a/curator/storage/__init__.py
+++ b/curator/storage/__init__.py
@@ -1,6 +1,14 @@
 """SQLite storage primitives for Stash Curator."""
 
-from curator.storage.database import StorageError, backup_database, connect_database, transaction
+from curator.storage.artifacts import generation_diagnostics, recognized_artifacts
+from curator.storage.database import (
+    StorageError,
+    backup_database,
+    compact_legacy_generations,
+    compaction_status,
+    connect_database,
+    transaction,
+)
 from curator.storage.migrations import MigrationError, MigrationRunner
 from curator.storage.models import ModelStore, ModelVersion
 from curator.storage.retention import RetentionResult, prune_snapshots
@@ -13,7 +21,11 @@ __all__ = [
     "RetentionResult",
     "StorageError",
     "backup_database",
+    "compact_legacy_generations",
+    "compaction_status",
     "connect_database",
+    "generation_diagnostics",
     "prune_snapshots",
+    "recognized_artifacts",
     "transaction",
 ]

--- a/curator/storage/artifacts.py
+++ b/curator/storage/artifacts.py
@@ -224,11 +224,19 @@ def attach_build_sources(
 
 
 def validate_artifact(
-    connection: sqlite3.Connection, kind: str, counts: dict[str, int]
+    connection: sqlite3.Connection,
+    kind: str,
+    counts: dict[str, int],
+    *,
+    check_integrity: bool = True,
 ) -> dict[str, object]:
-    integrity = str(connection.execute("PRAGMA quick_check").fetchone()[0])
+    integrity = (
+        str(connection.execute("PRAGMA quick_check").fetchone()[0])
+        if check_integrity
+        else "skipped"
+    )
     schema_version = int(connection.execute("PRAGMA user_version").fetchone()[0])
-    if integrity != "ok" or schema_version != ARTIFACT_SCHEMA_VERSION:
+    if (check_integrity and integrity != "ok") or schema_version != ARTIFACT_SCHEMA_VERSION:
         raise StorageError(
             f"{kind} artifact validation failed: integrity={integrity}, schema={schema_version}"
         )

--- a/curator/storage/artifacts.py
+++ b/curator/storage/artifacts.py
@@ -1,0 +1,392 @@
+"""Immutable feature/model SQLite generation files."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+from pathlib import Path
+from uuid import uuid4
+
+from curator.storage.database import StorageError
+
+ARTIFACT_SCHEMA_VERSION = 1
+SUPPORTED_ARTIFACT_SCHEMA_VERSIONS = frozenset({1, 2})
+_FINAL_NAME = re.compile(r"(feature-fv-[0-9a-f]{20}|model-[0-9a-f]{20})\.sqlite3")
+_TEMP_NAME = re.compile(r"\.(feature-fv-[0-9a-f]{20}|model-[0-9a-f]{20})\.[0-9a-f]{32}\.tmp")
+FEATURE_TABLES = ("feature_definition", "entity_feature", "scene_content_search")
+MODEL_TABLES = (
+    "feature_affinity",
+    "direct_scene_state",
+    "model_scene_score",
+    "model_scene_reason",
+    "model_scene_lane",
+    "model_lane_candidate_cache",
+    "model_lane_order",
+    "model_lane_order_state",
+)
+
+FEATURE_SCHEMA = """
+CREATE TABLE artifact_meta (
+    kind TEXT NOT NULL, generation_id TEXT NOT NULL, schema_version INTEGER NOT NULL
+) STRICT;
+CREATE TABLE feature_definition (
+    feature_id TEXT PRIMARY KEY, feature_version TEXT NOT NULL, family TEXT NOT NULL,
+    name TEXT NOT NULL, provenance TEXT NOT NULL, metadata_json TEXT NOT NULL DEFAULT '{}'
+) STRICT;
+CREATE TABLE entity_feature (
+    feature_version TEXT NOT NULL, entity_type TEXT NOT NULL, entity_id TEXT NOT NULL,
+    feature_id TEXT NOT NULL REFERENCES feature_definition(feature_id) ON DELETE CASCADE,
+    value REAL NOT NULL, confidence REAL NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+    PRIMARY KEY (feature_version, entity_type, entity_id, feature_id)
+) STRICT, WITHOUT ROWID;
+CREATE TABLE scene_content_search (
+    feature_version TEXT NOT NULL, feature_id TEXT NOT NULL, scene_id TEXT NOT NULL,
+    value REAL NOT NULL, PRIMARY KEY (feature_id, scene_id)
+) STRICT, WITHOUT ROWID;
+"""
+
+MODEL_SCHEMA = """
+CREATE TABLE artifact_meta (
+    kind TEXT NOT NULL, generation_id TEXT NOT NULL, schema_version INTEGER NOT NULL
+) STRICT;
+CREATE TABLE feature_affinity (
+    model_id TEXT NOT NULL, feature_id TEXT NOT NULL,
+    affinity REAL NOT NULL CHECK (affinity BETWEEN -1 AND 1),
+    confidence REAL NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+    effective_support REAL NOT NULL CHECK (effective_support >= 0),
+    distinct_scene_count INTEGER NOT NULL CHECK (distinct_scene_count >= 0),
+    metadata_json TEXT NOT NULL DEFAULT '{}', PRIMARY KEY (model_id, feature_id)
+) STRICT, WITHOUT ROWID;
+CREATE TABLE direct_scene_state (
+    model_id TEXT NOT NULL, scene_id TEXT NOT NULL,
+    direct_appeal REAL NOT NULL CHECK (direct_appeal BETWEEN -1 AND 1),
+    effective_evidence REAL NOT NULL CHECK (effective_evidence >= 0),
+    confidence REAL NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+    residual REAL NOT NULL CHECK (residual BETWEEN -2 AND 2),
+    PRIMARY KEY (model_id, scene_id)
+) STRICT, WITHOUT ROWID;
+CREATE TABLE model_scene_score (
+    model_id TEXT NOT NULL, scene_id TEXT NOT NULL,
+    general_appeal REAL NOT NULL CHECK (general_appeal BETWEEN -1 AND 1),
+    direct_appeal REAL NOT NULL CHECK (direct_appeal BETWEEN -1 AND 1),
+    direct_confidence REAL NOT NULL CHECK (direct_confidence BETWEEN 0 AND 1),
+    appeal REAL NOT NULL CHECK (appeal BETWEEN -1 AND 1),
+    current_fit REAL NOT NULL CHECK (current_fit BETWEEN -1 AND 1),
+    confidence REAL NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+    metadata_confidence REAL NOT NULL CHECK (metadata_confidence BETWEEN 0 AND 1),
+    recovery REAL NOT NULL CHECK (recovery BETWEEN 0 AND 1),
+    components_json TEXT NOT NULL, neighbors_json TEXT NOT NULL DEFAULT '[]',
+    eligibility_json TEXT NOT NULL DEFAULT '{}', PRIMARY KEY (model_id, scene_id)
+) STRICT, WITHOUT ROWID;
+CREATE TABLE model_scene_reason (
+    model_id TEXT NOT NULL, scene_id TEXT NOT NULL,
+    reason_index INTEGER NOT NULL CHECK (reason_index >= 0), reason_code TEXT NOT NULL,
+    direction TEXT NOT NULL CHECK (direction IN ('positive','negative','unknown','neutral')),
+    magnitude REAL NOT NULL CHECK (magnitude BETWEEN 0 AND 1),
+    confidence REAL NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+    subject_type TEXT, subject_id TEXT,
+    visibility TEXT NOT NULL CHECK (visibility IN ('standard','sensitive','private')),
+    provenance TEXT NOT NULL, detail_json TEXT NOT NULL DEFAULT '{}',
+    PRIMARY KEY (model_id, scene_id, reason_index)
+) STRICT, WITHOUT ROWID;
+CREATE TABLE model_scene_lane (
+    model_id TEXT NOT NULL, scene_id TEXT NOT NULL,
+    lane TEXT NOT NULL CHECK (lane IN ('for_you','best_bets','revisit','discover','adventure')),
+    subtype TEXT, lane_value REAL NOT NULL, qualification_json TEXT NOT NULL DEFAULT '{}',
+    appeal REAL, PRIMARY KEY (model_id, scene_id, lane)
+) STRICT, WITHOUT ROWID;
+CREATE TABLE model_lane_candidate_cache (
+    model_id TEXT NOT NULL,
+    lane TEXT NOT NULL CHECK (lane IN ('best_bets','revisit','discover','adventure')),
+    candidates_json TEXT NOT NULL, candidate_count INTEGER NOT NULL CHECK (candidate_count >= 0),
+    created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0), PRIMARY KEY (model_id, lane)
+) STRICT, WITHOUT ROWID;
+CREATE TABLE model_lane_order (
+    model_id TEXT NOT NULL,
+    lane TEXT NOT NULL CHECK (lane IN ('for_you','best_bets','revisit','discover','adventure')),
+    ordering TEXT NOT NULL CHECK (ordering IN ('score_first','varied')),
+    position INTEGER NOT NULL CHECK (position >= 0), scene_id TEXT NOT NULL,
+    source_lane TEXT NOT NULL CHECK (
+        source_lane IN ('best_bets','revisit','discover','adventure')
+    ),
+    utility REAL NOT NULL, ranking_json TEXT NOT NULL DEFAULT '{}',
+    PRIMARY KEY (model_id, lane, ordering, position),
+    UNIQUE (model_id, lane, ordering, scene_id)
+) STRICT, WITHOUT ROWID;
+CREATE TABLE model_lane_order_state (
+    model_id TEXT PRIMARY KEY, created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0)
+) STRICT, WITHOUT ROWID;
+"""
+
+
+def database_path(connection: sqlite3.Connection) -> Path:
+    row = next(row for row in connection.execute("PRAGMA database_list") if row["name"] == "main")
+    if not row["file"]:
+        raise StorageError("generation artifacts require a file-backed core database")
+    return Path(str(row["file"])).resolve()
+
+
+def cache_directory(core_path: Path) -> Path:
+    return core_path.resolve().with_name(f"{core_path.stem}-derived")
+
+
+def artifact_path(core_path: Path, basename: str, *, temporary: bool = False) -> Path:
+    pattern = _TEMP_NAME if temporary else _FINAL_NAME
+    if Path(basename).name != basename or not pattern.fullmatch(basename):
+        raise StorageError(f"invalid artifact basename: {basename}")
+    directory = cache_directory(core_path)
+    if directory.exists() and (directory.is_symlink() or not directory.is_dir()):
+        raise StorageError(f"unsafe derived-cache directory: {directory}")
+    path = directory / basename
+    if path.is_symlink() or path.resolve(strict=False).parent != directory.resolve(strict=False):
+        raise StorageError(f"unsafe artifact path: {basename}")
+    return path
+
+
+def _readonly_uri(path: Path, *, immutable: bool = True) -> str:
+    suffix = "&immutable=1" if immutable else ""
+    return f"{path.as_uri()}?mode=ro{suffix}"
+
+
+def _quote(identifier: str) -> str:
+    return '"' + identifier.replace('"', '""') + '"'
+
+
+def create_artifact(
+    core: sqlite3.Connection, kind: str, identifier: str
+) -> tuple[sqlite3.Connection, Path, Path]:
+    if kind not in {"feature", "model"}:
+        raise ValueError(f"unknown artifact kind: {kind}")
+    expected = f"feature-{identifier}" if kind == "feature" else identifier
+    final = artifact_path(database_path(core), f"{expected}.sqlite3")
+    directory = final.parent
+    directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+    temporary = artifact_path(database_path(core), f".{expected}.{uuid4().hex}.tmp", temporary=True)
+    connection = sqlite3.connect(temporary, isolation_level=None, timeout=30)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys=ON")
+    connection.execute(f"PRAGMA user_version={ARTIFACT_SCHEMA_VERSION}")
+    connection.executescript(FEATURE_SCHEMA if kind == "feature" else MODEL_SCHEMA)
+    connection.execute(
+        "INSERT INTO artifact_meta(kind, generation_id, schema_version) VALUES (?, ?, ?)",
+        (kind, identifier, ARTIFACT_SCHEMA_VERSION),
+    )
+    return connection, temporary, final
+
+
+def create_indexes(connection: sqlite3.Connection, kind: str) -> None:
+    if kind == "feature":
+        connection.executescript(
+            """
+            CREATE INDEX entity_feature_feature_idx ON entity_feature(feature_id);
+            CREATE INDEX scene_content_search_scene_idx
+            ON scene_content_search(feature_version, scene_id, feature_id);
+            """
+        )
+    else:
+        connection.executescript(
+            """
+            CREATE INDEX model_scene_score_fit_idx
+            ON model_scene_score(model_id, current_fit DESC);
+            CREATE INDEX model_scene_score_prune_idx
+            ON model_scene_score(model_id, appeal, confidence, scene_id);
+            CREATE INDEX model_scene_lane_value_idx
+            ON model_scene_lane(model_id, lane, lane_value DESC);
+            CREATE INDEX model_scene_lane_appeal_idx
+            ON model_scene_lane(model_id, scene_id, appeal);
+            """
+        )
+
+
+def attach_build_sources(
+    connection: sqlite3.Connection, core: sqlite3.Connection, feature_path: Path
+) -> None:
+    connection.execute(
+        "ATTACH DATABASE ? AS core",
+        (_readonly_uri(database_path(core), immutable=False),),
+    )
+    connection.execute("ATTACH DATABASE ? AS feature_generation", (_readonly_uri(feature_path),))
+    owned = set(MODEL_TABLES) | set(FEATURE_TABLES)
+    for row in connection.execute(
+        "SELECT name FROM core.sqlite_master WHERE type='table' ORDER BY name"
+    ):
+        name = str(row[0])
+        if name not in owned and not name.startswith("sqlite_"):
+            quoted = _quote(name)
+            connection.execute(f"CREATE TEMP VIEW {quoted} AS SELECT * FROM core.{quoted}")
+    for name in FEATURE_TABLES:
+        quoted = _quote(name)
+        connection.execute(
+            f"CREATE TEMP VIEW {quoted} AS SELECT * FROM feature_generation.{quoted}"
+        )
+
+
+def validate_artifact(
+    connection: sqlite3.Connection, kind: str, counts: dict[str, int]
+) -> dict[str, object]:
+    integrity = str(connection.execute("PRAGMA quick_check").fetchone()[0])
+    schema_version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+    if integrity != "ok" or schema_version != ARTIFACT_SCHEMA_VERSION:
+        raise StorageError(
+            f"{kind} artifact validation failed: integrity={integrity}, schema={schema_version}"
+        )
+    return {
+        "integrity": integrity,
+        "schema_version": schema_version,
+        "counts": counts,
+    }
+
+
+def publish_file(connection: sqlite3.Connection, temporary: Path, final: Path) -> int:
+    connection.close()
+    os.replace(temporary, final)
+    return final.stat().st_size
+
+
+def discard_artifact(connection: sqlite3.Connection | None, temporary: Path | None) -> None:
+    if connection is not None:
+        connection.close()
+    if temporary is not None:
+        temporary.unlink(missing_ok=True)
+
+
+def _registry_columns(connection: sqlite3.Connection, table: str) -> set[str]:
+    return {str(row["name"]) for row in connection.execute(f"PRAGMA table_info({_quote(table)})")}
+
+
+def attach_active_artifacts(connection: sqlite3.Connection) -> None:
+    if "artifact_basename" not in _registry_columns(connection, "feature_build"):
+        return
+    core = database_path(connection)
+    rows = (
+        (
+            "feature_generation",
+            FEATURE_TABLES,
+            connection.execute(
+                """
+                SELECT artifact_basename FROM feature_build
+                WHERE status='published' AND validation_status='valid'
+                """
+            ).fetchone(),
+        ),
+        (
+            "model_generation",
+            MODEL_TABLES,
+            connection.execute(
+                """
+                SELECT artifact_basename FROM model_version
+                WHERE status='published' AND validation_status='valid'
+                """
+            ).fetchone(),
+        ),
+    )
+    for alias, tables, row in rows:
+        if row is None or not row[0]:
+            continue
+        path = artifact_path(core, str(row[0]))
+        if not path.is_file():
+            raise StorageError(f"active artifact is missing: {path.name}")
+        connection.execute(f"ATTACH DATABASE ? AS {alias}", (_readonly_uri(path),))
+        if (
+            int(connection.execute(f"PRAGMA {alias}.user_version").fetchone()[0])
+            not in SUPPORTED_ARTIFACT_SCHEMA_VERSIONS
+        ):
+            raise StorageError(f"unsupported active artifact schema: {path.name}")
+        for table in tables:
+            quoted = _quote(table)
+            connection.execute(f"CREATE TEMP VIEW {quoted} AS SELECT * FROM {alias}.{quoted}")
+
+
+def activate_artifact(connection: sqlite3.Connection, kind: str, path: Path) -> None:
+    alias, tables = (
+        ("feature_generation", FEATURE_TABLES)
+        if kind == "feature"
+        else ("model_generation", MODEL_TABLES)
+    )
+    for table in tables:
+        connection.execute(f"DROP VIEW IF EXISTS temp.{_quote(table)}")
+    attached = {str(row["name"]) for row in connection.execute("PRAGMA database_list")}
+    if alias in attached:
+        connection.execute(f"DETACH DATABASE {alias}")
+    connection.execute(f"ATTACH DATABASE ? AS {alias}", (_readonly_uri(path),))
+    if (
+        int(connection.execute(f"PRAGMA {alias}.user_version").fetchone()[0])
+        not in SUPPORTED_ARTIFACT_SCHEMA_VERSIONS
+    ):
+        connection.execute(f"DETACH DATABASE {alias}")
+        raise StorageError(f"unsupported active artifact schema: {path.name}")
+    for table in tables:
+        quoted = _quote(table)
+        connection.execute(f"CREATE TEMP VIEW {quoted} AS SELECT * FROM {alias}.{quoted}")
+
+
+def artifact_attached(connection: sqlite3.Connection, kind: str) -> bool:
+    alias = f"{kind}_generation"
+    return alias in {str(row["name"]) for row in connection.execute("PRAGMA database_list")}
+
+
+def attached_generation_id(connection: sqlite3.Connection, kind: str) -> str | None:
+    if not artifact_attached(connection, kind):
+        return None
+    row = connection.execute(
+        f"SELECT generation_id FROM {kind}_generation.artifact_meta"
+    ).fetchone()
+    return str(row[0]) if row else None
+
+
+def generation_diagnostics(connection: sqlite3.Connection) -> dict[str, object]:
+    result: dict[str, object] = {
+        "cleanup_retry_count": sum(
+            int(
+                connection.execute(
+                    f"SELECT count(*) FROM {table} WHERE cleanup_error IS NOT NULL"
+                ).fetchone()[0]
+            )
+            for table in ("feature_build", "model_version")
+            if "cleanup_error" in _registry_columns(connection, table)
+        )
+    }
+    for kind, table, identifier in (
+        ("feature", "feature_build", "feature_version"),
+        ("model", "model_version", "model_id"),
+    ):
+        if "artifact_basename" not in _registry_columns(connection, table):
+            result[kind] = None
+            continue
+        row = connection.execute(
+            f"""
+            SELECT {identifier}, artifact_basename, artifact_schema_version, artifact_bytes,
+                   validation_status, validation_summary_json, cleanup_error, reuse_count
+            FROM {table} WHERE status='published'
+            """
+        ).fetchone()
+        result[kind] = (
+            {
+                identifier: row[identifier],
+                "artifact_basename": row["artifact_basename"],
+                "schema_version": row["artifact_schema_version"],
+                "bytes": row["artifact_bytes"],
+                "validation_status": row["validation_status"],
+                "validation": json.loads(row["validation_summary_json"] or "{}"),
+                "reuse_count": int(row["reuse_count"]),
+                "cleanup_retry": bool(row["cleanup_error"]),
+            }
+            if row
+            else None
+        )
+    return result
+
+
+def recognized_artifacts(core_path: Path) -> tuple[Path, ...]:
+    directory = cache_directory(core_path)
+    if not directory.is_dir() or directory.is_symlink():
+        return ()
+    return tuple(
+        path
+        for path in directory.iterdir()
+        if not path.is_symlink()
+        and path.is_file()
+        and (_FINAL_NAME.fullmatch(path.name) or _TEMP_NAME.fullmatch(path.name))
+    )

--- a/curator/storage/artifacts.py
+++ b/curator/storage/artifacts.py
@@ -164,7 +164,7 @@ def create_artifact(
     directory = final.parent
     directory.mkdir(mode=0o700, parents=True, exist_ok=True)
     temporary = artifact_path(database_path(core), f".{expected}.{uuid4().hex}.tmp", temporary=True)
-    connection = sqlite3.connect(temporary, isolation_level=None, timeout=30)
+    connection = sqlite3.connect(temporary.as_uri(), uri=True, isolation_level=None, timeout=30)
     connection.row_factory = sqlite3.Row
     connection.execute("PRAGMA foreign_keys=ON")
     connection.execute(f"PRAGMA user_version={ARTIFACT_SCHEMA_VERSION}")

--- a/curator/storage/database.py
+++ b/curator/storage/database.py
@@ -119,7 +119,8 @@ def connect_database(
     else:
         path.parent.mkdir(parents=True, exist_ok=True)
         connection = sqlite3.connect(
-            path,
+            path.as_uri(),
+            uri=True,
             isolation_level=None,
             timeout=30,
             factory=ProfiledConnection if current_trace() else sqlite3.Connection,

--- a/curator/storage/database.py
+++ b/curator/storage/database.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import re
 import sqlite3
@@ -16,6 +18,25 @@ from curator.profiling import current_trace, span
 
 class StorageError(RuntimeError):
     """Raised when a storage operation violates a Curator invariant."""
+
+
+_LEGACY_DERIVED_TABLES = (
+    ("model_scene_reason", "model_id", ("model_id", "scene_id", "reason_index")),
+    ("model_lane_order", "model_id", ("model_id", "lane", "ordering", "position")),
+    ("model_scene_lane", "model_id", ("model_id", "scene_id", "lane")),
+    ("model_scene_score", "model_id", ("model_id", "scene_id")),
+    ("direct_scene_state", "model_id", ("model_id", "scene_id")),
+    ("feature_affinity", "model_id", ("model_id", "feature_id")),
+    ("model_lane_candidate_cache", "model_id", ("model_id", "lane")),
+    ("model_lane_order_state", "model_id", ("model_id",)),
+    ("scene_content_search", "feature_version", ("feature_id", "scene_id")),
+    (
+        "entity_feature",
+        "feature_version",
+        ("feature_version", "entity_type", "entity_id", "feature_id"),
+    ),
+    ("feature_definition", "feature_version", ("feature_id",)),
+)
 
 
 def _sql_details(statement: str) -> tuple[str, dict[str, object]]:
@@ -76,7 +97,9 @@ class ProfiledConnection(sqlite3.Connection):
             super().rollback()
 
 
-def connect_database(path: Path, *, readonly: bool = False) -> sqlite3.Connection:
+def connect_database(
+    path: Path, *, readonly: bool = False, attach_artifacts: bool = True
+) -> sqlite3.Connection:
     """Open a configured SQLite connection.
 
     Writable databases use WAL mode. Transactions are controlled explicitly rather
@@ -109,6 +132,10 @@ def connect_database(path: Path, *, readonly: bool = False) -> sqlite3.Connectio
         if str(connection.execute("PRAGMA journal_mode").fetchone()[0]).casefold() != "wal":
             connection.execute("PRAGMA journal_mode = WAL")
         connection.execute("PRAGMA synchronous = NORMAL")
+    if attach_artifacts:
+        from curator.storage.artifacts import attach_active_artifacts
+
+        attach_active_artifacts(connection)
     return connection
 
 
@@ -150,3 +177,223 @@ def backup_database(
         temporary.unlink(missing_ok=True)
         raise
     return destination
+
+
+def _validated_artifact(path: Path, kind: str, generation_id: str) -> None:
+    from curator.storage.artifacts import (
+        FEATURE_TABLES,
+        MODEL_TABLES,
+        SUPPORTED_ARTIFACT_SCHEMA_VERSIONS,
+    )
+
+    artifact = sqlite3.connect(f"{path.as_uri()}?mode=ro&immutable=1", uri=True)
+    try:
+        meta = artifact.execute(
+            "SELECT kind, generation_id, schema_version FROM artifact_meta"
+        ).fetchone()
+        tables = {
+            str(row[0])
+            for row in artifact.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        if (
+            meta is None
+            or tuple(meta[:2]) != (kind, generation_id)
+            or int(meta[2]) not in SUPPORTED_ARTIFACT_SCHEMA_VERSIONS
+            or not set(FEATURE_TABLES if kind == "feature" else MODEL_TABLES) <= tables
+            or str(artifact.execute("PRAGMA quick_check").fetchone()[0]) != "ok"
+        ):
+            raise StorageError(f"invalid {kind} artifact: {path.name}")
+    finally:
+        artifact.close()
+
+
+def _compaction_targets(
+    connection: sqlite3.Connection,
+) -> tuple[tuple[str, ...], tuple[str, ...], str]:
+    from curator.storage.artifacts import artifact_path, database_path
+
+    core = database_path(connection)
+    targets: dict[str, list[str]] = {"feature": [], "model": []}
+    validated: dict[str, list[str]] = {"feature": [], "model": []}
+    for kind, table, identifier in (
+        ("feature", "feature_build", "feature_version"),
+        ("model", "model_version", "model_id"),
+    ):
+        rows = connection.execute(
+            f"""
+            SELECT {identifier}, status, artifact_basename, validation_summary_json
+            FROM {table}
+            WHERE status IN ('published', 'superseded')
+              AND validation_status='valid' AND artifact_basename IS NOT NULL
+            """
+        ).fetchall()
+        active = False
+        for row in rows:
+            summary = json.loads(str(row["validation_summary_json"] or "{}"))
+            path = artifact_path(core, str(row["artifact_basename"]))
+            if summary.get("integrity") != "ok" or not path.is_file():
+                continue
+            generation_id = str(row[identifier])
+            _validated_artifact(path, kind, generation_id)
+            targets[kind].append(generation_id)
+            validated[kind].append(generation_id)
+            active |= str(row["status"]) == "published"
+        if not active:
+            raise StorageError(f"legacy compaction requires a valid active {kind} artifact")
+    targets["model"].extend(
+        str(row[0])
+        for row in connection.execute(
+            """
+            SELECT model_id FROM model_version
+            WHERE status='superseded' AND validation_status='retired'
+              AND artifact_basename IS NULL
+            """
+        )
+    )
+    fingerprint = hashlib.sha256(
+        "\0".join((*sorted(validated["feature"]), *sorted(validated["model"]))).encode()
+    ).hexdigest()
+    return tuple(targets["feature"]), tuple(targets["model"]), fingerprint
+
+
+def _logical_database_bytes(connection: sqlite3.Connection) -> int:
+    try:
+        return int(
+            connection.execute(
+                "SELECT coalesce(sum(pgsize-unused), 0) FROM dbstat(?)", ("main",)
+            ).fetchone()[0]
+        )
+    except sqlite3.OperationalError:
+        return 0
+
+
+def compaction_status(connection: sqlite3.Connection) -> dict[str, object]:
+    row = connection.execute(
+        "SELECT value FROM application_meta WHERE key='legacy_compaction'"
+    ).fetchone()
+    stored = json.loads(str(row[0])) if row else {}
+    page_size = int(connection.execute("PRAGMA page_size").fetchone()[0])
+    freelist_count = int(connection.execute("PRAGMA freelist_count").fetchone()[0])
+    return {
+        "status": str(stored.get("status", "never_run")),
+        "rows_deleted": int(stored.get("rows_deleted", 0)),
+        "logical_bytes_removed": int(stored.get("logical_bytes_removed", 0)),
+        "reclaimable_bytes": freelist_count * page_size,
+        "vacuum_pending": freelist_count > 0,
+    }
+
+
+def compact_legacy_generations(
+    connection: sqlite3.Connection,
+    *,
+    batch_size: int = 5_000,
+    max_batches: int | None = None,
+) -> dict[str, object]:
+    """Delete rebuildable core rows in restartable transactions."""
+    if not 1 <= batch_size <= 50_000:
+        raise ValueError("compaction batch size must be between 1 and 50000")
+    if {str(row["name"]) for row in connection.execute("PRAGMA database_list")} & {
+        "feature_generation",
+        "model_generation",
+    }:
+        raise StorageError("legacy compaction requires a core-only connection")
+
+    feature_ids, model_ids, fingerprint = _compaction_targets(connection)
+    target_ids = {"feature_version": feature_ids, "model_id": model_ids}
+    previous_row = connection.execute(
+        "SELECT value FROM application_meta WHERE key='legacy_compaction'"
+    ).fetchone()
+    previous = json.loads(str(previous_row[0])) if previous_row else {}
+    rows_deleted = (
+        int(previous.get("rows_deleted", 0)) if previous.get("fingerprint") == fingerprint else 0
+    )
+    logical_bytes_removed = (
+        int(previous.get("logical_bytes_removed", 0))
+        if previous.get("fingerprint") == fingerprint
+        else 0
+    )
+    before_bytes = _logical_database_bytes(connection)
+    before_freelist = int(connection.execute("PRAGMA freelist_count").fetchone()[0])
+    batches = 0
+    per_table: dict[str, int] = {}
+
+    stopped = False
+    for table, generation_column, key_columns in _LEGACY_DERIVED_TABLES:
+        for generation_id in target_ids[generation_column]:
+            keys = ", ".join(key_columns)
+            while True:
+                with transaction(connection):
+                    cursor = connection.execute(
+                        f"""
+                        DELETE FROM {table}
+                        WHERE {generation_column}=?
+                          AND ({keys}) IN (
+                            SELECT {keys} FROM {table}
+                            WHERE {generation_column}=? LIMIT ?
+                          )
+                        """,
+                        (generation_id, generation_id, batch_size),
+                    )
+                    deleted = cursor.rowcount
+                    if deleted:
+                        rows_deleted += deleted
+                        per_table[table] = per_table.get(table, 0) + deleted
+                        state = {
+                            "status": "in_progress",
+                            "fingerprint": fingerprint,
+                            "rows_deleted": rows_deleted,
+                        }
+                        connection.execute(
+                            """
+                            INSERT INTO application_meta(key, value)
+                            VALUES ('legacy_compaction', ?)
+                            ON CONFLICT(key) DO UPDATE SET value=excluded.value
+                            """,
+                            (json.dumps(state, sort_keys=True, separators=(",", ":")),),
+                        )
+                if not deleted:
+                    break
+                batches += 1
+                if max_batches is not None and batches >= max_batches:
+                    stopped = True
+                    break
+            if stopped:
+                break
+        if stopped:
+            break
+
+    remaining_rows = 0
+    for table, generation_column, _ in _LEGACY_DERIVED_TABLES:
+        ids = target_ids[generation_column]
+        placeholders = ",".join("?" for _ in ids)
+        remaining_rows += int(
+            connection.execute(
+                f"SELECT count(*) FROM {table} WHERE {generation_column} IN ({placeholders})",
+                ids,
+            ).fetchone()[0]
+        )
+    after_bytes = _logical_database_bytes(connection)
+    page_size = int(connection.execute("PRAGMA page_size").fetchone()[0])
+    result: dict[str, object] = {
+        "status": "complete" if remaining_rows == 0 else "in_progress",
+        "rows_deleted": rows_deleted,
+        "rows_deleted_this_run": sum(per_table.values()),
+        "rows_remaining": remaining_rows,
+        "logical_bytes_removed": logical_bytes_removed + max(0, before_bytes - after_bytes),
+        "reclaimable_bytes_added": max(
+            0,
+            (int(connection.execute("PRAGMA freelist_count").fetchone()[0]) - before_freelist)
+            * page_size,
+        ),
+        "vacuum_required_to_shrink_file": True,
+    }
+    stored = {**result, "fingerprint": fingerprint}
+    with transaction(connection):
+        connection.execute(
+            """
+            INSERT INTO application_meta(key, value) VALUES ('legacy_compaction', ?)
+            ON CONFLICT(key) DO UPDATE SET value=excluded.value
+            """,
+            (json.dumps(stored, sort_keys=True, separators=(",", ":")),),
+        )
+    return result

--- a/curator/storage/database.py
+++ b/curator/storage/database.py
@@ -159,6 +159,7 @@ def backup_database(
     destination: Path,
     *,
     overwrite: bool = False,
+    progress: Callable[[int, int], None] | None = None,
 ) -> Path:
     """Create a consistent backup and publish it atomically."""
     destination = destination.expanduser().resolve()
@@ -169,7 +170,15 @@ def backup_database(
     temporary = destination.with_name(f".{destination.name}.{uuid4().hex}.tmp")
     target = sqlite3.connect(temporary, isolation_level=None)
     try:
-        source.backup(target)
+        source.backup(
+            target,
+            pages=256,
+            progress=(
+                lambda _status, remaining, total: (
+                    progress(total - remaining, total) if progress else None
+                )
+            ),
+        )
         target.close()
         os.replace(temporary, destination)
     except BaseException:
@@ -288,6 +297,7 @@ def compact_legacy_generations(
     *,
     batch_size: int = 5_000,
     max_batches: int | None = None,
+    progress: Callable[[int, int], None] | None = None,
 ) -> dict[str, object]:
     """Delete rebuildable core rows in restartable transactions."""
     if not 1 <= batch_size <= 50_000:
@@ -300,6 +310,25 @@ def compact_legacy_generations(
 
     feature_ids, model_ids, fingerprint = _compaction_targets(connection)
     target_ids = {"feature_version": feature_ids, "model_id": model_ids}
+
+    def count_remaining() -> int:
+        count = 0
+        for table, generation_column, _ in _LEGACY_DERIVED_TABLES:
+            ids = target_ids[generation_column]
+            if not ids:
+                continue
+            placeholders = ",".join("?" for _ in ids)
+            count += int(
+                connection.execute(
+                    f"SELECT count(*) FROM {table} WHERE {generation_column} IN ({placeholders})",
+                    ids,
+                ).fetchone()[0]
+            )
+        return count
+
+    target_row_count = count_remaining()
+    if progress:
+        progress(0, max(1, target_row_count))
     previous_row = connection.execute(
         "SELECT value FROM application_meta WHERE key='legacy_compaction'"
     ).fetchone()
@@ -354,6 +383,8 @@ def compact_legacy_generations(
                 if not deleted:
                     break
                 batches += 1
+                if progress:
+                    progress(sum(per_table.values()), max(1, target_row_count))
                 if max_batches is not None and batches >= max_batches:
                     stopped = True
                     break
@@ -362,16 +393,9 @@ def compact_legacy_generations(
         if stopped:
             break
 
-    remaining_rows = 0
-    for table, generation_column, _ in _LEGACY_DERIVED_TABLES:
-        ids = target_ids[generation_column]
-        placeholders = ",".join("?" for _ in ids)
-        remaining_rows += int(
-            connection.execute(
-                f"SELECT count(*) FROM {table} WHERE {generation_column} IN ({placeholders})",
-                ids,
-            ).fetchone()[0]
-        )
+    remaining_rows = count_remaining()
+    if progress and not target_row_count:
+        progress(1, 1)
     after_bytes = _logical_database_bytes(connection)
     page_size = int(connection.execute("PRAGMA page_size").fetchone()[0])
     result: dict[str, object] = {

--- a/curator/storage/retention.py
+++ b/curator/storage/retention.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import sqlite3
 from dataclasses import dataclass
 
+from curator.storage.artifacts import artifact_path, database_path
 from curator.storage.database import transaction
 
 
@@ -29,50 +30,102 @@ def prune_snapshots(
             """
         )
     }
-    models = [
-        str(row[0])
+    model_rows = [
+        (str(row["model_id"]), str(row["artifact_basename"]) if row["artifact_basename"] else None)
         for row in connection.execute(
             """
-            SELECT model_id FROM model_version
-            WHERE status IN ('superseded', 'failed')
+            SELECT model_id, artifact_basename FROM model_version
+            WHERE status IN ('superseded', 'failed') OR (
+                status='building' AND created_at_ms < COALESCE(
+                    (SELECT max(created_at_ms) FROM model_version WHERE status='published'),
+                    created_at_ms
+                )
+            )
             ORDER BY COALESCE(published_at_ms, created_at_ms), model_id
             """
         )
-        if str(row[0]) not in retained_models
+        if str(row["model_id"]) not in retained_models
     ]
-    model_deletes = models if limit is None else models[:limit]
+    model_deletes = model_rows if limit is None else model_rows[:limit]
 
     referenced_features = {
         str(row["feature_version"])
         for row in connection.execute("SELECT model_id, feature_version FROM model_version")
-        if str(row["model_id"]) not in model_deletes
+        if str(row["model_id"]) not in {model_id for model_id, _ in model_deletes}
     }
-    features = [
-        str(row[0])
+    feature_rows = [
+        (
+            str(row["feature_version"]),
+            str(row["artifact_basename"]) if row["artifact_basename"] else None,
+        )
         for row in connection.execute(
             """
-            SELECT feature_version FROM feature_build
+            SELECT feature_version, artifact_basename FROM feature_build
             WHERE status IN ('superseded', 'failed')
             ORDER BY COALESCE(published_at_ms, created_at_ms), feature_version
             """
         )
-        if str(row[0]) not in referenced_features
+        if str(row["feature_version"]) not in referenced_features
     ]
-    feature_deletes = features if limit is None else features[:limit]
+    feature_deletes = feature_rows if limit is None else feature_rows[:limit]
     if not dry_run and (model_deletes or feature_deletes):
+        successful_models: list[tuple[str, str | None]] = []
+        successful_features: list[tuple[str, str | None]] = []
+        core_path = database_path(connection)
+        for table, identifier, rows, successful in (
+            ("model_version", "model_id", model_deletes, successful_models),
+            ("feature_build", "feature_version", feature_deletes, successful_features),
+        ):
+            for item, basename in rows:
+                if basename:
+                    try:
+                        artifact_path(core_path, basename).unlink(missing_ok=True)
+                    except OSError as error:
+                        with transaction(connection):
+                            connection.execute(
+                                f"UPDATE {table} SET cleanup_error=? WHERE {identifier}=?",
+                                (str(error)[:2000], item),
+                            )
+                        continue
+                successful.append((item, basename))
         with transaction(connection):
-            connection.executemany(
-                "DELETE FROM model_version WHERE model_id=?", ((item,) for item in model_deletes)
-            )
-            for version in feature_deletes:
-                connection.execute("DELETE FROM entity_feature WHERE feature_version=?", (version,))
-                connection.execute(
-                    "DELETE FROM feature_definition WHERE feature_version=?", (version,)
-                )
-                connection.execute("DELETE FROM feature_build WHERE feature_version=?", (version,))
+            for model_id, basename in successful_models:
+                if basename:
+                    connection.execute(
+                        """
+                        UPDATE model_version SET artifact_basename=NULL,
+                            validation_status='retired', cleanup_error=NULL
+                        WHERE model_id=?
+                        """,
+                        (model_id,),
+                    )
+                else:
+                    connection.execute("DELETE FROM model_version WHERE model_id=?", (model_id,))
+            for version, basename in successful_features:
+                if basename:
+                    connection.execute(
+                        """
+                        UPDATE feature_build SET artifact_basename=NULL,
+                            validation_status='retired', cleanup_error=NULL
+                        WHERE feature_version=?
+                        """,
+                        (version,),
+                    )
+                else:
+                    connection.execute(
+                        "DELETE FROM entity_feature WHERE feature_version=?", (version,)
+                    )
+                    connection.execute(
+                        "DELETE FROM feature_definition WHERE feature_version=?", (version,)
+                    )
+                    connection.execute(
+                        "DELETE FROM feature_build WHERE feature_version=?", (version,)
+                    )
+        model_deletes = successful_models
+        feature_deletes = successful_features
     return RetentionResult(
-        len(models),
-        len(features),
+        len(model_rows),
+        len(feature_rows),
         len(model_deletes) if not dry_run else 0,
         len(feature_deletes) if not dry_run else 0,
     )

--- a/curator/storage/sql/0017_drop_unused_lane_order_scene_index.sql
+++ b/curator/storage/sql/0017_drop_unused_lane_order_scene_index.sql
@@ -1,0 +1,1 @@
+DROP INDEX model_lane_order_scene_idx;

--- a/curator/storage/sql/0018_feature_build_counts.sql
+++ b/curator/storage/sql/0018_feature_build_counts.sql
@@ -1,0 +1,19 @@
+ALTER TABLE feature_build ADD COLUMN scene_count INTEGER CHECK (scene_count >= 0);
+ALTER TABLE feature_build ADD COLUMN performer_count INTEGER CHECK (performer_count >= 0);
+ALTER TABLE feature_build ADD COLUMN feature_count INTEGER CHECK (feature_count >= 0);
+
+UPDATE feature_build
+SET scene_count = (
+        SELECT count(DISTINCT entity_id) FROM entity_feature
+        WHERE entity_feature.feature_version = feature_build.feature_version
+          AND entity_type = 'scene'
+    ),
+    performer_count = (
+        SELECT count(DISTINCT entity_id) FROM entity_feature
+        WHERE entity_feature.feature_version = feature_build.feature_version
+          AND entity_type = 'performer'
+    ),
+    feature_count = (
+        SELECT count(*) FROM feature_definition
+        WHERE feature_definition.feature_version = feature_build.feature_version
+    );

--- a/curator/storage/sql/0019_generation_artifacts.sql
+++ b/curator/storage/sql/0019_generation_artifacts.sql
@@ -1,0 +1,21 @@
+ALTER TABLE feature_build ADD COLUMN artifact_basename TEXT;
+ALTER TABLE feature_build ADD COLUMN artifact_schema_version INTEGER;
+ALTER TABLE feature_build ADD COLUMN artifact_bytes INTEGER CHECK (artifact_bytes >= 0);
+ALTER TABLE feature_build ADD COLUMN validation_status TEXT;
+ALTER TABLE feature_build ADD COLUMN validation_summary_json TEXT;
+ALTER TABLE feature_build ADD COLUMN cleanup_error TEXT;
+ALTER TABLE feature_build ADD COLUMN reuse_count INTEGER NOT NULL DEFAULT 0
+    CHECK (reuse_count >= 0);
+
+ALTER TABLE model_version ADD COLUMN artifact_basename TEXT;
+ALTER TABLE model_version ADD COLUMN artifact_schema_version INTEGER;
+ALTER TABLE model_version ADD COLUMN artifact_bytes INTEGER CHECK (artifact_bytes >= 0);
+ALTER TABLE model_version ADD COLUMN scene_count INTEGER CHECK (scene_count >= 0);
+ALTER TABLE model_version ADD COLUMN lane_count INTEGER CHECK (lane_count >= 0);
+ALTER TABLE model_version ADD COLUMN reason_scene_count INTEGER CHECK (reason_scene_count >= 0);
+ALTER TABLE model_version ADD COLUMN reason_count INTEGER CHECK (reason_count >= 0);
+ALTER TABLE model_version ADD COLUMN validation_status TEXT;
+ALTER TABLE model_version ADD COLUMN validation_summary_json TEXT;
+ALTER TABLE model_version ADD COLUMN cleanup_error TEXT;
+ALTER TABLE model_version ADD COLUMN reuse_count INTEGER NOT NULL DEFAULT 0
+    CHECK (reuse_count >= 0);

--- a/curator/sync/repository.py
+++ b/curator/sync/repository.py
@@ -119,10 +119,12 @@ class SyncRepository:
         page_high_watermark: str | None,
         now_ms: int,
         record_seen: bool,
-    ) -> None:
+    ) -> tuple[str, ...]:
+        changed: list[str] = []
         with transaction(self.connection):
             for item in items:
-                self._upsert(item)
+                if self._upsert(item):
+                    changed.append(item.id)
                 if record_seen:
                     self.connection.execute(
                         """
@@ -144,6 +146,7 @@ class SyncRepository:
                 """,
                 (str(next_page), pending, now_ms, entity_type, run_id),
             )
+        return tuple(changed)
 
     def complete_entity(self, run_id: str, entity_type: str, now_ms: int) -> None:
         with transaction(self.connection):
@@ -233,7 +236,18 @@ class SyncRepository:
                     (now_ms, entity_type, run_id),
                 )
 
-    def _upsert(self, entity: SourceEntity) -> None:
+    def _upsert(self, entity: SourceEntity) -> bool:
+        table, column = {
+            Tag: ("source_tag", "tag_id"),
+            Studio: ("source_studio", "studio_id"),
+            Performer: ("source_performer", "performer_id"),
+            Scene: ("source_scene", "scene_id"),
+        }[type(entity)]
+        row = self.connection.execute(
+            f"SELECT source_hash FROM {table} WHERE {column}=?", (entity.id,)
+        ).fetchone()
+        if row and row[0] == _hash(entity):
+            return False
         if isinstance(entity, Tag):
             self._upsert_tag(entity)
         elif isinstance(entity, Studio):
@@ -242,10 +256,23 @@ class SyncRepository:
             self._upsert_performer(entity)
         else:
             self._upsert_scene(entity)
+        return True
 
     def _upsert_tag(self, tag: Tag, *, replace_parents: bool = True) -> None:
         for parent in tag.parents:
             self._upsert_tag(parent, replace_parents=False)
+        if not replace_parents:
+            self.connection.execute(
+                """
+                INSERT INTO source_tag(tag_id, name, updated_at, source_hash)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT(tag_id) DO UPDATE SET
+                    name=COALESCE(excluded.name, source_tag.name),
+                    updated_at=COALESCE(excluded.updated_at, source_tag.updated_at)
+                """,
+                (tag.id, tag.name, tag.updated_at, _hash(tag)),
+            )
+            return
         self.connection.execute(
             """
             INSERT INTO source_tag(tag_id, name, updated_at, source_hash) VALUES (?, ?, ?, ?)
@@ -366,7 +393,7 @@ class SyncRepository:
 
     def _upsert_scene(self, scene: Scene) -> None:
         if scene.studio:
-            self._upsert_studio(scene.studio)
+            self._upsert_studio(scene.studio, replace_details=False)
         for tag in scene.tags:
             self._upsert_tag(tag, replace_parents=False)
         for performer in scene.performers:

--- a/curator/sync/service.py
+++ b/curator/sync/service.py
@@ -31,6 +31,7 @@ class SyncResult:
     server_version: str
     resumed: bool
     entity_counts: dict[str, int]
+    changed_entity_counts: dict[str, int]
     scene_ids: tuple[str, ...]
 
 
@@ -107,6 +108,7 @@ class SyncService:
             self.repository.resume_run(run_id)
 
         counts: dict[str, int] = {}
+        changed_counts: dict[str, int] = {}
         scene_ids: set[str] = set()
         current_entity: str | None = None
         try:
@@ -120,6 +122,7 @@ class SyncService:
                     entity_count=len(ENTITY_OPERATIONS),
                 )
                 counts[current_entity] = count
+                changed_counts[current_entity] = len(ids)
                 if current_entity == "scene":
                     scene_ids.update(ids)
             current_entity = None
@@ -130,7 +133,13 @@ class SyncService:
             self.repository.fail_run(run_id, current_entity, str(error), self.clock_ms())
             raise
         return SyncResult(
-            run_id, mode, capabilities.server_version, resumed, counts, tuple(sorted(scene_ids))
+            run_id,
+            mode,
+            capabilities.server_version,
+            resumed,
+            counts,
+            changed_counts,
+            tuple(sorted(scene_ids)),
         )
 
     def _sync_entity(
@@ -163,7 +172,7 @@ class SyncService:
                 for timestamp in (self._updated_at(item) for item in adapted.items)
                 if timestamp
             )
-            self.repository.save_page(
+            changed = self.repository.save_page(
                 run_id,
                 operation.entity_type,
                 adapted.items,
@@ -173,7 +182,7 @@ class SyncService:
                 record_seen=full,
             )
             processed += len(adapted.items)
-            ids.extend(item.id for item in adapted.items)
+            ids.extend(changed)
             if self.progress:
                 self.progress(
                     operation.entity_type,

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,11 +48,15 @@ local recommendations do not depend on it.
 
 ## Refresh and update
 
-Use **Sync library** when Stash metadata or history changes substantially. Playback
-and Curator feedback use a smaller preference rebuild and do not require a new
-library sync. Stash does not give plugins a reliable background scheduler or startup
-hook, so unattended syncs must call **Sync and build recommendations** through
-Stash's task API from a host scheduler.
+Use **Sync library** after Stash metadata or history changes. It fetches only changed
+records and refreshes recommendations when needed. Use **Rebuild model** to force a
+refresh from Curator's already-synced data; it does not contact Stash. Playback and
+Curator feedback already request a smaller preference rebuild, so neither command is
+normally needed for them.
+
+Stash does not give plugins a reliable background scheduler or startup hook, so
+unattended syncs must call **Sync and build recommendations** through Stash's task API
+from a host scheduler.
 
 Plugin updates come from the same source URL. Back up first, update in Stash, allow
 database migrations to finish, then load Curator and confirm the model is ready.

--- a/docs/handover.md
+++ b/docs/handover.md
@@ -1,6 +1,6 @@
 # Stash Curator handover
 
-Updated: 2026-07-21 on `docs/showcase`.
+Updated: 2026-07-30 after Stage 4 live storage cutover.
 
 ## Current state
 
@@ -9,11 +9,25 @@ architecture, privacy, and contributor guidance now lives in the main `docs/` pa
 Historical design and research records are retained in `docs/archive/` but are not
 current guidance or part of the published site.
 
+Stage 4 is complete. A native backup validated, restartable legacy compaction removed
+1,189,457 rebuildable rows, explicit vacuum reduced the core from 775,700,480 to
+95,678,464 bytes, and post-restart installed verification passes. Schema-1 artifacts,
+durable state, all pre-existing backups, and the protected pre-repair copy remain.
+
 ## Open acceptance work
 
 - Complete installed desktop/mobile keyboard, playback, Prune, StashDB failure, and
   restart checks before calling the project 1.0-ready.
 - After publishing, smoke-test every route and fetch the public `index.yml` source.
+
+## Next work package
+
+Retain these installed UI follow-ups as a separate coherent package:
+
+- Rename the feedback-facing history label to clearer product language, likely
+  **Feedback history** or **Review feedback**.
+- Fix black option text in the **Recommendation history** dropdown under the dark
+  theme.
 
 ## Guardrails
 

--- a/docs/handover.md
+++ b/docs/handover.md
@@ -29,6 +29,35 @@ Retain these installed UI follow-ups as a separate coherent package:
 - Fix black option text in the **Recommendation history** dropdown under the dark
   theme.
 
+## Model-build performance follow-ups
+
+Installed profiling on a 23,891-scene library measured a 409-second model build.
+Similarity took 132 seconds: 76 seconds for content neighbors and 56 seconds for
+performer similarity. Publication took 243 seconds, including a broad 144-second
+classification/order/reason/index stage and 88 seconds validating the generated
+540 MiB artifact. The model-integrity scan is removed in the current work package;
+schema, cardinality, reason-coverage, and lane-state validation remain.
+
+Keep these two independent follow-ups for later measurement:
+
+1. Bound performer-similarity propagation to meaningful learned affinities. The live
+   model had 334 performer-identity affinities, but only 206 had effective absolute
+   affinity of at least 0.005 and 149 reached 0.01. Start with a fixed 0.005 cutoff,
+   retain the existing exact identity contribution, and compare recommendation quality
+   before changing the threshold. The current profile suggests roughly 20 seconds of
+   build-time savings.
+2. Generate explanations for requested scenes instead of materializing every reason,
+   and serve exact score-first ordering from indexed queries. The current artifact
+   stores 218,770 reason rows using 268 MiB and 135,304 order rows using about 39 MiB
+   including its unique index. Reuse the existing targeted reason-building flow, keep
+   globally varied ordering precomputed for stable pagination, and measure page latency
+   before removing persisted rows.
+
+Before either change, split the current broad indexing timer into lane classification,
+score-first ordering, varied ordering, reason generation, and SQLite index creation.
+Run the installed operation cold and warm; retain ranking, explanation, and stable-page
+tests plus a private before/after quality review.
+
 ## Guardrails
 
 Never delete or reset a sidecar to solve migration trouble. Never commit private

--- a/docs/stage-2-handover.md
+++ b/docs/stage-2-handover.md
@@ -1,0 +1,136 @@
+# Stage 2 generation-storage handover
+
+## Objective
+
+Implement immutable feature and model SQLite generation files. Keep durable state in
+`curator.sqlite3`; build, validate, and atomically publish rebuildable data beside it:
+
+- `feature-<fingerprint>.sqlite3`
+- `model-<model-id>.sqlite3`
+
+Use Python and SQLite only. Preserve public behavior for recommendations, lanes,
+explanations, reports, Similar, Expand, and Prune.
+
+## Starting state
+
+Stage 1 is implemented, verified, and locally installed:
+
+- migration 18 stores feature scene, performer, and definition counts;
+- reused feature results do not scan `entity_feature` for counts;
+- feature/model builds report granular stage timings;
+- existing fingerprint, top-K, and retention changes are the baseline;
+- the full suite passed with 201 tests.
+
+The worktree is intentionally dirty. Read `AGENTS.md`, `docs/handover.md`,
+`docs/architecture.md`, `git status --short`, and the complete diff first. Preserve
+every existing change. Migrations 17 and 18 are uncommitted but installed locally;
+the next migration must be 19.
+
+Live observations:
+
+- core database: about 1.56 GB;
+- real model build: 675.6 seconds;
+- model reuse checks: 22.6 and 11.7 seconds;
+- cold `get_slate`: 9.5 seconds, including 5.3 seconds materialized selection and
+  2.9 seconds explanations;
+- warm lane selection: 6–11 ms;
+- only 20 of 23,891 scored scenes had reason rows, confirming runtime explanation
+  generation is a cold-load cost;
+- migration 17's removed lane-order index is unrelated; live queries use primary
+  keys.
+
+Do not put private live IDs, URLs, credentials, reports, or recommendation data in
+tracked files or output.
+
+## Required implementation
+
+### Registry and paths
+
+Reuse `feature_build` and `model_version` as the core registry. Add validated artifact
+basename, schema version, byte size, counts, and validation summary/status.
+
+Resolve artifacts only inside a derived-cache directory beside the core database.
+Reject absolute paths, traversal, symlinks, unexpected names, and files outside that
+directory.
+
+### Artifact lifecycle
+
+For each generation:
+
+1. create a recognized temporary file on the same filesystem;
+2. create tables and bulk-load before secondary indexes;
+3. create indexes and every explanation/reason row;
+4. validate integrity, schema version, counts, lane state, and complete reason
+   coverage;
+5. close handles and atomically rename to the final basename;
+6. switch the active core pointer in one short transaction.
+
+Any failure must leave the previous generation active and usable. Mark the attempt
+failed and clean its temporary file when safe.
+
+### Storage split
+
+Feature artifacts own rebuildable feature data, including `feature_definition`,
+`entity_feature`, and `scene_content_search`.
+
+Model artifacts own rebuildable model data, including affinities, direct scene state,
+scores, lane classifications/caches/orders/state, and `model_scene_reason`.
+
+Keep durable source cache, jobs, feedback/events, impressions, history, exclusions,
+pruning state, settings, and lightweight registry metadata in the core.
+
+Do not delete legacy core derived rows yet. A schema-18 database should continue
+working until the next successful build publishes generation files.
+
+### Read compatibility
+
+Attach the active feature/model files read-only. A connection keeps the generation it
+attached; a new connection sees a newly published pointer.
+
+Keep existing Python interfaces where practical. Trace and cover `FeatureStore`,
+`RecommendationModelStore`, `LanePolicy`, `SlateBuilder`, explanations, reporting,
+Similar, Expand, Prune, and API diagnostics.
+
+Runtime reads must never write an immutable artifact. Generate all reason rows before
+publication while preserving current response shape and factual content.
+
+### Retention and operations
+
+Retain the active and previous models plus their referenced feature files. Retire
+older generations by unlinking validated artifact files, not cascading through core
+rows. Failed unlink must be retryable and must not fail publication.
+
+Core backups exclude artifacts. Restore invalidates the active generation pointer and
+reports that recommendations need rebuilding. Reset removes only exact core files and
+recognized artifacts/temporaries; never recursively delete a directory.
+
+Expose aggregate diagnostics for active generations, artifact sizes/schema versions,
+validation, reuse, reason coverage, and cleanup retries.
+
+## Tests
+
+Cover:
+
+- artifact path validation;
+- temporary creation, validation, rename, and atomic pointer switch;
+- failed build/validation retaining the old generation;
+- readers spanning publication;
+- complete build-time reason coverage and read-only runtime explanations;
+- cleanup retention and unlink retry;
+- backup exclusion and restore invalidation;
+- safe reset boundaries;
+- schema-18 transition;
+- parity for slates, lanes, scores, explanations, reports, Similar, Expand, and Prune.
+
+Run focused checks during implementation and `scripts/verify full` once at completion.
+Inspect `git diff --check`, file-specific diffs, and final status.
+
+## Boundaries
+
+Do not implement Stage 3 candidate/similarity caches, bounded reranking, legacy
+compaction, or backup deletion. Add no service or dependency.
+
+Do not commit, push, install, or mutate the live Stash/Curator databases. If the full
+cutover cannot be completed safely in one package, stop at a real tested compatibility
+boundary; do not create artifact copies that retain cascade deletion and runtime
+writes.

--- a/docs/stage-3-handover.md
+++ b/docs/stage-3-handover.md
@@ -1,0 +1,251 @@
+# Stage 3 performance-and-compaction handover
+
+## Objective
+
+Finish the generation-storage rollout with measured candidate/similarity caches,
+bounded request-time reranking, safe legacy-core compaction, and explicit backup
+deletion. Keep Python and SQLite as the only runtime dependencies and preserve public
+behavior for recommendations, lanes, explanations, reports, Similar, Expand, and
+Prune.
+
+Do not add a cache merely because Stage 3 names one. Measure the installed paths
+first, retain the Stage 2 implementation where it is already fast, and add only the
+smallest persisted data that removes a demonstrated bottleneck.
+
+## Starting state
+
+Stages 1 and 2 are implemented, verified, and locally installed:
+
+- migrations 17 through 19 are uncommitted;
+- feature and model data publish as validated immutable SQLite artifacts;
+- active artifacts attach read-only and readers keep their attached generation;
+- model builds generate reason rows for every scored scene;
+- retention unlinks validated artifacts with retry metadata;
+- core backups exclude artifacts, restore invalidates generation pointers, and reset
+  removes only recognized files;
+- diagnostics expose generation sizes, schema versions, validation, reuse, reason
+  coverage, and cleanup retries;
+- a failed-build retry bug was fixed by preserving `last_error` until the next build
+  actually starts;
+- the full suite passes with 206 tests.
+
+The worktree is intentionally dirty. Read `AGENTS.md`, `docs/handover.md`,
+`docs/architecture.md`, `docs/stage-2-handover.md`, `git status --short`, and the
+complete diff first. Preserve every existing change. The next migration must be 20.
+
+Do not put private live IDs, URLs, credentials, reports, recommendation data, or
+evaluation notes in tracked files or command output.
+
+## Installed results
+
+The first Stage 2 publication exposed two defects before a generation could become
+active:
+
+1. 126 scored scenes had no specific structured evidence. A factual neutral
+   `fallback` reason now supplies complete coverage without changing rendered claims.
+2. An immediate retry cleared the prior failure too early and looked like an active
+   build. `ModelUpdateCoordinator.request()` now leaves error clearing to build start.
+
+The successful installed build reported:
+
+- total model build: 525.4 seconds, down from 675.6 seconds;
+- feature lookup/reuse: 10.0 seconds;
+- affinities: 7.1 seconds;
+- similarity: 99.7 seconds;
+- scoring: 10.6 seconds;
+- artifact writes: 8.4 seconds;
+- lane/reason indexing: 80.8 seconds;
+- validation: 276.5 seconds;
+- publication: 75 ms;
+- cleanup: 31.7 seconds.
+
+Published generations:
+
+- feature artifact: 193,437,696 bytes, 4,675 definitions, 23,745 scenes, and
+  2,352 performers;
+- model artifact: 536,911,872 bytes, 23,891 scores, 43,074 lane rows, and
+  218,676 reasons;
+- reason coverage: 23,891 of 23,891 scored scenes;
+- both artifacts pass `PRAGMA quick_check`.
+
+Read-only checks for 20 For You items:
+
+- connection open/attach: 55 ms;
+- cold materialized slate: 165 ms;
+- cold stored explanations: 187 ms;
+- warm materialized slate: 23 ms;
+- warm stored explanations: 159 ms.
+
+These timings bypass impression recording and browser/Stash transport, so compare
+them with the corresponding backend stages rather than the complete HTTP request.
+
+## Core repair performed
+
+After publication, SQLite reported a malformed B-tree isolated to `curator_job`.
+Both generation artifacts were healthy. A byte-for-byte pre-repair copy was created
+beside the core and verified with an identical SHA-256 hash.
+
+Normal transactional `DROP TABLE` could not traverse the damaged B-tree. The repair:
+
+1. removed only the `curator_job` table, auto-index, and started-time index entries
+   through SQLite writable-schema recovery;
+2. recreated the table and index exactly from migration 6;
+3. ran `VACUUM` to discard the orphaned damaged pages;
+4. ran both `PRAGMA quick_check` and full `PRAGMA integrity_check`.
+
+Both checks return `ok`, migration 19 remains applied, and the repaired core is
+775,479,296 bytes. Historical `curator_job` rows were intentionally lost; all other
+logical tables and active generation metadata remain. The verified pre-repair copy
+must not be removed by automatic backup cleanup.
+
+The final normal-backend diagnostics invocation was blocked by the execution
+environment's approval quota. The next session should first run diagnostics and one
+native task-status query through a fresh process or the Stash UI. Stash itself was not
+reachable from this host during validation, so the installed backend task was invoked
+directly against the sidecar.
+
+## Required Stage 3 work
+
+### Measure before caching
+
+Capture bounded profiles for:
+
+- cold and warm For You plus one source lane;
+- Similar for scenes and performers;
+- Expand local ranking and cached external results;
+- Prune candidate reads;
+- model similarity construction and validation;
+- core and artifact table/index sizes via SQLite `dbstat` when available.
+
+The Stage 2 slate path is already fast. Keep it unless an end-to-end installed profile
+shows a material bottleneck. Validation is currently the largest build stage, followed
+by similarity construction and lane/reason indexing.
+
+### Artifact schema compatibility
+
+If Stage 3 adds artifact tables, write schema version 2 while continuing to read the
+installed schema-1 artifacts until a successful replacement publishes. Never make a
+code upgrade invalidate the only active generation before rebuilding.
+
+Build every new cache before publication and keep runtime attachments read-only.
+Validate cache bounds and parity against uncached calculations.
+
+### Candidate and similarity caches
+
+Persist only measured reusable work:
+
+- bounded lane candidate inputs needed for request-time reranking;
+- bounded scene/performer similarity neighbors when direct sparse queries or model
+  construction are proven expensive;
+- the generation/config fingerprints needed to reject stale cache rows.
+
+Set explicit per-entity and global bounds. Bulk-load before secondary indexes. Do not
+copy durable history, exclusions, or feedback into artifacts.
+
+### Bounded reranking
+
+Rerank only a bounded cached window. Preserve:
+
+- hard eligibility and exclusion rules;
+- live cooldown behavior;
+- deterministic score-first and varied ordering;
+- stable pagination and current response shapes;
+- lane qualification and truthful ranking reasons.
+
+Keep the existing materialized-order path as the parity oracle until installed
+measurements and tests show the bounded path is equivalent.
+
+### Legacy core compaction
+
+Compact only rebuildable legacy rows whose registry entry has a valid published
+artifact. Keep the legacy table schemas so restore/schema-18 compatibility can still
+fall back until a new generation publishes.
+
+Use bounded, restartable batches rather than a long migration transaction. Never
+delete source cache, feedback/events, impressions, recommendation history,
+exclusions, pruning state, settings, jobs, registry metadata, or the active/previous
+artifact files. Report rows and bytes reclaimed, then run `VACUUM` only as an explicit
+operation.
+
+### Backup deletion
+
+Add explicit deletion for recognized completed Curator backups only:
+
+- reject absolute paths, traversal, symlinks, temporary files, artifacts, and
+  unrecognized names;
+- require exact user confirmation;
+- refuse deletion while a Curator job is running;
+- never automatically delete the pre-repair safety copy;
+- do not add automatic age/count retention until requested.
+
+Failed deletion must be reported without affecting the core or generations.
+
+## Tests
+
+Cover:
+
+- schema-1 artifacts remain readable after a schema-2-capable upgrade;
+- cache bounds, fingerprint invalidation, and cached/uncached parity;
+- readers spanning schema-2 publication;
+- bounded reranking parity, eligibility, cooldown, variety, and pagination;
+- runtime attempts cannot write artifact caches;
+- interrupted/resumed legacy compaction and exact durable-table preservation;
+- compaction refusal without a valid active artifact;
+- backup deletion path validation, confirmation, running-job refusal, and preservation
+  of safety/temporary/unrecognized files;
+- diagnostics after the empty `curator_job` repair;
+- parity for slates, scores, explanations, reports, Similar, Expand, and Prune.
+
+Run focused checks while iterating and `scripts/verify full` once near completion.
+Inspect `git diff --check`, file-specific diffs, and final status. Install or mutate
+the live sidecar only when explicitly requested.
+
+## Boundaries
+
+Do not add a service, scheduler, dependency, approximate vector database, or
+distributed cache. Do not redesign the recommendation model, feedback semantics, or
+UI. Do not delete media or mutate Stash except for the existing explicit reversible
+Prune-tag operation.
+
+If measurements show that a named Stage 3 cache or reranker is unnecessary, keep the
+existing path, record the evidence in tests/diagnostics, and complete the remaining
+measured work instead.
+
+## Implementation record
+
+Fresh installed diagnostics and native task status passed after the `curator_job`
+repair. Migration 19 is current, both schema-1 artifacts validate, readiness is
+complete, no update is pending, and subsequent build and sync-build jobs completed
+without errors.
+
+Installed read-only measurements:
+
+- For You ranking/explanations: 521/395 ms cold and 27/172 ms warm;
+- source-lane ranking/explanations: 216/240 ms cold and 24/159 ms warm;
+- Similar scenes: 2.8 seconds cold and 1.7 seconds warm;
+- Similar performers: 2.2 seconds cold and 2.0 seconds warm;
+- Expand cached/local ranking: 120/1,031 ms;
+- Prune candidate read: 80 ms;
+- model similarity/indexing/validation: 89.4/107.2/187.3 seconds;
+- feature/model artifact `quick_check`: 13.1/80.3 seconds.
+
+`dbstat` measured 526.5 MB of logical core pages. The largest rebuildable legacy
+allocations were scores (190.1 MB), feature rows/index (113.1 MB), content
+search/index (68.7 MB), lane orders (29.6 MB), and lane rows (16.4 MB).
+
+No new candidate/similarity cache or bounded reranker was added. Existing immutable
+materialized score-first/varied orders already provide fast request-time selection
+while preserving live eligibility and cooldown behavior. Prebuilding global
+similarity neighbors would increase the already dominant build and validation stages
+for a path bounded below three seconds, so the existing sparse calculation remains.
+
+Stage 3 adds schema-1/2 read compatibility, artifact-validated restartable legacy
+compaction, aggregate compaction diagnostics, a separate explicit `VACUUM` task, and
+exact-confirmation deletion of validated completed backups. Compaction and vacuum
+remain unrun against the installed sidecar; the protected pre-repair safety copy is
+unrecognized by deletion and remains untouched.
+
+The verified worktree was locally installed on 2026-07-30. Installed source hashes
+match the worktree, diagnostics and native task status pass, materialized For You,
+Similar, Expand, Prune, and explanations return normally, artifact writes are
+refused, and backup-deletion safety checks pass without deleting anything.

--- a/docs/stage-4-handover.md
+++ b/docs/stage-4-handover.md
@@ -1,0 +1,178 @@
+# Stage 4 live storage cutover handover
+
+## Objective
+
+Prove the installed Stage 3 storage lifecycle against the live sidecar: native backup,
+restartable legacy compaction, explicit vacuum, restart, and post-operation parity.
+This is an operational acceptance stage. Do not add another cache, schema, abstraction,
+or dependency unless a reproduced failure requires the smallest tested fix.
+
+## Starting state
+
+- Stages 1 through 3 are implemented, locally installed, and uncommitted.
+- The full suite passes with 210 tests.
+- Installed source hashes match the worktree.
+- Fresh diagnostics and native task status pass after the `curator_job` repair.
+- Migration 19 is current; the next migration, if genuinely needed, must be 20.
+- Active schema-1 feature and model artifacts validate and remain readable.
+- For You, Similar, Expand, Prune, explanations, and artifact immutability pass
+  installed read-only smoke checks.
+- Legacy compaction has never run.
+- The core reports 249,159,680 existing reclaimable bytes from earlier repair work;
+  `vacuum_pending=true` alone therefore does not prove Stage 4 compaction ran.
+- Three recognized completed backups exist. The verified pre-repair safety copy is
+  intentionally unrecognized and must remain untouched.
+- The worktree is intentionally dirty. Preserve every existing change.
+
+Do not expose private URLs, credentials, entity IDs, reports, recommendation data, or
+backup paths in tracked files or command output.
+
+## Authorization boundary
+
+Live compaction and vacuum are destructive to rebuildable legacy rows and require
+explicit user authorization in the new thread. They never authorize deleting media,
+resetting/restoring the sidecar, pruning, or deleting pre-existing backups.
+
+Before creating another backup, check available disk space. If a fresh backup cannot
+be created safely, stop and ask; do not delete an old backup to make room.
+
+## Required sequence
+
+### 1. Establish the baseline
+
+Through fresh installed processes:
+
+- run diagnostics and native task status;
+- confirm no Curator job is running;
+- record core/artifact sizes, schema versions, validation status, and integrity;
+- record aggregate row counts for every durable table class: source cache, feedback
+  and events, impressions and history, exclusions, pruning state, settings, jobs,
+  registries, and generation pointers;
+- record legacy derived row counts separately;
+- confirm the pre-repair safety copy still exists without printing its full path.
+
+Use aggregate counts and hashes only.
+
+### 2. Resolve native backup acceptance
+
+Run **Backup Curator data** through Stash's native task path and measure:
+
+- Stash task state/progress and elapsed time;
+- matching `curator_job` state;
+- completed file size;
+- SQLite `quick_check` and migration compatibility.
+
+Do not start compaction if completion is ambiguous, the task remains running, the
+backup is invalid, or the timeout defect reproduces. Diagnose and make the smallest
+tested fix, reinstall it, and repeat the native backup check first.
+
+### 3. Run restartable compaction
+
+After a fresh backup is verified, run **Compact legacy Curator data** once.
+
+- Let artifact validation finish; it may take several minutes.
+- Poll no more often than every 30–60 seconds.
+- If interrupted, inspect diagnostics and integrity. Resume by running the same task;
+  do not reset or restore merely because compaction is incomplete.
+- Record rows deleted, rows remaining, logical bytes removed, reclaimable bytes, and
+  final task state.
+
+Then confirm:
+
+- compaction status is `complete`;
+- legacy rows for validated artifact generations are zero;
+- every durable aggregate count exactly matches the baseline;
+- core and both active artifacts pass `quick_check`;
+- all active/previous artifact files and registry metadata remain.
+
+Do not run vacuum until these checks pass.
+
+### 4. Run explicit vacuum
+
+Run **Vacuum compacted Curator data** once. Record file bytes before/after and elapsed
+time. Then rerun core `quick_check`, diagnostics, native task status, and the durable
+aggregate comparison.
+
+Never use writable-schema recovery, manual deletes, reset, or restore in this stage.
+
+### 5. Restart and verify parity
+
+Restart local Stash once, then verify:
+
+- diagnostics and native task status;
+- cold and warm For You plus one source lane;
+- explanations and recommendation history;
+- Similar for a scene and performer;
+- Expand cached and local ranking;
+- Prune candidate reads without applying/removing tags;
+- backup listing and exact-confirmation refusal;
+- desktop/mobile route loading and keyboard navigation.
+
+Creating and deleting one new disposable backup is permitted only when the user's
+new-thread prompt explicitly authorizes deletion of that exact newly created file.
+Never delete a pre-existing, restore-safety, or pre-repair backup.
+
+## If a code change is required
+
+Reproduce first, trace every caller, and fix the shared root with one focused
+regression test. Run `scripts/verify changed <test>` while iterating and
+`scripts/verify full` once before reinstalling. Preserve schema-1 artifact
+compatibility and every durable table invariant.
+
+Do not commit, push, publish, restore, reset, or mutate Stash media unless separately
+authorized.
+
+## Exit criteria
+
+Stage 4 is complete when the native backup task finishes truthfully, compaction and
+vacuum finish once, durable counts remain exact, integrity checks pass, the restarted
+installed plugin preserves all public read behavior, and the protected backups remain.
+
+## Implementation record
+
+Stage 4 completed on 2026-07-30.
+
+- The native backup task finished in 14.4 seconds. The sole new 775,700,480-byte
+  backup passed `quick_check` and migration-19 compatibility.
+- Initial compaction stopped safely after 981,927 rows with a foreign-key error. A
+  retired superseded model still owned legacy affinities referencing active feature
+  definitions. The compactor now includes only retired, superseded, artifact-free
+  model generations after validating the active artifacts; a focused regression and
+  the full 210-test suite pass.
+- The resumed task removed the remaining 207,530 rows. Total legacy deletion was
+  1,189,457 rows, with zero derived rows remaining and clean foreign-key/integrity
+  checks.
+- Explicit vacuum completed once and reduced the core from 775,700,480 to 95,678,464
+  bytes. Stable pre/post-vacuum durable aggregates and generation pointers matched.
+- After the container restart, diagnostics, task status, cold/warm For You and Best
+  Bets, explanations, history, scene/performer Similar, scene/performer Expand, and
+  Prune candidate reads passed. Desktop and mobile routes loaded without horizontal
+  overflow and real Tab-key focus navigation worked.
+- The exact new disposable backup was deleted after validation. All three pre-existing
+  completed backups, the older temporary file, active/retained artifacts, and the
+  protected pre-repair copy remain.
+
+## Next-thread prompt
+
+```text
+Read AGENTS.md, docs/handover.md, docs/architecture.md,
+docs/stage-3-handover.md, and docs/stage-4-handover.md, then execute Stage 4
+completely. Preserve all existing worktree changes and inspect the complete diff
+first.
+
+I authorize these live operations only in the handover's order: create and validate
+one fresh Curator backup through Stash's native task path; run the existing Compact
+legacy Curator data task; after its integrity and durable-count checks pass, run the
+existing Vacuum compacted Curator data task; restart local Stash once; and perform
+the specified read-only installed verification.
+
+I also authorize deleting only the exact new disposable backup created during this
+Stage 4 run, after it validates and after you show that its identity is unambiguous.
+Do not delete any pre-existing backup or the pre-repair safety copy. Do not reset or
+restore the sidecar, mutate media, apply Prune tags, commit, push, or publish.
+
+Resolve the pending native backup-task timeout before compaction if it reproduces.
+Keep schema-1 artifacts readable, use aggregate/private-safe output, poll long tasks
+no more often than every 30–60 seconds, and stop if backup validity, integrity, or
+durable-count parity is uncertain.
+```

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -120,6 +120,12 @@ def _progress(value: float) -> None:
     _log("p", f"{max(0.0, min(value, 1.0)):.4f}")
 
 
+def _mapped_progress(start: float, end: float) -> Callable[[int, int], None]:
+    return lambda processed, total: _progress(
+        start + (end - start) * min(processed / max(1, total), 1.0)
+    )
+
+
 def _stash_connection(payload: dict[str, Any]) -> tuple[str, dict[str, str]]:
     server = payload.get("server_connection") or {}
     host = server.get("Host") or "127.0.0.1"
@@ -976,19 +982,29 @@ def _diagnostics(connection: Any) -> dict[str, object]:
     }
 
 
-def _classify_lanes(connection: Any, model: Any) -> int:
+def _classify_lanes(
+    connection: Any,
+    model_id: str,
+    progress: Callable[[int, int], None] | None = None,
+) -> int:
     count = int(
         connection.execute(
-            "SELECT count(*) FROM model_scene_lane WHERE model_id=?", (model.model_id,)
+            "SELECT count(*) FROM model_scene_lane WHERE model_id=?", (model_id,)
         ).fetchone()[0]
     )
     if count:
+        if progress:
+            progress(1, 1)
         return count
-    return len(LanePolicy(connection).classify(model.model_id))
+    return len(LanePolicy(connection).classify(model_id, progress=progress))
 
 
-def _prepare_lanes(connection: Any, model_id: str) -> dict[str, int]:
-    return SlateBuilder(connection).materialize(model_id)
+def _prepare_lanes(
+    connection: Any,
+    model_id: str,
+    progress: Callable[[int, int], None] | None = None,
+) -> dict[str, int]:
+    return SlateBuilder(connection).materialize(model_id, progress=progress)
 
 
 def _run_task_body(
@@ -1052,7 +1068,7 @@ def _run_task_body(
                 entity: str, processed: int, total: int, position: int, entity_count: int
             ) -> None:
                 fraction = 1.0 if total == 0 else min(processed / total, 1.0)
-                _progress(0.05 + 0.7 * ((position + fraction) / entity_count))
+                _progress(0.03 + 0.52 * ((position + fraction) / entity_count))
                 milestone = int(fraction * 10)
                 if milestone > logged_milestones.get(entity, -1):
                     logged_milestones[entity] = milestone
@@ -1067,43 +1083,67 @@ def _run_task_body(
                     progress=report_sync,
                 ).sync(full=mode == "full-sync-build")
             with span("python", "task.reconcile_prune"):
-                CuratorAPI(connection).reconcile_prune_tag(str(sidecar_config["prune_tag_name"]))
-            _progress(0.78)
+                prune_changed = CuratorAPI(connection).reconcile_prune_tag(
+                    str(sidecar_config["prune_tag_name"])
+                )
+            _progress(0.58)
             _log("i", "Rebuilding historical preference signals")
             with span("python", "task.historical_events"):
                 historical = HistoricalEventStore(connection).rebuild(
-                    None if mode == "full-sync-build" or synced.resumed else synced.scene_ids
+                    None if mode == "full-sync-build" or synced.resumed else synced.scene_ids,
+                    progress=_mapped_progress(0.58, 0.68),
                 )
-            _progress(0.86)
-            _log("i", "Building the recommendation model")
+            _progress(0.68)
             coordinator = ModelUpdateCoordinator(connection)
-            coordinator.request("source_sync")
-            with span("python", "task.model_build"):
-                model = coordinator.drain(
-                    force=True,
-                    max_builds=1,
-                    progress=lambda processed, total: _progress(
-                        0.86 + 0.08 * (processed / max(1, total))
-                    ),
-                )[0]
-            _progress(0.94)
+            source_changed = (
+                mode == "full-sync-build"
+                or synced.resumed
+                or any(synced.changed_entity_counts.values())
+                or prune_changed
+            )
+            current_model_id = RecommendationModelStore(connection).current_model_id()
+            if source_changed or current_model_id is None:
+                coordinator.request("source_sync")
+            if source_changed or coordinator.status().pending or current_model_id is None:
+                _log("i", "Building the recommendation model")
+                with span("python", "task.model_build"):
+                    model = coordinator.drain(
+                        force=True,
+                        max_builds=1,
+                        progress=_mapped_progress(0.68, 0.95),
+                    )[0]
+                model_id = model.model_id
+                stage_timings_ms = model.stage_timings_ms
+            else:
+                _progress(0.95)
+                _log("i", "No Stash changes; keeping the current recommendation model")
+                model_id = current_model_id
+                stage_timings_ms = {}
+            _progress(0.95)
             _log("i", "Organizing scenes into recommendation lanes")
             with span("python", "task.lane_classification"):
-                lane_count = _classify_lanes(connection, model)
-            _progress(0.96)
+                lane_count = _classify_lanes(
+                    connection,
+                    model_id,
+                    progress=_mapped_progress(0.95, 0.97),
+                )
+            _progress(0.97)
             _log("i", "Preparing recommendation pages")
             with span("python", "task.prepare_pages"):
-                lane_caches = _prepare_lanes(connection, model.model_id)
-            _progress(0.98)
-            _log("i", f"Published recommendation model {model.model_id}")
+                lane_caches = _prepare_lanes(
+                    connection, model_id, progress=_mapped_progress(0.97, 0.99)
+                )
+            _progress(0.99)
+            _log("i", f"Recommendation model ready: {model_id}")
             summary: dict[str, object] = {
                 "sync_run_id": synced.run_id,
                 "entity_counts": synced.entity_counts,
+                "changed_entity_counts": synced.changed_entity_counts,
                 "historical_scenes": historical.scene_count,
-                "model_id": model.model_id,
+                "model_id": model_id,
                 "lane_classifications": lane_count,
                 "lane_candidate_caches": lane_caches,
-                "stage_timings_ms": model.stage_timings_ms,
+                "stage_timings_ms": stage_timings_ms,
             }
         elif mode in {"build", "update-model"}:
             _progress(0.1)
@@ -1113,11 +1153,11 @@ def _run_task_body(
             def report_model(processed: int, total: int) -> None:
                 nonlocal model_milestone
                 fraction = 1.0 if total == 0 else min(processed / total, 1.0)
-                _progress(0.12 + 0.78 * fraction)
+                _progress(0.03 + 0.92 * fraction)
                 milestone = int(fraction * 10)
                 if milestone > model_milestone:
                     model_milestone = milestone
-                    _log("i", f"Scoring scenes: {processed}/{total}")
+                    _log("i", f"Building recommendation model: {milestone * 10}%")
 
             coordinator = ModelUpdateCoordinator(connection)
             if mode == "build":
@@ -1130,15 +1170,19 @@ def _run_task_body(
                 _log("i", "No pending preference changes")
             else:
                 model = models[-1]
-                _progress(0.94)
+                _progress(0.95)
                 _log("i", "Organizing scenes into recommendation lanes")
                 with span("python", "task.lane_classification"):
-                    lane_count = _classify_lanes(connection, model)
-                _progress(0.96)
+                    lane_count = _classify_lanes(
+                        connection, model.model_id, progress=_mapped_progress(0.95, 0.97)
+                    )
+                _progress(0.97)
                 _log("i", "Preparing recommendation pages")
                 with span("python", "task.prepare_pages"):
-                    lane_caches = _prepare_lanes(connection, model.model_id)
-                _progress(0.98)
+                    lane_caches = _prepare_lanes(
+                        connection, model.model_id, progress=_mapped_progress(0.97, 0.99)
+                    )
+                _progress(0.99)
                 summary = {
                     "updated": True,
                     "model_id": model.model_id,
@@ -1147,39 +1191,45 @@ def _run_task_body(
                     "stage_timings_ms": model.stage_timings_ms,
                 }
         elif mode == "prepare":
-            _progress(0.1)
-            model_id = RecommendationModelStore(connection).current_model_id()
-            if model_id is None:
+            _progress(0.05)
+            prepared_model_id = RecommendationModelStore(connection).current_model_id()
+            if prepared_model_id is None:
                 raise RuntimeError("no published model; build recommendations first")
             _log("i", "Preparing recommendation pages")
             with span("python", "task.prepare_pages"):
-                lane_caches = _prepare_lanes(connection, model_id)
-            _progress(0.98)
-            summary = {"model_id": model_id, "lane_candidate_caches": lane_caches}
+                lane_caches = _prepare_lanes(
+                    connection, prepared_model_id, progress=_mapped_progress(0.05, 0.99)
+                )
+            _progress(0.99)
+            summary = {"model_id": prepared_model_id, "lane_candidate_caches": lane_caches}
         elif mode == "backup":
-            _progress(0.1)
+            _progress(0.05)
             destination = (
                 _backup_directory(payload, settings) / f"curator-{started_at_ms}.sqlite3.backup"
             )
             with span("python", "task.backup"):
-                backup_database(connection, destination)
+                backup_database(connection, destination, progress=_mapped_progress(0.05, 0.95))
             _progress(0.98)
             summary = {"backup": str(destination)}
         elif mode == "compact":
             _progress(0.1)
             _log("i", "Validating generation artifacts")
             with span("python", "task.compact"):
-                summary = compact_legacy_generations(connection)
+                summary = compact_legacy_generations(
+                    connection, progress=_mapped_progress(0.10, 0.95)
+                )
             _progress(0.98)
         elif mode == "vacuum":
             if compaction_status(connection)["status"] != "complete":
                 raise RuntimeError("compact legacy Curator data before vacuuming")
-            _progress(0.1)
+            _progress(0.05)
             database = _database_path(payload, settings).expanduser().resolve()
             before = database.stat().st_size
             _log("i", "Vacuuming compacted Curator data")
             with span("python", "task.vacuum"):
+                _progress(0.10)
                 connection.execute("VACUUM")
+                _progress(0.94)
                 connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
             _progress(0.98)
             summary = {
@@ -1187,11 +1237,10 @@ def _run_task_body(
                 "bytes_after": database.stat().st_size,
             }
         elif mode == "expand-refresh":
-            _progress(0.1)
+            _progress(0.05)
             config = CuratorAPI(connection).config()["config"]
             assert isinstance(config, dict)
             _log("i", "Collecting bounded StashDB candidates")
-            _progress(0.25)
             with span("python", "task.expand_refresh"):
                 summary = ExpandService(connection).refresh(
                     _stashdb(payload),
@@ -1199,6 +1248,7 @@ def _run_task_body(
                     horizon_days=int(config["expand_horizon_days"]),
                     gender=str(config["expand_gender"]),
                     wildcard=bool(config["expand_wildcard"]),
+                    progress=_mapped_progress(0.05, 0.98),
                 )
             _progress(0.98)
         else:

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -41,7 +41,10 @@ from curator.ranking import LanePolicy, SlateBuilder  # noqa: E402
 from curator.storage import (  # noqa: E402
     MigrationRunner,
     backup_database,
+    compact_legacy_generations,
+    compaction_status,
     connect_database,
+    generation_diagnostics,
     transaction,
 )
 from curator.sync import SyncService  # noqa: E402
@@ -255,7 +258,7 @@ def _list_backups(payload: dict[str, Any], settings: dict[str, Any]) -> list[dic
 
 
 def _validate_backup(path: Path) -> None:
-    connection = connect_database(path, readonly=True)
+    connection = connect_database(path, readonly=True, attach_artifacts=False)
     try:
         if str(connection.execute("PRAGMA quick_check").fetchone()[0]) != "ok":
             raise ValueError("backup failed SQLite integrity validation")
@@ -307,6 +310,16 @@ def _backup_control(
             or backup.is_symlink()
         ):
             raise ValueError("select a recognized Curator backup")
+        if operation == "delete_backup":
+            if str(args.get("confirmation") or "") != f"DELETE {backup_id}":
+                raise ValueError("deletion requires explicit confirmation")
+            _validate_backup(backup)
+            backup.unlink()
+            return {
+                "schema_version": SCHEMA_VERSION,
+                "deleted": backup_id,
+                "items": _list_backups(payload, settings),
+            }
         if str(args.get("confirmation") or "") != f"RESTORE {backup_id}":
             raise ValueError("restore requires explicit confirmation")
         _validate_backup(backup)
@@ -318,17 +331,37 @@ def _backup_control(
         connection.close()
     for suffix in ("-wal", "-shm"):
         Path(f"{database}{suffix}").unlink(missing_ok=True)
-    source = connect_database(backup, readonly=True)
+    source = connect_database(backup, readonly=True, attach_artifacts=False)
     try:
         backup_database(source, database, overwrite=True)
     finally:
         source.close()
-    restored = _open(payload, settings)
-    restored.close()
+    restored = connect_database(database, attach_artifacts=False)
+    try:
+        MigrationRunner(restored).migrate(applied_at_ms=now_ms)
+        with transaction(restored):
+            restored.execute(
+                """
+                UPDATE model_version SET status='superseded',
+                    validation_status='restore_invalidated'
+                WHERE status='published'
+                """
+            )
+            restored.execute(
+                """
+                UPDATE feature_build SET status='superseded',
+                    validation_status='restore_invalidated'
+                WHERE status='published'
+                """
+            )
+            restored.execute("DELETE FROM application_meta WHERE key='current_model_id'")
+    finally:
+        restored.close()
     return {
         "schema_version": SCHEMA_VERSION,
         "restored_from": str(backup.resolve()),
         "safety_backup": str(safety),
+        "recommendations_need_rebuilding": True,
     }
 
 
@@ -371,8 +404,15 @@ def _apply_plugin_settings(connection: Any, settings: dict[str, Any]) -> None:
         )
 
 
-def _open(payload: dict[str, Any], settings: dict[str, Any] | None = None):  # type: ignore[no-untyped-def]
-    connection = connect_database(_database_path(payload, settings))
+def _open(  # type: ignore[no-untyped-def]
+    payload: dict[str, Any],
+    settings: dict[str, Any] | None = None,
+    *,
+    attach_artifacts: bool = True,
+):
+    connection = connect_database(
+        _database_path(payload, settings), attach_artifacts=attach_artifacts
+    )
     MigrationRunner(connection).migrate(applied_at_ms=time.time_ns() // 1_000_000)
     _apply_plugin_settings(connection, settings or {})
     return connection
@@ -388,6 +428,8 @@ def _health(payload: dict[str, Any]) -> dict[str, object]:
         "Apply recent Curator feedback",
         "Prepare recommendation pages",
         "Backup Curator data",
+        "Compact legacy Curator data",
+        "Vacuum compacted Curator data",
         "Refresh Expand cache",
     }
     active_job = next(
@@ -838,6 +880,8 @@ DIAGNOSTIC_JOB_TYPES = {
     "update-model",
     "prepare",
     "backup",
+    "compact",
+    "vacuum",
     "expand-refresh",
 }
 
@@ -910,6 +954,8 @@ def _diagnostics(connection: Any) -> dict[str, object]:
                 > int(model_update["published_generation"])
             ),
         },
+        "generations": generation_diagnostics(connection),
+        "compaction": compaction_status(connection),
         "recent_jobs": recent_jobs,
         "timing_ms": {
             "last_model_update": (
@@ -991,6 +1037,9 @@ def _run_task_body(
             "already_running": True,
             "job_type": str(existing["job_type"]),
         }
+    if mode in {"compact", "vacuum"}:
+        connection.close()
+        connection = _open(payload, settings, attach_artifacts=False)
     _log("i", f"Stash Curator {mode} started")
     _progress(0.01)
     try:
@@ -1116,6 +1165,27 @@ def _run_task_body(
                 backup_database(connection, destination)
             _progress(0.98)
             summary = {"backup": str(destination)}
+        elif mode == "compact":
+            _progress(0.1)
+            _log("i", "Validating generation artifacts")
+            with span("python", "task.compact"):
+                summary = compact_legacy_generations(connection)
+            _progress(0.98)
+        elif mode == "vacuum":
+            if compaction_status(connection)["status"] != "complete":
+                raise RuntimeError("compact legacy Curator data before vacuuming")
+            _progress(0.1)
+            database = _database_path(payload, settings).expanduser().resolve()
+            before = database.stat().st_size
+            _log("i", "Vacuuming compacted Curator data")
+            with span("python", "task.vacuum"):
+                connection.execute("VACUUM")
+                connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+            _progress(0.98)
+            summary = {
+                "bytes_before": before,
+                "bytes_after": database.stat().st_size,
+            }
         elif mode == "expand-refresh":
             _progress(0.1)
             config = CuratorAPI(connection).config()["config"]
@@ -1206,7 +1276,7 @@ def dispatch(payload: dict[str, Any]) -> dict[str, object]:
         return _health(payload)
     if operation == "round_trip":
         return _round_trip(payload)
-    if operation in {"list_backups", "create_backup", "restore_backup"}:
+    if operation in {"list_backups", "create_backup", "restore_backup", "delete_backup"}:
         return _backup_control(payload, operation, _settings(payload))
     if operation == "reset":
         if str((payload.get("args") or {}).get("confirmation") or "") != "RESET":
@@ -1220,7 +1290,14 @@ def dispatch(payload: dict[str, Any]) -> dict[str, object]:
         connection.close()
         if running:
             raise RuntimeError("cannot reset Curator while a job is running")
-        for path in (database, Path(f"{database}-wal"), Path(f"{database}-shm")):
+        from curator.storage.artifacts import recognized_artifacts
+
+        for path in (
+            database,
+            Path(f"{database}-wal"),
+            Path(f"{database}-shm"),
+            *recognized_artifacts(database),
+        ):
             path.unlink(missing_ok=True)
         connection = _open(payload, settings)
         connection.close()

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -1843,8 +1843,8 @@
         React.createElement(
           "div",
           { className: "curator-task-buttons" },
-          React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Sync library: fetch changed Stash metadata and refresh recommendations.", "aria-label": "Sync library", onClick: () => start("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync })),
-          React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Rebuild model from the existing synchronized data.", "aria-label": "Rebuild model", onClick: () => start("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench })),
+          React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Use after Stash library changes. Sync changed metadata and history, then refresh recommendations.", "aria-label": "Sync library changes and refresh recommendations", onClick: () => start("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync })),
+          React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Force a recommendation refresh from already-synced data. Does not contact Stash.", "aria-label": "Rebuild recommendations without syncing Stash", onClick: () => start("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench })),
           React.createElement(Button, { className: "curator-icon-button curator-profiling-button", size: "sm", variant: profilingActive ? "primary" : "secondary", title: "Open performance profiles.", "aria-label": "Open performance profiles", "aria-pressed": profilingActive, onClick: onProfiling }, React.createElement(FontAwesomeIcon, { icon: faDev })),
           React.createElement(NavLink, { className: "btn btn-secondary btn-sm curator-icon-button", title: "Open Curator's plugin settings.", "aria-label": "Plugin settings", to: "/settings?tab=plugins" }, React.createElement(FontAwesomeIcon, { icon: faCog }))
         )

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -1565,6 +1565,24 @@
         setBusy(false);
       }
     }
+    async function remove(item) {
+      if (!window.confirm(`Delete completed Curator backup ${item.id}?`)) return;
+      setBusy(true);
+      setError("");
+      try {
+        const result = await operation({
+          operation: "delete_backup",
+          backup_id: item.id,
+          confirmation: `DELETE ${item.id}`,
+        });
+        setMessage(`Deleted backup ${result.deleted}.`);
+        setData((current) => ({ ...current, items: result.items }));
+      } catch (failure) {
+        setError(failure.message);
+      } finally {
+        setBusy(false);
+      }
+    }
     return React.createElement(
       "section",
       { className: "curator-backup-page" },
@@ -1586,7 +1604,7 @@
             React.createElement("td", null, new Date(item.created_at_ms).toLocaleString()),
             React.createElement("td", null, `${(item.size_bytes / 1048576).toFixed(1)} MB`),
             React.createElement("td", null, item.id),
-            React.createElement("td", null, React.createElement(Button, { size: "sm", variant: "danger", disabled: busy, onClick: () => restore(item) }, "Restore"))
+            React.createElement("td", null, React.createElement(Button, { size: "sm", disabled: busy, onClick: () => restore(item) }, "Restore"), " ", React.createElement(Button, { size: "sm", variant: "danger", disabled: busy, onClick: () => remove(item) }, "Delete"))
           )))
         )
       )

--- a/plugin/stash-curator.yml
+++ b/plugin/stash-curator.yml
@@ -114,6 +114,14 @@ tasks:
     description: Create a timestamped sidecar backup in the plugin data directory.
     execArgs:
       - backup
+  - name: Compact legacy Curator data
+    description: Delete rebuildable legacy rows after validating published generation artifacts.
+    execArgs:
+      - compact
+  - name: Vacuum compacted Curator data
+    description: Explicitly reclaim file space after legacy compaction completes.
+    execArgs:
+      - vacuum
   - name: Refresh Expand cache
     description: Refresh promising StashDB scenes and performers without affecting library sync.
     execArgs:

--- a/plugin/stash-curator.yml
+++ b/plugin/stash-curator.yml
@@ -91,7 +91,7 @@ settings:
     type: BOOLEAN
 tasks:
   - name: Sync and build recommendations
-    description: Incrementally synchronize Stash and publish a fresh model.
+    description: Use after Stash library changes. Sync changed metadata and history, then refresh recommendations.
     execArgs:
       - sync-build
   - name: Full sync and build recommendations
@@ -99,7 +99,7 @@ tasks:
     execArgs:
       - full-sync-build
   - name: Rebuild recommendation model
-    description: Rebuild preferences from the existing sidecar cache.
+    description: Force a recommendation refresh from already-synced data without contacting Stash.
     execArgs:
       - build
   - name: Apply recent Curator feedback

--- a/tests/events/test_repository.py
+++ b/tests/events/test_repository.py
@@ -34,14 +34,16 @@ def test_historical_projection_is_idempotent_and_inspectable(
     connection: sqlite3.Connection,
 ) -> None:
     store = HistoricalEventStore(connection)
+    progress: list[tuple[int, int]] = []
 
-    first = store.rebuild()
+    first = store.rebuild(progress=lambda processed, total: progress.append((processed, total)))
     second = store.rebuild()
 
     assert first == second
     assert first.scene_count == 1
     assert first.session_count == 2
     assert first.outcome_count == 2
+    assert progress == [(1, 2), (2, 2)]
     assert connection.execute("SELECT count(*) FROM play_session").fetchone()[0] == 2
     events = connection.execute(
         "SELECT outcome, confidence, payload_json FROM behavior_event ORDER BY occurred_at_ms"

--- a/tests/explanations/test_reasons.py
+++ b/tests/explanations/test_reasons.py
@@ -65,6 +65,26 @@ def test_reason_graph_is_versioned_truthful_and_deterministic(tmp_path: Path) ->
     assert explanation.selected_reasons == (reason,)
 
 
+def test_scene_without_specific_evidence_gets_factual_fallback(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    connection.execute(
+        """
+        UPDATE model_scene_score
+        SET direct_appeal=0, direct_confidence=0, components_json='{}', neighbors_json='[]'
+        WHERE model_id='model' AND scene_id='a-best'
+        """
+    )
+
+    store = ReasonGraphStore(connection)
+    store.build("model", {"a-best"})
+
+    reason = store.reasons("model", "a-best")[0]
+    assert reason.code == "fallback"
+    assert reason.direction == "neutral"
+    assert reason.provenance == "model_baseline"
+    assert reason.detail.keys() == {"appeal", "current_fit", "confidence"}
+
+
 def test_recommendation_explanation_names_the_exploration_tradeoff(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     item = next(

--- a/tests/features/test_builder.py
+++ b/tests/features/test_builder.py
@@ -103,10 +103,24 @@ def test_feature_build_is_deterministic_versioned_and_explainable(tmp_path: Path
     builder = FeatureBuilder(connection, CuratorConfig(), clock_ms=lambda: 100)
 
     first = builder.build()
+    statements: list[str] = []
+    connection.set_trace_callback(statements.append)
     second = builder.build()
+    connection.set_trace_callback(None)
 
     assert second.feature_version == first.feature_version
     assert second.reused is True
+    assert not any("FROM entity_feature" in statement for statement in statements)
+    assert set(first.stage_timings_ms) == {
+        "lookup",
+        "build",
+        "database_writing",
+        "indexing",
+        "validation",
+        "publication",
+        "total",
+    }
+    assert set(second.stage_timings_ms) == {"lookup", "total"}
     admin_role = connection.execute(
         "SELECT role, resolution_reason FROM tag_role WHERE tag_id='admin'"
     ).fetchone()
@@ -118,7 +132,7 @@ def test_feature_build_is_deterministic_versioned_and_explainable(tmp_path: Path
     assert "tag:content" in vectors["scene-1"]
     assert "tag:parent" in vectors["scene-1"]
     assert "tag:admin" not in vectors["scene-1"]
-    statements: list[str] = []
+    statements = []
     connection.set_trace_callback(statements.append)
     assert (
         FeatureStore(connection).scene_content_overlaps(first.feature_version, "scene-1")["scene-2"]
@@ -127,7 +141,7 @@ def test_feature_build_is_deterministic_versioned_and_explainable(tmp_path: Path
     connection.set_trace_callback(None)
     overlap_query = next(statement for statement in statements if "WITH target AS" in statement)
     plan = connection.execute(f"EXPLAIN QUERY PLAN {overlap_query}")
-    assert any("SEARCH other USING PRIMARY KEY (feature_id=?)" in row["detail"] for row in plan)
+    assert any("feature_id=?" in row["detail"] for row in plan)
     scene_features = FeatureStore(connection).entity_features(first.feature_version, "scene")
     families = {feature.family for feature in scene_features["scene-1"]}
     assert {"content", "performer_identity", "studio"} <= families
@@ -147,23 +161,27 @@ def test_feature_build_is_deterministic_versioned_and_explainable(tmp_path: Path
     assert profiles["performer-2"].blocks.get("measurements") is None
 
 
-def test_source_change_publishes_new_version_and_supersedes_old(tmp_path: Path) -> None:
+def test_only_feature_source_changes_publish_new_version(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     builder = FeatureBuilder(connection, clock_ms=lambda: 100)
     first = builder.build()
     connection.execute("UPDATE source_scene SET source_hash='changed' WHERE scene_id='scene-1'")
 
     second = builder.build()
+    connection.execute("UPDATE source_scene SET scene_date='2025-01-01' WHERE scene_id='scene-1'")
+    third = builder.build()
 
-    assert second.feature_version != first.feature_version
+    assert second.feature_version == first.feature_version
+    assert second.reused is True
+    assert third.feature_version != first.feature_version
     statuses = {
         row["feature_version"]: row["status"]
         for row in connection.execute("SELECT feature_version, status FROM feature_build")
     }
     assert statuses[first.feature_version] == "superseded"
-    assert statuses[second.feature_version] == "published"
+    assert statuses[third.feature_version] == "published"
     indexed_versions = {
         str(row[0])
         for row in connection.execute("SELECT feature_version FROM scene_content_search")
     }
-    assert indexed_versions == {second.feature_version}
+    assert indexed_versions == {third.feature_version}

--- a/tests/features/test_builder.py
+++ b/tests/features/test_builder.py
@@ -100,9 +100,17 @@ def _database(path: Path) -> sqlite3.Connection:
 
 def test_feature_build_is_deterministic_versioned_and_explainable(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
-    builder = FeatureBuilder(connection, CuratorConfig(), clock_ms=lambda: 100)
+    progress: list[tuple[int, int]] = []
+    builder = FeatureBuilder(
+        connection,
+        CuratorConfig(),
+        clock_ms=lambda: 100,
+        progress=lambda processed, total: progress.append((processed, total)),
+    )
 
     first = builder.build()
+    first_progress = tuple(progress)
+    progress.clear()
     statements: list[str] = []
     connection.set_trace_callback(statements.append)
     second = builder.build()
@@ -110,6 +118,13 @@ def test_feature_build_is_deterministic_versioned_and_explainable(tmp_path: Path
 
     assert second.feature_version == first.feature_version
     assert second.reused is True
+    assert {50, 100, 450, 600, 750, 850, 930, 980, 1_000} <= {
+        processed for processed, total in first_progress if total == 1_000
+    }
+    assert [processed for processed, _ in first_progress] == sorted(
+        processed for processed, _ in first_progress
+    )
+    assert progress[-1] == (1_000, 1_000)
     assert not any("FROM entity_feature" in statement for statement in statements)
     assert set(first.stage_timings_ms) == {
         "lookup",

--- a/tests/integration/test_sync.py
+++ b/tests/integration/test_sync.py
@@ -292,3 +292,18 @@ def test_incremental_sync_stops_after_crossing_previous_watermark(
     assert (
         connection.execute("SELECT count(*) FROM source_tag WHERE tag_id = 't3'").fetchone()[0] == 1
     )
+    assert result.changed_entity_counts["tag"] == 1
+    assert result.scene_ids == ()
+
+
+def test_incremental_sync_skips_unchanged_source_rows(connection: sqlite3.Connection) -> None:
+    service = SyncService(SyntheticClient(_entities()), SyncRepository(connection), page_size=2)
+    service.sync()
+    statements: list[str] = []
+    connection.set_trace_callback(statements.append)
+
+    result = service.sync()
+
+    assert not any(result.changed_entity_counts.values())
+    assert result.scene_ids == ()
+    assert not any(statement.startswith("DELETE FROM source_") for statement in statements)

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -9,6 +9,7 @@ import pytest
 import curator.model.builder as builder_module
 from curator.cli import run
 from curator.config import DEFAULT_CONFIG
+from curator.explanations import ReasonGraphStore
 from curator.interactions import InteractionStore
 from curator.model import PreferenceModelBuilder, RecommendationModelStore
 from curator.storage import MigrationRunner, connect_database
@@ -138,6 +139,26 @@ def test_complete_model_is_bounded_reproducible_and_applies_cooldown(tmp_path: P
 
     assert second.model_id == first.model_id
     assert second.reused is True
+    statements = []
+    connection.set_trace_callback(statements.append)
+    ReasonGraphStore(connection).ensure(first.model_id, set(scores))
+    connection.set_trace_callback(None)
+    assert not any(
+        statement.startswith(("INSERT INTO model_scene_reason", "DELETE FROM model_scene_reason"))
+        for statement in statements
+    )
+    assert {
+        "feature_lookup",
+        "feature_build",
+        "similarity",
+        "scoring",
+        "database_writing",
+        "indexing",
+        "validation",
+        "publication",
+        "cleanup",
+        "total",
+    } <= set(first.stage_timings_ms)
     assert set(scores) == {
         "old-good",
         "recent-good",
@@ -453,6 +474,20 @@ def test_model_build_refreshes_feature_version_after_feature_config_change(
     ).build()
 
     assert second.feature_version != first.feature_version
+    assert second.model_id != first.model_id
+
+
+def test_playback_change_reuses_features_but_rebuilds_model(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    first = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    connection.execute(
+        "INSERT INTO source_play(scene_id, played_at_ms, ordinal) VALUES (?, ?, 0)",
+        ("unseen-good", REFERENCE_MS - 2 * DAY_MS),
+    )
+
+    second = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+
+    assert second.feature_version == first.feature_version
     assert second.model_id != first.model_id
 
 

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -331,7 +331,19 @@ def test_model_build_reports_stage_progress(tmp_path: Path) -> None:
         progress=lambda processed, total: progress.append((processed, total)),
     ).build()
 
-    assert {(50, 1_000), (100, 1_000), (200, 1_000), (1_000, 1_000)} <= set(progress)
+    assert {
+        (250, 1_000),
+        (300, 1_000),
+        (350, 1_000),
+        (780, 1_000),
+        (850, 1_000),
+        (940, 1_000),
+        (980, 1_000),
+        (1_000, 1_000),
+    } <= set(progress)
+    assert [processed for processed, _ in progress] == sorted(
+        processed for processed, _ in progress
+    )
     assert progress[-1] == (1_000, 1_000)
 
 

--- a/tests/model/test_updates.py
+++ b/tests/model/test_updates.py
@@ -49,6 +49,15 @@ def test_failed_update_remains_pending(tmp_path: Path, monkeypatch: pytest.Monke
     assert coordinator.status().pending is True
     assert coordinator.status().last_error == "build failed"
 
+    coordinator.request("manual_retry")
+    assert coordinator.status().last_error == "build failed"
+    monkeypatch.setattr(
+        PreferenceModelBuilder,
+        "build",
+        lambda _builder: ModelBuildResult("model", "features", 1, 1, False, {"total": 1}),
+    )
+    assert len(coordinator.drain(force=True, max_builds=1)) == 1
+
 
 def test_coordinator_does_not_duplicate_an_active_build(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -96,6 +96,8 @@ def test_plugin_archive_contains_runtime_and_core(tmp_path: Path) -> None:
     )
     assert json.loads(task.stdout)["output"]["backup"].endswith(".sqlite3.backup")
     assert "Stash Curator backup completed" in task.stderr
+    assert "\x01p\x020.0500" in task.stderr
+    assert "\x01p\x020.9500" in task.stderr
     assert "\x01p\x021.0000" in task.stderr
     with sqlite3.connect(installed / "data" / "curator.sqlite3") as connection:
         assert connection.execute("SELECT last_error FROM model_update_state").fetchone()[0]
@@ -759,7 +761,7 @@ def test_reused_model_keeps_existing_lane_classifications(
     cursor = SimpleNamespace(fetchone=lambda: (3,))
     connection = SimpleNamespace(execute=lambda *_args: cursor)
 
-    assert module._classify_lanes(connection, SimpleNamespace(model_id="model", reused=True)) == 3
+    assert module._classify_lanes(connection, "model") == 3
 
 
 def test_plugin_settings_are_applied_to_sidecar_config(tmp_path: Path) -> None:
@@ -809,7 +811,8 @@ def test_plugin_settings_are_applied_to_sidecar_config(tmp_path: Path) -> None:
 def test_model_tasks_prepare_recommendation_pages() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "backend.py").read_text(encoding="utf-8")
 
-    assert source.count("_prepare_lanes(connection, model.model_id)") == 2
+    assert source.count("_mapped_progress(0.97, 0.99)") == 2
+    assert "_mapped_progress(0.05, 0.99)" in source
     assert '"lane_candidate_caches": lane_caches' in source
 
 

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -72,6 +72,8 @@ def test_plugin_archive_contains_runtime_and_core(tmp_path: Path) -> None:
     installed = tmp_path / "installed"
     assert "Apply recent Curator feedback" in (installed / "stash-curator.yml").read_text()
     assert "Prepare recommendation pages" in (installed / "stash-curator.yml").read_text()
+    assert "Compact legacy Curator data" in (installed / "stash-curator.yml").read_text()
+    assert "Vacuum compacted Curator data" in (installed / "stash-curator.yml").read_text()
     javascript = (installed / "stash-curator.js").read_text()
     assert "data:image/png;base64" in javascript
     assert "curator-whisparr-fallback" in javascript
@@ -111,10 +113,12 @@ def test_backup_management_uses_recognized_ids_and_explicit_confirmation() -> No
     assert "backup_id: item.id" in source
     assert "confirmation: `RESTORE ${item.id}`" in source
     assert "Safety backup:" in source
+    assert 'operation: "delete_backup"' in source
+    assert "confirmation: `DELETE ${item.id}`" in source
 
 
 def test_backup_controls_validate_ids_refuse_jobs_and_restore_with_safety_copy(
-    tmp_path: Path,
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     backend = Path(__file__).parents[2] / "plugin" / "backend.py"
     spec = importlib.util.spec_from_file_location("curator_plugin_backups", backend)
@@ -127,11 +131,37 @@ def test_backup_controls_validate_ids_refuse_jobs_and_restore_with_safety_copy(
     settings = {"backupPath": str(backups)}
     connection = module._open(payload, settings)
     module.CuratorAPI(connection).update_config({"page_size": 12}, now_ms=1)
+    connection.execute(
+        """
+        INSERT INTO feature_build(
+            feature_version, status, config_json, source_fingerprint, created_at_ms
+        ) VALUES ('feature', 'published', '{}', 'source', 1)
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO model_version(
+            model_id, status, feature_version, config_json, created_at_ms
+        ) VALUES ('model', 'published', 'feature', '{}', 1)
+        """
+    )
     connection.close()
 
     created = module._backup_control(payload, "create_backup", settings)
     backup_id = Path(str(created["backup_path"])).name
     assert created["items"][0]["id"] == backup_id
+    restore_copy = module._backup_control(payload, "create_backup", settings)
+    restore_id = Path(str(restore_copy["backup_path"])).name
+    safety = backups / "curator-before-job-repair-20260730T060149Z.sqlite3.backup"
+    temporary = backups / f".{backup_id}.temporary"
+    unrelated = backups / "other.sqlite3.backup"
+    linked = backups / "curator-123.sqlite3.backup"
+    incomplete = backups / "curator-124.sqlite3.backup"
+    safety.touch()
+    temporary.touch()
+    unrelated.touch()
+    linked.symlink_to(created["backup_path"])
+    incomplete.touch()
 
     connection = module._open(payload, settings)
     module.CuratorAPI(connection).update_config({"page_size": 30}, now_ms=2)
@@ -144,6 +174,13 @@ def test_backup_controls_validate_ids_refuse_jobs_and_restore_with_safety_copy(
     connection.close()
     with pytest.raises(RuntimeError, match="job is running"):
         module._backup_control(payload, "create_backup", settings)
+    payload["args"] = {
+        "database_path": str(database),
+        "backup_id": backup_id,
+        "confirmation": f"DELETE {backup_id}",
+    }
+    with pytest.raises(RuntimeError, match="job is running"):
+        module._backup_control(payload, "delete_backup", settings)
     connection = module._open(payload, settings)
     connection.execute("DELETE FROM curator_job WHERE job_id='running'")
     connection.close()
@@ -155,18 +192,127 @@ def test_backup_controls_validate_ids_refuse_jobs_and_restore_with_safety_copy(
     }
     with pytest.raises(ValueError, match="recognized"):
         module._backup_control(payload, "restore_backup", settings)
+    for invalid in (
+        f"../{backup_id}",
+        str(Path(str(created["backup_path"])).resolve()),
+        safety.name,
+        temporary.name,
+        unrelated.name,
+        linked.name,
+    ):
+        payload["args"] = {
+            "database_path": str(database),
+            "backup_id": invalid,
+            "confirmation": f"DELETE {invalid}",
+        }
+        with pytest.raises(ValueError, match="recognized"):
+            module._backup_control(payload, "delete_backup", settings)
+    payload["args"] = {
+        "database_path": str(database),
+        "backup_id": incomplete.name,
+        "confirmation": f"DELETE {incomplete.name}",
+    }
+    with pytest.raises(ValueError, match="incompatible"):
+        module._backup_control(payload, "delete_backup", settings)
     payload["args"] = {
         "database_path": str(database),
         "backup_id": backup_id,
-        "confirmation": f"RESTORE {backup_id}",
+        "confirmation": "DELETE wrong",
+    }
+    with pytest.raises(ValueError, match="confirmation"):
+        module._backup_control(payload, "delete_backup", settings)
+    with monkeypatch.context() as patch:
+        original_unlink = Path.unlink
+
+        def fail_backup_delete(path: Path, *args: object, **kwargs: object) -> None:
+            if path == Path(str(created["backup_path"])):
+                raise OSError("busy")
+            original_unlink(path, *args, **kwargs)
+
+        patch.setattr(Path, "unlink", fail_backup_delete)
+        with pytest.raises(OSError, match="busy"):
+            module._backup_control(
+                {
+                    "args": {
+                        "database_path": str(database),
+                        "backup_id": backup_id,
+                        "confirmation": f"DELETE {backup_id}",
+                    }
+                },
+                "delete_backup",
+                settings,
+            )
+    connection = module._open(payload, settings)
+    assert module.CuratorAPI(connection).config()["config"]["page_size"] == 30
+    assert connection.execute("SELECT status FROM model_version").fetchone()[0] == "published"
+    connection.close()
+    deleted = module._backup_control(
+        {
+            "args": {
+                "database_path": str(database),
+                "backup_id": backup_id,
+                "confirmation": f"DELETE {backup_id}",
+            }
+        },
+        "delete_backup",
+        settings,
+    )
+    assert deleted["deleted"] == backup_id
+    assert not Path(str(created["backup_path"])).exists()
+    assert (
+        safety.is_file()
+        and temporary.is_file()
+        and unrelated.is_file()
+        and linked.is_symlink()
+        and incomplete.is_file()
+    )
+    payload["args"] = {
+        "database_path": str(database),
+        "backup_id": restore_id,
+        "confirmation": f"RESTORE {restore_id}",
     }
     restored = module._backup_control(payload, "restore_backup", settings)
 
-    assert Path(str(restored["restored_from"])).name == backup_id
+    assert Path(str(restored["restored_from"])).name == restore_id
     assert Path(str(restored["safety_backup"])).is_file()
+    assert restored["recommendations_need_rebuilding"] is True
     connection = module._open(payload, settings)
     assert module.CuratorAPI(connection).config()["config"]["page_size"] == 12
+    assert (
+        connection.execute("SELECT status FROM model_version WHERE model_id='model'").fetchone()[0]
+        == "superseded"
+    )
     connection.close()
+
+
+def test_reset_removes_only_core_and_recognized_artifacts(tmp_path: Path) -> None:
+    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
+    spec = importlib.util.spec_from_file_location("curator_plugin_reset", backend)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    database = tmp_path / "curator.sqlite3"
+    payload = {
+        "args": {
+            "operation": "reset",
+            "database_path": str(database),
+            "confirmation": "RESET",
+        }
+    }
+    connection = module._open(payload, {})
+    connection.close()
+    derived = tmp_path / "curator-derived"
+    derived.mkdir()
+    artifact = derived / f"model-{'a' * 20}.sqlite3"
+    unrelated = derived / "keep-me.txt"
+    artifact.touch()
+    unrelated.touch()
+
+    assert module.dispatch(payload)["reset"] is True
+
+    assert database.is_file()
+    assert not artifact.exists()
+    assert unrelated.is_file()
 
 
 def test_curator_tabs_update_browser_history() -> None:
@@ -468,6 +614,8 @@ def test_diagnostics_allowlist_cannot_emit_representative_private_fields(
         "api_schema_version",
         "migration",
         "readiness",
+        "generations",
+        "compaction",
         "recent_jobs",
         "timing_ms",
     }
@@ -486,6 +634,23 @@ def test_diagnostics_allowlist_cannot_emit_representative_private_fields(
         "PRIVATE_SQL",
     ):
         assert private not in serialized
+
+
+def test_diagnostics_work_with_an_empty_repaired_job_table(tmp_path: Path) -> None:
+    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
+    spec = importlib.util.spec_from_file_location("curator_plugin_empty_jobs", backend)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    payload = {"args": {"database_path": str(tmp_path / "curator.sqlite3")}}
+    connection = module._open(payload, {})
+    connection.execute("DELETE FROM curator_job")
+    connection.close()
+
+    report = module._api(payload, "get_diagnostics", {})
+
+    assert report["recent_jobs"] == []
+    assert report["migration"]["pending_count"] == 0
 
 
 def test_external_links_collect_normalized_local_phashes(

--- a/tests/ranking/test_slate.py
+++ b/tests/ranking/test_slate.py
@@ -245,7 +245,10 @@ def _database(path: Path) -> sqlite3.Connection:
 
 def test_lane_policy_assigns_expected_subtypes_and_excludes_hard_failures(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
-    classifications = LanePolicy(connection).classify("model")
+    progress: list[tuple[int, int]] = []
+    classifications = LanePolicy(connection).classify(
+        "model", progress=lambda processed, total: progress.append((processed, total))
+    )
     lookup = {(item.scene_id, item.lane): item for item in classifications}
 
     assert ("a-best", "best_bets") in lookup
@@ -265,6 +268,22 @@ def test_lane_policy_assigns_expected_subtypes_and_excludes_hard_failures(tmp_pa
     assert {
         (item.scene_id, item.lane): item for item in LanePolicy(connection).load("model")
     } == lookup
+    assert progress[-1][0] == progress[-1][1]
+
+
+def test_materialize_reports_each_lane_ordering(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    LanePolicy(connection).classify("model")
+    progress: list[tuple[int, int]] = []
+
+    counts = SlateBuilder(connection).materialize(
+        "model",
+        force=True,
+        progress=lambda processed, total: progress.append((processed, total)),
+    )
+
+    assert set(counts) == {"best_bets", "revisit", "discover", "adventure"}
+    assert progress == [(position, 10) for position in range(1, 11)]
 
 
 def test_new_slate_builder_reuses_persisted_lane_classifications(

--- a/tests/storage/test_artifacts.py
+++ b/tests/storage/test_artifacts.py
@@ -5,7 +5,7 @@ import pytest
 
 from curator.features import FeatureBuilder, FeatureStore
 from curator.storage import MigrationRunner, StorageError, connect_database, prune_snapshots
-from curator.storage.artifacts import artifact_path, cache_directory
+from curator.storage.artifacts import artifact_path, cache_directory, validate_artifact
 
 
 def _database(path: Path):
@@ -26,6 +26,18 @@ def test_artifact_paths_reject_escape_and_symlinks(tmp_path: Path) -> None:
     linked.symlink_to(tmp_path / "elsewhere")
     with pytest.raises(StorageError, match="unsafe artifact path"):
         artifact_path(core, linked.name)
+
+
+def test_rebuildable_artifact_validation_can_skip_full_file_scan() -> None:
+    connection = sqlite3.connect(":memory:")
+    connection.execute("PRAGMA user_version=1")
+    statements: list[str] = []
+    connection.set_trace_callback(statements.append)
+
+    result = validate_artifact(connection, "model", {"scenes": 2}, check_integrity=False)
+
+    assert result == {"integrity": "skipped", "schema_version": 1, "counts": {"scenes": 2}}
+    assert "PRAGMA quick_check" not in statements
 
 
 def test_reader_keeps_attached_feature_generation_across_publication(

--- a/tests/storage/test_artifacts.py
+++ b/tests/storage/test_artifacts.py
@@ -1,0 +1,141 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from curator.features import FeatureBuilder, FeatureStore
+from curator.storage import MigrationRunner, StorageError, connect_database, prune_snapshots
+from curator.storage.artifacts import artifact_path, cache_directory
+
+
+def _database(path: Path):
+    connection = connect_database(path)
+    MigrationRunner(connection).migrate(applied_at_ms=1)
+    return connection
+
+
+def test_artifact_paths_reject_escape_and_symlinks(tmp_path: Path) -> None:
+    core = tmp_path / "curator.sqlite3"
+    for basename in ("/tmp/feature-fv-" + "a" * 20 + ".sqlite3", "../model-" + "a" * 20):
+        with pytest.raises(StorageError, match="invalid artifact basename"):
+            artifact_path(core, basename)
+
+    directory = cache_directory(core)
+    directory.mkdir()
+    linked = directory / f"model-{'a' * 20}.sqlite3"
+    linked.symlink_to(tmp_path / "elsewhere")
+    with pytest.raises(StorageError, match="unsafe artifact path"):
+        artifact_path(core, linked.name)
+
+
+def test_reader_keeps_attached_feature_generation_across_publication(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "curator.sqlite3"
+    writer = _database(database)
+    first = FeatureBuilder(writer, clock_ms=lambda: 1).build()
+    reader = connect_database(database)
+
+    writer.execute("INSERT INTO source_tag(tag_id, name, source_hash) VALUES ('tag', 'Tag', 'tag')")
+    writer.execute(
+        """
+        INSERT INTO source_scene(scene_id, title, source_hash)
+        VALUES ('scene', 'Scene', 'scene')
+        """
+    )
+    writer.execute(
+        "INSERT INTO scene_tag(scene_id, tag_id, provenance) VALUES ('scene', 'tag', 'scene')"
+    )
+    second = FeatureBuilder(writer, clock_ms=lambda: 2).build()
+    fresh = connect_database(database)
+    try:
+        assert first.feature_version != second.feature_version
+        assert FeatureStore(reader).current_version() == first.feature_version
+        assert FeatureStore(fresh).current_version() == second.feature_version
+    finally:
+        fresh.close()
+        reader.close()
+        writer.close()
+
+
+def test_schema_two_capable_reader_keeps_schema_one_artifacts_read_only(tmp_path: Path) -> None:
+    database = tmp_path / "curator.sqlite3"
+    writer = _database(database)
+    built = FeatureBuilder(writer, clock_ms=lambda: 1).build()
+    artifact = artifact_path(database, f"feature-{built.feature_version}.sqlite3")
+    writer.close()
+
+    connection = connect_database(database)
+    try:
+        assert FeatureStore(connection).current_version() == built.feature_version
+        with pytest.raises(sqlite3.OperationalError, match="view"):
+            connection.execute("DELETE FROM entity_feature")
+    finally:
+        connection.close()
+
+    raw = sqlite3.connect(artifact)
+    raw.execute("PRAGMA user_version=2")
+    raw.execute("UPDATE artifact_meta SET schema_version=2")
+    raw.close()
+    connection = connect_database(database)
+    try:
+        assert FeatureStore(connection).current_version() == built.feature_version
+    finally:
+        connection.close()
+
+
+def test_failed_artifact_unlink_is_retried(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    database = tmp_path / "curator.sqlite3"
+    connection = _database(database)
+    connection.execute(
+        """
+        INSERT INTO feature_build(
+            feature_version, status, config_json, source_fingerprint, created_at_ms
+        ) VALUES ('feature', 'published', '{}', 'source', 1)
+        """
+    )
+    models = (
+        ("model-" + "1" * 20, "superseded", 1),
+        ("model-" + "2" * 20, "superseded", 2),
+        ("model-" + "3" * 20, "published", 3),
+    )
+    connection.executemany(
+        """
+        INSERT INTO model_version(
+            model_id, status, feature_version, config_json, created_at_ms,
+            published_at_ms, artifact_basename, validation_status
+        ) VALUES (?, ?, 'feature', '{}', ?, ?, ?, 'valid')
+        """,
+        (
+            (model_id, status, created, created, f"{model_id}.sqlite3")
+            for model_id, status, created in models
+        ),
+    )
+    target = artifact_path(database, f"{models[0][0]}.sqlite3")
+    target.parent.mkdir()
+    target.touch()
+    original_unlink = Path.unlink
+    attempts = 0
+
+    def flaky_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        nonlocal attempts
+        if path == target and attempts == 0:
+            attempts += 1
+            raise OSError("busy")
+        original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", flaky_unlink)
+    assert prune_snapshots(connection).deleted_models == 0
+    assert connection.execute(
+        "SELECT cleanup_error FROM model_version WHERE model_id=?", (models[0][0],)
+    ).fetchone()[0]
+
+    assert prune_snapshots(connection).deleted_models == 1
+    row = connection.execute(
+        """
+        SELECT artifact_basename, validation_status, cleanup_error
+        FROM model_version WHERE model_id=?
+        """,
+        (models[0][0],),
+    ).fetchone()
+    assert tuple(row) == (None, "retired", None)

--- a/tests/storage/test_cli_db.py
+++ b/tests/storage/test_cli_db.py
@@ -15,7 +15,7 @@ def test_database_cli_migrate_status_and_backup(
 
     assert run(["--db", str(database), "db", "migrate", "--json"]) == 0
     migrated = json.loads(capsys.readouterr().out)
-    assert migrated["current_version"] == migrated["latest_version"] == 16
+    assert migrated["current_version"] == migrated["latest_version"] == 19
 
     assert run(["--db", str(database), "db", "status", "--json"]) == 0
     status = json.loads(capsys.readouterr().out)

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -53,13 +53,25 @@ def test_backup_is_consistent_and_does_not_overwrite(tmp_path: Path) -> None:
     database = tmp_path / "curator.sqlite3"
     backup = tmp_path / "backups" / "curator.sqlite3"
     connection = connect_database(database)
-    connection.execute("CREATE TABLE example(value TEXT NOT NULL) STRICT")
-    connection.execute("INSERT INTO example(value) VALUES ('persisted')")
+    connection.execute("CREATE TABLE example(value TEXT NOT NULL, payload BLOB) STRICT")
+    connection.execute(
+        "INSERT INTO example(value, payload) VALUES ('persisted', zeroblob(2000000))"
+    )
+    progress: list[tuple[int, int]] = []
     derived = database.with_name("curator-derived")
     derived.mkdir()
     (derived / f"model-{'a' * 20}.sqlite3").touch()
     try:
-        assert backup_database(connection, backup) == backup.resolve()
+        assert (
+            backup_database(
+                connection,
+                backup,
+                progress=lambda processed, total: progress.append((processed, total)),
+            )
+            == backup.resolve()
+        )
+        assert len(progress) > 1
+        assert progress[-1][0] == progress[-1][1]
         assert not backup.with_name("curator-derived").exists()
         with pytest.raises(StorageError, match="already exists"):
             backup_database(connection, backup)
@@ -181,13 +193,27 @@ def test_legacy_compaction_is_validated_batched_restartable_and_preserves_durabl
         if str(row[0]) not in derived | {"application_meta"}
     }
 
-    partial = compact_legacy_generations(connection, batch_size=1, max_batches=1)
+    partial_progress: list[tuple[int, int]] = []
+    partial = compact_legacy_generations(
+        connection,
+        batch_size=1,
+        max_batches=1,
+        progress=lambda processed, total: partial_progress.append((processed, total)),
+    )
     assert partial["status"] == "in_progress"
     assert partial["rows_deleted_this_run"] == 1
-    complete = compact_legacy_generations(connection, batch_size=1)
+    complete_progress: list[tuple[int, int]] = []
+    complete = compact_legacy_generations(
+        connection,
+        batch_size=1,
+        progress=lambda processed, total: complete_progress.append((processed, total)),
+    )
     assert complete["status"] == "complete"
     assert complete["rows_deleted"] == 5
     assert complete["rows_remaining"] == 0
+    assert partial_progress == [(0, 5), (1, 5)]
+    assert complete_progress[0] == (0, 4)
+    assert complete_progress[-1] == (4, 4)
     assert connection.execute("SELECT count(*) FROM model_scene_score").fetchone()[0] == 0
     assert connection.execute("SELECT count(*) FROM entity_feature").fetchone()[0] == 0
     assert connection.execute("SELECT count(*) FROM feature_definition").fetchone()[0] == 0

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -1,9 +1,19 @@
+import json
 import sqlite3
 from pathlib import Path
 
 import pytest
 
-from curator.storage import StorageError, backup_database, connect_database, transaction
+from curator.storage import (
+    MigrationRunner,
+    StorageError,
+    backup_database,
+    compact_legacy_generations,
+    connect_database,
+    transaction,
+)
+from curator.storage.artifacts import create_artifact, publish_file
+from curator.storage.database import _LEGACY_DERIVED_TABLES
 
 
 def test_connection_enables_required_pragmas(tmp_path: Path) -> None:
@@ -45,8 +55,12 @@ def test_backup_is_consistent_and_does_not_overwrite(tmp_path: Path) -> None:
     connection = connect_database(database)
     connection.execute("CREATE TABLE example(value TEXT NOT NULL) STRICT")
     connection.execute("INSERT INTO example(value) VALUES ('persisted')")
+    derived = database.with_name("curator-derived")
+    derived.mkdir()
+    (derived / f"model-{'a' * 20}.sqlite3").touch()
     try:
         assert backup_database(connection, backup) == backup.resolve()
+        assert not backup.with_name("curator-derived").exists()
         with pytest.raises(StorageError, match="already exists"):
             backup_database(connection, backup)
     finally:
@@ -57,3 +71,140 @@ def test_backup_is_consistent_and_does_not_overwrite(tmp_path: Path) -> None:
         assert restored.execute("SELECT value FROM example").fetchone()[0] == "persisted"
     finally:
         restored.close()
+
+
+def _publish_artifact(connection: sqlite3.Connection, kind: str, identifier: str) -> str:
+    artifact, temporary, final = create_artifact(connection, kind, identifier)
+    publish_file(artifact, temporary, final)
+    return final.name
+
+
+def test_legacy_compaction_is_validated_batched_restartable_and_preserves_durable_rows(
+    tmp_path: Path,
+) -> None:
+    database = tmp_path / "curator.sqlite3"
+    connection = connect_database(database, attach_artifacts=False)
+    MigrationRunner(connection).migrate(applied_at_ms=1)
+    feature_id = "fv-" + "a" * 20
+    model_ids = ("model-" + "b" * 20, "model-" + "c" * 20)
+    retired_model_id = "model-" + "d" * 20
+    feature_artifact = _publish_artifact(connection, "feature", feature_id)
+    model_artifacts = {
+        model_id: _publish_artifact(connection, "model", model_id) for model_id in model_ids
+    }
+    valid = json.dumps({"integrity": "ok", "schema_version": 1, "counts": {}})
+    connection.execute(
+        """
+        INSERT INTO feature_build(
+            feature_version, status, config_json, source_fingerprint, created_at_ms,
+            published_at_ms, artifact_basename, artifact_schema_version,
+            validation_status, validation_summary_json
+        ) VALUES (?, 'published', '{}', 'source', 1, 1, ?, 1, 'valid', ?)
+        """,
+        (feature_id, feature_artifact, valid),
+    )
+    connection.executemany(
+        """
+        INSERT INTO model_version(
+            model_id, status, feature_version, config_json, created_at_ms,
+            published_at_ms, artifact_basename, artifact_schema_version,
+            validation_status, validation_summary_json
+        ) VALUES (?, ?, ?, '{}', 1, 1, ?, 1, 'valid', ?)
+        """,
+        (
+            (model_id, status, feature_id, model_artifacts[model_id], valid)
+            for model_id, status in zip(model_ids, ("superseded", "published"), strict=True)
+        ),
+    )
+    connection.execute(
+        """
+        INSERT INTO model_version(
+            model_id, status, feature_version, config_json, created_at_ms,
+            validation_status
+        ) VALUES (?, 'superseded', ?, '{}', 1, 'retired')
+        """,
+        (retired_model_id, feature_id),
+    )
+    connection.execute(
+        """
+        INSERT INTO feature_definition(
+            feature_id, feature_version, family, name, provenance
+        ) VALUES ('feature', ?, 'content', 'tag:test', 'test')
+        """,
+        (feature_id,),
+    )
+    connection.execute(
+        """
+        INSERT INTO feature_affinity(
+            model_id, feature_id, affinity, confidence, effective_support,
+            distinct_scene_count
+        ) VALUES (?, 'feature', 0, 0, 0, 0)
+        """,
+        (retired_model_id,),
+    )
+    connection.execute(
+        """
+        INSERT INTO entity_feature(
+            feature_version, entity_type, entity_id, feature_id, value, confidence
+        ) VALUES (?, 'scene', 'scene', 'feature', 1, 1)
+        """,
+        (feature_id,),
+    )
+    connection.execute(
+        """
+        INSERT INTO source_scene(scene_id, title, source_hash)
+        VALUES ('scene', 'Durable scene', 'scene')
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO feedback(feedback_id, scene_id, feedback_type, occurred_at_ms)
+        VALUES ('feedback', 'scene', 'thumb_up', 1)
+        """
+    )
+    connection.executemany(
+        """
+        INSERT INTO model_scene_score(
+            model_id, scene_id, general_appeal, direct_appeal, direct_confidence,
+            appeal, current_fit, confidence, metadata_confidence, recovery,
+            components_json, neighbors_json, eligibility_json
+        ) VALUES (?, 'scene', 0, 0, 0, 0, 0, 0, 0, 1, '{}', '[]', '{}')
+        """,
+        ((model_id,) for model_id in model_ids),
+    )
+    derived = {table for table, _, _ in _LEGACY_DERIVED_TABLES}
+    durable_counts = {
+        str(row[0]): int(connection.execute(f"SELECT count(*) FROM {row[0]}").fetchone()[0])
+        for row in connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+        )
+        if str(row[0]) not in derived | {"application_meta"}
+    }
+
+    partial = compact_legacy_generations(connection, batch_size=1, max_batches=1)
+    assert partial["status"] == "in_progress"
+    assert partial["rows_deleted_this_run"] == 1
+    complete = compact_legacy_generations(connection, batch_size=1)
+    assert complete["status"] == "complete"
+    assert complete["rows_deleted"] == 5
+    assert complete["rows_remaining"] == 0
+    assert connection.execute("SELECT count(*) FROM model_scene_score").fetchone()[0] == 0
+    assert connection.execute("SELECT count(*) FROM entity_feature").fetchone()[0] == 0
+    assert connection.execute("SELECT count(*) FROM feature_definition").fetchone()[0] == 0
+    assert connection.execute("SELECT count(*) FROM feature_affinity").fetchone()[0] == 0
+    assert connection.execute("SELECT title FROM source_scene").fetchone()[0] == "Durable scene"
+    assert connection.execute("SELECT feedback_type FROM feedback").fetchone()[0] == "thumb_up"
+    assert durable_counts == {
+        table: int(connection.execute(f"SELECT count(*) FROM {table}").fetchone()[0])
+        for table in durable_counts
+    }
+    assert database.is_file()
+    connection.close()
+
+
+def test_legacy_compaction_refuses_missing_active_artifacts(tmp_path: Path) -> None:
+    connection = connect_database(tmp_path / "curator.sqlite3", attach_artifacts=False)
+    MigrationRunner(connection).migrate(applied_at_ms=1)
+    with pytest.raises(StorageError, match="valid active feature artifact"):
+        compact_legacy_generations(connection)
+    connection.close()

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -11,10 +11,30 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
         runner = MigrationRunner(connection)
         before = runner.status()
         assert before.current_version == 0
-        assert before.pending_versions == (1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
+        assert before.pending_versions == (
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+        )
 
         after = runner.migrate(applied_at_ms=1234)
-        assert after.current_version == 16
+        assert after.current_version == 19
         assert after.pending_versions == ()
         assert runner.migrate(applied_at_ms=5678) == after
 
@@ -46,6 +66,9 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
         assert connection.execute(
             "SELECT 1 FROM sqlite_master WHERE type='index' AND name='model_scene_score_prune_idx'"
         ).fetchone()
+        assert not connection.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='index' AND name='model_lane_order_scene_idx'"
+        ).fetchone()
     finally:
         connection.close()
 
@@ -60,6 +83,47 @@ def test_changed_applied_migration_is_rejected(tmp_path: Path) -> None:
             runner.status()
     finally:
         connection.close()
+
+
+def test_feature_count_migration_backfills_existing_builds(tmp_path: Path) -> None:
+    connection = connect_database(tmp_path / "curator.sqlite3")
+    runner = MigrationRunner(connection)
+    original = runner.migrations
+    runner.migrations = original[:-2]
+    runner.migrate(applied_at_ms=1)
+    connection.execute(
+        """
+        INSERT INTO feature_build(
+            feature_version, status, config_json, source_fingerprint, created_at_ms
+        ) VALUES ('fv-old', 'published', '{}', 'source', 1)
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO feature_definition(
+            feature_id, feature_version, family, name, provenance
+        ) VALUES ('f1', 'fv-old', 'content', 'tag:one', 'test')
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO entity_feature(
+            feature_version, entity_type, entity_id, feature_id, value, confidence
+        ) VALUES ('fv-old', 'scene', 's1', 'f1', 1, 1)
+        """
+    )
+
+    runner.migrations = original
+    runner.migrate(applied_at_ms=2)
+
+    assert tuple(
+        connection.execute(
+            """
+            SELECT scene_count, performer_count, feature_count FROM feature_build
+            WHERE feature_version='fv-old'
+            """
+        ).fetchone()
+    ) == (1, 0, 1)
 
 
 def test_unknown_future_migration_is_rejected(tmp_path: Path) -> None:
@@ -87,7 +151,7 @@ def test_status_stays_read_only_after_migrations(tmp_path: Path) -> None:
     reader.execute("PRAGMA busy_timeout=1")
     try:
         writer.execute("BEGIN IMMEDIATE")
-        assert MigrationRunner(reader).status().current_version == 16
+        assert MigrationRunner(reader).status().current_version == 19
     finally:
         writer.rollback()
         reader.close()
@@ -113,7 +177,7 @@ def test_stale_concurrent_migrator_rechecks_after_writer_lock(
 
     monkeypatch.setattr(second_runner, "status", status)
     try:
-        assert second_runner.migrate(applied_at_ms=2).current_version == 16
+        assert second_runner.migrate(applied_at_ms=2).current_version == 19
     finally:
         second.close()
         first.close()

--- a/tests/storage/test_retention.py
+++ b/tests/storage/test_retention.py
@@ -39,3 +39,44 @@ def test_retention_keeps_current_and_previous_snapshots(tmp_path: Path) -> None:
         "m2",
         "m3",
     ]
+
+
+def test_retention_removes_abandoned_build_and_its_features(tmp_path: Path) -> None:
+    connection = connect_database(tmp_path / "curator.sqlite3")
+    MigrationRunner(connection).migrate(applied_at_ms=1)
+    connection.execute(
+        """
+        INSERT INTO feature_build(
+            feature_version, status, config_json, source_fingerprint, created_at_ms
+        ) VALUES ('orphan-feature', 'superseded', '{}', 'orphan', 1)
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO feature_build(
+            feature_version, status, config_json, source_fingerprint,
+            created_at_ms, published_at_ms
+        ) VALUES ('current-feature', 'published', '{}', 'current', 2, 2)
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO model_version(
+            model_id, status, feature_version, config_json, created_at_ms
+        ) VALUES ('orphan-model', 'building', 'orphan-feature', '{}', 1)
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO model_version(
+            model_id, status, feature_version, config_json, created_at_ms, published_at_ms
+        ) VALUES ('current-model', 'published', 'current-feature', '{}', 2, 2)
+        """
+    )
+
+    result = prune_snapshots(connection)
+
+    assert result.deleted_models == 1
+    assert result.deleted_features == 1
+    assert connection.execute("SELECT count(*) FROM model_version").fetchone()[0] == 1
+    assert connection.execute("SELECT count(*) FROM feature_build").fetchone()[0] == 1

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,7 +38,15 @@ def test_slate_api_records_impression_and_bundles_explanations(tmp_path: Path) -
             (result["model_id"],),
         )
     }
-    assert explained <= {str(item["scene_id"]) for item in result["items"]}
+    scored = {
+        str(row[0])
+        for row in connection.execute(
+            "SELECT scene_id FROM model_scene_score WHERE model_id=?",
+            (result["model_id"],),
+        )
+    }
+    assert explained == scored
+    assert {str(item["scene_id"]) for item in result["items"]} <= explained
     assert (
         connection.execute(
             "SELECT count(*) FROM impression WHERE impression_id='api-impression'"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -492,6 +492,16 @@ def test_prune_candidates_are_reversible_tags_not_deletions(tmp_path: Path) -> N
 
     api.record_prune_tags(["disliked"], True, "prune-tag", "[Prune]")
     assert api.prune_candidates("tagged")["items"][0]["scene_id"] == "disliked"
+    updated_at_ms = connection.execute(
+        "SELECT updated_at_ms FROM pruning_candidate WHERE scene_id='disliked'"
+    ).fetchone()[0]
+    assert api.reconcile_prune_tag("[Prune]") is False
+    assert (
+        connection.execute(
+            "SELECT updated_at_ms FROM pruning_candidate WHERE scene_id='disliked'"
+        ).fetchone()[0]
+        == updated_at_ms
+    )
     assert (
         connection.execute(
             "SELECT state FROM pruning_candidate WHERE scene_id='disliked'"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_doctor_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
     assert result["status"] == "ok"
     assert result["stash"] == "not_configured"
     assert result["schema_current"] == 0
-    assert result["schema_latest"] == 16
+    assert result["schema_latest"] == 19
 
 
 def test_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -158,9 +158,14 @@ def test_expand_refresh_is_bounded_owned_filtered_and_cached(tmp_path: Path) -> 
         "performers": {"p1": "known-external-performer"},
         "studios": {"studio-1": "external-studio"},
     }
+    progress: list[tuple[int, int]] = []
 
     refreshed = ExpandService(connection).refresh(
-        client, links, now_ms=REFERENCE_MS, candidate_limit=10
+        client,
+        links,
+        now_ms=REFERENCE_MS,
+        candidate_limit=10,
+        progress=lambda processed, total: progress.append((processed, total)),
     )
 
     assert refreshed == {
@@ -169,6 +174,10 @@ def test_expand_refresh_is_bounded_owned_filtered_and_cached(tmp_path: Path) -> 
         "taxonomy_refreshed": False,
     }
     assert 1 <= len(client.inputs) <= 3
+    assert [processed for processed, _ in progress] == sorted(
+        processed for processed, _ in progress
+    )
+    assert progress[-1] == (1_000, 1_000)
     result = ExpandService(connection).results("scene")
     assert result["ready"] is True
     assert [item["id"] for item in result["items"]] == ["new-external-scene"]


### PR DESCRIPTION
## Summary
- publish rebuildable feature and model data as immutable SQLite generation artifacts
- skip unchanged incremental writes, historical reconstruction, and model rebuilds
- make task progress reflect actual feature, scoring, ranking, backup, compaction, and Expand stages
- skip the full-file integrity scan for atomic rebuildable model artifacts while retaining schema, cardinality, reason-coverage, and lane-state validation
- clarify when to sync Stash versus rebuild from synchronized data

## Impact
- preserve complete stored reasons and existing recommendation behavior
- reduce the writable core from 775.7 MB to 95.7 MB in installed storage validation
- reduce an unchanged installed sync/build run to about 3 seconds
- remove about 88 seconds from the profiled 409-second full model build
- retain full integrity validation for feature artifacts and backups

## Verification
- focused validation: 48 passed
- full suite: 213 passed
- pre-push full suite: 213 passed
- installed sync short-circuit verified cold and warm
- installed native backup, compaction, vacuum, restart, and read-only desktop/mobile verification

## Follow-up
- docs/handover.md records measured performer-similarity cutoff and on-demand explanation/query-time ordering options for separate work.