### PR TITLE
Bound performer similarity propagation

### DIFF
--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -36,6 +36,10 @@ from curator.storage.artifacts import (
 )
 from curator.storage.retention import prune_snapshots
 
+# ponytail: 0.005 removed 38% of measured seeds; make configurable only if
+# library-specific timing and quality measurements justify the extra surface.
+PERFORMER_SIMILARITY_AFFINITY_CUTOFF = 0.005
+
 
 @dataclass(frozen=True)
 class ModelBuildResult:
@@ -154,7 +158,8 @@ class PreferenceModelBuilder:
         model_digest = hashlib.sha256(
             (
                 f"{feature_version}\0{evidence_fingerprint}\0{self._source_fingerprint()}\0"
-                f"{self.config.canonical_json()}\0{reference_at_ms}"
+                f"{self.config.canonical_json()}\0{PERFORMER_SIMILARITY_AFFINITY_CUTOFF}\0"
+                f"{reference_at_ms}"
             ).encode()
         ).hexdigest()
         model_id = f"model-{model_digest[:20]}"
@@ -968,7 +973,11 @@ class PreferenceModelBuilder:
                 )
         profiles = FeatureStore(self.connection).performer_profiles(feature_version)
         weights = dict(self.config.feature.performer_block_weights)
-        known = {key: profiles[key] for key in identity_affinity if key in profiles}
+        known = {
+            key: profiles[key]
+            for key, (value, _) in identity_affinity.items()
+            if key in profiles and abs(value) >= PERFORMER_SIMILARITY_AFFINITY_CUTOFF
+        }
         matches_by_performer: dict[str, list[dict[str, object]]] = {
             performer_id: [] for performer_id in profiles
         }

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -358,6 +358,39 @@ def test_model_compares_known_performer_pairs_once(
     assert counted.call_count == 3
 
 
+def test_model_ignores_negligible_performer_similarity_seeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    builder = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS)
+    built = builder.build()
+    scene_features = builder_module.FeatureStore(connection).entity_features(
+        built.feature_version, "scene"
+    )
+    identities = {
+        feature.name.removeprefix("performer:"): feature
+        for features in scene_features.values()
+        for feature in features
+        if feature.family == "performer_identity"
+    }
+    affinities = {
+        identities[performer_id].feature_id: builder_module._Affinity(
+            identities[performer_id].feature_id, value, 1.0, 1.0, 1, {}
+        )
+        for performer_id, value in (("p1", 0.006), ("p2", 0.004))
+    }
+    counted = Mock(wraps=builder_module.performer_similarity)
+    monkeypatch.setattr(builder_module, "performer_similarity", counted)
+
+    builder._performer_similarity_scores(built.feature_version, scene_features, affinities)
+
+    compared = {
+        frozenset((call.args[0].performer_id, call.args[1].performer_id))
+        for call in counted.call_args_list
+    }
+    assert compared == {frozenset(("p1", "p2")), frozenset(("p1", "p3"))}
+
+
 def test_wrong_metadata_is_not_reused_but_direct_scene_evidence_remains(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     connection.execute(


### PR DESCRIPTION
## Summary
- exclude performer-similarity seeds below `abs(affinity * confidence) < 0.005`
- include the fixed heuristic in the model digest so installed rebuilds cannot reuse stale artifacts
- preserve exact performer-identity scoring and known-pair deduplication

## Verification
- `scripts/verify changed tests/model/test_builder.py` — 13 passed
- `scripts/verify full` — 214 passed
- pre-push verification — 214 passed

## Installed validation
- warmed performer-similarity span: 94.4s unfiltered → 62.8s filtered (33.5% faster)
- warmed total model build: 389.4s → 373.9s
- exact performer-identity components unchanged
- maximum Appeal/Current Fit delta for weak-only scenes: 0.0205

Stacked on #36 because the current generation-storage branch has not merged yet.