### PR TITLE
Derive explanations and query score-first lanes

### DIFF
--- a/curator/api.py
+++ b/curator/api.py
@@ -110,29 +110,7 @@ class CuratorAPI:
         InteractionStore(self.connection).record_impression(impression_id, slate, now_ms, context)
         timings["impression"] = round((time.perf_counter() - stage_started) * 1000)
         record_duration("python", "slate.impression", timings["impression"])
-        stage_started = time.perf_counter()
-        explanations = ExplanationService(self.connection)
-        explanations.ensure(slate.model_id, {item.scene_id for item in slate.items})
-        items = []
-        for item in slate.items:
-            explanation = explanations.explain_recommendation(item)
-            payload = asdict(item)
-            payload["impression_id"] = impression_id
-            payload["explanation"] = explanation.summary
-            payload["supporting_reasons"] = [
-                {
-                    "code": reason.code,
-                    "direction": reason.direction,
-                    "magnitude": reason.magnitude,
-                    "subject_type": reason.subject_type,
-                    "subject_id": reason.subject_id,
-                    "detail": reason.detail,
-                }
-                for reason in explanation.selected_reasons
-            ]
-            items.append(payload)
-        timings["explanations"] = round((time.perf_counter() - stage_started) * 1000)
-        record_duration("python", "slate.explanations", timings["explanations"])
+        items = [{**asdict(item), "impression_id": impression_id} for item in slate.items]
         timings["total"] = round((time.perf_counter() - started) * 1000)
         return {
             "schema_version": API_SCHEMA_VERSION,
@@ -311,6 +289,7 @@ class CuratorAPI:
             "scene_id": scene_id,
             "summary": explanation.summary,
             "reasons": [asdict(reason) for reason in explanation.all_reasons],
+            "supporting_reasons": [asdict(reason) for reason in explanation.selected_reasons],
         }
 
     def recommendation_history(

--- a/curator/explanations/reasons.py
+++ b/curator/explanations/reasons.py
@@ -45,20 +45,7 @@ class ReasonGraphStore:
 
     def build(self, model_id: str, scene_ids: Collection[str] | None = None) -> None:
         selected = set(map(str, scene_ids)) if scene_ids is not None else None
-        scores = RecommendationModelStore(self.connection).scores(model_id, selected)
-        row = self.connection.execute(
-            "SELECT feature_version FROM model_version WHERE model_id=?", (model_id,)
-        ).fetchone()
-        if row is None:
-            raise RuntimeError(f"unknown model: {model_id}")
-        feature_version = str(row[0])
-        self._prepare_neighbor_context(
-            model_id, feature_version, scores, targeted=selected is not None
-        )
-        graphs = {
-            scene_id: self._scene_reasons(score, feature_version)
-            for scene_id, score in scores.items()
-        }
+        graphs = self._derive(model_id, selected)
         with transaction(self.connection):
             if selected is None:
                 self.connection.execute(
@@ -98,6 +85,25 @@ class ReasonGraphStore:
                     for index, reason in enumerate(reasons)
                 ),
             )
+
+    def derive(self, model_id: str, scene_ids: Collection[str]) -> dict[str, tuple[Reason, ...]]:
+        return self._derive(model_id, set(map(str, scene_ids)))
+
+    def _derive(self, model_id: str, selected: set[str] | None) -> dict[str, tuple[Reason, ...]]:
+        scores = RecommendationModelStore(self.connection).scores(model_id, selected)
+        row = self.connection.execute(
+            "SELECT feature_version FROM model_version WHERE model_id=?", (model_id,)
+        ).fetchone()
+        if row is None:
+            raise RuntimeError(f"unknown model: {model_id}")
+        feature_version = str(row[0])
+        self._prepare_neighbor_context(
+            model_id, feature_version, scores, targeted=selected is not None
+        )
+        return {
+            scene_id: self._scene_reasons(score, feature_version)
+            for scene_id, score in scores.items()
+        }
 
     def ensure(self, model_id: str, scene_ids: Collection[str] | None = None) -> None:
         if artifact_attached(self.connection, "model"):

--- a/curator/explanations/render.py
+++ b/curator/explanations/render.py
@@ -28,39 +28,53 @@ class ExplanationService:
         self.planner = Microplanner()
         self.catalog = RealizationCatalog.load()
         self._ensured: set[str] = set()
+        self._derived: dict[tuple[str, str], tuple[Reason, ...]] = {}
 
     def ensure(self, model_id: str, scene_ids: Collection[str]) -> None:
-        self.store.ensure(model_id, scene_ids)
-        self._ensured.update(map(str, scene_ids))
+        selected = set(map(str, scene_ids))
+        if artifact_attached(self.connection, "model"):
+            missing = set()
+            for scene_id in selected:
+                if reasons := self.store.reasons(model_id, scene_id):
+                    self._derived[(model_id, scene_id)] = reasons
+                else:
+                    missing.add(scene_id)
+            derived = self.store.derive(model_id, missing)
+            self._derived.update(
+                ((model_id, scene_id), derived.get(scene_id, ())) for scene_id in missing
+            )
+        else:
+            self.store.ensure(model_id, selected)
+        self._ensured.update(selected)
 
     def explain_scene(self, model_id: str, scene_id: str) -> Explanation:
-        reasons = self.store.reasons(model_id, scene_id)
-        if (
-            not reasons
-            and scene_id not in self._ensured
-            and not artifact_attached(self.connection, "model")
-        ):
-            self.store.build(model_id, {scene_id})
-            self._ensured.add(scene_id)
-            reasons = self.store.reasons(model_id, scene_id)
+        reasons = self._reasons(model_id, scene_id)
         return self._render(reasons, f"{model_id}\0{scene_id}")
 
     def explain_recommendation(self, item: RecommendationItem) -> Explanation:
         model_id = self._current_model_id()
-        base = self.store.reasons(model_id, item.scene_id)
-        if (
-            not base
-            and item.scene_id not in self._ensured
-            and not artifact_attached(self.connection, "model")
-        ):
-            self.store.build(model_id, {item.scene_id})
-            self._ensured.add(item.scene_id)
-            base = self.store.reasons(model_id, item.scene_id)
+        base = self._reasons(model_id, item.scene_id)
         reasons = (*base, *self._ranking_reasons(model_id, item))
         return self._render(
             reasons,
             f"{model_id}\0{item.scene_id}\0{item.lane}\0{item.source_lane}\0{item.position}",
         )
+
+    def _reasons(self, model_id: str, scene_id: str) -> tuple[Reason, ...]:
+        key = (model_id, scene_id)
+        if key in self._derived:
+            return self._derived[key]
+        reasons = self.store.reasons(model_id, scene_id)
+        if reasons:
+            return reasons
+        if artifact_attached(self.connection, "model"):
+            derived = self.store.derive(model_id, {scene_id})
+            self._derived[key] = derived.get(scene_id, ())
+        elif scene_id not in self._ensured:
+            self.store.build(model_id, {scene_id})
+            self._ensured.add(scene_id)
+            return self.store.reasons(model_id, scene_id)
+        return self._derived.get(key, ())
 
     def _current_model_id(self) -> str:
         model_id = RecommendationModelStore(self.connection).current_model_id()

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -39,6 +39,7 @@ from curator.storage.retention import prune_snapshots
 # ponytail: 0.005 removed 38% of measured seeds; make configurable only if
 # library-specific timing and quality measurements justify the extra surface.
 PERFORMER_SIMILARITY_AFFINITY_CUTOFF = 0.005
+MODEL_BUILD_VERSION = 2
 
 
 @dataclass(frozen=True)
@@ -159,7 +160,7 @@ class PreferenceModelBuilder:
             (
                 f"{feature_version}\0{evidence_fingerprint}\0{self._source_fingerprint()}\0"
                 f"{self.config.canonical_json()}\0{PERFORMER_SIMILARITY_AFFINITY_CUTOFF}\0"
-                f"{reference_at_ms}"
+                f"{MODEL_BUILD_VERSION}\0{reference_at_ms}"
             ).encode()
         ).hexdigest()
         model_id = f"model-{model_digest[:20]}"
@@ -191,7 +192,11 @@ class PreferenceModelBuilder:
             )
 
         model_config_json = json.dumps(
-            {"config": asdict(self.config), "reference_at_ms": reference_at_ms},
+            {
+                "config": asdict(self.config),
+                "model_build_version": MODEL_BUILD_VERSION,
+                "reference_at_ms": reference_at_ms,
+            },
             sort_keys=True,
             separators=(",", ":"),
         )
@@ -1305,26 +1310,38 @@ class PreferenceModelBuilder:
             )
             self._report(0.85)
             timings["database_writing"] = round((time.perf_counter() - writing_started) * 1000)
-            from curator.explanations import ReasonGraphStore
             from curator.ranking import LanePolicy, SlateBuilder
 
             indexing_started = time.perf_counter()
+            stage_started = time.perf_counter()
             LanePolicy(artifact, self.config).classify(
                 model_id,
                 progress=lambda processed, total: self._report(
                     0.85 + 0.02 * processed / max(1, total)
                 ),
             )
-            SlateBuilder(artifact, self.config).materialize(
+            timings["lane_classification"] = round((time.perf_counter() - stage_started) * 1000)
+            record_duration("python", "model.lane_classification", timings["lane_classification"])
+            slate_builder = SlateBuilder(artifact, self.config)
+            slate_builder.materialize(
                 model_id,
                 force=True,
                 progress=lambda processed, total: self._report(
                     0.87 + 0.04 * processed / max(1, total)
                 ),
             )
-            ReasonGraphStore(artifact).build(model_id)
+            timings.update(slate_builder.materialize_timings_ms)
+            for name in ("score_first_ordering", "varied_ordering"):
+                record_duration("python", f"model.{name}", timings[name])
+            timings["reason_generation"] = 0
+            record_duration("python", "model.reason_generation", 0)
             self._report(0.94)
+            stage_started = time.perf_counter()
             create_indexes(artifact, "model")
+            timings["sqlite_index_creation"] = round((time.perf_counter() - stage_started) * 1000)
+            record_duration(
+                "python", "model.sqlite_index_creation", timings["sqlite_index_creation"]
+            )
             timings["indexing"] = round((time.perf_counter() - indexing_started) * 1000)
             self._report(0.96)
             validation_started = time.perf_counter()
@@ -1338,25 +1355,14 @@ class PreferenceModelBuilder:
                     "SELECT count(*) FROM model_scene_lane WHERE model_id=?", (model_id,)
                 ).fetchone()[0]
             )
-            reason_scene_count, reason_count = artifact.execute(
-                """
-                SELECT count(DISTINCT scene_id), count(*) FROM model_scene_reason
-                WHERE model_id=?
-                """,
-                (model_id,),
-            ).fetchone()
+            reason_scene_count = reason_count = 0
             lane_state = artifact.execute(
                 "SELECT 1 FROM model_lane_order_state WHERE model_id=?", (model_id,)
             ).fetchone()
-            if (
-                stored_count != len(scores)
-                or int(reason_scene_count) != stored_count
-                or lane_state is None
-            ):
+            if stored_count != len(scores) or lane_state is None:
                 raise RuntimeError(
                     "model validation failed: "
                     f"scores={stored_count}/{len(scores)}, "
-                    f"reason scenes={reason_scene_count}/{stored_count}, "
                     f"lane state={lane_state is not None}"
                 )
             summary = validate_artifact(

--- a/curator/ranking/slate.py
+++ b/curator/ranking/slate.py
@@ -45,6 +45,20 @@ ADVENTUROUS_PATTERN = (
     "discover",
     "adventure",
 )
+QUERIED_SCORE_FIRST_LANES = frozenset({"best_bets", "revisit", "discover"})
+SCORE_FIRST_RANKING_JSON = json.dumps(
+    {
+        "penalties": {
+            "performer": 0.0,
+            "studio": 0.0,
+            "content": 0.0,
+            "history": 0.0,
+            "live_cooldown": 0.0,
+        },
+        "bonuses": {"uncovered_content": 0.0},
+    },
+    separators=(",", ":"),
+)
 
 
 @dataclass(frozen=True)
@@ -104,6 +118,7 @@ class SlateBuilder:
         self._history_similarities: dict[str, float] = {}
         self._live_fit: dict[str, float] = {}
         self._live_cooldown: dict[str, float] = {}
+        self.materialize_timings_ms: dict[str, int] = {}
 
     def prepare(self, model_id: str, *, slate_size: int = 60) -> dict[str, int]:
         policy = LanePolicy(self.connection, self.config)
@@ -162,14 +177,19 @@ class SlateBuilder:
             )
             self.connection.execute("DELETE FROM model_lane_order WHERE model_id=?", (model_id,))
         completed = 0
-        total = (len(LANES) + 1) * 2
+        total = len(LANES) + 3
+        timings = {"score_first_ordering": 0, "varied_ordering": 0}
         for lane in (*LANES, "for_you"):
             lane_candidates = tuple(
                 candidate
                 for candidate in candidates
                 if lane == "for_you" or candidate.classification.lane == lane
             )
-            for ordering, varied in (("score_first", False), ("varied", True)):
+            orderings = [("varied", True)]
+            if lane not in QUERIED_SCORE_FIRST_LANES:
+                orderings.insert(0, ("score_first", False))
+            for ordering, varied in orderings:
+                ordering_started = time.perf_counter()
                 ordered = self._build_order(lane, lane_candidates, varied=varied)
                 with transaction(self.connection):
                     self.connection.executemany(
@@ -198,6 +218,9 @@ class SlateBuilder:
                             )
                         ),
                     )
+                timings[f"{ordering}_ordering"] += round(
+                    (time.perf_counter() - ordering_started) * 1000
+                )
                 completed += 1
                 if progress:
                     progress(completed, total)
@@ -208,6 +231,9 @@ class SlateBuilder:
                 """,
                 (model_id, time.time_ns() // 1_000_000),
             )
+        self.materialize_timings_ms = timings
+        for name, duration in timings.items():
+            record_duration("python", f"ranking.{name}", duration)
         return counts
 
     def _build_order(
@@ -631,6 +657,7 @@ class SlateBuilder:
         ).fetchone():
             return None
         ordering = "varied" if self.diversity_enabled else "score_first"
+        query_score_first = not self.diversity_enabled and lane in QUERIED_SCORE_FIRST_LANES
         direct_plays = {
             str(row["scene_id"]): int(row["last_played"])
             for row in self.connection.execute(
@@ -653,15 +680,28 @@ class SlateBuilder:
         offset = 0
         chunk_size = max(100, count)
         while len(selected_rows) < count:
-            rows = self.connection.execute(
-                """
-                SELECT position, scene_id, source_lane, utility, ranking_json
-                FROM model_lane_order
-                WHERE model_id=? AND lane=? AND ordering=?
-                ORDER BY position LIMIT ? OFFSET ?
-                """,
-                (model_id, lane, ordering, chunk_size, offset),
-            ).fetchall()
+            if query_score_first:
+                rows = self.connection.execute(
+                    """
+                    SELECT 0 AS position, scene_id, lane AS source_lane,
+                           lane_value AS utility, ? AS ranking_json
+                    FROM model_scene_lane
+                    WHERE model_id=? AND lane=?
+                    ORDER BY lane_value DESC, scene_id
+                    LIMIT ? OFFSET ?
+                    """,
+                    (SCORE_FIRST_RANKING_JSON, model_id, lane, chunk_size, offset),
+                ).fetchall()
+            else:
+                rows = self.connection.execute(
+                    """
+                    SELECT position, scene_id, source_lane, utility, ranking_json
+                    FROM model_lane_order
+                    WHERE model_id=? AND lane=? AND ordering=?
+                    ORDER BY position LIMIT ? OFFSET ?
+                    """,
+                    (model_id, lane, ordering, chunk_size, offset),
+                ).fetchall()
             if not rows:
                 break
             offset += len(rows)

--- a/curator/reporting/html.py
+++ b/curator/reporting/html.py
@@ -49,6 +49,7 @@ class ReportGenerator:
         slate_builder = SlateBuilder(self.connection)
         for lane in lanes:
             slate = slate_builder.recommend(lane, count)
+            explanation_service.ensure(model_id, {item.scene_id for item in slate.items})
             lane_counts[lane] = len(slate.items)
             cards = []
             for item in slate.items:

--- a/curator/storage/artifacts.py
+++ b/curator/storage/artifacts.py
@@ -193,7 +193,7 @@ def create_indexes(connection: sqlite3.Connection, kind: str) -> None:
             CREATE INDEX model_scene_score_prune_idx
             ON model_scene_score(model_id, appeal, confidence, scene_id);
             CREATE INDEX model_scene_lane_value_idx
-            ON model_scene_lane(model_id, lane, lane_value DESC);
+            ON model_scene_lane(model_id, lane, lane_value DESC, scene_id);
             CREATE INDEX model_scene_lane_appeal_idx
             ON model_scene_lane(model_id, scene_id, appeal);
             """

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,7 +37,8 @@ source cache ──► normalized events                  StashDB
 - `curator/graphql/` and `curator/sync/` incrementally copy the required Stash facts.
 - `curator/events/` conservatively reconstructs history and stores direct outcomes.
 - `curator/features/`, `curator/model/`, and `curator/ranking/` publish immutable
-  feature/model versions with indexed score-first and varied lane orders.
+  feature/model versions with indexed score-first queries and stable varied lane
+  orders.
 - `curator/similarity.py`, `curator/expand.py`, and `curator/explanations/` serve
   Similar, StashDB discovery, and factual reasons.
 - `curator/storage/sql/` contains ordered, checksummed, transactional migrations.
@@ -45,11 +46,12 @@ source cache ──► normalized events                  StashDB
 ## Data flow and failure boundaries
 
 Sync writes normalized source tables, then event and feature builders create a new
-version. Lane classifications and both page orders are built before model publication:
-readers see the old complete model or the new complete model, never a partial build.
-Interactive lane and Similar requests use
-compact SQLite indexes and return stable IDs; the browser fetches current display
-metadata from Stash.
+version. Lane classifications, varied page orders, and the scheduled score-first
+orders are built before model publication; simple score-first lanes use the published
+classification index directly. Readers see the old complete model or the new complete
+model, never a partial build. Interactive lane and Similar requests use compact SQLite
+indexes and return stable IDs; the browser fetches current display metadata from
+Stash.
 
 Feedback and playback increment a durable generation counter and trigger a smaller
 preference rebuild after a short debounce. They do not rerun library sync. Full

--- a/docs/handover-performer-similarity.md
+++ b/docs/handover-performer-similarity.md
@@ -1,0 +1,96 @@
+# Performer-similarity build optimization handover
+
+Updated: 2026-07-30.
+
+## Goal
+
+Reduce model-build time by excluding negligible learned performer affinities from
+similarity propagation. Keep direct performer-identity scoring unchanged.
+
+This is independent of runtime explanations and score-first ordering. Do not combine
+the work packages.
+
+## Measured baseline
+
+Installed profiling on a 23,891-scene library measured:
+
+- full model build: about 409 seconds;
+- all similarity work: about 132 seconds;
+- performer similarity: about 56 seconds;
+- learned performer-identity affinities: 334 total, 206 with effective absolute
+  affinity at least `0.005`, and 149 at least `0.01`.
+
+Filtering at `0.005` should remove about 38% of the similarity seeds and may save
+roughly 20 seconds. Treat that as a hypothesis to measure, not a promised result.
+Keep private scene, performer, and library identifiers out of tracked files and
+command output.
+
+## Current flow
+
+`PreferenceModelBuilder._performer_similarity_scores()` in
+`curator/model/builder.py`:
+
+1. derives an effective identity affinity as `affinity * confidence`;
+2. loads all performer profiles;
+3. compares every profile with every known-affinity profile, avoiding duplicate
+   known/known comparisons;
+4. retains the five most similar matches and propagates their affinity and
+   confidence.
+
+`performer_similarity()` and profile block behavior live in
+`curator/features/profiles.py`. Existing coverage is primarily in
+`tests/model/test_builder.py`, including the known-pair comparison-count test.
+
+The build already records the `model.score_performer_similarity` span. Use it for the
+installed before/after comparison.
+
+## Smallest implementation
+
+Filter only the `known` similarity seed set to entries whose effective affinity has
+`abs(value) >= 0.005`. Do not filter the identity-affinity data used by exact
+performer scoring, change `performer_similarity()`, add configuration, or add a
+dependency.
+
+The cutoff deliberately changes propagation from near-neutral performers: their exact
+identity contribution remains, but they no longer act as similarity neighbors.
+Document the fixed heuristic next to the filter with its measured ceiling and upgrade
+path if the code would otherwise make the number look arbitrary.
+
+Split the broad publication `indexing` timer only if needed to obtain trustworthy
+stage measurements; avoid an unrelated timing refactor.
+
+## Required checks
+
+- Add one focused regression test proving sub-threshold identities are not compared
+  while above-threshold identities are, and keep the existing known-pair deduplication
+  assertion.
+- Run `scripts/verify changed tests/model/test_builder.py` while iterating and
+  `scripts/verify full` once near completion.
+- For installed validation, compare cold and warm
+  `model.score_performer_similarity` and total build times.
+- Privately compare recommendation quality and explanations before and after,
+  especially scenes whose only useful evidence comes from weak performer affinities.
+- Do not commit, push, or install unless the user asks in that thread.
+
+## Acceptance
+
+- Exact performer-identity contribution is unchanged.
+- Similarity calls use only seeds at or above the fixed effective-affinity cutoff.
+- Ordering and output remain deterministic.
+- Synthetic tests pass and installed timings improve materially without a visible
+  recommendation-quality regression.
+
+## Copy-paste prompt
+
+```text
+Read AGENTS.md and docs/handover-performer-similarity.md completely. Implement only
+the bounded performer-similarity propagation optimization; do not touch runtime
+explanations or score-first ordering.
+
+Trace the complete builder/profile flow and tests before editing. Use the fixed
+effective-affinity cutoff abs(affinity * confidence) >= 0.005 only for similarity
+seeds, preserving exact performer-identity scoring. Add one focused regression test,
+run scripts/verify changed tests/model/test_builder.py, then scripts/verify full once.
+Report the diff and checks. Do not commit, push, or install unless I explicitly ask.
+Keep all live-library identifiers and evaluation details private.
+```

--- a/docs/handover-runtime-model-data.md
+++ b/docs/handover-runtime-model-data.md
@@ -1,0 +1,153 @@
+# Runtime explanations and score-first ordering handover
+
+Updated: 2026-07-30.
+
+## Implementation status
+
+The code change is complete. Published artifacts now leave `model_scene_reason` empty,
+derive requested reasons through the existing reason algorithm, query exact
+score-first order for Best Bets, Revisit, and Discover, and retain materialized
+score-first order for Adventure and For You. All varied orders remain materialized.
+
+Installed validation is complete. Storage improved materially, and recommendation
+cards now derive explanations only when **Why this?** is expanded.
+
+## Goal
+
+Make generated model artifacts smaller and faster to build by:
+
+1. deriving explanations only for requested scenes; and
+2. serving exact score-first results from indexed model data while retaining
+   precomputed varied ordering for stable pagination.
+
+This is an experiment with two removal decisions, not a mandate to delete both stored
+datasets at once. Measure and prove runtime parity before removing either one. It is
+independent of performer-similarity propagation.
+
+## Measured baseline
+
+Installed profiling on a 23,891-scene library measured:
+
+- full model build: about 409 seconds;
+- publication: about 243 seconds;
+- combined lane classification, ordering, reason generation, and index creation:
+  about 144 seconds;
+- generated artifact: about 540 MiB;
+- `model_scene_reason`: 218,770 rows and about 268 MiB;
+- `model_lane_order`: 135,304 rows and about 30.8 MiB, plus an 8.6 MiB unique index.
+
+The former 88-second whole-artifact integrity scan has already been removed. Schema,
+cardinality, and lane-state validation remain.
+
+Keep private scene, performer, and library identifiers out of tracked files and
+command output.
+
+## Current flow
+
+### Reasons
+
+`PreferenceModelBuilder._publish()` in `curator/model/builder.py` leaves the
+compatibility reason table empty and records reason generation as zero.
+
+`ReasonGraphStore.build(model_id, scene_ids=...)` in
+`curator/explanations/reasons.py` already has a targeted calculation path, including
+bounded neighbor context, but it persists results to `model_scene_reason`.
+
+`ReasonGraphStore.derive()` reuses `_prepare_neighbor_context()` and
+`_scene_reasons()` without writing. `ExplanationService` retains derived results only
+for that service instance. Existing artifacts with persisted reasons remain readable.
+
+`CuratorAPI.get_slate()` returns ranking data without generating prose. Expanding
+**Why this?** calls the existing single-scene explanation endpoint and displays
+accessible loading and error states.
+
+### Ordering
+
+`SlateBuilder.materialize()` stores every `varied` order plus the scheduled
+`score_first` orders for Adventure and For You. `_load_materialized_slate()` queries
+Best Bets, Revisit, and Discover by `(model_id, lane, lane_value DESC, scene_id)` when
+diversity is disabled, then applies the same live eligibility, direct-play, recovery,
+and cooldown rules.
+
+Adventure retains subtype scheduling and For You retains source-lane mixing, so their
+score-first rows remain materialized. Full-order parity tests prove the three queried
+lanes match `_build_order(..., varied=False)`.
+
+Keep varied ordering precomputed. It carries diversity state and stable pagination
+semantics that should not be reconstructed independently for every request.
+
+## Implemented changes
+
+### Instrumentation
+
+Publication now reports lane classification, score-first ordering, varied ordering,
+reason generation, and SQLite index creation separately.
+
+Installed timings are recorded below.
+
+### Runtime reasons
+
+`ReasonGraphStore.derive()` returns requested reasons without writes. Recommendation
+cards call it through the existing explanation endpoint only when **Why this?** opens.
+Synthetic fixtures prove parity with persisted reasons.
+
+Bulk generation and reason-coverage validation are removed. The empty compatibility
+table remains, avoiding a migration or artifact schema change.
+
+### Queried score-first ordering
+
+Best Bets, Revisit, and Discover use the indexed query. Adventure and For You retain
+materialized score-first rows, and all lanes retain varied rows.
+
+## Verification
+
+- Reason parity tests in `tests/explanations/test_reasons.py`.
+- Ordering parity, filtering, refill, and stable-page tests in
+  `tests/ranking/test_slate.py`.
+- API tests in `tests/test_api.py` proving returned recommendations still have
+  truthful explanations without bulk reason rows.
+- Artifact validation and archive/runtime tests affected by the storage change.
+- `scripts/verify changed` with the focused test files while iterating, then
+  `scripts/verify full` once near completion.
+- `scripts/verify full`: 217 tests passed.
+- Installed integrity, artifact layout, score-first parity, and truthful explanation
+  checks passed.
+
+## Installed results
+
+The first native rebuild reused the prior artifact because model IDs did not include
+an implementation revision. `MODEL_BUILD_VERSION` now invalidates artifacts when
+model-building semantics change, with a regression test.
+
+The subsequent cold build completed in 1,038.5 seconds:
+
+- similarity: 535.1 seconds;
+- lane classification: 118.0 seconds;
+- score-first ordering: 45.1 seconds;
+- varied ordering: 114.3 seconds;
+- reason generation: 0 seconds;
+- SQLite index creation: 7.3 seconds;
+- validation: 0.1 seconds.
+
+The model artifact is 253,177,856 bytes, down from about 540 MiB. It contains zero
+persisted reason rows and 115,418 order rows: varied order for every lane and
+score-first order only for Adventure and For You.
+
+Initial installed 20-item requests generated every explanation eagerly:
+
+- For You: 2,178 ms cold and 1,875 ms warm, including 1,223/1,475 ms for explanations;
+- Best Bets: 1,412 ms cold and 1,600 ms warm, including 799/1,302 ms for explanations;
+- indexed score-first Best Bets: 905 ms cold and 81 ms warm;
+- single-scene explanation: 640 ms cold and 450 ms warm.
+
+After moving recommendation explanations behind **Why this?**, For You returns in
+571 ms cold and 369 ms warm. Opening one explanation takes about 0.8–1.0 seconds and
+returns complete and selected reasons.
+
+Core and artifact `PRAGMA quick_check` return `ok`; core foreign-key violations are
+zero. The smaller artifact meets the storage goal without slowing initial page
+delivery. No durable cache or migration was added.
+
+Do not accept a smaller artifact that makes normal page requests visibly slow. Do
+not add a cache unless on-demand explanation latency itself becomes a measured
+problem.

--- a/docs/handover.md
+++ b/docs/handover.md
@@ -36,27 +36,12 @@ Similarity took 132 seconds: 76 seconds for content neighbors and 56 seconds for
 performer similarity. Publication took 243 seconds, including a broad 144-second
 classification/order/reason/index stage and 88 seconds validating the generated
 540 MiB artifact. The model-integrity scan is removed in the current work package;
-schema, cardinality, reason-coverage, and lane-state validation remain.
+schema, cardinality, and lane-state validation remain.
 
-Keep these two independent follow-ups for later measurement:
+The two independent follow-ups now have self-contained handovers:
 
-1. Bound performer-similarity propagation to meaningful learned affinities. The live
-   model had 334 performer-identity affinities, but only 206 had effective absolute
-   affinity of at least 0.005 and 149 reached 0.01. Start with a fixed 0.005 cutoff,
-   retain the existing exact identity contribution, and compare recommendation quality
-   before changing the threshold. The current profile suggests roughly 20 seconds of
-   build-time savings.
-2. Generate explanations for requested scenes instead of materializing every reason,
-   and serve exact score-first ordering from indexed queries. The current artifact
-   stores 218,770 reason rows using 268 MiB and 135,304 order rows using about 39 MiB
-   including its unique index. Reuse the existing targeted reason-building flow, keep
-   globally varied ordering precomputed for stable pagination, and measure page latency
-   before removing persisted rows.
-
-Before either change, split the current broad indexing timer into lane classification,
-score-first ordering, varied ordering, reason generation, and SQLite index creation.
-Run the installed operation cold and warm; retain ranking, explanation, and stable-page
-tests plus a private before/after quality review.
+1. [Bound performer-similarity propagation](handover-performer-similarity.md).
+2. [Derive requested explanations and query exact score-first ordering](handover-runtime-model-data.md).
 
 ## Guardrails
 

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -46,7 +46,8 @@ therefore be varied without pretending your preferences changed.
 
 ## Why the explanation is trustworthy
 
-Every explanation is planned from stored reason codes and evidence. Deterministic
-prose combines the strongest facts, while the expanded score tree exposes the
-underlying contributions, confidence, timing changes, exploration reason, and final
-lane choice. The wording may vary; the evidence cannot invent new facts.
+Every explanation is planned from reason codes derived from published model evidence.
+Curator derives it when you expand **Why this?**, keeping the recommendation page
+fast. Deterministic prose combines the strongest facts, while the expanded score tree
+exposes the underlying contributions, confidence, timing changes, exploration reason,
+and final lane choice. The wording may vary; the evidence cannot invent new facts.

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -829,6 +829,13 @@
   function RecommendationCard({ item, scene, slate, onRemove, onThumbDown }) {
     const { SceneCard } = Api.components;
     const card = React.useRef(null);
+    const [explanation, setExplanation] = React.useState(
+      item.explanation
+        ? { summary: item.explanation, supporting_reasons: item.supporting_reasons || [] }
+        : null
+    );
+    const [explanationLoading, setExplanationLoading] = React.useState(false);
+    const [explanationError, setExplanationError] = React.useState("");
     React.useEffect(() => {
       let timer;
       let qualified = false;
@@ -873,6 +880,20 @@
         })
       );
     }
+    async function explain(event) {
+      if (!event.currentTarget.open || explanation || explanationLoading) return;
+      setExplanationLoading(true);
+      setExplanationError("");
+      try {
+        setExplanation(
+          await operation({ operation: "get_explanation", scene_id: item.scene_id }, 60000)
+        );
+      } catch (failure) {
+        setExplanationError(failure.message);
+      } finally {
+        setExplanationLoading(false);
+      }
+    }
     return React.createElement(
       "article",
       { className: `curator-card curator-source-${item.source_lane}`, onClickCapture: rememberOrigin, ref: card },
@@ -892,13 +913,15 @@
           { className: "curator-card-details" },
           React.createElement(
             "details",
-            { className: "curator-evidence" },
+            { className: "curator-evidence", onToggle: explain },
             React.createElement("summary", null, "Why this?"),
-            React.createElement("p", { className: "curator-explanation" }, item.explanation),
-            React.createElement(
+            explanationLoading && React.createElement("small", { role: "status" }, "Explaining…"),
+            explanationError && React.createElement("small", { className: "text-danger", role: "alert" }, explanationError),
+            explanation && React.createElement("p", { className: "curator-explanation" }, explanation.summary),
+            explanation && React.createElement(
               "ul",
               null,
-              item.supporting_reasons.map((reason, index) =>
+              explanation.supporting_reasons.map((reason, index) =>
                 React.createElement(
                   "li",
                   { key: `${reason.code}-${index}` },
@@ -2076,7 +2099,7 @@
           React.createElement(
             "section",
             { className: "curator-grid", role: "tabpanel", "aria-live": "polite" },
-            slate.items.map((item) => React.createElement(RecommendationCard, { key: item.scene_id, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp }))
+            slate.items.map((item) => React.createElement(RecommendationCard, { key: `${item.impression_id}:${item.scene_id}`, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp }))
           ),
           React.createElement(Pager, { page, hasMore: slate.has_more, loading, onPage: setPage, label: `${laneOption.label} pages` })
         )

--- a/tests/explanations/test_reasons.py
+++ b/tests/explanations/test_reasons.py
@@ -65,6 +65,17 @@ def test_reason_graph_is_versioned_truthful_and_deterministic(tmp_path: Path) ->
     assert explanation.selected_reasons == (reason,)
 
 
+def test_derived_reasons_match_persisted_reasons(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    _add_explainable_content(connection)
+    store = ReasonGraphStore(connection)
+
+    derived = store.derive("model", {"a-best", "d-revisit"})
+    store.build("model", derived)
+
+    assert derived == {scene_id: store.reasons("model", scene_id) for scene_id in sorted(derived)}
+
+
 def test_scene_without_specific_evidence_gets_factual_fallback(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     connection.execute(

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -153,6 +153,11 @@ def test_complete_model_is_bounded_reproducible_and_applies_cooldown(tmp_path: P
         "similarity",
         "scoring",
         "database_writing",
+        "lane_classification",
+        "score_first_ordering",
+        "varied_ordering",
+        "reason_generation",
+        "sqlite_index_creation",
         "indexing",
         "validation",
         "publication",
@@ -190,6 +195,12 @@ def test_complete_model_is_bounded_reproducible_and_applies_cooldown(tmp_path: P
     assert connection.execute(
         "SELECT 1 FROM model_lane_order_state WHERE model_id=?", (first.model_id,)
     ).fetchone()
+    assert (
+        connection.execute(
+            "SELECT count(*) FROM model_scene_reason WHERE model_id=?", (first.model_id,)
+        ).fetchone()[0]
+        == 0
+    )
     assert {
         str(row[0])
         for row in connection.execute(
@@ -197,6 +208,16 @@ def test_complete_model_is_bounded_reproducible_and_applies_cooldown(tmp_path: P
             (first.model_id,),
         )
     } == {"score_first", "varied"}
+    assert {
+        str(row[0])
+        for row in connection.execute(
+            """
+            SELECT DISTINCT lane FROM model_lane_order
+            WHERE model_id=? AND ordering='score_first'
+            """,
+            (first.model_id,),
+        )
+    } == {"adventure", "for_you"}
     assert [
         str(row[0])
         for row in connection.execute(
@@ -519,6 +540,21 @@ def test_model_build_refreshes_feature_version_after_feature_config_change(
     ).build()
 
     assert second.feature_version != first.feature_version
+    assert second.model_id != first.model_id
+
+
+def test_model_build_version_invalidates_published_artifact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    first = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    monkeypatch.setattr(
+        builder_module, "MODEL_BUILD_VERSION", builder_module.MODEL_BUILD_VERSION + 1
+    )
+
+    second = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+
+    assert second.reused is False
     assert second.model_id != first.model_id
 
 

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -514,6 +514,9 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     assert 'className: "image-thumbnail"' in source
     assert 'className: "tag-item tag-link badge badge-secondary"' in source
     assert 'React.createElement("summary", null, "Why this?")' in source
+    assert '{ className: "curator-evidence", onToggle: explain }' in source
+    assert 'operation({ operation: "get_explanation", scene_id: item.scene_id }, 60000)' in source
+    assert '"Explaining…"' in source
     assert 'React.createElement("summary", null, `Score · ${item.score.toFixed(2)}`)' in source
     assert 'React.createElement("summary", null, `Score · ${item.rank_score.toFixed(2)}`)' in source
     assert (

--- a/tests/ranking/test_slate.py
+++ b/tests/ranking/test_slate.py
@@ -276,14 +276,55 @@ def test_materialize_reports_each_lane_ordering(tmp_path: Path) -> None:
     LanePolicy(connection).classify("model")
     progress: list[tuple[int, int]] = []
 
-    counts = SlateBuilder(connection).materialize(
+    builder = SlateBuilder(connection)
+    counts = builder.materialize(
         "model",
         force=True,
         progress=lambda processed, total: progress.append((processed, total)),
     )
 
     assert set(counts) == {"best_bets", "revisit", "discover", "adventure"}
-    assert progress == [(position, 10) for position in range(1, 11)]
+    assert progress == [(position, 7) for position in range(1, 8)]
+    assert set(builder.materialize_timings_ms) == {
+        "score_first_ordering",
+        "varied_ordering",
+    }
+    assert {
+        str(row[0])
+        for row in connection.execute(
+            """
+            SELECT DISTINCT lane FROM model_lane_order
+            WHERE model_id='model' AND ordering='score_first'
+            """
+        )
+    } == {"adventure", "for_you"}
+
+
+def test_queried_score_first_lanes_match_full_materialized_order(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    classifications = LanePolicy(connection).classify("model")
+    builder = SlateBuilder(connection, diversity_enabled=False)
+    candidates = builder._candidates("model", classifications)
+    expected = {
+        lane: [
+            candidate.classification.scene_id
+            for candidate, *_rest in builder._build_order(
+                lane,
+                tuple(
+                    candidate for candidate in candidates if candidate.classification.lane == lane
+                ),
+                varied=False,
+            )
+        ]
+        for lane in ("best_bets", "revisit", "discover")
+    }
+
+    builder.materialize("model", force=True)
+
+    for lane, scene_ids in expected.items():
+        slate = builder._load_materialized_slate("model", lane, len(scene_ids))
+        assert slate is not None
+        assert [item.scene_id for item in slate.items] == scene_ids
 
 
 def test_new_slate_builder_reuses_persisted_lane_classifications(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from curator.api import CuratorAPI
+from curator.explanations import ExplanationService
 from curator.features import FeatureStore
 from curator.model import ModelUpdateCoordinator, PreferenceModelBuilder
 from curator.similarity import SimilarityService
@@ -10,9 +11,16 @@ from curator.storage import connect_database
 from tests.model.test_builder import REFERENCE_MS, _database
 
 
-def test_slate_api_records_impression_and_bundles_explanations(tmp_path: Path) -> None:
+def test_slate_api_defers_explanations_until_requested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    monkeypatch.setattr(
+        ExplanationService,
+        "ensure",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("eager explanation")),
+    )
 
     result = CuratorAPI(connection).get_slate(
         "for_you", 3, impression_id="api-impression", now_ms=REFERENCE_MS
@@ -26,27 +34,22 @@ def test_slate_api_records_impression_and_bundles_explanations(tmp_path: Path) -
         "model_update",
         "ranking",
         "impression",
-        "explanations",
         "total",
     }
     assert len(result["items"]) == 3
-    assert all(item["explanation"] for item in result["items"])
-    explained = {
-        str(row[0])
-        for row in connection.execute(
-            "SELECT DISTINCT scene_id FROM model_scene_reason WHERE model_id=?",
+    assert all(
+        "explanation" not in item and "supporting_reasons" not in item for item in result["items"]
+    )
+    assert (
+        connection.execute(
+            "SELECT count(*) FROM model_scene_reason WHERE model_id=?",
             (result["model_id"],),
-        )
-    }
-    scored = {
-        str(row[0])
-        for row in connection.execute(
-            "SELECT scene_id FROM model_scene_score WHERE model_id=?",
-            (result["model_id"],),
-        )
-    }
-    assert explained == scored
-    assert {str(item["scene_id"]) for item in result["items"]} <= explained
+        ).fetchone()[0]
+        == 0
+    )
+    explanation = CuratorAPI(connection).explanation(str(result["items"][0]["scene_id"]))
+    assert explanation["summary"]
+    assert explanation["supporting_reasons"]
     assert (
         connection.execute(
             "SELECT count(*) FROM impression WHERE impression_id='api-impression'"


### PR DESCRIPTION
## Summary
- derive recommendation explanations only when Why this? is expanded
- stop persisting bulk reason rows and invalidate stale model artifacts
- query exact score-first ordering for Best Bets, Revisit, and Discover while retaining materialized varied orders
- document measured storage, build, and live request results

## Verification
- scripts/verify full: 217 passed
- pre-push scripts/verify full: 217 passed in 100.24s
- installed integrity and ordering checks passed
- live For You request: 571 ms cold, 369 ms warm; on-demand explanation about 0.8–1.0 s