### PR TITLE
Capture view history from Stash and the player

### DIFF
--- a/curator/events/__init__.py
+++ b/curator/events/__init__.py
@@ -1,6 +1,7 @@
 """Behavioral session and outcome normalization."""
 
 from curator.events.contracts import (
+    OBSERVED_PLAYBACK_SQL,
     DirectSessionInput,
     EventCalibration,
     NormalizedOutcome,
@@ -14,6 +15,7 @@ from curator.events.replacements import quick_replacement_outcome
 from curator.events.repository import HistoricalEventStore
 
 __all__ = [
+    "OBSERVED_PLAYBACK_SQL",
     "DirectSessionInput",
     "EventCalibration",
     "HistoricalEventStore",

--- a/curator/events/contracts.py
+++ b/curator/events/contracts.py
@@ -130,6 +130,29 @@ class DirectSessionInput:
         if self.origin is SessionOrigin.CURATOR and self.impression_id is None:
             raise ValueError("Curator-originated sessions require an impression_id")
 
+    @property
+    def observed_playback(self) -> bool:
+        """Whether the browser actually watched the video advance.
+
+        A tracker that never receives player events reports elapsed wall time with no active
+        seconds and no progress. That is missing evidence, not a short exit, so it must not be
+        read as watching behavior.
+        """
+        return (
+            self.active_seconds > 0
+            or bool(self.played_ranges)
+            or self.maximum_position_seconds > self.start_position_seconds
+        )
+
+
+# The same test as DirectSessionInput.observed_playback, against a stored play_session row.
+OBSERVED_PLAYBACK_SQL = """(
+    active_seconds > 0
+    OR json_array_length(COALESCE(json_extract(summary_json, '$.played_ranges'), '[]')) > 0
+    OR COALESCE(json_extract(summary_json, '$.maximum_position_seconds'), 0)
+       > COALESCE(json_extract(summary_json, '$.start_position_seconds'), 0)
+)"""
+
 
 @dataclass(frozen=True)
 class OutcomeSignal:

--- a/curator/graphql/operations.py
+++ b/curator/graphql/operations.py
@@ -2,7 +2,30 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from curator.graphql.adapters import SourceEntity
+
+
+def _updated_at(item: SourceEntity) -> str | None:
+    return item.updated_at
+
+
+def _last_played_at(item: SourceEntity) -> str | None:
+    """Stash leaves updated_at alone when it records a play, so plays need their own mark."""
+    history = getattr(item, "play_history_ms", ())
+    if not history:
+        return None
+    return datetime.fromtimestamp(max(history) / 1000, UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _played_since(watermark: str | None) -> dict[str, object]:
+    criteria: dict[str, object] = {"play_count": {"value": 0, "modifier": "GREATER_THAN"}}
+    if watermark:
+        criteria["last_played_at"] = {"value": watermark, "modifier": "GREATER_THAN"}
+    return {"sceneFilter": criteria}
 
 
 @dataclass(frozen=True)
@@ -14,6 +37,10 @@ class EntityOperation:
     document: str
     root_key: str
     items_key: str
+    sort: str = "updated_at"
+    watermark_of: Callable[[SourceEntity], str | None] = field(default=_updated_at)
+    variables_for: Callable[[str | None], dict[str, object]] | None = None
+    incremental_only: bool = False
 
 
 CAPABILITIES = """
@@ -23,6 +50,7 @@ query CuratorCapabilities {
   sceneType: __type(name: "Scene") { fields { name } }
   performerType: __type(name: "Performer") { fields { name } }
   tagType: __type(name: "Tag") { fields { name } }
+  sceneFilterType: __type(name: "SceneFilterType") { inputFields { name } }
 }
 """
 
@@ -83,14 +111,7 @@ query CuratorPerformers(
     "performers",
 )
 
-SCENES = EntityOperation(
-    "scene",
-    "CuratorScenes",
-    """
-query CuratorScenes($page: Int!, $perPage: Int!, $sort: String!, $direction: SortDirectionEnum!) {
-  findScenes(filter: {page: $page, per_page: $perPage, sort: $sort, direction: $direction}) {
-    count
-    scenes {
+SCENE_FIELDS = """
       id title details date rating100 updated_at play_count play_duration play_history o_history
       studio { id name favorite rating100 updated_at parent_studio { id name updated_at } }
       tags { id name updated_at }
@@ -101,13 +122,49 @@ query CuratorScenes($page: Int!, $perPage: Int!, $sort: String!, $direction: Sor
         primary_tag { id name updated_at }
         tags { id name updated_at }
       }
-    }
-  }
-}
+"""
+
+SCENES = EntityOperation(
+    "scene",
+    "CuratorScenes",
+    f"""
+query CuratorScenes($page: Int!, $perPage: Int!, $sort: String!, $direction: SortDirectionEnum!) {{
+  findScenes(filter: {{page: $page, per_page: $perPage, sort: $sort, direction: $direction}}) {{
+    count
+    scenes {{{SCENE_FIELDS}}}
+  }}
+}}
 """,
     "findScenes",
     "scenes",
 )
 
-ENTITY_OPERATIONS = (TAGS, STUDIOS, PERFORMERS, SCENES)
+# Stash does not touch scenes.updated_at when it records a play, so the scene pass above can
+# never observe one. This pass walks played scenes on their own last_played_at watermark.
+SCENE_PLAYS = EntityOperation(
+    "scene_play",
+    "CuratorScenePlays",
+    f"""
+query CuratorScenePlays(
+  $page: Int!, $perPage: Int!, $sort: String!, $direction: SortDirectionEnum!,
+  $sceneFilter: SceneFilterType
+) {{
+  findScenes(
+    filter: {{page: $page, per_page: $perPage, sort: $sort, direction: $direction}}
+    scene_filter: $sceneFilter
+  ) {{
+    count
+    scenes {{{SCENE_FIELDS}}}
+  }}
+}}
+""",
+    "findScenes",
+    "scenes",
+    sort="last_played_at",
+    watermark_of=_last_played_at,
+    variables_for=_played_since,
+    incremental_only=True,
+)
+
+ENTITY_OPERATIONS = (TAGS, STUDIOS, PERFORMERS, SCENES, SCENE_PLAYS)
 ALL_DOCUMENTS = (CAPABILITIES, *(operation.document for operation in ENTITY_OPERATIONS))

--- a/curator/interactions.py
+++ b/curator/interactions.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from curator.config import DEFAULT_CONFIG
 from curator.events import (
+    OBSERVED_PLAYBACK_SQL,
     DirectSessionInput,
     PlayedRange,
     SessionOrigin,
@@ -353,11 +354,17 @@ class InteractionStore:
                 if not cursor.rowcount:
                     continue
                 inserted += 1
-                outcome = viewing_outcome(session.active_seconds, session.ended_at_ms)
-                if outcome is not None:
-                    self._insert_signal(
-                        f"{session.session_id}:view", session.scene_id, session.session_id, outcome
-                    )
+                # Without observed playback there is no viewing evidence to grade; reading the
+                # empty session as a short exit would penalize a scene the user may have watched.
+                if session.observed_playback:
+                    outcome = viewing_outcome(session.active_seconds, session.ended_at_ms)
+                    if outcome is not None:
+                        self._insert_signal(
+                            f"{session.session_id}:view",
+                            session.scene_id,
+                            session.session_id,
+                            outcome,
+                        )
                 self._insert_replacement(session)
             if inserted:
                 ModelUpdateCoordinator(self.connection).request("session_outcome")
@@ -408,10 +415,12 @@ class InteractionStore:
         )
 
     def _insert_replacement(self, replacement: DirectSessionInput) -> None:
+        # Only a session whose playback was observed can be judged as abandoned early.
         row = self.connection.execute(
-            """
+            f"""
             SELECT summary_json FROM play_session
             WHERE provenance='direct_player' AND session_id<>? AND ended_at_ms<=?
+            AND {OBSERVED_PLAYBACK_SQL}
             ORDER BY ended_at_ms DESC LIMIT 1
             """,
             (replacement.session_id, replacement.started_at_ms),

--- a/curator/ranking/policy.py
+++ b/curator/ranking/policy.py
@@ -9,6 +9,7 @@ from collections.abc import Callable, Collection
 from dataclasses import dataclass
 
 from curator.config import DEFAULT_CONFIG, CuratorConfig
+from curator.events.contracts import OBSERVED_PLAYBACK_SQL
 from curator.features import FeatureStore
 from curator.model import ModelSceneScore, RecommendationModelStore
 from curator.storage import transaction
@@ -76,10 +77,7 @@ class LanePolicy:
             for scene_id, score in scores.items()
             if bool(score.eligibility.get("eligible", False))
         }
-        played_scene_ids = {
-            str(row[0])
-            for row in self.connection.execute("SELECT DISTINCT scene_id FROM source_play")
-        }
+        played_scene_ids = self._played_scene_ids()
         content_ranks = _percentiles(
             {
                 scene_id: _component_value(score, "content")
@@ -325,6 +323,24 @@ class LanePolicy:
             for row in rows
         )
 
+    def _played_scene_ids(self) -> set[str]:
+        """Scenes the user has watched, from Stash history and from Curator's own player.
+
+        Stash only reports a play once its own threshold is met and a sync has run since, so
+        classification would otherwise keep offering back scenes watched in this session.
+        """
+        return {
+            str(row[0])
+            for row in self.connection.execute(
+                f"""
+                SELECT DISTINCT scene_id FROM source_play
+                UNION
+                SELECT DISTINCT scene_id FROM play_session
+                WHERE provenance<>'direct_player' OR {OBSERVED_PLAYBACK_SQL}
+                """
+            )
+        }
+
     @staticmethod
     def _adventure_subtype(
         score: ModelSceneScore,
@@ -350,10 +366,7 @@ class LanePolicy:
             "SELECT feature_version FROM model_version WHERE model_id=?", (model_id,)
         ).fetchone()
         vectors = FeatureStore(self.connection).scene_content_vectors(str(feature_row[0]))
-        played = {
-            str(row[0])
-            for row in self.connection.execute("SELECT DISTINCT scene_id FROM source_play")
-        }
+        played = self._played_scene_ids()
         library_count: dict[str, int] = {}
         played_count: dict[str, int] = {}
         for scene_id, vector in vectors.items():
@@ -376,20 +389,14 @@ class LanePolicy:
             gaps[scene_id] = weighted_gap / weight if weight else 0.0
         coverage_ranks = _percentiles(gaps)
 
-        known_performers = {
-            str(row[0])
-            for row in self.connection.execute(
-                """
-                SELECT DISTINCT sp.performer_id FROM scene_performer sp
-                JOIN source_play p ON p.scene_id=sp.scene_id
-                """
-            )
-        }
         performers: dict[str, list[str]] = {}
         for row in self.connection.execute(
             "SELECT scene_id, performer_id FROM scene_performer ORDER BY scene_id, position"
         ):
             performers.setdefault(str(row["scene_id"]), []).append(str(row["performer_id"]))
+        known_performers = {
+            performer for scene_id in played for performer in performers.get(scene_id, ())
+        }
         unknown_performers = {
             scene_id: (
                 sum(performer not in known_performers for performer in performers.get(scene_id, ()))
@@ -399,20 +406,14 @@ class LanePolicy:
             )
             for scene_id in scene_ids
         }
-        known_studios = {
-            str(row[0])
-            for row in self.connection.execute(
-                """
-                SELECT DISTINCT s.studio_id FROM source_scene s
-                JOIN source_play p ON p.scene_id=s.scene_id WHERE s.studio_id IS NOT NULL
-                """
-            )
-        }
         scene_studios = {
             str(row["scene_id"]): str(row["studio_id"])
             for row in self.connection.execute(
                 "SELECT scene_id, studio_id FROM source_scene WHERE studio_id IS NOT NULL"
             )
+        }
+        known_studios = {
+            scene_studios[scene_id] for scene_id in played if scene_id in scene_studios
         }
         unknown_studios = {
             scene_id: float(

--- a/curator/ranking/slate.py
+++ b/curator/ranking/slate.py
@@ -13,6 +13,7 @@ from heapq import heappop, heappush
 from typing import Any
 
 from curator.config import DEFAULT_CONFIG, CuratorConfig
+from curator.events.contracts import OBSERVED_PLAYBACK_SQL
 from curator.features import FeatureStore
 from curator.model import RecommendationModelStore
 from curator.model.boundaries import scene_eligibility
@@ -832,9 +833,9 @@ class SlateBuilder:
         direct_plays = {
             str(row["scene_id"]): int(row["last_played"])
             for row in self.connection.execute(
-                """
+                f"""
                 SELECT scene_id, max(ended_at_ms) AS last_played FROM play_session
-                WHERE provenance='direct_player' GROUP BY scene_id
+                WHERE provenance='direct_player' AND {OBSERVED_PLAYBACK_SQL} GROUP BY scene_id
                 """
             )
         }
@@ -911,6 +912,7 @@ class SlateBuilder:
                 f"""
                 SELECT scene_id FROM play_session
                 WHERE ended_at_ms>=? AND scene_id IN ({placeholders})
+                AND (provenance<>'direct_player' OR {OBSERVED_PLAYBACK_SQL})
                 """,
                 (created_at_ms, *scene_ids),
             )

--- a/curator/storage/sql/0020_unobserved_playback_penalties.sql
+++ b/curator/storage/sql/0020_unobserved_playback_penalties.sql
@@ -1,0 +1,15 @@
+-- Between 2026-07-19 and this release the browser tracker attached to a Stash player that
+-- never reported progress, so every direct session recorded zero active seconds and no played
+-- ranges. Those empty sessions were graded as short exits and penalized scenes the user may
+-- have watched in full. Remove the penalties; the sessions themselves stay as navigation facts.
+DELETE FROM behavior_event
+WHERE provenance = 'direct_player'
+  AND outcome < 0
+  AND session_id IN (
+    SELECT session_id FROM play_session
+    WHERE provenance = 'direct_player'
+      AND active_seconds <= 0
+      AND json_array_length(COALESCE(json_extract(summary_json, '$.played_ranges'), '[]')) = 0
+      AND COALESCE(json_extract(summary_json, '$.maximum_position_seconds'), 0)
+          <= COALESCE(json_extract(summary_json, '$.start_position_seconds'), 0)
+  );

--- a/curator/sync/service.py
+++ b/curator/sync/service.py
@@ -8,7 +8,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Protocol
 
-from curator.graphql.adapters import SourceEntity, adapt_page
+from curator.graphql.adapters import adapt_page
 from curator.graphql.operations import CAPABILITIES, ENTITY_OPERATIONS, EntityOperation
 from curator.sync.repository import SyncRepository
 
@@ -58,13 +58,19 @@ def probe_capabilities(client: QueryClient) -> Capabilities:
         "performerType": {"id", "updated_at", "favorite", "weight", "fake_tits"},
         "tagType": {"id", "updated_at", "stash_ids"},
     }
-    for type_key, required_fields in requirements.items():
+    # last_played_at is how the play pass observes plays; Stash never bumps scene updated_at
+    # for one, so without it view history would silently stop updating.
+    for type_key, required_fields in {
+        **requirements,
+        "sceneFilterType": {"play_count", "last_played_at"},
+    }.items():
+        field_key = "inputFields" if type_key.endswith("FilterType") else "fields"
         type_data = data.get(type_key)
-        if not isinstance(type_data, Mapping) or not isinstance(type_data.get("fields"), list):
+        if not isinstance(type_data, Mapping) or not isinstance(type_data.get(field_key), list):
             raise RuntimeError(f"Stash capability probe is missing {type_key}")
         available = {
             field["name"]
-            for field in type_data["fields"]
+            for field in type_data[field_key]
             if isinstance(field, Mapping) and isinstance(field.get("name"), str)
         }
         missing = sorted(required_fields - available)
@@ -111,19 +117,25 @@ class SyncService:
         changed_counts: dict[str, int] = {}
         scene_ids: set[str] = set()
         current_entity: str | None = None
+        # A full sweep walks every scene by id, so the incremental play pass adds nothing.
+        operations = tuple(
+            operation
+            for operation in ENTITY_OPERATIONS
+            if not (full and operation.incremental_only)
+        )
         try:
-            for position, operation in enumerate(ENTITY_OPERATIONS):
+            for position, operation in enumerate(operations):
                 current_entity = operation.entity_type
                 count, ids = self._sync_entity(
                     run_id,
                     operation,
                     full=full,
                     position=position,
-                    entity_count=len(ENTITY_OPERATIONS),
+                    entity_count=len(operations),
                 )
                 counts[current_entity] = count
                 changed_counts[current_entity] = len(ids)
-                if current_entity == "scene":
+                if operation.items_key == "scenes":
                     scene_ids.update(ids)
             current_entity = None
             if full:
@@ -159,17 +171,26 @@ class SyncService:
         baseline, _ = self.repository.cursor_watermarks(operation.entity_type)
         processed = 0
         ids: list[str] = []
-        sort = "id" if full else "updated_at"
+        sort = "id" if full else operation.sort
         direction = "ASC" if full else "DESC"
+        variables: dict[str, object] = (
+            operation.variables_for(baseline) if operation.variables_for else {}
+        )
         while True:
             data = self.client.execute(
                 operation.document,
-                {"page": page, "perPage": self.page_size, "sort": sort, "direction": direction},
+                {
+                    "page": page,
+                    "perPage": self.page_size,
+                    "sort": sort,
+                    "direction": direction,
+                    **variables,
+                },
             )
             adapted = adapt_page(data, root_key=operation.root_key, items_key=operation.items_key)
             timestamps = tuple(
                 timestamp
-                for timestamp in (self._updated_at(item) for item in adapted.items)
+                for timestamp in (operation.watermark_of(item) for item in adapted.items)
                 if timestamp
             )
             changed = self.repository.save_page(
@@ -199,7 +220,3 @@ class SyncService:
                 self.repository.complete_entity(run_id, operation.entity_type, self.clock_ms())
                 return processed, tuple(ids)
             page += 1
-
-    @staticmethod
-    def _updated_at(item: SourceEntity) -> str | None:
-        return item.updated_at

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2231,6 +2231,15 @@
     enqueue({ ...value, ended_at_ms: Date.now(), natural_completion: naturalCompletion });
   }
 
+  // ponytail: getPlayer() resolves one registered Video.js wrapper, which goes stale when Stash
+  // rebuilds the player for a scene. Bind the media element itself and re-bind when it changes,
+  // so a replaced player cannot silently record a session that observed nothing.
+  function mediaElement() {
+    const player = Api.utils.InteractiveUtils.getPlayer();
+    const root = player && !player.isDisposed?.() ? player.el?.() : null;
+    return root?.querySelector("video") || document.querySelector(".video-js video, video.vjs-tech");
+  }
+
   function attachPlayer(pathname) {
     const match = pathname.match(/^\/scenes\/(\d+)/);
     if (!match) {
@@ -2240,70 +2249,100 @@
     const sceneId = match[1];
     if (tracker?.value.scene_id === sceneId) return;
     finishTracker(false);
-    function findPlayer(attempt = 0) {
-      if (location.pathname !== pathname || tracker?.value.scene_id === sceneId) return;
-      const player = Api.utils.InteractiveUtils.getPlayer();
-      if (!player) {
-        if (attempt < 20) setTimeout(() => findPlayer(attempt + 1), 250);
-        return;
-      }
-      let origin = null;
-      try {
-        origin = JSON.parse(sessionStorage.getItem(ORIGIN_KEY) || "null");
-      } catch (_) {}
-      if (origin?.scene_id !== sceneId) origin = null;
-      if (origin) sessionStorage.removeItem(ORIGIN_KEY);
-      const started = Date.now();
-      const handlers = {};
-      const value = {
-        session_id: uuid(),
-        scene_id: sceneId,
-        started_at_ms: started,
-        active_seconds: 0,
-        origin: origin ? "curator" : "stash",
-        source_route: pathname,
-        start_position_seconds: Number(player.currentTime() || 0),
-        maximum_position_seconds: Number(player.currentTime() || 0),
-        final_position_seconds: Number(player.currentTime() || 0),
-        played_ranges: [],
-        seek_destinations_seconds: [],
-        ...(origin || {}),
-      };
-      let playing = false;
-      let lastWall = performance.now();
-      let rangeStart = null;
-      function tick() {
-        const now = performance.now();
-        if (playing) value.active_seconds += Math.min(5, Math.max(0, (now - lastWall) / 1000));
-        lastWall = now;
-        const position = Number(player.currentTime() || 0);
-        value.final_position_seconds = position;
-        value.maximum_position_seconds = Math.max(value.maximum_position_seconds, position);
-      }
-      function closeRange() {
-        if (rangeStart === null) return;
-        const end = Number(player.currentTime() || rangeStart);
-        if (end >= rangeStart) value.played_ranges.push({ start_seconds: rangeStart, end_seconds: end });
-        rangeStart = null;
-      }
-      handlers.play = () => { lastWall = performance.now(); };
-      handlers.playing = () => { tick(); playing = true; rangeStart ??= Number(player.currentTime() || 0); };
-      handlers.waiting = () => { tick(); playing = false; closeRange(); };
-      handlers.pause = () => { tick(); playing = false; closeRange(); };
-      handlers.timeupdate = tick;
-      handlers.seeking = () => { tick(); closeRange(); };
-      handlers.seeked = () => { value.seek_destinations_seconds.push(Number(player.currentTime() || 0)); if (playing) rangeStart = Number(player.currentTime() || 0); };
-      handlers.ended = () => finishTracker(true);
-      Object.entries(handlers).forEach(([event, handler]) => player.on(event, handler));
-      tracker = {
-        value,
-        tick,
-        closeRange,
-        detach: () => Object.entries(handlers).forEach(([event, handler]) => player.off(event, handler)),
-      };
-      if (!player.paused()) handlers.playing();
+    let origin = null;
+    try {
+      origin = JSON.parse(sessionStorage.getItem(ORIGIN_KEY) || "null");
+    } catch (_) {}
+    if (origin?.scene_id !== sceneId) origin = null;
+    if (origin) sessionStorage.removeItem(ORIGIN_KEY);
+    const value = {
+      session_id: uuid(),
+      scene_id: sceneId,
+      started_at_ms: Date.now(),
+      active_seconds: 0,
+      origin: origin ? "curator" : "stash",
+      source_route: pathname,
+      start_position_seconds: 0,
+      maximum_position_seconds: 0,
+      final_position_seconds: 0,
+      played_ranges: [],
+      seek_destinations_seconds: [],
+      ...(origin || {}),
+    };
+    let media = null;
+    let playing = false;
+    let positioned = false;
+    let lastWall = performance.now();
+    let rangeStart = null;
+    function position() {
+      return Number(media?.currentTime || 0);
     }
-    setTimeout(findPlayer, 250);
+    function tick() {
+      const now = performance.now();
+      if (playing) value.active_seconds += Math.min(5, Math.max(0, (now - lastWall) / 1000));
+      lastWall = now;
+      // A replaced or removed element reports nothing; keep the last position we did observe.
+      if (!media) return;
+      const current = position();
+      // Stash resumes part-way into a scene, so the opening position is only known once the
+      // media reports one. Until then a zero would understate everything watched before it.
+      if (!positioned && current > 0) {
+        positioned = true;
+        value.start_position_seconds = current;
+      }
+      value.final_position_seconds = current;
+      value.maximum_position_seconds = Math.max(value.maximum_position_seconds, current);
+    }
+    function closeRange() {
+      if (rangeStart === null) return;
+      const end = Math.max(rangeStart, position());
+      value.played_ranges.push({ start_seconds: rangeStart, end_seconds: end });
+      rangeStart = null;
+    }
+    const handlers = {
+      play: () => { lastWall = performance.now(); },
+      playing: () => { tick(); playing = true; rangeStart ??= position(); },
+      waiting: () => { tick(); playing = false; closeRange(); },
+      pause: () => { tick(); playing = false; closeRange(); },
+      timeupdate: tick,
+      seeking: () => { tick(); closeRange(); },
+      seeked: () => { value.seek_destinations_seconds.push(position()); if (playing) rangeStart = position(); },
+      ended: () => finishTracker(true),
+    };
+    function unbind() {
+      if (!media) return;
+      Object.entries(handlers).forEach(([event, handler]) => media.removeEventListener(event, handler));
+      media = null;
+    }
+    function bind(element) {
+      if (media === element) return;
+      tick();
+      closeRange();
+      playing = false;
+      unbind();
+      media = element;
+      Object.entries(handlers).forEach(([event, handler]) => media.addEventListener(event, handler));
+      if (!media.paused) handlers.playing();
+      else tick();
+    }
+    // Playback can begin long after navigation, and the element can be replaced mid-scene.
+    const watch = setInterval(() => {
+      if (location.pathname !== pathname) return;
+      const element = mediaElement();
+      if (element && element.isConnected) bind(element);
+      else if (media && !media.isConnected) { tick(); closeRange(); playing = false; unbind(); }
+    }, 500);
+    tracker = {
+      value,
+      tick,
+      closeRange,
+      detach: () => {
+        clearInterval(watch);
+        unbind();
+      },
+    };
+    const element = mediaElement();
+    if (element?.isConnected) bind(element);
   }
 
   Api.register.route("/plugins/stash-curator", CuratorPage);

--- a/tests/integration/test_sync.py
+++ b/tests/integration/test_sync.py
@@ -74,6 +74,12 @@ def _scene(identifier: str, performer: str, tag: str, studio: str) -> dict[str, 
     }
 
 
+def _last_play(scene: Mapping[str, object]) -> str:
+    history = scene.get("play_history")
+    assert isinstance(history, list)
+    return max((str(item) for item in history), default="")
+
+
 class SyntheticClient:
     def __init__(
         self,
@@ -85,6 +91,7 @@ class SyntheticClient:
         self.fail_once = fail_once
         self.failed = False
         self.calls: list[tuple[str, int | None]] = []
+        self.variables: list[tuple[str, dict[str, object]]] = []
 
     def execute(
         self, document: str, variables: Mapping[str, object] | None = None
@@ -125,11 +132,17 @@ class SyntheticClient:
                 "tagType": {
                     "fields": [{"name": name} for name in ("id", "updated_at", "stash_ids")]
                 },
+                "sceneFilterType": {
+                    "inputFields": [
+                        {"name": name} for name in ("play_count", "last_played_at", "updated_at")
+                    ]
+                },
             }
         names = {
             "CuratorTags": ("tag", "findTags", "tags"),
             "CuratorStudios": ("studio", "findStudios", "studios"),
             "CuratorPerformers": ("performer", "findPerformers", "performers"),
+            "CuratorScenePlays": ("scene_play", "findScenes", "scenes"),
             "CuratorScenes": ("scene", "findScenes", "scenes"),
         }
         entity_type, root, collection = next(
@@ -143,12 +156,39 @@ class SyntheticClient:
         page = page_value
         per_page = per_page_value
         self.calls.append((entity_type, page))
+        self.variables.append((entity_type, dict(variables)))
         if self.fail_once == (entity_type, page) and not self.failed:
             self.failed = True
             raise RuntimeError("synthetic interruption")
-        all_items = self.entities[entity_type]
+        all_items = (
+            self._played_scenes(variables.get("sceneFilter"))
+            if entity_type == "scene_play"
+            else self._ordered(self.entities[entity_type], variables)
+        )
         start = (page - 1) * per_page
         return {root: {"count": len(all_items), collection: all_items[start : start + per_page]}}
+
+    @staticmethod
+    def _ordered(
+        items: list[dict[str, object]], variables: Mapping[str, object]
+    ) -> list[dict[str, object]]:
+        key = str(variables["sort"])
+        return sorted(
+            items, key=lambda item: str(item[key]), reverse=variables["direction"] == "DESC"
+        )
+
+    def _played_scenes(self, scene_filter: object) -> list[dict[str, object]]:
+        """Mimic Stash: played scenes only, newest play first, honoring last_played_at."""
+        assert isinstance(scene_filter, Mapping)
+        assert scene_filter["play_count"] == {"value": 0, "modifier": "GREATER_THAN"}
+        played = scene_filter.get("last_played_at")
+        since = str(played["value"]) if isinstance(played, Mapping) else None
+        selected = [
+            scene
+            for scene in self.entities["scene"]
+            if _last_play(scene) and (since is None or str(_last_play(scene)) > since)
+        ]
+        return sorted(selected, key=_last_play, reverse=True)
 
 
 @pytest.fixture
@@ -192,8 +232,77 @@ def test_sync_reports_page_progress(connection: sqlite3.Connection) -> None:
         progress=lambda *update: updates.append(update),
     ).sync()
 
-    assert updates[-1] == ("scene", 2, 2, 3, 4)
-    assert ("tag", 1, 2, 0, 4) in updates
+    assert updates[-1] == ("scene_play", 2, 2, 4, 5)
+    assert ("tag", 1, 2, 0, 5) in updates
+
+
+def test_incremental_sync_imports_plays_without_an_updated_at_change(
+    connection: sqlite3.Connection,
+) -> None:
+    entities = _entities()
+    client = SyntheticClient(entities)
+    # One scene per page, so the updated_at pass stops at its watermark before reaching scene 1.
+    service = SyncService(client, SyncRepository(connection), page_size=1)
+    service.sync()
+
+    # Stash records a play without touching scenes.updated_at.
+    scene = entities["scene"][0]
+    history = scene["play_history"]
+    assert isinstance(history, list)
+    history.append("2026-02-01T09:30:00Z")
+    scene["play_count"] = 2
+    client.calls.clear()
+
+    result = service.sync()
+    assert ("scene", 2) not in client.calls
+
+    played = connection.execute(
+        "SELECT played_at_ms FROM source_play WHERE scene_id='1' ORDER BY ordinal"
+    ).fetchall()
+    assert len(played) == 2
+    assert (
+        connection.execute("SELECT play_count FROM source_scene WHERE scene_id='1'").fetchone()[0]
+        == 2
+    )
+    assert "1" in result.scene_ids
+    assert result.changed_entity_counts["scene"] == 0
+    assert result.changed_entity_counts["scene_play"] == 1
+
+
+def test_play_pass_resumes_from_its_own_watermark(connection: sqlite3.Connection) -> None:
+    client = SyntheticClient(_entities())
+    service = SyncService(client, SyncRepository(connection), page_size=10)
+    service.sync()
+    client.variables.clear()
+    service.sync()
+
+    filters = [
+        variables["sceneFilter"]
+        for entity_type, variables in client.variables
+        if entity_type == "scene_play"
+    ]
+    assert filters == [
+        {
+            "play_count": {"value": 0, "modifier": "GREATER_THAN"},
+            "last_played_at": {"value": "2026-01-01T12:00:00Z", "modifier": "GREATER_THAN"},
+        }
+    ]
+    assert (
+        connection.execute(
+            "SELECT watermark FROM sync_cursor WHERE entity_type='scene_play'"
+        ).fetchone()[0]
+        == "2026-01-01T12:00:00Z"
+    )
+
+
+def test_full_sync_skips_the_play_pass(connection: sqlite3.Connection) -> None:
+    client = SyntheticClient(_entities())
+    SyncService(client, SyncRepository(connection), page_size=10).sync(full=True)
+
+    assert not [entity_type for entity_type, _ in client.calls if entity_type == "scene_play"]
+    assert (
+        connection.execute("SELECT count(*) FROM source_play WHERE scene_id='1'").fetchone()[0] == 1
+    )
 
 
 def test_full_sync_resumes_at_transactionally_saved_page(

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -103,6 +103,18 @@ def test_plugin_archive_contains_runtime_and_core(tmp_path: Path) -> None:
         assert connection.execute("SELECT last_error FROM model_update_state").fetchone()[0]
 
 
+def test_playback_capture_binds_the_media_element_and_rebinds_when_replaced() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
+
+    # A Video.js wrapper resolved once goes stale when Stash rebuilds the player, which
+    # silently produced sessions with no observed playback.
+    assert "media.addEventListener(event, handler)" in source
+    assert "media.removeEventListener(event, handler)" in source
+    assert "player.on(event, handler)" not in source
+    assert "element.isConnected" in source
+    assert "!media.isConnected" in source
+
+
 def test_backup_management_uses_recognized_ids_and_explicit_confirmation() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
 

--- a/tests/ranking/test_slate.py
+++ b/tests/ranking/test_slate.py
@@ -459,6 +459,95 @@ def test_direct_play_updates_prebuilt_lanes_without_rebuilding(
     assert not any(item.scene_id == "d-revisit" for item in builder.recommend("revisit", 5).items)
 
 
+_UNOBSERVED_SUMMARY = (
+    '{"played_ranges":[],"start_position_seconds":0.0,"maximum_position_seconds":0.0}'
+)
+
+
+def _play_session(
+    connection: sqlite3.Connection,
+    session_id: str,
+    scene_id: str,
+    ended_at_ms: int,
+    *,
+    active_seconds: float,
+    summary_json: str,
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO play_session(
+            session_id, scene_id, started_at_ms, ended_at_ms, active_seconds,
+            provenance, confidence, summary_json
+        ) VALUES (?, ?, ?, ?, ?, 'direct_player', 1, ?)
+        """,
+        (
+            session_id,
+            scene_id,
+            max(0, ended_at_ms - 1_000),
+            ended_at_ms,
+            active_seconds,
+            summary_json,
+        ),
+    )
+
+
+def test_session_without_observed_playback_does_not_suppress_best_bets(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    builder = SlateBuilder(connection)
+    now_ms = 100 * 86_400_000
+    monkeypatch.setattr("curator.ranking.slate.time.time_ns", lambda: now_ms * 1_000_000)
+    builder.prepare("model")
+    _play_session(
+        connection,
+        "opened-only",
+        "a-best",
+        now_ms,
+        active_seconds=0.0,
+        summary_json=_UNOBSERVED_SUMMARY,
+    )
+
+    assert builder.recommend("best_bets", 1).items[0].scene_id == "a-best"
+
+    _play_session(
+        connection,
+        "watched",
+        "a-best",
+        now_ms,
+        active_seconds=0.0,
+        summary_json='{"played_ranges":[],"start_position_seconds":0.0,'
+        '"maximum_position_seconds":42.0}',
+    )
+
+    assert builder.recommend("best_bets", 1).items[0].scene_id != "a-best"
+
+
+def test_lane_classification_uses_plays_captured_since_the_last_sync(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    _play_session(
+        connection,
+        "watched",
+        "a-best",
+        2,
+        active_seconds=120.0,
+        summary_json=_UNOBSERVED_SUMMARY,
+    )
+    _play_session(
+        connection,
+        "opened-only",
+        "b-best",
+        2,
+        active_seconds=0.0,
+        summary_json=_UNOBSERVED_SUMMARY,
+    )
+
+    lanes = {(item.scene_id, item.lane) for item in LanePolicy(connection).classify("model")}
+
+    assert ("a-best", "best_bets") not in lanes
+    assert ("b-best", "best_bets") in lanes
+
+
 def test_greedy_slate_enforces_adjacency_and_soft_penalties_only_reorder(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     builder = SlateBuilder(connection)

--- a/tests/storage/test_cli_db.py
+++ b/tests/storage/test_cli_db.py
@@ -15,7 +15,7 @@ def test_database_cli_migrate_status_and_backup(
 
     assert run(["--db", str(database), "db", "migrate", "--json"]) == 0
     migrated = json.loads(capsys.readouterr().out)
-    assert migrated["current_version"] == migrated["latest_version"] == 19
+    assert migrated["current_version"] == migrated["latest_version"] == 20
 
     assert run(["--db", str(database), "db", "status", "--json"]) == 0
     status = json.loads(capsys.readouterr().out)

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -31,10 +31,11 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
             17,
             18,
             19,
+            20,
         )
 
         after = runner.migrate(applied_at_ms=1234)
-        assert after.current_version == 19
+        assert after.current_version == 20
         assert after.pending_versions == ()
         assert runner.migrate(applied_at_ms=5678) == after
 
@@ -89,7 +90,7 @@ def test_feature_count_migration_backfills_existing_builds(tmp_path: Path) -> No
     connection = connect_database(tmp_path / "curator.sqlite3")
     runner = MigrationRunner(connection)
     original = runner.migrations
-    runner.migrations = original[:-2]
+    runner.migrations = original[:-3]
     runner.migrate(applied_at_ms=1)
     connection.execute(
         """
@@ -126,6 +127,45 @@ def test_feature_count_migration_backfills_existing_builds(tmp_path: Path) -> No
     ) == (1, 0, 1)
 
 
+def test_unobserved_penalty_migration_keeps_graded_evidence(tmp_path: Path) -> None:
+    connection = connect_database(tmp_path / "curator.sqlite3")
+    runner = MigrationRunner(connection)
+    original = runner.migrations
+    runner.migrations = original[:-1]
+    runner.migrate(applied_at_ms=1)
+    sessions = (
+        ("empty", "opened", 0.0, '{"played_ranges":[],"maximum_position_seconds":0.0}'),
+        ("watched", "played", 120.0, '{"played_ranges":[],"maximum_position_seconds":120.0}'),
+    )
+    for session_id, scene_id, active_seconds, summary in sessions:
+        connection.execute(
+            """
+            INSERT INTO play_session(
+                session_id, scene_id, started_at_ms, ended_at_ms, active_seconds,
+                provenance, confidence, summary_json
+            ) VALUES (?, ?, 0, 1000, ?, 'direct_player', 1, ?)
+            """,
+            (session_id, scene_id, active_seconds, summary),
+        )
+        connection.execute(
+            """
+            INSERT INTO behavior_event(
+                event_id, event_type, scene_id, occurred_at_ms, outcome, confidence,
+                provenance, session_id
+            ) VALUES (?, 'occasion_outcome', ?, 1000, -0.1, 0.8, 'direct_player', ?)
+            """,
+            (f"{session_id}:view", scene_id, session_id),
+        )
+
+    runner.migrations = original
+    runner.migrate(applied_at_ms=2)
+
+    assert [
+        str(row[0])
+        for row in connection.execute("SELECT scene_id FROM behavior_event ORDER BY scene_id")
+    ] == ["played"]
+
+
 def test_unknown_future_migration_is_rejected(tmp_path: Path) -> None:
     connection = connect_database(tmp_path / "curator.sqlite3")
     try:
@@ -151,7 +191,7 @@ def test_status_stays_read_only_after_migrations(tmp_path: Path) -> None:
     reader.execute("PRAGMA busy_timeout=1")
     try:
         writer.execute("BEGIN IMMEDIATE")
-        assert MigrationRunner(reader).status().current_version == 19
+        assert MigrationRunner(reader).status().current_version == 20
     finally:
         writer.rollback()
         reader.close()
@@ -177,7 +217,7 @@ def test_stale_concurrent_migrator_rechecks_after_writer_lock(
 
     monkeypatch.setattr(second_runner, "status", status)
     try:
-        assert second_runner.migrate(applied_at_ms=2).current_version == 19
+        assert second_runner.migrate(applied_at_ms=2).current_version == 20
     finally:
         second.close()
         first.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_doctor_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
     assert result["status"] == "ok"
     assert result["stash"] == "not_configured"
     assert result["schema_current"] == 0
-    assert result["schema_latest"] == 19
+    assert result["schema_latest"] == 20
 
 
 def test_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -123,6 +123,81 @@ def test_direct_sessions_record_views_and_quick_replacement(tmp_path: Path) -> N
     assert not any('"primary_signal":"quick_replacement"' in item for item in signals)
 
 
+def test_session_without_observed_playback_records_no_view_evidence(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    store = InteractionStore(connection)
+    unobserved = {
+        "session_id": "opened-only",
+        "scene_id": "watched-elsewhere",
+        "started_at_ms": 1_000,
+        "ended_at_ms": 31_000,
+        "active_seconds": 0,
+        "origin": "stash",
+        "source_route": "/scenes/watched-elsewhere",
+        "start_position_seconds": 0,
+        "maximum_position_seconds": 0,
+        "final_position_seconds": 0,
+    }
+
+    assert store.submit_sessions([unobserved]) == 1
+
+    assert (
+        connection.execute(
+            "SELECT count(*) FROM play_session WHERE scene_id='watched-elsewhere'"
+        ).fetchone()[0]
+        == 1
+    )
+    assert (
+        connection.execute(
+            "SELECT count(*) FROM behavior_event WHERE scene_id='watched-elsewhere'"
+        ).fetchone()[0]
+        == 0
+    )
+
+
+def test_unobserved_session_is_never_graded_as_abandoned(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    store = InteractionStore(connection)
+    connection.execute(
+        """
+        INSERT INTO impression(impression_id, requested_at_ms, lane, model_id, config_version)
+        VALUES ('impression', 1, 'best_bets', NULL, 'config')
+        """
+    )
+    curator_choice = {
+        "session_id": "curator-choice",
+        "scene_id": "chosen",
+        "started_at_ms": 1_000,
+        "ended_at_ms": 31_000,
+        "active_seconds": 0,
+        "origin": "curator",
+        "impression_id": "impression",
+        "source_route": "/plugins/stash-curator",
+        "start_position_seconds": 0,
+        "maximum_position_seconds": 0,
+        "final_position_seconds": 0,
+    }
+    replacement = {
+        **curator_choice,
+        "session_id": "replacement",
+        "scene_id": "next-scene",
+        "started_at_ms": 60_000,
+        "ended_at_ms": 180_000,
+        "active_seconds": 120,
+        "maximum_position_seconds": 120,
+        "final_position_seconds": 120,
+    }
+
+    assert store.submit_sessions([curator_choice, replacement]) == 2
+
+    assert (
+        connection.execute(
+            "SELECT count(*) FROM behavior_event WHERE scene_id='chosen'"
+        ).fetchone()[0]
+        == 0
+    )
+
+
 def test_never_show_and_pruning_apply_operational_state(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     store = InteractionStore(connection)


### PR DESCRIPTION
Watched scenes kept coming back in Best Bets. The lane was a symptom: Curator had no record of the plays at all.

## Root causes

**Stash does not touch `scenes.updated_at` when it records a play.** The incremental sync pages `findScenes` sorted by `updated_at` and stops at its watermark, so a play alone could never make a scene eligible for re-fetch. Curator's newest imported play was five days stale, and five scenes had plays it had never seen. Only a full sync could recover them, and none had ever run on the live instance.

**The browser tracker resolved a Video.js wrapper through `getPlayer()`**, which is a registry lookup by id that goes stale when Stash rebuilds the player. Sixteen of the last seventeen sessions recorded zero active seconds — and each was graded as a short exit, penalizing scenes the user may have watched in full. Capture had been silently dead since 19 July.

## Changes

- **`scene_play` sync pass** on its own `last_played_at` watermark, filtered to `play_count > 0`. First run sweeps the played set once and repairs the gap; later runs cost one query. `EntityOperation` now carries `sort`, `watermark_of`, `variables_for`, and `incremental_only`, leaving the four existing passes unchanged. The capability probe requires `last_played_at` so an incompatible server fails loudly rather than going blind.
- **Media-element playback capture.** Binds the `<video>` element and re-binds when it is replaced or disconnected, so a swapped player cannot produce a silent empty session. Start position is captured when the media first reports one, which resumed scenes need.
- **Observed playback required for grading.** A session that observed nothing records the navigation without inventing viewing evidence, and cannot be judged as abandoned by the quick-replacement rule. Defined once as `DirectSessionInput.observed_playback` / `OBSERVED_PLAYBACK_SQL`.
- **Lane classification consults plays**, unioning `source_play` with observed sessions instead of depending on sync timing.
- **Migration 0020** removes the penalties the broken tracker already wrote.

The watermark derives from `max(play_history_ms)` rather than a new `Scene` field on purpose: adding a field would change every `source_hash` and mark all 23,902 scenes changed on the next sync.

## Verification

`scripts/verify full` passes (229 tests). New regression tests cover the play pass (including full-mode skip and watermark reuse), suppression through both the materialized and prepared-slate paths, unobserved-session grading, and the migration.

Verified against the live instance:

```
first run : scene_play 34 changed — all 5 missing plays imported
second run: scene_play 0 changed, watermark 2026-08-03T20:56:30Z
real watch: active 24.2s, positions 0.05 → 2250.2, 4 played ranges, 3 seeks
empty session: no behavior_event written
```

## Known gap

A scene that gains an O with no new play is still invisible — Stash exposes no `last_o_at` filter. O history rides along whenever a play accompanies it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)