### PR TITLE
Reuse library links and profile work in Expand

### DIFF
--- a/curator/expand.py
+++ b/curator/expand.py
@@ -10,13 +10,20 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from contextvars import copy_context
+from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Any
 
 from curator.config import DEFAULT_CONFIG
 from curator.features import FeatureStore, PerformerProfile, performer_similarity
 from curator.features.measurements import CUP_ALIASES, augmentation_category
-from curator.features.profiles import ProfileValue
+from curator.features.profiles import (
+    ProfileValue,
+    block_similarities,
+    block_similarity,
+    combine_similarities,
+    similarity_penalty,
+)
 from curator.features.profiles import SimilarityResult as ProfileSimilarityResult
 from curator.graphql import GraphQLClient
 from curator.model import ModelUpdateCoordinator, RecommendationModelStore
@@ -72,6 +79,97 @@ def normalize_phash(value: object) -> str | None:
     except ValueError:
         return None
     return normalized
+
+
+@dataclass(frozen=True)
+class _AnchorTerms:
+    """One anchor comparison with everything that does not vary by scene already measured."""
+
+    anchor: PerformerProfile
+    evidence: dict[str, Any]
+    similarities: dict[str, float]
+    weights: dict[str, float]
+    numerator: float
+    denominator: float
+    penalty: float
+
+
+class _AnchorMatcher:
+    """Match external performers against local anchors, reusing work across their scenes.
+
+    A performer appears in many of the scenes a hunt returns, and only their age at recording
+    differs between those appearances. Measuring every block for every appearance repeats the
+    same comparisons hundreds of times, so the scene-independent blocks are measured once per
+    performer and combined with a fresh age term for each scene.
+    """
+
+    def __init__(
+        self,
+        anchors: list[tuple[PerformerProfile, dict[str, Any]]],
+        weights: dict[str, float],
+    ) -> None:
+        self.anchors = anchors
+        self.weights = weights
+        self.age_weight = weights.get("age", 0.0)
+        self.relevant = sum(value for key, value in weights.items() if key != "content")
+        self._terms: dict[str, tuple[_AnchorTerms, ...]] = {}
+
+    def _timeless(self, performer: dict[str, Any]) -> tuple[_AnchorTerms, ...]:
+        external_id = str(performer["id"])
+        cached = self._terms.get(external_id)
+        if cached is not None:
+            return cached
+        profile = ExpandService._profile(performer)
+        undated = PerformerProfile(
+            profile.performer_id,
+            {block: values for block, values in profile.blocks.items() if block != "age"},
+        )
+        terms = []
+        for anchor, evidence in self.anchors:
+            similarities, used = block_similarities(undated, anchor, self.weights)
+            terms.append(
+                _AnchorTerms(
+                    anchor,
+                    evidence,
+                    similarities,
+                    used,
+                    sum(similarities[block] * used[block] for block in similarities),
+                    sum(used.values()),
+                    similarity_penalty(undated, anchor),
+                )
+            )
+        self._terms[external_id] = tuple(terms)
+        return self._terms[external_id]
+
+    def best(
+        self, performer: dict[str, Any], recorded: object
+    ) -> tuple[float, ProfileSimilarityResult, float, dict[str, Any]] | None:
+        terms = self._timeless(performer)
+        if not terms:
+            return None
+        profile = ExpandService._profile(performer, recorded)
+        chosen: _AnchorTerms | None = None
+        chosen_age: float | None = None
+        best_value = -1.0
+        for term in terms:
+            age = block_similarity(profile, term.anchor, "age") if self.age_weight > 0 else None
+            numerator = term.numerator + (age * self.age_weight if age is not None else 0.0)
+            denominator = term.denominator + (self.age_weight if age is not None else 0.0)
+            similarity = (numerator / denominator if denominator else 0.0) * term.penalty
+            coverage = min(1.0, denominator / self.relevant) if self.relevant else 0.0
+            value = similarity * math.sqrt(coverage)
+            if value > best_value:
+                best_value, chosen, chosen_age = value, term, age
+        if chosen is None:
+            return None
+        similarities = dict(chosen.similarities)
+        weights = dict(chosen.weights)
+        if chosen_age is not None:
+            similarities["age"] = chosen_age
+            weights["age"] = self.age_weight
+        result = combine_similarities(profile, chosen.anchor, similarities, weights)
+        coverage = min(1.0, sum(weights.values()) / self.relevant) if self.relevant else 0.0
+        return result.similarity * math.sqrt(coverage), result, coverage, chosen.evidence
 
 
 class ExpandService:
@@ -1336,6 +1434,7 @@ class ExpandService:
             (profiles[key], item) for key, item in evidence_by_local.items() if key in profiles
         ]
         weights = dict(DEFAULT_CONFIG.feature.performer_block_weights)
+        matcher = _AnchorMatcher(anchors, weights)
         performer_rows: dict[str, dict[str, Any]] = {}
         scene_rows = []
         for scene in scenes:
@@ -1362,18 +1461,14 @@ class ExpandService:
             for performer in cast:
                 external_id = str(performer["id"])
                 local = evidence.get(external_id)
-                profile = self._profile(
-                    performer, scene.get("production_date") or scene.get("release_date")
-                )
-                matches = (
-                    [
-                        (*self._profile_match(profile, anchor, weights), anchor_evidence)
-                        for anchor, anchor_evidence in anchors
-                    ]
+                match = (
+                    matcher.best(
+                        performer,
+                        scene.get("production_date") or scene.get("release_date"),
+                    )
                     if local is None
-                    else []
+                    else None
                 )
-                match = max(matches, key=lambda item: item[0]) if matches else None
                 strength = float(match[3].get("strength", 0)) if match else 0.0
                 similarity_value = max(
                     similarity_value, (match[0] if match else 0.0) * strength * cast_weight

--- a/curator/features/profiles.py
+++ b/curator/features/profiles.py
@@ -82,40 +82,73 @@ def _numeric(left: dict[str, ProfileValue], right: dict[str, ProfileValue]) -> f
     return sum(values) / len(values)
 
 
-def performer_similarity(
+def block_similarity(
+    left: PerformerProfile,
+    right: PerformerProfile,
+    block: str,
+) -> float | None:
+    """Compare one shared block, or return None when it carries no usable evidence."""
+    if block not in left.blocks or block not in right.blocks:
+        return None
+    if block in NUMERIC_BLOCKS:
+        return _numeric(left.blocks[block], right.blocks[block])
+    return _cosine(left.blocks[block], right.blocks[block], left.norms[block], right.norms[block])
+
+
+def block_similarities(
     left: PerformerProfile,
     right: PerformerProfile,
     block_weights: dict[str, float],
-) -> SimilarityResult:
+) -> tuple[dict[str, float], dict[str, float]]:
+    """Per-block similarities and the weights they were measured with."""
     similarities: dict[str, float] = {}
     used_weights: dict[str, float] = {}
     for block in sorted(set(left.blocks) & set(right.blocks)):
         weight = block_weights.get(block, 0.0)
         if weight <= 0:
             continue
-        similarity = (
-            _numeric(left.blocks[block], right.blocks[block])
-            if block in NUMERIC_BLOCKS
-            else _cosine(
-                left.blocks[block], right.blocks[block], left.norms[block], right.norms[block]
-            )
-        )
+        similarity = block_similarity(left, right, block)
         if similarity is None:
             continue
         similarities[block] = similarity
         used_weights[block] = weight
+    return similarities, used_weights
+
+
+def similarity_penalty(left: PerformerProfile, right: PerformerProfile) -> float:
+    """Scale contradicting body evidence down; depends on no block that varies by scene."""
+    penalty = 1.0
+    left_cup = left.blocks.get("measurements", {}).get("cup_index")
+    right_cup = right.blocks.get("measurements", {}).get("cup_index")
+    if left_cup and right_cup:
+        penalty *= math.exp(-0.18 * max(0.0, abs(left_cup.value - right_cup.value) - 1))
+    left_aug = set(left.blocks.get("augmentation", {}))
+    right_aug = set(right.blocks.get("augmentation", {}))
+    if left_aug and right_aug and not left_aug & right_aug:
+        penalty *= 0.65
+    return penalty
+
+
+def combine_similarities(
+    left: PerformerProfile,
+    right: PerformerProfile,
+    similarities: dict[str, float],
+    used_weights: dict[str, float],
+) -> SimilarityResult:
+    """Weight measured blocks into one score, so callers can reuse per-block work."""
     denominator = sum(used_weights.values())
     total = (
         sum(similarities[block] * used_weights[block] for block in similarities) / denominator
         if denominator
         else 0.0
     )
-    left_cup = left.blocks.get("measurements", {}).get("cup_index")
-    right_cup = right.blocks.get("measurements", {}).get("cup_index")
-    if left_cup and right_cup:
-        total *= math.exp(-0.18 * max(0.0, abs(left_cup.value - right_cup.value) - 1))
-    left_aug = set(left.blocks.get("augmentation", {}))
-    right_aug = set(right.blocks.get("augmentation", {}))
-    if left_aug and right_aug and not left_aug & right_aug:
-        total *= 0.65
-    return SimilarityResult(total, similarities, used_weights)
+    return SimilarityResult(total * similarity_penalty(left, right), similarities, used_weights)
+
+
+def performer_similarity(
+    left: PerformerProfile,
+    right: PerformerProfile,
+    block_weights: dict[str, float],
+) -> SimilarityResult:
+    similarities, used_weights = block_similarities(left, right, block_weights)
+    return combine_similarities(left, right, similarities, used_weights)

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import re
+import sqlite3
 import sys
 import time
 from collections.abc import Callable
@@ -95,6 +96,26 @@ query CuratorExternalLinks($page: Int!, $perPage: Int!) {
   ) { count studios { id stash_ids { endpoint stash_id } } }
 }
 """
+EXTERNAL_LINKS_STATE_QUERY = """
+query CuratorExternalLinksState {
+  scenes: findScenes(
+    scene_filter: {stash_id_endpoint: {endpoint: "https://stashdb.org/graphql", modifier: NOT_NULL}}
+    filter: {page: 1, per_page: 1, sort: "updated_at", direction: DESC}
+  ) { count scenes { updated_at } }
+  performers: findPerformers(
+    performer_filter: {stash_id_endpoint: {
+      endpoint: "https://stashdb.org/graphql", modifier: NOT_NULL
+    }}
+    filter: {page: 1, per_page: 1, sort: "updated_at", direction: DESC}
+  ) { count performers { updated_at } }
+  studios: findStudios(
+    studio_filter: {stash_id_endpoint: {
+      endpoint: "https://stashdb.org/graphql", modifier: NOT_NULL
+    }}
+    filter: {page: 1, per_page: 1, sort: "updated_at", direction: DESC}
+  ) { count studios { updated_at } }
+}
+"""
 FIND_PRUNE_TAG = """
 query CuratorFindPruneTag($name: String!) {
   findTags(filter: {q: $name, per_page: 20}) { tags { id name } }
@@ -163,7 +184,59 @@ def _stashdb(payload: dict[str, Any]) -> GraphQLClient:
     )
 
 
-def _external_links(payload: dict[str, Any]) -> dict[str, dict[str, str]]:
+EXTERNAL_LINKS_CACHE_KEY = "external_links"
+
+
+def _external_links_state(payload: dict[str, Any]) -> str:
+    """Cheap description of the linked library, so the full scan can be skipped."""
+    data = _client(payload).execute(EXTERNAL_LINKS_STATE_QUERY)
+    return json.dumps(
+        {
+            kind: [
+                int(data[kind]["count"]),
+                str((data[kind][kind][:1] or [{}])[0].get("updated_at") or ""),
+            ]
+            for kind in ("scenes", "performers", "studios")
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def _cached_external_links(
+    connection: sqlite3.Connection, state: str
+) -> dict[str, dict[str, str]] | None:
+    row = connection.execute(
+        "SELECT value FROM application_meta WHERE key=?", (EXTERNAL_LINKS_CACHE_KEY,)
+    ).fetchone()
+    if row is None:
+        return None
+    try:
+        payload = json.loads(str(row[0]))
+    except json.JSONDecodeError:
+        return None
+    if payload.get("state") != state:
+        return None
+    links = payload.get("links")
+    return links if isinstance(links, dict) else None
+
+
+def _external_links(
+    payload: dict[str, Any],
+    connection: sqlite3.Connection | None = None,
+    *,
+    refresh: bool = False,
+) -> dict[str, dict[str, str]]:
+    """Map local entities to their StashDB ids, reusing the last scan while Stash is unchanged.
+
+    Rebuilding this walks every linked scene for its fingerprints, which dominates the cost of
+    the operations that need it, so it is kept until Stash reports a different library.
+    """
+    state = _external_links_state(payload) if connection is not None else ""
+    if connection is not None and not refresh:
+        cached = _cached_external_links(connection, state)
+        if cached is not None:
+            return cached
     result: dict[str, dict[str, str]] = {
         "scenes": {},
         "scene_ids": {},
@@ -200,8 +273,21 @@ def _external_links(payload: dict[str, Any]) -> dict[str, dict[str, str]]:
                                     result["scene_phashes"].setdefault(value, str(row["id"]))
             more |= page * 500 < int(collection["count"])
         if not more:
-            return result
+            break
         page += 1
+    if connection is not None:
+        with transaction(connection):
+            connection.execute(
+                """
+                INSERT INTO application_meta(key, value) VALUES (?, ?)
+                ON CONFLICT(key) DO UPDATE SET value=excluded.value
+                """,
+                (
+                    EXTERNAL_LINKS_CACHE_KEY,
+                    json.dumps({"state": state, "links": result}, separators=(",", ":")),
+                ),
+            )
+    return result
 
 
 def _settings(payload: dict[str, Any]) -> dict[str, Any]:
@@ -628,7 +714,7 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
         if operation == "get_performer_hunt":
             return ExpandService(connection).performer_hunt(
                 _stashdb(payload),
-                _external_links(payload),
+                _external_links(payload, connection),
                 str(args.get("performer_id") or ""),
                 limit=PERFORMER_HUNT_LIMIT,
             )
@@ -644,7 +730,7 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
             assert isinstance(config, dict)
             return ExpandService(connection).targeted_similar(
                 _stashdb(payload),
-                _external_links(payload),
+                _external_links(payload, connection),
                 str(args.get("entity_type") or ""),
                 str(args.get("entity_id") or ""),
                 count=100,
@@ -1249,7 +1335,8 @@ def _run_task_body(
             with span("python", "task.expand_refresh"):
                 summary = ExpandService(connection).refresh(
                     _stashdb(payload),
-                    _external_links(payload),
+                    # The refresh task is the escape hatch when Stash under-reports a change.
+                    _external_links(payload, connection, refresh=True),
                     horizon_days=int(config["expand_horizon_days"]),
                     gender=str(config["expand_gender"]),
                     wildcard=bool(config["expand_wildcard"]),

--- a/tests/features/test_profiles.py
+++ b/tests/features/test_profiles.py
@@ -73,3 +73,65 @@ def test_cosine_norms_are_computed_once(monkeypatch) -> None:
     performer_similarity(profile, profile, WEIGHTS)
 
     assert sqrt.call_count == 1
+
+
+def test_reusing_block_work_matches_measuring_every_block() -> None:
+    """Expand caches the scene-independent blocks; the split must not move the score."""
+    weights = {**WEIGHTS, "age": 0.6, "ethnicity": 0.8}
+    anchor = PerformerProfile(
+        "anchor",
+        {
+            "measurements": {
+                "cup_index": ProfileValue(4, 1),
+                "waist_inches": ProfileValue(25, 1),
+            },
+            "height": {"height_cm": ProfileValue(170, 1)},
+            "ethnicity": {"ethnicity:white": ProfileValue(1, 0.9)},
+            "augmentation": {"augmented": ProfileValue(1, 1)},
+            "age": {"age_recording": ProfileValue(29.5, 0.9)},
+        },
+    )
+    undated_blocks = {
+        "measurements": {"cup_index": ProfileValue(5, 1), "waist_inches": ProfileValue(27, 1)},
+        "height": {"height_cm": ProfileValue(165, 1)},
+        "ethnicity": {"ethnicity:white": ProfileValue(1, 0.9)},
+        "augmentation": {"natural": ProfileValue(1, 1)},
+    }
+    undated = PerformerProfile("candidate", undated_blocks)
+    similarities, used = profiles_module.block_similarities(undated, anchor, weights)
+    numerator = sum(similarities[block] * used[block] for block in similarities)
+    denominator = sum(used.values())
+    penalty = profiles_module.similarity_penalty(undated, anchor)
+
+    for age in (21.0, 29.5, 44.25):
+        dated = PerformerProfile(
+            "candidate", {**undated_blocks, "age": {"age_recording": ProfileValue(age, 0.9)}}
+        )
+        age_similarity = profiles_module.block_similarity(dated, anchor, "age")
+        assert age_similarity is not None
+        reused = (numerator + age_similarity * weights["age"]) / (denominator + weights["age"])
+        direct = performer_similarity(dated, anchor, weights)
+
+        assert reused * penalty == direct.similarity
+        assert (
+            profiles_module.combine_similarities(
+                dated,
+                anchor,
+                {**similarities, "age": age_similarity},
+                {**used, "age": weights["age"]},
+            )
+            == direct
+        )
+
+
+def test_block_work_split_handles_a_missing_age_block() -> None:
+    anchor = PerformerProfile("anchor", {"height": {"height_cm": ProfileValue(170, 1)}})
+    ageless = PerformerProfile("candidate", {"height": {"height_cm": ProfileValue(168, 1)}})
+    similarities, used = profiles_module.block_similarities(
+        ageless, anchor, {**WEIGHTS, "age": 0.6}
+    )
+
+    assert profiles_module.block_similarity(ageless, anchor, "age") is None
+    assert profiles_module.combine_similarities(
+        ageless, anchor, similarities, used
+    ) == performer_similarity(ageless, anchor, {**WEIGHTS, "age": 0.6})

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -868,3 +868,66 @@ def test_backend_profiles_only_when_enabled_and_exposes_profile_api(
         module._api(payload, "clear_profiles", {"profilingEnabled": False})
     payload["args"] = {"database_path": str(database), "confirmation": "CLEAR"}
     assert module._api(payload, "clear_profiles", {"profilingEnabled": False})["deleted"] == 1
+
+
+def test_external_links_reuse_the_last_scan_until_stash_reports_a_change(
+    tmp_path: Path,
+) -> None:
+    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
+    spec = importlib.util.spec_from_file_location("curator_plugin_links", backend)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    connection = module._open({"args": {"database_path": str(tmp_path / "curator.sqlite3")}}, {})
+
+    scanned = 0
+    state = {"count": 1, "updated_at": "2026-01-01T00:00:00Z"}
+
+    class FakeClient:
+        def execute(self, document: str, variables: object = None) -> dict[str, object]:
+            nonlocal scanned
+            if "CuratorExternalLinksState" in document:
+                return {
+                    kind: {"count": state["count"], kind: [{"updated_at": state["updated_at"]}]}
+                    for kind in ("scenes", "performers", "studios")
+                }
+            scanned += 1
+            return {
+                "scenes": {
+                    "count": 1,
+                    "scenes": [
+                        {
+                            "id": "7",
+                            "stash_ids": [
+                                {"endpoint": module.STASHDB, "stash_id": "external-scene"}
+                            ],
+                            "files": [
+                                {"fingerprints": [{"type": "phash", "value": "0123456789abcdef"}]}
+                            ],
+                        }
+                    ],
+                },
+                "performers": {"count": 0, "performers": []},
+                "studios": {"count": 0, "studios": []},
+            }
+
+    module._client = lambda payload: FakeClient()
+    first = module._external_links({}, connection)
+
+    assert scanned == 1
+    assert first["scenes"] == {"7": "external-scene"}
+    assert first["scene_phashes"] == {"0123456789abcdef": "7"}
+
+    assert module._external_links({}, connection) == first
+    assert scanned == 1, "an unchanged library must not be walked again"
+
+    module._external_links({}, connection, refresh=True)
+    assert scanned == 2, "the refresh task must be able to force a rescan"
+
+    state["updated_at"] = "2026-02-02T00:00:00Z"
+    module._external_links({}, connection)
+    assert scanned == 3, "an edited library must invalidate the cache"
+
+    state["count"] = 2
+    module._external_links({}, connection)
+    assert scanned == 4, "an added or deleted link must invalidate the cache"


### PR DESCRIPTION
Performer Hunt timed out for performers with large StashDB catalogues. Measured against the live instance: **146 s** of work against a **60 s** client timeout.

StashDB was the smallest part of it:

| stage | before | after |
|---|---|---|
| local link map | 48–60 s | 14 s cold, **0.1 s warm** |
| StashDB fetch | 4.9 s | unchanged |
| scoring | 15.2 s | **9.2 s** |
| **total** | **146 s** | **24 s cold, 15 s warm** |

## Link map

`_external_links` rebuilt the local↔StashDB id map on every call — 20,594 linked scenes over ~42 requests, pulling `files { fingerprints }` for each to build the phash table — and nothing reused it. It is now kept in `application_meta` next to a cheap description of the linked library (per entity type: count and newest `updated_at`, one small query), and rebuilt only when Stash reports something different. The "Refresh Expand cache" task passes `refresh=True`, so an under-reported change is still recoverable.

No migration: this uses the existing `application_meta` key/value table, which also keeps the ordered-migration numbering free for #40.

## Profile matching

Every unmatched cast member was compared against all ~449 local anchors once per scene it appears in — 393,324 `performer_similarity` calls for one hunt — even though the same performer recurs across many scenes in the same result set.

Only **age at recording** varies between a performer's appearances, so the scene-independent blocks are now measured once per performer and combined with a fresh age term per scene. Rather than duplicate the aggregation, `performer_similarity` is split into `block_similarities` / `similarity_penalty` / `combine_similarities` and composed from them, so the direct path and the reused path share one implementation.

Note this is less than the naive "memoize by performer id" would suggest: that would drop the age term and change results. Measured 1.6× on scoring, not 2.7×, because the per-anchor age term still runs per appearance.

## Verification

`scripts/verify full` passes (223 tests). New tests pin the reuse path to the direct call — including the no-age-block case — and cover cache reuse, forced refresh, and invalidation on both edits and count changes.

Equivalence checked against the live library by scoring all 853 hunted scenes with `main` and with this branch:

```
scenes compared: 853 | identical key set: True
scenes whose score changed: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)