### PR TITLE
Remove scenes deleted from Stash during incremental sync

### DIFF
--- a/curator/graphql/adapters.py
+++ b/curator/graphql/adapters.py
@@ -102,6 +102,12 @@ class EntityPage:
     items: tuple[SourceEntity, ...]
 
 
+@dataclass(frozen=True)
+class IdPage:
+    total: int
+    ids: tuple[str, ...]
+
+
 def _object(value: object, label: str) -> Mapping[str, Any]:
     if not isinstance(value, Mapping):
         raise AdapterError(f"{label} must be an object")
@@ -241,6 +247,17 @@ def adapt_scene(value: object) -> Scene:
         ),
         files=files,
         markers=tuple(markers),
+    )
+
+
+def adapt_id_page(data: Mapping[str, Any], *, root_key: str, items_key: str) -> IdPage:
+    """Adapt one id-only find* response page."""
+    root = _object(data.get(root_key), root_key)
+    count = root.get("count")
+    if not isinstance(count, int):
+        raise AdapterError(f"{root_key}.count must be an integer")
+    return IdPage(
+        count, tuple(_id(item, items_key) for item in _objects(root.get(items_key), items_key))
     )
 
 

--- a/curator/graphql/operations.py
+++ b/curator/graphql/operations.py
@@ -28,6 +28,18 @@ def _played_since(watermark: str | None) -> dict[str, object]:
     return {"sceneFilter": criteria}
 
 
+def _ids_document(name: str, root_key: str, items_key: str) -> str:
+    """An id-only sweep, sorted by id so appends never shift an unread page."""
+    return f"""
+query {name}($page: Int!, $perPage: Int!) {{
+  {root_key}(filter: {{page: $page, per_page: $perPage, sort: "id", direction: ASC}}) {{
+    count
+    {items_key} {{ id }}
+  }}
+}}
+"""
+
+
 @dataclass(frozen=True)
 class EntityOperation:
     """A paginated source entity query and its response keys."""
@@ -41,6 +53,7 @@ class EntityOperation:
     watermark_of: Callable[[SourceEntity], str | None] = field(default=_updated_at)
     variables_for: Callable[[str | None], dict[str, object]] | None = None
     incremental_only: bool = False
+    ids_document: str | None = None
 
 
 CAPABILITIES = """
@@ -70,6 +83,7 @@ query CuratorTags($page: Int!, $perPage: Int!, $sort: String!, $direction: SortD
 """,
     "findTags",
     "tags",
+    ids_document=_ids_document("CuratorTagIds", "findTags", "tags"),
 )
 
 STUDIOS = EntityOperation(
@@ -88,6 +102,7 @@ query CuratorStudios($page: Int!, $perPage: Int!, $sort: String!, $direction: So
 """,
     "findStudios",
     "studios",
+    ids_document=_ids_document("CuratorStudioIds", "findStudios", "studios"),
 )
 
 PERFORMERS = EntityOperation(
@@ -109,6 +124,7 @@ query CuratorPerformers(
 """,
     "findPerformers",
     "performers",
+    ids_document=_ids_document("CuratorPerformerIds", "findPerformers", "performers"),
 )
 
 SCENE_FIELDS = """
@@ -137,6 +153,7 @@ query CuratorScenes($page: Int!, $perPage: Int!, $sort: String!, $direction: Sor
 """,
     "findScenes",
     "scenes",
+    ids_document=_ids_document("CuratorSceneIds", "findScenes", "scenes"),
 )
 
 # Stash does not touch scenes.updated_at when it records a play, so the scene pass above can
@@ -167,4 +184,12 @@ query CuratorScenePlays(
 )
 
 ENTITY_OPERATIONS = (TAGS, STUDIOS, PERFORMERS, SCENES, SCENE_PLAYS)
-ALL_DOCUMENTS = (CAPABILITIES, *(operation.document for operation in ENTITY_OPERATIONS))
+ALL_DOCUMENTS = (
+    CAPABILITIES,
+    *(operation.document for operation in ENTITY_OPERATIONS),
+    *(
+        operation.ids_document
+        for operation in ENTITY_OPERATIONS
+        if operation.ids_document is not None
+    ),
+)

--- a/curator/sync/repository.py
+++ b/curator/sync/repository.py
@@ -17,6 +17,14 @@ def _hash(entity: SourceEntity | SourceFile | Marker) -> str:
     return hashlib.sha256(payload.encode()).hexdigest()
 
 
+ENTITY_TABLES = {
+    "tag": ("source_tag", "tag_id"),
+    "studio": ("source_studio", "studio_id"),
+    "performer": ("source_performer", "performer_id"),
+    "scene": ("source_scene", "scene_id"),
+}
+
+
 def _later(left: str | None, right: str | None) -> str | None:
     values = [value for value in (left, right) if value]
     return max(values, default=None)
@@ -160,55 +168,77 @@ class SyncRepository:
                 (now_ms, entity_type, run_id),
             )
 
+    def entity_count(self, entity_type: str) -> int:
+        table, _ = ENTITY_TABLES[entity_type]
+        row = self.connection.execute(f"SELECT count(*) FROM {table}").fetchone()
+        return int(row[0])
+
+    def delete_absent(self, entity_type: str, present_ids: set[str]) -> tuple[str, ...]:
+        """Remove entities Stash no longer has, given a complete id sweep."""
+        table, column = ENTITY_TABLES[entity_type]
+        with transaction(self.connection):
+            deleted = tuple(
+                sorted(
+                    str(row[0])
+                    for row in self.connection.execute(f"SELECT {column} FROM {table}")
+                    if str(row[0]) not in present_ids
+                )
+            )
+            self._delete_entities(entity_type, deleted)
+        return deleted
+
     def reconcile(self, run_id: str) -> None:
         """Delete only entities absent from a successfully traversed full snapshot."""
         with transaction(self.connection):
-            self.connection.execute(
-                """
-                DELETE FROM source_scene WHERE NOT EXISTS (
-                    SELECT 1 FROM sync_seen
-                    WHERE run_id = ? AND entity_type = 'scene' AND entity_id = scene_id
+            # Scenes first: their markers hold the tag references SQLite will not cascade.
+            for entity_type in ("scene", "performer", "tag", "studio"):
+                table, column = ENTITY_TABLES[entity_type]
+                deleted = tuple(
+                    str(row[0])
+                    for row in self.connection.execute(
+                        f"""
+                        SELECT {column} FROM {table} WHERE NOT EXISTS (
+                            SELECT 1 FROM sync_seen
+                            WHERE run_id = ? AND entity_type = ? AND entity_id = {column}
+                        )
+                        """,
+                        (run_id, entity_type),
+                    )
                 )
-                """,
-                (run_id,),
+                self._delete_entities(entity_type, deleted)
+
+    def _delete_entities(self, entity_type: str, deleted: tuple[str, ...]) -> None:
+        """Delete entities, releasing the references SQLite does not cascade."""
+        if not deleted:
+            return
+        table, column = ENTITY_TABLES[entity_type]
+        self.connection.execute("CREATE TEMP TABLE IF NOT EXISTS deleted_entity(entity_id TEXT)")
+        self.connection.execute("DELETE FROM deleted_entity")
+        self.connection.executemany(
+            "INSERT INTO deleted_entity(entity_id) VALUES (?)",
+            ((identifier,) for identifier in deleted),
+        )
+        if entity_type == "tag":
+            # Stash drops a marker along with its primary tag, and nothing here reads a
+            # marker without one.
+            self.connection.execute(
+                "DELETE FROM scene_marker "
+                "WHERE primary_tag_id IN (SELECT entity_id FROM deleted_entity)"
+            )
+        elif entity_type == "studio":
+            # A child studio and a scene both outlive the studio they point at.
+            self.connection.execute(
+                "UPDATE source_studio SET parent_studio_id = NULL "
+                "WHERE parent_studio_id IN (SELECT entity_id FROM deleted_entity)"
             )
             self.connection.execute(
-                """
-                DELETE FROM source_performer WHERE NOT EXISTS (
-                    SELECT 1 FROM sync_seen
-                    WHERE run_id = ? AND entity_type = 'performer' AND entity_id = performer_id
-                )
-                """,
-                (run_id,),
+                "UPDATE source_scene SET studio_id = NULL "
+                "WHERE studio_id IN (SELECT entity_id FROM deleted_entity)"
             )
-            self.connection.execute(
-                """
-                DELETE FROM source_tag WHERE NOT EXISTS (
-                    SELECT 1 FROM sync_seen
-                    WHERE run_id = ? AND entity_type = 'tag' AND entity_id = tag_id
-                )
-                """,
-                (run_id,),
-            )
-            self.connection.execute(
-                """
-                UPDATE source_studio SET parent_studio_id = NULL
-                WHERE NOT EXISTS (
-                    SELECT 1 FROM sync_seen
-                    WHERE run_id = ? AND entity_type = 'studio' AND entity_id = studio_id
-                )
-                """,
-                (run_id,),
-            )
-            self.connection.execute(
-                """
-                DELETE FROM source_studio WHERE NOT EXISTS (
-                    SELECT 1 FROM sync_seen
-                    WHERE run_id = ? AND entity_type = 'studio' AND entity_id = studio_id
-                )
-                """,
-                (run_id,),
-            )
+        self.connection.execute(
+            f"DELETE FROM {table} WHERE {column} IN (SELECT entity_id FROM deleted_entity)"
+        )
+        self.connection.execute("DELETE FROM deleted_entity")
 
     def finish_run(self, run_id: str, now_ms: int) -> None:
         with transaction(self.connection):

--- a/curator/sync/service.py
+++ b/curator/sync/service.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import time
 import uuid
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Protocol
 
-from curator.graphql.adapters import adapt_page
+from curator.graphql.adapters import adapt_id_page, adapt_page
 from curator.graphql.operations import CAPABILITIES, ENTITY_OPERATIONS, EntityOperation
 from curator.sync.repository import SyncRepository
+
+# Id-only rows are small, and the sweep cost is dominated by per-request overhead.
+SWEEP_PAGE_SIZE = 5_000
 
 
 class QueryClient(Protocol):
@@ -33,6 +36,7 @@ class SyncResult:
     entity_counts: dict[str, int]
     changed_entity_counts: dict[str, int]
     scene_ids: tuple[str, ...]
+    deleted_entity_counts: dict[str, int] = field(default_factory=dict)
 
 
 def probe_capabilities(client: QueryClient) -> Capabilities:
@@ -115,6 +119,7 @@ class SyncService:
 
         counts: dict[str, int] = {}
         changed_counts: dict[str, int] = {}
+        deleted_counts: dict[str, int] = {}
         scene_ids: set[str] = set()
         current_entity: str | None = None
         # A full sweep walks every scene by id, so the incremental play pass adds nothing.
@@ -140,6 +145,13 @@ class SyncService:
             current_entity = None
             if full:
                 self.repository.reconcile(run_id)
+            else:
+                for operation in operations:
+                    current_entity = operation.entity_type
+                    deleted = self._prune_deleted(operation)
+                    if deleted:
+                        deleted_counts[operation.entity_type] = len(deleted)
+                current_entity = None
             self.repository.finish_run(run_id, self.clock_ms())
         except Exception as error:
             self.repository.fail_run(run_id, current_entity, str(error), self.clock_ms())
@@ -152,7 +164,45 @@ class SyncService:
             counts,
             changed_counts,
             tuple(sorted(scene_ids)),
+            deleted_counts,
         )
+
+    def _prune_deleted(self, operation: EntityOperation) -> tuple[str, ...]:
+        """Drop entities Stash no longer has.
+
+        Incremental passes only ever add: a deleted entity has no updated_at to carry it past
+        the watermark, so it lingers until a full sync. Stash exposes no deletion feed, so
+        the only way to see one is to compare id sets. The count probe is a single cheap
+        request; the sweep behind it runs only once drift actually exists.
+        """
+        if operation.ids_document is None:
+            return ()
+        local_total = self.repository.entity_count(operation.entity_type)
+        probe = self.client.execute(operation.ids_document, {"page": 1, "perPage": 0})
+        remote_total = adapt_id_page(
+            probe, root_key=operation.root_key, items_key=operation.items_key
+        ).total
+        # The passes above already applied every addition, so local can only exceed remote by
+        # entities Stash has dropped.
+        if local_total <= remote_total:
+            return ()
+        present: set[str] = set()
+        page = 1
+        while True:
+            data = self.client.execute(
+                operation.ids_document, {"page": page, "perPage": SWEEP_PAGE_SIZE}
+            )
+            adapted = adapt_id_page(
+                data, root_key=operation.root_key, items_key=operation.items_key
+            )
+            present.update(adapted.ids)
+            if not adapted.ids or len(present) >= adapted.total:
+                break
+            page += 1
+        if not present:
+            # An empty library is indistinguishable from a broken response; never act on it.
+            return ()
+        return self.repository.delete_absent(operation.entity_type, present)
 
     def _sync_entity(
         self,

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -1186,10 +1186,13 @@ def _run_task_body(
                 )
             _progress(0.68)
             coordinator = ModelUpdateCoordinator(connection)
+            for entity, removed in sorted(synced.deleted_entity_counts.items()):
+                _log("i", f"Removed {removed} {entity}s deleted from Stash")
             source_changed = (
                 mode == "full-sync-build"
                 or synced.resumed
                 or any(synced.changed_entity_counts.values())
+                or any(synced.deleted_entity_counts.values())
                 or prune_changed
             )
             current_model_id = RecommendationModelStore(connection).current_model_id()

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2027,6 +2027,12 @@
     const scenes = new Map(
       (scenesQuery.data?.findScenes?.scenes || []).map((scene) => [String(scene.id), scene])
     );
+    // A scene deleted in Stash lingers in the model until the next sync; hide it rather than
+    // draw a placeholder card. Only once the lookup resolved, or everything looks deleted.
+    const resolved = !scenesQuery.loading && !scenesQuery.error && Boolean(scenesQuery.data);
+    const visibleItems = resolved
+      ? (slate?.items || []).filter((item) => scenes.has(String(item.scene_id)))
+      : slate?.items || [];
     function remove(sceneId) {
       clearSlateCache();
       const excluded = laneExclusions.get(lane) || new Set();
@@ -2168,11 +2174,11 @@
         React.createElement(
           React.Fragment,
           null,
-          slate.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "Nothing qualifies for this lane right now."),
+          visibleItems.length === 0 && React.createElement("div", { className: "alert alert-info" }, "Nothing qualifies for this lane right now."),
           React.createElement(
             "section",
             { className: "curator-grid", role: "tabpanel", "aria-live": "polite" },
-            slate.items.map((item) => React.createElement(RecommendationCard, { key: `${item.impression_id}:${item.scene_id}`, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp }))
+            visibleItems.map((item) => React.createElement(RecommendationCard, { key: `${item.impression_id}:${item.scene_id}`, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp }))
           ),
           React.createElement(Pager, { page, total: slate.total, pageSize: slate.page_size, hasMore: slate.has_more, loading, onPage: setPage, label: `${laneOption.label} pages` })
         )

--- a/tests/integration/test_sync.py
+++ b/tests/integration/test_sync.py
@@ -138,6 +138,15 @@ class SyntheticClient:
                     ]
                 },
             }
+        id_names = {
+            "CuratorTagIds": ("tag", "findTags", "tags"),
+            "CuratorStudioIds": ("studio", "findStudios", "studios"),
+            "CuratorPerformerIds": ("performer", "findPerformers", "performers"),
+            "CuratorSceneIds": ("scene", "findScenes", "scenes"),
+        }
+        sweep = next((value for name, value in id_names.items() if name in document), None)
+        if sweep is not None:
+            return self._id_page(sweep, variables)
         names = {
             "CuratorTags": ("tag", "findTags", "tags"),
             "CuratorStudios": ("studio", "findStudios", "studios"),
@@ -167,6 +176,26 @@ class SyntheticClient:
         )
         start = (page - 1) * per_page
         return {root: {"count": len(all_items), collection: all_items[start : start + per_page]}}
+
+    def _id_page(
+        self, sweep: tuple[str, str, str], variables: Mapping[str, object] | None
+    ) -> dict[str, object]:
+        entity_type, root, collection = sweep
+        assert variables is not None
+        page = variables["page"]
+        per_page = variables["perPage"]
+        assert isinstance(page, int)
+        assert isinstance(per_page, int)
+        self.calls.append((f"{entity_type}_ids", page))
+        self.variables.append((f"{entity_type}_ids", dict(variables)))
+        items = sorted(self.entities[entity_type], key=lambda item: str(item["id"]))
+        start = (page - 1) * per_page
+        return {
+            root: {
+                "count": len(items),
+                collection: [{"id": item["id"]} for item in items[start : start + per_page]],
+            }
+        }
 
     @staticmethod
     def _ordered(
@@ -368,6 +397,161 @@ def test_full_sync_reconciles_deleted_source_entities(connection: sqlite3.Connec
     assert scene_ids == ["2"]
     assert tag_ids == ["t2"]
     assert connection.execute("SELECT favorite FROM source_performer").fetchone()[0] == 1
+
+
+def _swept(client: SyntheticClient) -> set[str]:
+    """Entity types whose id sweep ran, as opposed to only its count probe."""
+    return {
+        entity
+        for entity, variables in client.variables
+        if entity.endswith("_ids") and int(str(variables["perPage"])) > 0
+    }
+
+
+def test_incremental_sync_removes_entities_deleted_from_stash(
+    connection: sqlite3.Connection,
+) -> None:
+    entities = _entities()
+    client = SyntheticClient(entities)
+    service = SyncService(client, SyncRepository(connection), page_size=2)
+    service.sync()
+    assert connection.execute("SELECT count(*) FROM source_scene").fetchone()[0] == 2
+
+    # A deleted scene has no updated_at to carry it past the watermark, so only an id sweep
+    # can observe it.
+    entities["scene"] = [scene for scene in entities["scene"] if scene["id"] != "1"]
+    entities["tag"] = [tag for tag in entities["tag"] if tag["id"] != "t2"]
+    client.calls.clear()
+    client.variables.clear()
+
+    result = service.sync()
+
+    assert [row[0] for row in connection.execute("SELECT scene_id FROM source_scene")] == ["2"]
+    assert [row[0] for row in connection.execute("SELECT tag_id FROM source_tag")] == ["t1"]
+    assert result.deleted_entity_counts == {"scene": 1, "tag": 1}
+    # Dependent rows follow the scene out.
+    assert (
+        connection.execute("SELECT count(*) FROM source_play WHERE scene_id='1'").fetchone()[0] == 0
+    )
+    assert (
+        connection.execute("SELECT count(*) FROM source_file WHERE scene_id='1'").fetchone()[0] == 0
+    )
+    # Only the drifted entities are swept; the rest stop at their count probe.
+    assert _swept(client) == {"scene_ids", "tag_ids"}
+
+
+def test_incremental_sync_releases_references_sqlite_will_not_cascade(
+    connection: sqlite3.Connection,
+) -> None:
+    entities = _entities()
+    entities["studio"].append(_studio("s2"))
+    marked = entities["scene"][0]
+    marked["scene_markers"] = [
+        {
+            "id": "m1",
+            "seconds": 10.0,
+            "end_seconds": None,
+            "primary_tag": _tag("t2"),
+            "tags": [],
+        }
+    ]
+    client = SyntheticClient(entities)
+    service = SyncService(client, SyncRepository(connection), page_size=2)
+    service.sync()
+    assert connection.execute("SELECT count(*) FROM scene_marker").fetchone()[0] == 1
+
+    # The surviving scenes still point at both: their marker's primary tag and their studio.
+    entities["tag"] = [tag for tag in entities["tag"] if tag["id"] != "t2"]
+    entities["studio"] = [studio for studio in entities["studio"] if studio["id"] != "s1"]
+
+    result = service.sync()
+
+    assert result.deleted_entity_counts == {"tag": 1, "studio": 1}
+    assert connection.execute("SELECT count(*) FROM scene_marker").fetchone()[0] == 0
+    assert [row[0] for row in connection.execute("SELECT studio_id FROM source_studio")] == ["s2"]
+    assert connection.execute("SELECT count(*) FROM source_scene").fetchone()[0] == 2
+    assert connection.execute("SELECT DISTINCT studio_id FROM source_scene").fetchone()[0] is None
+
+
+def test_full_sync_releases_references_sqlite_will_not_cascade(
+    connection: sqlite3.Connection,
+) -> None:
+    entities = _entities()
+    entities["scene"][0]["scene_markers"] = [
+        {
+            "id": "m1",
+            "seconds": 10.0,
+            "end_seconds": None,
+            "primary_tag": _tag("t2"),
+            "tags": [],
+        }
+    ]
+    SyncService(
+        SyntheticClient(entities),
+        SyncRepository(connection),
+        page_size=2,
+        id_factory=lambda: "run-1",
+    ).sync(full=True)
+
+    reduced = _entities()
+    reduced["tag"] = [_tag("t1")]
+    reduced["studio"] = []
+    SyncService(
+        SyntheticClient(reduced),
+        SyncRepository(connection),
+        page_size=2,
+        id_factory=lambda: "run-2",
+    ).sync(full=True)
+
+    assert connection.execute("SELECT count(*) FROM scene_marker").fetchone()[0] == 0
+    assert connection.execute("SELECT count(*) FROM source_studio").fetchone()[0] == 0
+    assert connection.execute("SELECT count(*) FROM source_scene").fetchone()[0] == 2
+
+
+def test_incremental_sync_probes_for_deletions_without_sweeping_ids(
+    connection: sqlite3.Connection,
+) -> None:
+    client = SyntheticClient(_entities())
+    service = SyncService(client, SyncRepository(connection), page_size=2)
+    service.sync()
+    client.calls.clear()
+    client.variables.clear()
+
+    result = service.sync()
+
+    # Every entity is probed for drift, but a matching count costs nothing more.
+    assert result.deleted_entity_counts == {}
+    assert [call for call in client.calls if call[0].endswith("_ids")] == [
+        ("tag_ids", 1),
+        ("studio_ids", 1),
+        ("performer_ids", 1),
+        ("scene_ids", 1),
+    ]
+    assert _swept(client) == set()
+
+
+def test_incremental_sync_keeps_local_entities_when_stash_returns_none(
+    connection: sqlite3.Connection,
+) -> None:
+    entities = _entities()
+    client = SyntheticClient(entities)
+    service = SyncService(client, SyncRepository(connection), page_size=2)
+    service.sync()
+
+    # An empty response is indistinguishable from a broken one, so it must never delete.
+    entities["scene"] = []
+
+    result = service.sync()
+
+    assert connection.execute("SELECT count(*) FROM source_scene").fetchone()[0] == 2
+    assert result.deleted_entity_counts == {}
+
+
+def test_full_sync_does_not_run_the_deletion_sweep(connection: sqlite3.Connection) -> None:
+    client = SyntheticClient(_entities())
+    SyncService(client, SyncRepository(connection), page_size=2).sync(full=True)
+
+    assert not [call for call in client.calls if call[0].endswith("_ids")]
 
 
 def test_incremental_sync_stops_after_crossing_previous_watermark(

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -416,6 +416,18 @@ def test_feedback_history_can_undo_or_replace_append_only_actions() -> None:
     assert "scheduleModelUpdate();" in source
 
 
+def test_recommendation_grid_hides_scenes_stash_no_longer_has() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
+
+    assert (
+        "const resolved = !scenesQuery.loading && !scenesQuery.error && Boolean(scenesQuery.data);"
+        in source
+    )
+    assert "scenes.has(String(item.scene_id))" in source
+    assert "visibleItems.map((item) => React.createElement(RecommendationCard" in source
+    assert "visibleItems.length === 0 && React.createElement" in source
+
+
 def test_external_scene_cards_can_rate_matching_local_tags() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
 


### PR DESCRIPTION
A deleted scene kept drawing a placeholder card in Best Bets. It was not alone: the live sidecar held **23 stale scenes and 2 stale tags**.

## Why

An incremental pass only ever adds. It walks `updated_at DESC` and stops at the watermark, and a deleted entity has no `updated_at` to carry it past that mark — so nothing in an incremental sync can observe a deletion. `SyncRepository.reconcile` handles this correctly, but only `full-sync-build` calls it, and this instance had never run one.

## How

Stash exposes no deletion feed, so each entity now probes its remote count after its pass. The passes above have already applied every addition, so a local count *above* the remote one can only mean deletions — only then does an id-only sweep run to find them.

Measured against a 23.9k-scene library:

| | cost |
|---|---|
| no-op sync (4 count probes) | 3.6s → 5.9s |
| sweep, only on drift | ~11s |

Deleting from `source_scene` is enough to clear every lane: `scene_eligibility` marks a scene with no available file `file_unavailable`, which the materialized path already filters, so stale rows in a published generation artifact cannot resurrect it. The recommendation grid also hides cards Stash no longer resolves, so a deletion disappears before the next sync instead of rendering broken.

## Two references SQLite will not cascade

Real library data failed the first delete outright with `FOREIGN KEY constraint failed`. `scene_marker.primary_tag_id` and `source_scene.studio_id` are `NO ACTION`, not `CASCADE`. Both are now released first — a deleted tag takes its markers with it, as Stash itself does, and a deleted studio is nulled out of the scenes and child studios that outlive it. This lives in the path full sync shares, where the same failure was latent.

## Verification

`scripts/verify full` passes (239). End to end against a scratch copy of the live sidecar:

```
scenes before: 23909   deleted: {'tag': 2, 'scene': 23}   scenes after: 23886   (= Stash exactly)
deleted scene present: 0   eligibility: {'eligible': False, 'reasons': ['file_unavailable']}
deleted scene in best_bets top 60: False
```

A second run reports `deleted={}` in 5.9s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
