### PR TITLE
Prune retired generations against the core tables

### DIFF
--- a/curator/storage/retention.py
+++ b/curator/storage/retention.py
@@ -112,11 +112,13 @@ def prune_snapshots(
                         (version,),
                     )
                 else:
+                    # An attached artifact shadows these names with a temp view, and a view
+                    # cannot be deleted from; the rows being retired are the core ones.
                     connection.execute(
-                        "DELETE FROM entity_feature WHERE feature_version=?", (version,)
+                        "DELETE FROM main.entity_feature WHERE feature_version=?", (version,)
                     )
                     connection.execute(
-                        "DELETE FROM feature_definition WHERE feature_version=?", (version,)
+                        "DELETE FROM main.feature_definition WHERE feature_version=?", (version,)
                     )
                     connection.execute(
                         "DELETE FROM feature_build WHERE feature_version=?", (version,)

--- a/tests/storage/test_retention.py
+++ b/tests/storage/test_retention.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from curator.features import FeatureBuilder
 from curator.storage import MigrationRunner, connect_database, prune_snapshots
 
 
@@ -80,3 +81,32 @@ def test_retention_removes_abandoned_build_and_its_features(tmp_path: Path) -> N
     assert result.deleted_features == 1
     assert connection.execute("SELECT count(*) FROM model_version").fetchone()[0] == 1
     assert connection.execute("SELECT count(*) FROM feature_build").fetchone()[0] == 1
+
+
+def test_retention_prunes_legacy_rows_an_attached_artifact_shadows(tmp_path: Path) -> None:
+    connection = connect_database(tmp_path / "curator.sqlite3")
+    MigrationRunner(connection).migrate(applied_at_ms=1)
+    built = FeatureBuilder(connection, clock_ms=lambda: 2).build()
+    # A generation whose artifact was already unlinked keeps its row with no basename, so the
+    # next pass takes the legacy branch -- against names the attached artifact now shadows.
+    connection.execute(
+        """
+        INSERT INTO feature_build(
+            feature_version, status, config_json, source_fingerprint,
+            created_at_ms, published_at_ms, validation_status
+        ) VALUES ('retired-feature', 'superseded', '{}', 'retired', 1, 1, 'retired')
+        """
+    )
+    assert (
+        connection.execute(
+            "SELECT type FROM temp.sqlite_master WHERE name='entity_feature'"
+        ).fetchone()[0]
+        == "view"
+    )
+
+    result = prune_snapshots(connection)
+
+    assert result.deleted_features == 1
+    assert [row[0] for row in connection.execute("SELECT feature_version FROM feature_build")] == [
+        built.feature_version
+    ]


### PR DESCRIPTION
Opening Curator surfaced `cannot modify entity_feature because it is a view`. Two jobs on the live instance died on it today (`update-model` 15:20, `sync-build` 19:00), each after completing all of its real work — `prune_snapshots` runs last in every model build.

## Why

Retiring an artifact unlinks the file and clears `artifact_basename` while keeping the `feature_build` row. The next retention pass sees a NULL basename, takes the legacy branch, and deletes the rows from the core tables — but a connection with an attached generation shadows `entity_feature` and `feature_definition` with temp views over the read-only artifact, and a view cannot be deleted from.

Because the statement threw before the `feature_build` row was deleted, the pass could never converge: it re-selected the same retired row and failed again on every subsequent build.

## Fix

Name the schema explicitly (`main.entity_feature`) so the delete reaches the core table past the view. The rows are the legacy ones by construction — anything still held in an artifact is retired by unlinking the file, never by deleting rows.

## Verification

Reproduced against a copy of the live sidecar, then confirmed fixed on the same copy: the retired generation is pruned, a second pass runs clean, and the published artifact still reports its 641,317 feature rows. The new test fails with the exact production error when the fix is reverted. `scripts/verify full` passes (233).

🤖 Generated with [Claude Code](https://claude.com/claude-code)