### PR TITLE
Keep performer hunt and similarity discoveries out of Expand

### DIFF
--- a/curator/expand.py
+++ b/curator/expand.py
@@ -273,8 +273,8 @@ class ExpandService:
             self.connection.executemany(
                 """
                 INSERT INTO external_entity(
-                  entity_type, external_id, payload_json, score, sources_json, fetched_at_ms
-                ) VALUES (?, ?, ?, ?, ?, ?)
+                  entity_type, external_id, payload_json, score, sources_json, fetched_at_ms, pool
+                ) VALUES (?, ?, ?, ?, ?, ?, 'candidate')
                 """,
                 (
                     (
@@ -443,7 +443,8 @@ class ExpandService:
         include_groups = equivalent_tag_names(self.connection, include_tags)
         exclude_groups = equivalent_tag_names(self.connection, exclude_tags)
         for row in self.connection.execute(
-            "SELECT * FROM external_entity WHERE entity_type=?", (entity_type,)
+            "SELECT * FROM external_entity WHERE entity_type=? AND pool='candidate'",
+            (entity_type,),
         ):
             if float(row["score"]) < minimum_score:
                 continue
@@ -1089,17 +1090,29 @@ class ExpandService:
                     sources[identifier].update(values)
         return rows, sources
 
-    def _merge_external(self, entity_type: str, items: Iterable[dict[str, Any]]) -> None:
+    def _merge_external(
+        self, entity_type: str, items: Iterable[dict[str, Any]], *, pool: str = "explore"
+    ) -> None:
+        """Merge discovered entities so they can be shortlisted or chained into.
+
+        Callers that browse on the user's behalf (a performer hunt, a "similar to
+        this" probe) merge with the default 'explore' pool: the row becomes
+        shortlistable and usable as a similarity anchor, but stays out of the
+        general Expand browse (`results()`), which only shows `refresh()`'s own
+        'candidate' pool. Otherwise one performer's whole catalog, or one scene's
+        probe, would bleed into another's Expand results until the next refresh.
+        """
         now_ms = time.time_ns() // 1_000_000
         with transaction(self.connection):
             self.connection.executemany(
                 """
                 INSERT INTO external_entity(
-                  entity_type, external_id, payload_json, score, sources_json, fetched_at_ms
-                ) VALUES (?, ?, ?, ?, ?, ?)
+                  entity_type, external_id, payload_json, score, sources_json, fetched_at_ms, pool
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(entity_type, external_id) DO UPDATE SET
                   payload_json=excluded.payload_json, score=excluded.score,
-                  sources_json=excluded.sources_json, fetched_at_ms=excluded.fetched_at_ms
+                  sources_json=excluded.sources_json, fetched_at_ms=excluded.fetched_at_ms,
+                  pool=CASE WHEN pool='candidate' THEN 'candidate' ELSE excluded.pool END
                 """,
                 (
                     (
@@ -1109,6 +1122,7 @@ class ExpandService:
                         float(item["score"]),
                         json.dumps(item["sources"], separators=(",", ":")),
                         now_ms,
+                        pool,
                     )
                     for item in items
                 ),

--- a/curator/storage/sql/0021_external_entity_pool.sql
+++ b/curator/storage/sql/0021_external_entity_pool.sql
@@ -1,0 +1,13 @@
+-- A performer hunt or a "similar to this" probe merges scenes it finds into
+-- external_entity so they can be shortlisted, but that table also backs the
+-- general Expand browse. Without a pool marker, one performer's whole StashDB
+-- catalog bleeds into another performer's Expand results until the next
+-- refresh() wipes the table. Only rows refresh() writes belong in Expand.
+-- Default existing rows to 'candidate' rather than 'explore': whatever is
+-- already in the table came from the last refresh() plus whatever hunts and
+-- similarity probes wrote since, and refresh() clears it wholesale on its
+-- next run regardless, so there is nothing to gain by blanking Expand now.
+ALTER TABLE external_entity ADD COLUMN pool TEXT NOT NULL DEFAULT 'candidate'
+    CHECK (pool IN ('candidate', 'explore'));
+
+CREATE INDEX external_entity_pool_idx ON external_entity(entity_type, pool, score DESC);

--- a/tests/storage/test_cli_db.py
+++ b/tests/storage/test_cli_db.py
@@ -15,7 +15,7 @@ def test_database_cli_migrate_status_and_backup(
 
     assert run(["--db", str(database), "db", "migrate", "--json"]) == 0
     migrated = json.loads(capsys.readouterr().out)
-    assert migrated["current_version"] == migrated["latest_version"] == 20
+    assert migrated["current_version"] == migrated["latest_version"] == 21
 
     assert run(["--db", str(database), "db", "status", "--json"]) == 0
     status = json.loads(capsys.readouterr().out)

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -32,10 +32,11 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
             18,
             19,
             20,
+            21,
         )
 
         after = runner.migrate(applied_at_ms=1234)
-        assert after.current_version == 20
+        assert after.current_version == 21
         assert after.pending_versions == ()
         assert runner.migrate(applied_at_ms=5678) == after
 
@@ -90,7 +91,7 @@ def test_feature_count_migration_backfills_existing_builds(tmp_path: Path) -> No
     connection = connect_database(tmp_path / "curator.sqlite3")
     runner = MigrationRunner(connection)
     original = runner.migrations
-    runner.migrations = original[:-3]
+    runner.migrations = [migration for migration in original if migration.version < 18]
     runner.migrate(applied_at_ms=1)
     connection.execute(
         """
@@ -131,7 +132,7 @@ def test_unobserved_penalty_migration_keeps_graded_evidence(tmp_path: Path) -> N
     connection = connect_database(tmp_path / "curator.sqlite3")
     runner = MigrationRunner(connection)
     original = runner.migrations
-    runner.migrations = original[:-1]
+    runner.migrations = [migration for migration in original if migration.version < 20]
     runner.migrate(applied_at_ms=1)
     sessions = (
         ("empty", "opened", 0.0, '{"played_ranges":[],"maximum_position_seconds":0.0}'),
@@ -191,7 +192,7 @@ def test_status_stays_read_only_after_migrations(tmp_path: Path) -> None:
     reader.execute("PRAGMA busy_timeout=1")
     try:
         writer.execute("BEGIN IMMEDIATE")
-        assert MigrationRunner(reader).status().current_version == 20
+        assert MigrationRunner(reader).status().current_version == 21
     finally:
         writer.rollback()
         reader.close()
@@ -217,7 +218,7 @@ def test_stale_concurrent_migrator_rechecks_after_writer_lock(
 
     monkeypatch.setattr(second_runner, "status", status)
     try:
-        assert second_runner.migrate(applied_at_ms=2).current_version == 20
+        assert second_runner.migrate(applied_at_ms=2).current_version == 21
     finally:
         second.close()
         first.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_doctor_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
     assert result["status"] == "ok"
     assert result["stash"] == "not_configured"
     assert result["schema_current"] == 0
-    assert result["schema_latest"] == 20
+    assert result["schema_latest"] == 21
 
 
 def test_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -399,7 +399,13 @@ def test_performer_hunt_requires_a_stashdb_link(tmp_path: Path) -> None:
         raise AssertionError("unlinked performers must be rejected")
 
 
-def test_performer_hunt_does_not_leak_owned_scenes_into_expand(tmp_path: Path) -> None:
+def test_performer_hunt_results_stay_out_of_expand(tmp_path: Path) -> None:
+    """A performer's whole catalog must not dilute the general Expand browse.
+
+    Hunting one performer used to merge every unowned scene it returned into the
+    same pool Expand reads from, so hunting several performers back to back left
+    their catalogs mixed into Expand with no way to tell them apart.
+    """
     connection = _database(tmp_path / "curator.sqlite3")
     PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
     links = {
@@ -414,11 +420,62 @@ def test_performer_hunt_does_not_leak_owned_scenes_into_expand(tmp_path: Path) -
     service = ExpandService(connection)
 
     service.refresh(FakeStashDB(), links, now_ms=REFERENCE_MS, candidate_limit=10)
+    before = {item["id"] for item in service.results("scene")["items"]}
     service.performer_hunt(PerformerHuntStashDB(), links, "p1", limit=10)
 
     identifiers = {item["id"] for item in service.results("scene")["items"]}
+    assert identifiers == before
+    assert "hunt-old" not in identifiers
     assert "hunt-linked" not in identifiers
-    assert "hunt-old" in identifiers
+
+
+def test_performer_hunt_results_remain_shortlistable(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    links = {
+        "scenes": {},
+        "scene_phashes": {},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {},
+    }
+    service = ExpandService(connection)
+
+    service.performer_hunt(PerformerHuntStashDB(), links, "p1", limit=10)
+    service.shortlist("scene", "hunt-old", True)
+
+    assert [item["id"] for item in service.shortlist_results()["items"]] == ["hunt-old"]
+
+
+def test_expand_candidate_pool_survives_a_later_explore_merge(tmp_path: Path) -> None:
+    """A scene refresh() legitimately placed in Expand must survive a later hunt.
+
+    Both write through the same upsert keyed only by (entity_type, external_id);
+    without care, an 'explore' merge that happens to revisit a 'candidate' scene
+    would downgrade it out of Expand until the next refresh.
+    """
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    links = {
+        "scenes": {},
+        "scene_phashes": {},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {},
+    }
+    service = ExpandService(connection)
+
+    service.refresh(FakeStashDB(), links, now_ms=REFERENCE_MS, candidate_limit=10)
+    assert "new-external-scene" in {
+        item["id"] for item in service.results("scene", gender="")["items"]
+    }
+
+    service._merge_external(
+        "scene",
+        [{"id": "new-external-scene", "payload": {}, "score": 0.5, "sources": ["performers"]}],
+    )
+
+    assert "new-external-scene" in {
+        item["id"] for item in service.results("scene", gender="")["items"]
+    }
 
 
 def test_expand_avoids_adjacent_repeated_performers() -> None:


### PR DESCRIPTION
## Summary
- Performer Hunt (and "similar to this") fetch scenes and merge them into `external_entity` so they can be shortlisted — but that's the same table Expand's general browse reads from, with nothing distinguishing where a row came from. Hunting a few performers back to back dumped their whole catalogs into Expand, mixed together with no attribution — reported as: "searches in performer hunt for [3 performers], now Expand shows a lot of these entries... they should be separate."
- Adds a `pool` column (`candidate` vs `explore`) to `external_entity`. Only `refresh()`'s own seeded candidates get `pool='candidate'`, which is what `results()` (the Expand browse) now filters to. Hunt and similarity merges write `pool='explore'` by default: still shortlistable, still usable as a similarity anchor, but no longer shown in the general Expand grid.
- A conflicting merge never downgrades an existing `candidate` row back to `explore`, so a scene `refresh()` legitimately placed in Expand survives a later hunt that happens to revisit it.

## Test plan
- [x] `scripts/verify full` (lint, format, mypy, full pytest suite, plugin build) — 234 passed
- [x] New/updated tests in `tests/test_expand.py`: hunt results stay out of `results()`, hunt results remain shortlistable, and a candidate row survives a later explore-pool merge of the same scene
- [x] Bumped hardcoded schema-version assertions (`tests/storage/test_migrations.py`, `tests/storage/test_cli_db.py`, `tests/test_cli.py`) for the new migration, and fixed two migration tests that were selecting "the last N migrations" by position rather than by version — they'd silently start testing the wrong migration once a new one was appended after them