### PR TITLE
Only wake model updates from sessions with real evidence

### DIFF
--- a/curator/interactions.py
+++ b/curator/interactions.py
@@ -332,6 +332,7 @@ class InteractionStore:
     def submit_sessions(self, entries: list[dict[str, Any]]) -> int:
         sessions = [self._session(entry) for entry in entries]
         inserted = 0
+        signaled = False
         with transaction(self.connection):
             for session in sessions:
                 cursor = self.connection.execute(
@@ -359,14 +360,17 @@ class InteractionStore:
                 if session.observed_playback:
                     outcome = viewing_outcome(session.active_seconds, session.ended_at_ms)
                     if outcome is not None:
-                        self._insert_signal(
+                        signaled |= self._insert_signal(
                             f"{session.session_id}:view",
                             session.scene_id,
                             session.session_id,
                             outcome,
                         )
-                self._insert_replacement(session)
-            if inserted:
+                signaled |= self._insert_replacement(session)
+            # A session that merely opened a scene without any observed playback or
+            # replacement evidence carries no preference signal; requesting a model update
+            # for it would repeatedly wake "Apply recent Curator feedback" on plain browsing.
+            if signaled:
                 ModelUpdateCoordinator(self.connection).request("session_outcome")
         return inserted
 
@@ -414,7 +418,7 @@ class InteractionStore:
             (entry["scene_id"], entry["occurred_at_ms"], entry["occurred_at_ms"], reason),
         )
 
-    def _insert_replacement(self, replacement: DirectSessionInput) -> None:
+    def _insert_replacement(self, replacement: DirectSessionInput) -> bool:
         # Only a session whose playback was observed can be judged as abandoned early.
         row = self.connection.execute(
             f"""
@@ -426,7 +430,7 @@ class InteractionStore:
             (replacement.session_id, replacement.started_at_ms),
         ).fetchone()
         if row is None:
-            return
+            return False
         original = self._session(json.loads(row[0]))
         positive = bool(
             self.connection.execute(
@@ -440,18 +444,19 @@ class InteractionStore:
         signal = quick_replacement_outcome(
             original, replacement, intervening_positive_feedback=positive
         )
-        if signal is not None:
-            self._insert_signal(
-                f"{replacement.session_id}:replacement",
-                original.scene_id,
-                original.session_id,
-                signal,
-            )
+        if signal is None:
+            return False
+        return self._insert_signal(
+            f"{replacement.session_id}:replacement",
+            original.scene_id,
+            original.session_id,
+            signal,
+        )
 
     def _insert_signal(
         self, event_id: str, scene_id: str, session_id: str | None, signal: Any
-    ) -> None:
-        self.connection.execute(
+    ) -> bool:
+        cursor = self.connection.execute(
             """
             INSERT OR IGNORE INTO behavior_event(
                 event_id, event_type, scene_id, occurred_at_ms, outcome, confidence,
@@ -469,6 +474,7 @@ class InteractionStore:
                 json.dumps({"primary_signal": signal.signal_type}, separators=(",", ":")),
             ),
         )
+        return bool(cursor.rowcount)
 
     @staticmethod
     def _impression_entry(entry: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from curator.interactions import InteractionStore
-from curator.model import PreferenceModelBuilder
+from curator.model import ModelUpdateCoordinator, PreferenceModelBuilder
 from curator.ranking import SlateBuilder
 from tests.model.test_builder import REFERENCE_MS, _database
 
@@ -153,6 +153,10 @@ def test_session_without_observed_playback_records_no_view_evidence(tmp_path: Pa
         ).fetchone()[0]
         == 0
     )
+    # A page open that produced no evidence must not wake "Apply recent Curator
+    # feedback" on the next Curator visit; otherwise plain browsing would keep
+    # marking the model dirty forever.
+    assert not ModelUpdateCoordinator(connection).status().pending
 
 
 def test_unobserved_session_is_never_graded_as_abandoned(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- `submit_sessions()` requested a model update on *any* inserted `play_session` row, even ones with zero observed playback and no derived signal — so merely opening a scene page without watching anything marked the model dirty.
- This meant the Curator page's health poll kept firing the "Apply recent Curator feedback" task on plain visits, with no actual feedback ever submitted.
- `_insert_signal` and `_insert_replacement` now report whether they actually wrote a `behavior_event`, and `submit_sessions` only requests a model update when a session produces real evidence (a view outcome or a quick-replacement signal).

## Test plan
- [x] `scripts/verify full` (ruff, mypy, full pytest suite, plugin build) — all passed
- [x] New regression test `test_session_without_observed_playback_records_no_view_evidence` asserts `ModelUpdateCoordinator(...).status().pending` is `False` after a no-evidence session; confirmed it fails against the pre-fix code (`pending=True`, `last_cause='session_outcome'`)
- [x] Installed locally via `scripts/install-local.sh` onto the live Stash instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)
