### PR TITLE
Cascade-delete playback telemetry when a scene leaves Stash

### DIFF
--- a/curator/interactions.py
+++ b/curator/interactions.py
@@ -335,23 +335,31 @@ class InteractionStore:
         signaled = False
         with transaction(self.connection):
             for session in sessions:
-                cursor = self.connection.execute(
-                    """
-                    INSERT OR IGNORE INTO play_session(
-                        session_id, scene_id, started_at_ms, ended_at_ms, active_seconds,
-                        provenance, confidence, impression_id, summary_json
-                    ) VALUES (?, ?, ?, ?, ?, 'direct_player', 1, ?, ?)
-                    """,
-                    (
-                        session.session_id,
-                        session.scene_id,
-                        session.started_at_ms,
-                        session.ended_at_ms,
-                        session.active_seconds,
-                        session.impression_id,
-                        json.dumps(asdict(session), sort_keys=True, separators=(",", ":")),
-                    ),
-                )
+                try:
+                    cursor = self.connection.execute(
+                        """
+                        INSERT OR IGNORE INTO play_session(
+                            session_id, scene_id, started_at_ms, ended_at_ms, active_seconds,
+                            provenance, confidence, impression_id, summary_json
+                        ) VALUES (?, ?, ?, ?, ?, 'direct_player', 1, ?, ?)
+                        """,
+                        (
+                            session.session_id,
+                            session.scene_id,
+                            session.started_at_ms,
+                            session.ended_at_ms,
+                            session.active_seconds,
+                            session.impression_id,
+                            json.dumps(asdict(session), sort_keys=True, separators=(",", ":")),
+                        ),
+                    )
+                except sqlite3.IntegrityError:
+                    # The live tracker reports whatever scene Stash is playing, which can name
+                    # a scene added after Curator's last sync. OR IGNORE does not cover foreign
+                    # key violations, so this scene_id would otherwise abort the whole batch;
+                    # drop just this session and keep going, since a later sync plus a later
+                    # watch will record it normally.
+                    continue
                 if not cursor.rowcount:
                     continue
                 inserted += 1

--- a/curator/interactions.py
+++ b/curator/interactions.py
@@ -332,6 +332,7 @@ class InteractionStore:
     def submit_sessions(self, entries: list[dict[str, Any]]) -> int:
         sessions = [self._session(entry) for entry in entries]
         inserted = 0
+        signaled = False
         with transaction(self.connection):
             for session in sessions:
                 cursor = self.connection.execute(
@@ -359,14 +360,17 @@ class InteractionStore:
                 if session.observed_playback:
                     outcome = viewing_outcome(session.active_seconds, session.ended_at_ms)
                     if outcome is not None:
-                        self._insert_signal(
+                        signaled |= self._insert_signal(
                             f"{session.session_id}:view",
                             session.scene_id,
                             session.session_id,
                             outcome,
                         )
-                self._insert_replacement(session)
-            if inserted:
+                signaled |= self._insert_replacement(session)
+            # A session that merely opened a scene without any observed playback or
+            # replacement evidence carries no preference signal; requesting a model update
+            # for it would repeatedly wake "Apply recent Curator feedback" on plain browsing.
+            if signaled:
                 ModelUpdateCoordinator(self.connection).request("session_outcome")
         return inserted
 
@@ -414,7 +418,7 @@ class InteractionStore:
             (entry["scene_id"], entry["occurred_at_ms"], entry["occurred_at_ms"], reason),
         )
 
-    def _insert_replacement(self, replacement: DirectSessionInput) -> None:
+    def _insert_replacement(self, replacement: DirectSessionInput) -> bool:
         # Only a session whose playback was observed can be judged as abandoned early.
         row = self.connection.execute(
             f"""
@@ -426,7 +430,7 @@ class InteractionStore:
             (replacement.session_id, replacement.started_at_ms),
         ).fetchone()
         if row is None:
-            return
+            return False
         original = self._session(json.loads(row[0]))
         positive = bool(
             self.connection.execute(
@@ -440,18 +444,19 @@ class InteractionStore:
         signal = quick_replacement_outcome(
             original, replacement, intervening_positive_feedback=positive
         )
-        if signal is not None:
-            self._insert_signal(
-                f"{replacement.session_id}:replacement",
-                original.scene_id,
-                original.session_id,
-                signal,
-            )
+        if signal is None:
+            return False
+        return self._insert_signal(
+            f"{replacement.session_id}:replacement",
+            original.scene_id,
+            original.session_id,
+            signal,
+        )
 
     def _insert_signal(
         self, event_id: str, scene_id: str, session_id: str | None, signal: Any
-    ) -> None:
-        self.connection.execute(
+    ) -> bool:
+        cursor = self.connection.execute(
             """
             INSERT OR IGNORE INTO behavior_event(
                 event_id, event_type, scene_id, occurred_at_ms, outcome, confidence,
@@ -469,6 +474,7 @@ class InteractionStore:
                 json.dumps({"primary_signal": signal.signal_type}, separators=(",", ":")),
             ),
         )
+        return bool(cursor.rowcount)
 
     @staticmethod
     def _impression_entry(entry: dict[str, Any]) -> dict[str, Any]:

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -1278,6 +1278,11 @@ class PreferenceModelBuilder:
                         ),
                     )
                     for scene_id, label in sorted(labels.items())
+                    # A scene deleted from Stash since these signals were recorded has no
+                    # score to compare against. feedback carries no foreign key to
+                    # source_scene (unlike behavior_event/play_session) because it is kept
+                    # as user-facing history past scene deletion, so this can still happen.
+                    if scene_id in scores_by_scene
                 ),
             )
             self._report(0.81)

--- a/curator/storage/sql/0022_purge_orphaned_playback_telemetry.sql
+++ b/curator/storage/sql/0022_purge_orphaned_playback_telemetry.sql
@@ -1,0 +1,13 @@
+-- play_session and behavior_event key on scene_id without a foreign key, so scenes deleted
+-- from Stash before this version lingered in them indefinitely. A model build then labeled
+-- those scenes from their orphaned telemetry and crashed cross-referencing the live scene
+-- list it never appears in. New deletions are now cleaned up as they happen; this sweeps
+-- whatever already accumulated. behavior_event goes first: it references play_session, which
+-- SQLite will not let this drop out from under it.
+DELETE FROM behavior_event WHERE (scene_id IS NOT NULL
+        AND scene_id NOT IN (SELECT scene_id FROM source_scene))
+    OR session_id IN (
+        SELECT session_id FROM play_session
+        WHERE scene_id NOT IN (SELECT scene_id FROM source_scene)
+    );
+DELETE FROM play_session WHERE scene_id NOT IN (SELECT scene_id FROM source_scene);

--- a/curator/storage/sql/0023_cascade_playback_telemetry_deletes.sql
+++ b/curator/storage/sql/0023_cascade_playback_telemetry_deletes.sql
@@ -1,0 +1,88 @@
+-- play_session and behavior_event keyed on scene_id with no foreign key, so a scene deleted
+-- from Stash left orphaned rows behind that a later model build would crash on (see the
+-- previous migration). SQLite cannot ALTER a constraint onto an existing column, so both
+-- tables are rebuilt here with ON DELETE CASCADE to source_scene, and behavior_event's
+-- existing (unenforced-by-default) link to play_session is upgraded to CASCADE too: without
+-- that, deleting a scene would cascade into play_session, then hit behavior_event's
+-- session_id constraint and abort the whole delete instead of cleaning up.
+--
+-- This never uses ALTER TABLE RENAME. A connection with a published model or feature
+-- generation attached creates temp views over table names like entity_feature so the rest of
+-- the code can read them uniformly; renaming *any* table while such a view exists makes
+-- SQLite rescan the whole schema (every attached database, to patch other objects' text) and
+-- that rescan hits a real SQLite bug ("views may not be indexed") on the shadowed name,
+-- unrelated to what's actually being renamed. Plain CREATE TABLE/DROP TABLE do not trigger
+-- that rescan, so both tables are staged under throwaway names, the old ones dropped, and the
+-- replacements created directly under their real names instead.
+--
+-- Foreign keys stay enforced throughout (PRAGMA foreign_keys is a no-op inside a transaction,
+-- and every migration runs in one), so behavior_event is staged before play_session is
+-- dropped: DROP TABLE on a table other rows still reference performs an implicit delete that
+-- re-triggers those references, and the staging copy carries no constraint on session_id to
+-- trip over that.
+
+CREATE TABLE play_session_staging (
+    session_id TEXT PRIMARY KEY,
+    scene_id TEXT NOT NULL,
+    started_at_ms INTEGER NOT NULL CHECK (started_at_ms >= 0),
+    ended_at_ms INTEGER CHECK (ended_at_ms IS NULL OR ended_at_ms >= started_at_ms),
+    active_seconds REAL NOT NULL DEFAULT 0 CHECK (active_seconds >= 0),
+    provenance TEXT NOT NULL,
+    confidence REAL NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+    impression_id TEXT REFERENCES impression(impression_id),
+    summary_json TEXT NOT NULL DEFAULT '{}'
+) STRICT;
+
+INSERT INTO play_session_staging SELECT * FROM play_session;
+
+CREATE TABLE behavior_event_staging (
+    event_id TEXT PRIMARY KEY,
+    event_type TEXT NOT NULL,
+    scene_id TEXT,
+    occurred_at_ms INTEGER NOT NULL CHECK (occurred_at_ms >= 0),
+    outcome REAL CHECK (outcome BETWEEN -1 AND 1),
+    confidence REAL NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+    provenance TEXT NOT NULL,
+    session_id TEXT,
+    impression_id TEXT REFERENCES impression(impression_id),
+    payload_json TEXT NOT NULL DEFAULT '{}'
+) STRICT;
+
+INSERT INTO behavior_event_staging SELECT * FROM behavior_event;
+
+DROP TABLE behavior_event;
+DROP TABLE play_session;
+
+CREATE TABLE play_session (
+    session_id TEXT PRIMARY KEY,
+    scene_id TEXT NOT NULL REFERENCES source_scene(scene_id) ON DELETE CASCADE,
+    started_at_ms INTEGER NOT NULL CHECK (started_at_ms >= 0),
+    ended_at_ms INTEGER CHECK (ended_at_ms IS NULL OR ended_at_ms >= started_at_ms),
+    active_seconds REAL NOT NULL DEFAULT 0 CHECK (active_seconds >= 0),
+    provenance TEXT NOT NULL,
+    confidence REAL NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+    impression_id TEXT REFERENCES impression(impression_id),
+    summary_json TEXT NOT NULL DEFAULT '{}'
+) STRICT;
+
+INSERT INTO play_session SELECT * FROM play_session_staging;
+DROP TABLE play_session_staging;
+
+CREATE TABLE behavior_event (
+    event_id TEXT PRIMARY KEY,
+    event_type TEXT NOT NULL,
+    scene_id TEXT REFERENCES source_scene(scene_id) ON DELETE CASCADE,
+    occurred_at_ms INTEGER NOT NULL CHECK (occurred_at_ms >= 0),
+    outcome REAL CHECK (outcome BETWEEN -1 AND 1),
+    confidence REAL NOT NULL CHECK (confidence BETWEEN 0 AND 1),
+    provenance TEXT NOT NULL,
+    session_id TEXT REFERENCES play_session(session_id) ON DELETE CASCADE,
+    impression_id TEXT REFERENCES impression(impression_id),
+    payload_json TEXT NOT NULL DEFAULT '{}'
+) STRICT;
+
+INSERT INTO behavior_event SELECT * FROM behavior_event_staging;
+DROP TABLE behavior_event_staging;
+
+CREATE INDEX play_session_scene_idx ON play_session(scene_id, started_at_ms);
+CREATE INDEX behavior_event_scene_idx ON behavior_event(scene_id, occurred_at_ms);

--- a/tests/integration/test_sync.py
+++ b/tests/integration/test_sync.py
@@ -416,6 +416,17 @@ def test_incremental_sync_removes_entities_deleted_from_stash(
     service = SyncService(client, SyncRepository(connection), page_size=2)
     service.sync()
     assert connection.execute("SELECT count(*) FROM source_scene").fetchone()[0] == 2
+    # Curator's own playback telemetry has no foreign key to source_scene, so a deletion
+    # sweep is the only thing that can ever clean it up.
+    connection.execute(
+        "INSERT INTO play_session(session_id, scene_id, started_at_ms, provenance, confidence) "
+        "VALUES ('session-1', '1', 100, 'stash', 1.0)"
+    )
+    connection.execute(
+        "INSERT INTO behavior_event(event_id, event_type, scene_id, occurred_at_ms, confidence, "
+        "provenance) VALUES ('event-1', 'play_started', '1', 100, 1.0, 'stash')"
+    )
+    connection.commit()
 
     # A deleted scene has no updated_at to carry it past the watermark, so only an id sweep
     # can observe it.
@@ -435,6 +446,14 @@ def test_incremental_sync_removes_entities_deleted_from_stash(
     )
     assert (
         connection.execute("SELECT count(*) FROM source_file WHERE scene_id='1'").fetchone()[0] == 0
+    )
+    assert (
+        connection.execute("SELECT count(*) FROM play_session WHERE scene_id='1'").fetchone()[0]
+        == 0
+    )
+    assert (
+        connection.execute("SELECT count(*) FROM behavior_event WHERE scene_id='1'").fetchone()[0]
+        == 0
     )
     # Only the drifted entities are swept; the rest stop at their count probe.
     assert _swept(client) == {"scene_ids", "tag_ids"}

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -434,6 +434,32 @@ def test_wrong_metadata_is_not_reused_but_direct_scene_evidence_remains(tmp_path
     ).fetchone()
 
 
+def test_feedback_for_a_scene_deleted_from_stash_does_not_crash_the_build(
+    tmp_path: Path,
+) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    # feedback carries no foreign key to source_scene, so it can still reference a scene
+    # deleted from Stash after the feedback was given (kept as user-facing history) — unlike
+    # behavior_event and play_session, which cascade out with the scene.
+    connection.execute(
+        """
+        INSERT INTO feedback(feedback_id, scene_id, feedback_type, occurred_at_ms)
+        VALUES ('orphaned', 'removed-scene', 'thumb_up', ?)
+        """,
+        (REFERENCE_MS,),
+    )
+    builder = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS)
+    labels = builder._scene_labels()
+    assert "removed-scene" in labels
+
+    result = builder.build()
+
+    assert not connection.execute(
+        "SELECT 1 FROM direct_scene_state WHERE model_id=? AND scene_id='removed-scene'",
+        (result.model_id,),
+    ).fetchone()
+
+
 def test_failed_rebuild_cannot_replace_published_model(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/storage/test_cli_db.py
+++ b/tests/storage/test_cli_db.py
@@ -15,7 +15,7 @@ def test_database_cli_migrate_status_and_backup(
 
     assert run(["--db", str(database), "db", "migrate", "--json"]) == 0
     migrated = json.loads(capsys.readouterr().out)
-    assert migrated["current_version"] == migrated["latest_version"] == 21
+    assert migrated["current_version"] == migrated["latest_version"] == 23
 
     assert run(["--db", str(database), "db", "status", "--json"]) == 0
     status = json.loads(capsys.readouterr().out)

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -33,10 +33,12 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
             19,
             20,
             21,
+            22,
+            23,
         )
 
         after = runner.migrate(applied_at_ms=1234)
-        assert after.current_version == 21
+        assert after.current_version == 23
         assert after.pending_versions == ()
         assert runner.migrate(applied_at_ms=5678) == after
 
@@ -138,6 +140,10 @@ def test_unobserved_penalty_migration_keeps_graded_evidence(tmp_path: Path) -> N
         ("empty", "opened", 0.0, '{"played_ranges":[],"maximum_position_seconds":0.0}'),
         ("watched", "played", 120.0, '{"played_ranges":[],"maximum_position_seconds":120.0}'),
     )
+    for _, scene_id, _, _ in sessions:
+        connection.execute(
+            "INSERT INTO source_scene(scene_id, source_hash) VALUES (?, 'hash')", (scene_id,)
+        )
     for session_id, scene_id, active_seconds, summary in sessions:
         connection.execute(
             """
@@ -167,6 +173,138 @@ def test_unobserved_penalty_migration_keeps_graded_evidence(tmp_path: Path) -> N
     ] == ["played"]
 
 
+def test_purge_orphaned_playback_telemetry_migration_drops_deleted_scenes(
+    tmp_path: Path,
+) -> None:
+    connection = connect_database(tmp_path / "curator.sqlite3")
+    runner = MigrationRunner(connection)
+    original = runner.migrations
+    runner.migrations = [migration for migration in original if migration.version < 22]
+    runner.migrate(applied_at_ms=1)
+    connection.execute("INSERT INTO source_scene(scene_id, source_hash) VALUES ('kept', 'hash')")
+    for scene_id in ("kept", "gone"):
+        connection.execute(
+            """
+            INSERT INTO play_session(session_id, scene_id, started_at_ms, provenance, confidence)
+            VALUES (?, ?, 0, 'direct_player', 1)
+            """,
+            (f"session-{scene_id}", scene_id),
+        )
+        connection.execute(
+            """
+            INSERT INTO behavior_event(event_id, event_type, scene_id, occurred_at_ms, confidence,
+                provenance)
+            VALUES (?, 'play_started', ?, 0, 1, 'direct_player')
+            """,
+            (f"event-{scene_id}", scene_id),
+        )
+
+    runner.migrations = original
+    runner.migrate(applied_at_ms=2)
+
+    assert [str(row[0]) for row in connection.execute("SELECT scene_id FROM play_session")] == [
+        "kept"
+    ]
+    assert [str(row[0]) for row in connection.execute("SELECT scene_id FROM behavior_event")] == [
+        "kept"
+    ]
+
+
+def test_playback_telemetry_cascades_when_a_scene_is_deleted(tmp_path: Path) -> None:
+    connection = connect_database(tmp_path / "curator.sqlite3")
+    MigrationRunner(connection).migrate(applied_at_ms=1)
+    connection.executemany(
+        "INSERT INTO source_scene(scene_id, source_hash) VALUES (?, 'hash')",
+        (("kept",), ("gone",)),
+    )
+    for scene_id in ("kept", "gone"):
+        connection.execute(
+            """
+            INSERT INTO play_session(session_id, scene_id, started_at_ms, provenance, confidence)
+            VALUES (?, ?, 0, 'direct_player', 1)
+            """,
+            (f"session-{scene_id}", scene_id),
+        )
+        # A behavior_event referencing its session but not carrying scene_id itself must
+        # still be caught by the cascade through play_session, not just the direct one.
+        connection.execute(
+            """
+            INSERT INTO behavior_event(event_id, event_type, scene_id, occurred_at_ms,
+                confidence, provenance, session_id)
+            VALUES (?, 'play_started', ?, 0, 1, 'direct_player', ?)
+            """,
+            (f"event-{scene_id}", scene_id, f"session-{scene_id}"),
+        )
+        connection.execute(
+            """
+            INSERT INTO behavior_event(event_id, event_type, scene_id, occurred_at_ms,
+                confidence, provenance, session_id)
+            VALUES (?, 'occasion_outcome', NULL, 0, 1, 'direct_player', ?)
+            """,
+            (f"event-{scene_id}-session-only", f"session-{scene_id}"),
+        )
+
+    connection.execute("DELETE FROM source_scene WHERE scene_id='gone'")
+
+    assert [str(row[0]) for row in connection.execute("SELECT scene_id FROM play_session")] == [
+        "kept"
+    ]
+    assert sorted(
+        str(row[0]) for row in connection.execute("SELECT event_id FROM behavior_event")
+    ) == ["event-kept", "event-kept-session-only"]
+
+
+def test_cascade_migration_survives_attached_generation_temp_views(tmp_path: Path) -> None:
+    # A connection with a published model or feature generation attached creates temp views
+    # over table names like entity_feature (see attach_active_artifacts). ALTER TABLE RENAME
+    # while any such view exists makes SQLite rescan the whole schema and trip a real SQLite
+    # bug ("views may not be indexed") on the shadowed name — unrelated to what is actually
+    # being renamed. This reproduces that shadowing directly, without needing a real attached
+    # artifact file, to prove migration 23 does not depend on RENAME at all.
+    connection = connect_database(tmp_path / "curator.sqlite3")
+    runner = MigrationRunner(connection)
+    original = runner.migrations
+    runner.migrations = [migration for migration in original if migration.version < 23]
+    runner.migrate(applied_at_ms=1)
+    connection.execute("INSERT INTO source_scene(scene_id, source_hash) VALUES ('s1', 'h')")
+    connection.execute(
+        "INSERT INTO play_session(session_id, scene_id, started_at_ms, provenance, confidence) "
+        "VALUES ('sess1', 's1', 0, 'direct_player', 1)"
+    )
+    connection.execute(
+        """
+        INSERT INTO behavior_event(event_id, event_type, scene_id, occurred_at_ms, confidence,
+            provenance, session_id)
+        VALUES ('e1', 'play_started', 's1', 0, 1, 'direct_player', 'sess1')
+        """
+    )
+    for name in (
+        "feature_definition",
+        "entity_feature",
+        "scene_content_search",
+        "model_scene_score",
+        "model_scene_reason",
+        "feature_affinity",
+        "direct_scene_state",
+    ):
+        connection.execute(f"CREATE TEMP VIEW {name} AS SELECT 1")
+
+    runner.migrations = original
+    runner.migrate(applied_at_ms=2)
+
+    ps_schema = connection.execute(
+        "SELECT sql FROM sqlite_master WHERE name='play_session'"
+    ).fetchone()[0]
+    be_schema = connection.execute(
+        "SELECT sql FROM sqlite_master WHERE name='behavior_event'"
+    ).fetchone()[0]
+    assert "ON DELETE CASCADE" in ps_schema
+    assert be_schema.count("ON DELETE CASCADE") == 2
+    assert connection.execute("SELECT count(*) FROM play_session").fetchone()[0] == 1
+    assert connection.execute("SELECT count(*) FROM behavior_event").fetchone()[0] == 1
+    assert connection.execute("PRAGMA foreign_key_check").fetchall() == []
+
+
 def test_unknown_future_migration_is_rejected(tmp_path: Path) -> None:
     connection = connect_database(tmp_path / "curator.sqlite3")
     try:
@@ -192,7 +330,7 @@ def test_status_stays_read_only_after_migrations(tmp_path: Path) -> None:
     reader.execute("PRAGMA busy_timeout=1")
     try:
         writer.execute("BEGIN IMMEDIATE")
-        assert MigrationRunner(reader).status().current_version == 21
+        assert MigrationRunner(reader).status().current_version == 23
     finally:
         writer.rollback()
         reader.close()
@@ -218,7 +356,7 @@ def test_stale_concurrent_migrator_rechecks_after_writer_lock(
 
     monkeypatch.setattr(second_runner, "status", status)
     try:
-        assert second_runner.migrate(applied_at_ms=2).current_version == 21
+        assert second_runner.migrate(applied_at_ms=2).current_version == 23
     finally:
         second.close()
         first.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_doctor_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
     assert result["status"] == "ok"
     assert result["stash"] == "not_configured"
     assert result["schema_current"] == 0
-    assert result["schema_latest"] == 21
+    assert result["schema_latest"] == 23
 
 
 def test_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from curator.interactions import InteractionStore
-from curator.model import PreferenceModelBuilder
+from curator.model import ModelUpdateCoordinator, PreferenceModelBuilder
 from curator.ranking import SlateBuilder
 from tests.model.test_builder import REFERENCE_MS, _database
 
@@ -153,6 +153,10 @@ def test_session_without_observed_playback_records_no_view_evidence(tmp_path: Pa
         ).fetchone()[0]
         == 0
     )
+    # A page open that produced no evidence must not wake "Apply recent Curator
+    # feedback" on the next Curator visit; otherwise plain browsing would keep
+    # marking the model dirty forever.
+    assert not ModelUpdateCoordinator(connection).status().pending
 
 
 def test_unobserved_session_is_never_graded_as_abandoned(tmp_path: Path) -> None:

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -123,8 +123,43 @@ def test_direct_sessions_record_views_and_quick_replacement(tmp_path: Path) -> N
     assert not any('"primary_signal":"quick_replacement"' in item for item in signals)
 
 
+def test_session_for_a_scene_not_yet_synced_is_dropped_not_fatal(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    store = InteractionStore(connection)
+    # The live Stash tracker names whatever scene is on screen, which can be one added to
+    # Stash after Curator's last sync. OR IGNORE does not cover foreign key violations, so
+    # this must be caught explicitly rather than aborting the whole submitted batch.
+    unsynced = {
+        "session_id": "too-new",
+        "scene_id": "not-yet-synced",
+        "started_at_ms": 1_000,
+        "ended_at_ms": 11_000,
+        "active_seconds": 10,
+        "origin": "stash",
+        "source_route": "/scenes/not-yet-synced",
+        "start_position_seconds": 0,
+        "maximum_position_seconds": 10,
+        "final_position_seconds": 10,
+    }
+    known = {
+        **unsynced,
+        "session_id": "known",
+        "scene_id": "old-good",
+        "source_route": "/scenes/old-good",
+    }
+
+    assert store.submit_sessions([unsynced, known]) == 1
+    assert not connection.execute(
+        "SELECT 1 FROM play_session WHERE scene_id='not-yet-synced'"
+    ).fetchone()
+    assert connection.execute("SELECT 1 FROM play_session WHERE scene_id='old-good'").fetchone()
+
+
 def test_session_without_observed_playback_records_no_view_evidence(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
+    connection.execute(
+        "INSERT INTO source_scene(scene_id, source_hash) VALUES ('watched-elsewhere', 'hash')"
+    )
     store = InteractionStore(connection)
     unobserved = {
         "session_id": "opened-only",
@@ -161,6 +196,10 @@ def test_session_without_observed_playback_records_no_view_evidence(tmp_path: Pa
 
 def test_unobserved_session_is_never_graded_as_abandoned(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
+    connection.executemany(
+        "INSERT INTO source_scene(scene_id, source_hash) VALUES (?, ?)",
+        (("chosen", "hash-chosen"), ("next-scene", "hash-next")),
+    )
     store = InteractionStore(connection)
     connection.execute(
         """


### PR DESCRIPTION
## Summary
- `play_session` and `behavior_event` keyed on `scene_id` with no foreign key, so a scene removed from Stash left orphaned rows in both. A later model build picked up the orphaned scene from that telemetry and crashed cross-referencing the live scene list it no longer appeared in — surfaced on the Curator page as a raw scene-id error.
- Both tables are rebuilt with `ON DELETE CASCADE` to `source_scene` (migration `0023`), and `behavior_event`'s existing unenforced link to `play_session` is upgraded to `CASCADE` too, since otherwise a scene delete would cascade into `play_session` and then abort on `behavior_event`'s constraint instead of cleaning up.
- A companion migration (`0022`) sweeps whatever had already accumulated on existing installs.
- The model builder gets a defensive skip for any label without a matching score — covers `feedback`, which is deliberately *not* cascaded since it's kept as user-facing history past scene deletion, plus any other future source of the same class of drift.
- `InteractionStore.submit_sessions` now catches the foreign-key violation from a session naming a scene Curator hasn't synced yet (a real race between live Stash browsing and periodic sync) and drops just that entry, since SQLite's `INSERT OR IGNORE` does not cover foreign-key violations.

## Test plan
- [x] `pytest` — 247 passed, including new coverage for the cascade behavior, the migration itself (including a case reproducing a real SQLite quirk where `ALTER TABLE RENAME` breaks while a generation artifact's temp views are attached — this is why the migration uses staged `CREATE TABLE`/`DROP TABLE` instead of `RENAME`), and the not-yet-synced-scene race.
- [x] Verified migration 0022+0023 end-to-end against a full backup of a real instance's sidecar database: orphaned rows removed, `PRAGMA foreign_key_check` clean, cascade confirmed live by deleting a scene and observing its telemetry rows disappear automatically, and a full model build completing successfully afterward.
- [x] Deployed and applied to that instance; a previously wedged model-rebuild job (repeatedly failing on the orphaned-scene crash) now completes cleanly.