### PR TITLE
Accelerate model builds ~4x with numpy, lean I/O, and batched fingerprints

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ database you control.
 ## Install
 
 Preview requirements: **Stash v0.31** and **Python 3.12+** available to Stash's
-plugin runtime. Add this source under **Settings → Plugins → Available Plugins**:
+plugin runtime (no third-party packages required; an optional numpy acceleration
+is installed by one Stash task). Add this source under
+**Settings → Plugins → Available Plugins**:
 
 ```text
 https://mrx-31415.github.io/stash-curator/index.yml

--- a/curator/features/builder.py
+++ b/curator/features/builder.py
@@ -20,6 +20,7 @@ from curator.features.measurements import (
     presence_category,
 )
 from curator.features.tag_roles import TagRole, TagRoleResolver, TagRoleResult
+from curator.profiling import record_duration, span
 from curator.storage import transaction
 from curator.storage.artifacts import (
     ARTIFACT_SCHEMA_VERSION,
@@ -156,11 +157,14 @@ class FeatureBuilder:
             )
         try:
             build_started = time.perf_counter()
-            roles = self._resolve_tag_roles()
+            with span("python", "feature.roles"):
+                roles = self._resolve_tag_roles()
             self._report(0.10)
-            scene_features = self._scene_features(roles)
+            with span("python", "feature.scene_features"):
+                scene_features = self._scene_features(roles)
             self._report(0.45)
-            performer_features = self._performer_features(scene_features)
+            with span("python", "feature.performer_features"):
+                performer_features = self._performer_features(scene_features)
             self._report(0.60)
             if self._source_fingerprint() != source_fingerprint:
                 raise FeatureBuildError("source cache changed during feature construction")
@@ -735,10 +739,12 @@ class FeatureBuilder:
                     ),
                 )
             timings["database_writing"] = round((time.perf_counter() - writing_started) * 1000)
+            record_duration("python", "feature.publish_write", timings["database_writing"])
             self._report(0.75)
             indexing_started = time.perf_counter()
             create_indexes(artifact, "feature")
             timings["indexing"] = round((time.perf_counter() - indexing_started) * 1000)
+            record_duration("python", "feature.publish_index", timings["indexing"])
             self._report(0.85)
             validation_started = time.perf_counter()
             stored = artifact.execute(

--- a/curator/features/builder.py
+++ b/curator/features/builder.py
@@ -11,6 +11,7 @@ from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date
+from typing import Any
 
 from curator.config import DEFAULT_CONFIG, CuratorConfig
 from curator.features.measurements import (
@@ -37,6 +38,31 @@ from curator.taxonomy.store import CATEGORY_ROLE_FINGERPRINT
 
 class FeatureBuildError(RuntimeError):
     pass
+
+
+def _fingerprint_table(
+    connection: sqlite3.Connection,
+    digest: Any,
+    label: str,
+    statement: str,
+) -> None:
+    """Hash one ordered source table into the fingerprint digest.
+
+    Rows are json-encoded in batches of a thousand and hashed with a single digest
+    update per batch; batching keeps the encoding collision-free (JSON escaping) while
+    cutting per-row json.dumps and hashlib call overhead by roughly an order of
+    magnitude on the multi-hundred-thousand-row tables.
+    """
+    digest.update(f"{label}\0".encode())
+    batch: list[tuple[object, ...]] = []
+    for row in connection.execute(statement):
+        batch.append(tuple(row))
+        if len(batch) == 1_000:
+            digest.update(json.dumps(batch, separators=(",", ":"), ensure_ascii=False).encode())
+            batch = []
+    if batch:
+        digest.update(json.dumps(batch, separators=(",", ":"), ensure_ascii=False).encode())
+    digest.update(b"\n")
 
 
 @dataclass(frozen=True)
@@ -227,12 +253,7 @@ class FeatureBuilder:
                 "ORDER BY tag_id, endpoint",
             ),
         ):
-            digest.update(f"{label}\0".encode())
-            for row in self.connection.execute(statement):
-                digest.update(
-                    json.dumps(tuple(row), separators=(",", ":"), ensure_ascii=False).encode()
-                )
-                digest.update(b"\n")
+            _fingerprint_table(self.connection, digest, label, statement)
         row = self.connection.execute(
             "SELECT value FROM application_meta WHERE key='taxonomy_snapshot_id'"
         ).fetchone()
@@ -583,7 +604,14 @@ class FeatureBuilder:
         definitions: dict[tuple[str, str, str], tuple[str, dict[str, object]]] = {}
         for feature in features:
             key = (feature.entity_type, feature.family, feature.name)
-            definitions.setdefault(key, (self._feature_id(feature_version, *key), feature.metadata))
+            # Membership check instead of setdefault: the default argument of
+            # setdefault is evaluated eagerly for every feature, wasting a sha256
+            # per duplicate instead of once per definition.
+            if key not in definitions:
+                definitions[key] = (
+                    self._feature_id(feature_version, *key),
+                    feature.metadata,
+                )
         scene_count = len(
             {feature.entity_id for feature in features if feature.entity_type == "scene"}
         )

--- a/curator/features/profiles.py
+++ b/curator/features/profiles.py
@@ -17,6 +17,7 @@ class PerformerProfile:
     performer_id: str
     blocks: dict[str, dict[str, ProfileValue]]
     norms: dict[str, float] = field(init=False, repr=False, compare=False)
+    keys: dict[str, frozenset[str]] = field(init=False, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -27,6 +28,13 @@ class PerformerProfile:
                 for block, values in self.blocks.items()
                 if block not in NUMERIC_BLOCKS
             },
+        )
+        # Frozen key sets avoid rebuilding a set from each block dict on every
+        # similarity call; the builder compares every profile against every known
+        # profile, so this is the difference between tens of millions of conversions
+        # and a single hash each.
+        object.__setattr__(
+            self, "keys", {block: frozenset(values) for block, values in self.blocks.items()}
         )
 
 
@@ -57,28 +65,53 @@ def _cosine(
     right: dict[str, ProfileValue],
     left_norm: float,
     right_norm: float,
+    left_keys: frozenset[str] | None = None,
+    right_keys: frozenset[str] | None = None,
 ) -> float | None:
-    shared = set(left) & set(right)
+    # Precomputed frozensets keep the same iteration order as freshly built sets
+    # (both derive from the same dict insertion order), so dot-product accumulation
+    # stays bit-identical to the previous set(left) & set(right) form.
+    shared = (left_keys or frozenset(left)) & (right_keys or frozenset(right))
     if not shared:
         return 0.0
-    dot = sum(left[key].value * right[key].value for key in shared)
+    dot = 0.0
+    confidence_sum = 0.0
+    for key in shared:
+        left_value = left[key]
+        right_value = right[key]
+        dot += left_value.value * right_value.value
+        right_confidence = right_value.confidence
+        left_confidence = left_value.confidence
+        confidence_sum += (
+            left_confidence if left_confidence < right_confidence else right_confidence
+        )
     if left_norm == 0 or right_norm == 0:
         return None
-    confidence = sum(min(left[key].confidence, right[key].confidence) for key in shared) / len(
-        shared
-    )
+    confidence = confidence_sum / len(shared)
     return max(0.0, min(1.0, dot / (left_norm * right_norm) * confidence))
 
 
-def _numeric(left: dict[str, ProfileValue], right: dict[str, ProfileValue]) -> float | None:
-    shared = set(left) & set(right)
+def _numeric(
+    left: dict[str, ProfileValue],
+    right: dict[str, ProfileValue],
+    left_keys: frozenset[str] | None = None,
+    right_keys: frozenset[str] | None = None,
+) -> float | None:
+    shared = (left_keys or frozenset(left)) & (right_keys or frozenset(right))
     if not shared:
         return None
     values = []
     for key in sorted(shared):
         scale = NUMERIC_SCALES.get(key, 1.0)
-        closeness = math.exp(-abs(left[key].value - right[key].value) / scale)
-        values.append(closeness * min(left[key].confidence, right[key].confidence))
+        left_value = left[key]
+        right_value = right[key]
+        closeness = math.exp(-abs(left_value.value - right_value.value) / scale)
+        right_confidence = right_value.confidence
+        left_confidence = left_value.confidence
+        values.append(
+            closeness
+            * (left_confidence if left_confidence < right_confidence else right_confidence)
+        )
     return sum(values) / len(values)
 
 
@@ -91,8 +124,17 @@ def block_similarity(
     if block not in left.blocks or block not in right.blocks:
         return None
     if block in NUMERIC_BLOCKS:
-        return _numeric(left.blocks[block], right.blocks[block])
-    return _cosine(left.blocks[block], right.blocks[block], left.norms[block], right.norms[block])
+        return _numeric(
+            left.blocks[block], right.blocks[block], left.keys[block], right.keys[block]
+        )
+    return _cosine(
+        left.blocks[block],
+        right.blocks[block],
+        left.norms[block],
+        right.norms[block],
+        left.keys[block],
+        right.keys[block],
+    )
 
 
 def block_similarities(

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -12,11 +12,13 @@ from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass
 from heapq import nsmallest
 from itertools import batched
+from typing import Any
 
+from curator import optional_deps
 from curator.config import DEFAULT_CONFIG, CuratorConfig
 from curator.events.contracts import DEFAULT_CALIBRATION
 from curator.features import FeatureBuilder, FeatureStore
-from curator.features.profiles import performer_similarity
+from curator.features.profiles import NUMERIC_BLOCKS, NUMERIC_SCALES, performer_similarity
 from curator.features.store import StoredFeature
 from curator.model.boundaries import scene_eligibility
 from curator.model.curves import blend_appeal, direct_confidence, scene_recovery
@@ -108,6 +110,69 @@ def _clamp(value: float, lower: float = -1.0, upper: float = 1.0) -> float:
 
 def _number(value: object) -> float:
     return float(value) if isinstance(value, (int, float)) else 0.0
+
+
+def _numpy_cosine_matrix(
+    np: Any,
+    values: Any,
+    known_values: Any,
+    confidences: Any,
+    known_confidences: Any,
+    norms: Any,
+    known_norms: Any,
+) -> Any:
+    """Vectorized block cosine for profile blocks that use the shared-key dot product.
+
+    Matches the pure-Python _cosine: dot over shared keys divided by the product of
+    norms, scaled by the mean of the pairwise minimum confidences, clamped to [0, 1].
+    """
+    dot = values @ known_values.T
+    # Shared counts never exceed the feature count, so float32 is exact and uses the
+    # BLAS matmul path; the confidence mean is then computed in float64.
+    shared = ((values != 0).astype(np.float32) @ (known_values != 0).astype(np.float32).T).astype(
+        np.float64
+    )
+    confidence_sum = np.zeros((values.shape[0], known_values.shape[0]), dtype=np.float64)
+    for column in range(values.shape[1]):
+        if not confidences[:, column].any() or not known_confidences[:, column].any():
+            continue
+        confidence_sum += np.minimum.outer(confidences[:, column], known_confidences[:, column])
+    with np.errstate(divide="ignore", invalid="ignore"):
+        confidence = np.where(shared > 0, confidence_sum / shared, 0.0)
+        cosine = dot / (norms[:, None] * known_norms[None, :]) * confidence
+    return np.clip(cosine, 0.0, 1.0)
+
+
+def _numpy_numeric_matrix(
+    np: Any,
+    values: Any,
+    known_values: Any,
+    confidences: Any,
+    known_confidences: Any,
+    scales: Any,
+) -> tuple[Any, Any]:
+    """Vectorized numeric-block closeness and shared-key counts.
+
+    Mirrors the pure-Python _numeric: each shared key contributes
+    exp(-abs difference / scale) * min confidence; the block value is the mean over
+    the shared keys.
+    """
+    value = np.zeros((values.shape[0], known_values.shape[0]), dtype=np.float64)
+    count = np.zeros_like(value)
+    for column in range(values.shape[1]):
+        both = np.outer(values[:, column] != 0, known_values[:, column] != 0)
+        if not both.any():
+            continue
+        closeness = np.exp(
+            -np.abs(np.subtract.outer(values[:, column], known_values[:, column])) / scales[column]
+        )
+        value += (
+            closeness
+            * np.minimum.outer(confidences[:, column], known_confidences[:, column])
+            * both
+        )
+        count += both
+    return value, count
 
 
 class PreferenceModelBuilder:
@@ -900,6 +965,17 @@ class PreferenceModelBuilder:
         label_mean: float,
         progress_total: int,
     ) -> dict[str, _NeighborEvidence]:
+        if optional_deps.NUMPY_AVAILABLE:
+            return self._content_neighbors_numpy(vectors, labels, label_mean, progress_total)
+        return self._content_neighbors_python(vectors, labels, label_mean, progress_total)
+
+    def _content_neighbors_python(
+        self,
+        vectors: dict[str, dict[str, float]],
+        labels: dict[str, _SceneLabel],
+        label_mean: float,
+        progress_total: int,
+    ) -> dict[str, _NeighborEvidence]:
         inverted: dict[str, list[tuple[str, float]]] = defaultdict(list)
         vector_count = len(vectors)
         for scene_id, vector in vectors.items():
@@ -960,7 +1036,132 @@ class PreferenceModelBuilder:
                 self._report(0.35 + 0.40 * vector_index / max(1, progress_total))
         return result
 
+    def _content_neighbors_numpy(
+        self,
+        vectors: dict[str, dict[str, float]],
+        labels: dict[str, _SceneLabel],
+        label_mean: float,
+        progress_total: int,
+    ) -> dict[str, _NeighborEvidence]:
+        np = optional_deps.np
+        assert np is not None
+        scene_ids = list(vectors)
+        # Labels for scenes that left Stash have no vector; they cannot act as
+        # candidates, mirroring the pure-Python inverted index over vectors only.
+        labeled_ids = sorted(scene_id for scene_id in labels if scene_id in vectors)
+        default = _NeighborEvidence(0.0, 0.0, 0.0, 0.0, 0.0, ())
+        result: dict[str, _NeighborEvidence] = {}
+        if not labeled_ids:
+            return {scene_id: default for scene_id in scene_ids}
+        column_names = sorted({name for scene_id in labeled_ids for name in vectors[scene_id]})
+        if not column_names:
+            return {scene_id: default for scene_id in scene_ids}
+        column_index = {name: index for index, name in enumerate(column_names)}
+        labeled_position = {scene_id: column for column, scene_id in enumerate(labeled_ids)}
+        labeled_values = np.zeros((len(labeled_ids), len(column_names)), dtype=np.float64)
+        for column, scene_id in enumerate(labeled_ids):
+            for name, value in vectors[scene_id].items():
+                labeled_values[column, column_index[name]] = value
+        target_values = np.zeros((len(scene_ids), len(column_names)), dtype=np.float64)
+        for row, scene_id in enumerate(scene_ids):
+            for name, value in vectors[scene_id].items():
+                if name not in column_index:
+                    continue
+                target_values[row, column_index[name]] = value
+        labeled_conf = np.array(
+            [labels[scene_id].confidence for scene_id in labeled_ids], dtype=np.float64
+        )
+        labeled_outcome = np.array(
+            [labels[scene_id].outcome for scene_id in labeled_ids], dtype=np.float64
+        )
+        labeled_binary = (labeled_values != 0).astype(np.float32)
+        target_binary = (target_values != 0).astype(np.float32)
+        self_column = np.array(
+            [labeled_position.get(scene_id, -1) for scene_id in scene_ids], dtype=np.int32
+        )
+        minimum_similarity = self.config.model.minimum_neighbor_similarity
+        neighbor_count = self.config.model.neighbor_count
+        confidence_scale = self.config.model.neighbor_confidence_scale
+        vector_count = len(scene_ids)
+        for start in range(0, vector_count, 4096):
+            end = min(start + 4096, vector_count)
+            similarities = target_values[start:end] @ labeled_values.T
+            # Shared counts never exceed the feature count, so float32 is exact and
+            # uses the BLAS matmul path (integer matmul has no optimized loop); the
+            # overlap factor is then computed in float64 to match the Python path.
+            shared = (target_binary[start:end] @ labeled_binary.T).astype(np.float64)
+            similarities *= 1.0 - np.exp(-shared / 4.0)
+            weights = similarities**3 * labeled_conf[np.newaxis, :]
+            valid = similarities >= minimum_similarity
+            for local_row in range(end - start):
+                own = int(self_column[start + local_row])
+                if own >= 0:
+                    valid[local_row, own] = False
+            for local_row in range(end - start):
+                scene_id = scene_ids[start + local_row]
+                valid_indices = np.flatnonzero(valid[local_row])
+                if len(valid_indices) == 0:
+                    result[scene_id] = default
+                    continue
+                row_weights = weights[local_row, valid_indices]
+                chosen = min(neighbor_count, len(row_weights))
+                boundary = float(
+                    np.partition(row_weights, len(row_weights) - chosen)[len(row_weights) - chosen]
+                )
+                candidates = valid_indices[row_weights >= boundary]
+                evidence = [
+                    (
+                        labeled_ids[int(column)],
+                        float(similarities[local_row, int(column)]),
+                        float(weights[local_row, int(column)]),
+                        float(labeled_outcome[int(column)]),
+                    )
+                    for column in candidates
+                ]
+                evidence.sort(key=lambda item: (-item[2], item[0]))
+                selected = evidence[:neighbor_count]
+                denominator = sum(item[2] for item in selected)
+                outcome_mean = (
+                    sum(item[2] * item[3] for item in selected) / denominator
+                    if denominator
+                    else 0.0
+                )
+                lift = outcome_mean - label_mean if denominator else 0.0
+                confidence = 1 - math.exp(-denominator / confidence_scale) if denominator else 0.0
+                result[scene_id] = _NeighborEvidence(
+                    lift * confidence,
+                    outcome_mean,
+                    lift,
+                    confidence,
+                    denominator,
+                    tuple(
+                        {
+                            "scene_id": item[0],
+                            "similarity": item[1],
+                            "weight": item[2],
+                            "outcome": item[3],
+                        }
+                        for item in selected[:5]
+                    ),
+                )
+                index = start + local_row + 1
+                if self.progress and (index == vector_count or index % 250 == 0):
+                    self._report(0.35 + 0.40 * index / max(1, progress_total))
+        return result
+
     def _performer_similarity_scores(
+        self,
+        feature_version: str,
+        scene_features: dict[str, tuple[StoredFeature, ...]],
+        affinities: dict[str, _Affinity],
+    ) -> dict[str, dict[str, object]]:
+        if optional_deps.NUMPY_AVAILABLE:
+            return self._performer_similarity_scores_numpy(
+                feature_version, scene_features, affinities
+            )
+        return self._performer_similarity_scores_python(feature_version, scene_features, affinities)
+
+    def _performer_similarity_scores_python(
         self,
         feature_version: str,
         scene_features: dict[str, tuple[StoredFeature, ...]],
@@ -1045,6 +1246,203 @@ class PreferenceModelBuilder:
             }
         return result
 
+    def _performer_similarity_scores_numpy(
+        self,
+        feature_version: str,
+        scene_features: dict[str, tuple[StoredFeature, ...]],
+        affinities: dict[str, _Affinity],
+    ) -> dict[str, dict[str, object]]:
+        np = optional_deps.np
+        assert np is not None
+        identity_affinity: dict[str, tuple[float, float]] = {}
+        for features in scene_features.values():
+            for feature in features:
+                if feature.family != "performer_identity" or feature.feature_id not in affinities:
+                    continue
+                affinity = affinities[feature.feature_id]
+                identity_affinity[feature.name.removeprefix("performer:")] = (
+                    affinity.affinity * affinity.confidence,
+                    affinity.confidence,
+                )
+        profiles = FeatureStore(self.connection).performer_profiles(feature_version)
+        weights = dict(self.config.feature.performer_block_weights)
+        known = {
+            key: profiles[key]
+            for key, (value, _) in identity_affinity.items()
+            if key in profiles and abs(value) >= PERFORMER_SIMILARITY_AFFINITY_CUTOFF
+        }
+        profile_ids = list(profiles)
+        known_ids = list(known)
+        known_position = {performer_id: column for column, performer_id in enumerate(known_ids)}
+        known_affinity = np.array(
+            [identity_affinity[performer_id][0] for performer_id in known_ids], dtype=np.float64
+        )
+        known_confidence = np.array(
+            [identity_affinity[performer_id][1] for performer_id in known_ids], dtype=np.float64
+        )
+        block_names = sorted({block for profile in profiles.values() for block in profile.blocks})
+        block_keys = {
+            block: sorted(
+                {key for profile in profiles.values() for key in profile.blocks.get(block, {})}
+            )
+            for block in block_names
+        }
+        values: dict[str, Any] = {}
+        confidences: dict[str, Any] = {}
+        present: dict[str, Any] = {}
+        for block in block_names:
+            keys = block_keys[block]
+            key_position = {key: column for column, key in enumerate(keys)}
+            block_values = np.zeros((len(profile_ids), len(keys)), dtype=np.float64)
+            block_confidences = np.zeros_like(block_values)
+            block_present = np.zeros(len(profile_ids), dtype=bool)
+            for row, performer_id in enumerate(profile_ids):
+                entries = profiles[performer_id].blocks.get(block)
+                if not entries:
+                    continue
+                block_present[row] = True
+                for key, item in entries.items():
+                    block_values[row, key_position[key]] = item.value
+                    block_confidences[row, key_position[key]] = item.confidence
+            values[block] = block_values
+            confidences[block] = block_confidences
+            present[block] = block_present
+        known_positions = np.array(
+            [profile_ids.index(performer_id) for performer_id in known_ids], dtype=np.int64
+        )
+        known_values = {block: values[block][known_positions, :] for block in block_names}
+        known_confidences = {block: confidences[block][known_positions, :] for block in block_names}
+        known_present = {block: present[block][known_positions] for block in block_names}
+        numerator = np.zeros((len(profile_ids), len(known_ids)), dtype=np.float64)
+        denominator = np.zeros_like(numerator)
+        block_similarities: dict[str, Any] = {}
+        used: dict[str, Any] = {}
+        for block in block_names:
+            weight = weights.get(block, 0.0)
+            if weight <= 0:
+                continue
+            both_present = np.outer(present[block], known_present[block])
+            if block in NUMERIC_BLOCKS:
+                numeric_values, numeric_counts = _numpy_numeric_matrix(
+                    np,
+                    values[block],
+                    known_values[block],
+                    confidences[block],
+                    known_confidences[block],
+                    np.array(
+                        [NUMERIC_SCALES.get(key, 1.0) for key in block_keys[block]],
+                        dtype=np.float64,
+                    ),
+                )
+                with np.errstate(divide="ignore", invalid="ignore"):
+                    block_value = np.divide(
+                        numeric_values,
+                        numeric_counts,
+                        out=np.zeros_like(numeric_values),
+                        where=numeric_counts > 0,
+                    )
+                block_used = both_present & (numeric_counts > 0)
+            else:
+                norms = np.array(
+                    [profiles[performer_id].norms.get(block, 0.0) for performer_id in profile_ids],
+                    dtype=np.float64,
+                )
+                known_norms = norms[known_positions]
+                block_value = _numpy_cosine_matrix(
+                    np,
+                    values[block],
+                    known_values[block],
+                    confidences[block],
+                    known_confidences[block],
+                    norms,
+                    known_norms,
+                )
+                block_used = both_present & (norms[:, None] != 0) & (known_norms[None, :] != 0)
+            block_similarities[block] = block_value
+            used[block] = block_used
+            numerator += block_value * block_used * weight
+            denominator += block_used * weight
+        penalty = np.ones((len(profile_ids), len(known_ids)), dtype=np.float64)
+        measurements = values.get("measurements")
+        if measurements is not None and measurements.shape[1]:
+            cup_position = (
+                block_keys["measurements"].index("cup_index")
+                if "cup_index" in block_keys["measurements"]
+                else -1
+            )
+            if cup_position >= 0:
+                cup_all = measurements[:, cup_position]
+                cup_known = known_values["measurements"][:, cup_position]
+                both_cup = np.outer(cup_all != 0, cup_known != 0)
+                cup_difference = np.abs(np.subtract.outer(cup_all, cup_known))
+                penalty *= np.where(
+                    both_cup, np.exp(-0.18 * np.maximum(0.0, cup_difference - 1.0)), 1.0
+                )
+        augmentation = values.get("augmentation")
+        if augmentation is not None and augmentation.shape[1]:
+            augmentation_binary = (augmentation != 0).astype(np.float32)
+            known_augmentation_binary = (known_values["augmentation"] != 0).astype(np.float32)
+            shared_augmentation = augmentation_binary @ known_augmentation_binary.T
+            both_augmentation = np.outer(
+                augmentation_binary.any(axis=1), known_augmentation_binary.any(axis=1)
+            )
+            penalty *= np.where(both_augmentation & (shared_augmentation == 0), 0.65, 1.0)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            similarity = np.where(denominator > 0, numerator / denominator * penalty, 0.0)
+        result: dict[str, dict[str, object]] = {}
+        for performer_index, performer_id in enumerate(profile_ids):
+            row = similarity[performer_index]
+            candidates = [
+                (known_ids[column], float(row[column]))
+                for column in range(len(known_ids))
+                if known_ids[column] != performer_id and float(row[column]) > 0
+            ]
+            selected = nsmallest(
+                5,
+                candidates,
+                key=lambda item: (-item[1], item[0]),
+            )
+            denominator = sum(item[1] ** 3 for item in selected)
+            value = (
+                sum(
+                    float(known_affinity[known_position[item[0]]]) * item[1] ** 3
+                    for item in selected
+                )
+                / denominator
+                if denominator
+                else 0.0
+            )
+            confidence = (
+                sum(
+                    float(known_confidence[known_position[item[0]]]) * item[1] ** 3
+                    for item in selected
+                )
+                / denominator
+                if denominator
+                else 0.0
+            )
+            result[performer_id] = {
+                "value": value,
+                "confidence": confidence,
+                "matches": [
+                    {
+                        "performer_id": known_id,
+                        "similarity": score,
+                        "affinity": identity_affinity[known_id][0],
+                        "confidence": identity_affinity[known_id][1],
+                        "blocks": {
+                            block: float(
+                                block_similarities[block][performer_index, known_position[known_id]]
+                            )
+                            for block in used
+                            if bool(used[block][performer_index, known_position[known_id]])
+                        },
+                    }
+                    for known_id, score in selected[:3]
+                ],
+            }
+        return result
+
     def _performer_priors(self) -> dict[str, _Prior]:
         result: dict[str, _Prior] = {}
         for row in self.connection.execute(
@@ -1118,7 +1516,9 @@ class PreferenceModelBuilder:
         ).fetchall()
         performers: dict[str, int] = {}
         studios: dict[str, int] = {}
-        recent_vectors = []
+        recent_by_name: dict[str, list[tuple[int, float]]] = {}
+        recent_scene_ids: list[str] = []
+        recent_played: list[int] = []
         for row in rows:
             scene_id = str(row["scene_id"])
             played_at = int(row["played_at"])
@@ -1129,7 +1529,11 @@ class PreferenceModelBuilder:
             for performer_id in scene_performers.get(scene_id, ()):
                 performers[performer_id] = max(played_at, performers.get(performer_id, 0))
             if scene_id in vectors:
-                recent_vectors.append((scene_id, played_at, vectors[scene_id]))
+                index = len(recent_scene_ids)
+                recent_scene_ids.append(scene_id)
+                recent_played.append(played_at)
+                for name, value in vectors[scene_id].items():
+                    recent_by_name.setdefault(name, []).append((index, value))
         return {
             "reference": reference_at_ms,
             "performers": performers,
@@ -1137,7 +1541,11 @@ class PreferenceModelBuilder:
             "scene_performers": scene_performers,
             "scene_studios": scene_studios,
             "not_now": not_now,
-            "vectors": recent_vectors,
+            # Transposed recent-content index: satiation dots accumulate once per
+            # candidate feature instead of once per (feature, recent scene) pair.
+            "recent_by_name": recent_by_name,
+            "recent_scene_ids": recent_scene_ids,
+            "recent_played": recent_played,
             "scene_vectors": vectors,
         }
 
@@ -1169,19 +1577,24 @@ class PreferenceModelBuilder:
             days = max(0.0, (reference - timestamp) / 86_400_000)
             studio_penalty = 0.03 * math.exp(-days / 7)
         content_penalty = 0.0
-        recent_vectors = context["vectors"]
+        recent_by_name = context["recent_by_name"]
+        recent_scene_ids = context["recent_scene_ids"]
+        recent_played = context["recent_played"]
         scene_vectors = context["scene_vectors"]
-        assert isinstance(recent_vectors, list)
+        assert isinstance(recent_by_name, dict)
+        assert isinstance(recent_scene_ids, list)
+        assert isinstance(recent_played, list)
         assert isinstance(scene_vectors, dict)
         candidate = scene_vectors.get(scene_id, {})
         if isinstance(candidate, dict) and candidate:
-            for recent_scene, played_at, vector in recent_vectors:
-                if recent_scene == scene_id or not isinstance(vector, dict):
+            dots: dict[int, float] = {}
+            for name, value in candidate.items():
+                for index, recent_value in recent_by_name.get(name, ()):
+                    dots[index] = dots.get(index, 0.0) + value * recent_value
+            for index, cosine in dots.items():
+                if recent_scene_ids[index] == scene_id:
                     continue
-                cosine = sum(
-                    float(value) * float(vector.get(name, 0.0)) for name, value in candidate.items()
-                )
-                days = max(0.0, (reference - int(played_at)) / 86_400_000)
+                days = max(0.0, (reference - recent_played[index]) / 86_400_000)
                 content_penalty = max(content_penalty, 0.04 * cosine * math.exp(-days / 7))
         return min(
             self.config.model.satiation_bound,

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -18,6 +18,7 @@ from curator import optional_deps
 from curator.config import DEFAULT_CONFIG, CuratorConfig
 from curator.events.contracts import DEFAULT_CALIBRATION
 from curator.features import FeatureBuilder, FeatureStore
+from curator.features.builder import _fingerprint_table
 from curator.features.profiles import NUMERIC_BLOCKS, NUMERIC_SCALES, performer_similarity
 from curator.features.store import StoredFeature
 from curator.model.boundaries import scene_eligibility
@@ -521,12 +522,7 @@ class PreferenceModelBuilder:
                 """,
             ),
         ):
-            digest.update(f"{label}\0".encode())
-            for row in self.connection.execute(statement):
-                digest.update(
-                    json.dumps(tuple(row), separators=(",", ":"), ensure_ascii=False).encode()
-                )
-                digest.update(b"\n")
+            _fingerprint_table(self.connection, digest, label, statement)
         return digest.hexdigest()
 
     def _affinities(

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -41,7 +41,7 @@ from curator.storage.retention import prune_snapshots
 # ponytail: 0.005 removed 38% of measured seeds; make configurable only if
 # library-specific timing and quality measurements justify the extra surface.
 PERFORMER_SIMILARITY_AFFINITY_CUTOFF = 0.005
-MODEL_BUILD_VERSION = 3
+MODEL_BUILD_VERSION = 4
 
 
 @dataclass(frozen=True)
@@ -110,6 +110,35 @@ def _clamp(value: float, lower: float = -1.0, upper: float = 1.0) -> float:
 
 def _number(value: object) -> float:
     return float(value) if isinstance(value, (int, float)) else 0.0
+
+
+_CLASSIFICATION_FAMILIES = (
+    "content",
+    "content_neighbor",
+    "performer_identity",
+    "performer_similarity",
+    "studio",
+    "structure",
+)
+
+
+def _classification_payload(components: dict[str, object]) -> dict[str, object]:
+    """Slim component view that lane classification reads.
+
+    Classification only needs the six family values and the direct signals; this
+    avoids storing (and later parsing) the full components_json with its
+    top-contributor metadata for every scene.
+    """
+    payload: dict[str, object] = {}
+    for family in _CLASSIFICATION_FAMILIES:
+        component = components.get(family)
+        value = component.get("value") if isinstance(component, dict) else 0.0
+        payload[family] = {"value": _number(value)}
+    direct = components.get("direct")
+    payload["direct"] = {
+        "signals": list(direct.get("signals", [])) if isinstance(direct, dict) else []
+    }
+    return payload
 
 
 def _numpy_cosine_matrix(
@@ -1704,8 +1733,8 @@ class PreferenceModelBuilder:
                 INSERT INTO model_scene_score(
                     model_id, scene_id, general_appeal, direct_appeal, direct_confidence,
                     appeal, current_fit, confidence, metadata_confidence, recovery,
-                    components_json, eligibility_json
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    components_json, classification_json, eligibility_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     (
@@ -1720,6 +1749,15 @@ class PreferenceModelBuilder:
                         score.metadata_confidence,
                         score.recovery,
                         json.dumps(score.components, sort_keys=True, separators=(",", ":")),
+                        # Lane classification reads only the six family values and the
+                        # direct signals; keeping them in a small document avoids
+                        # parsing the full components_json (with its top-contributor
+                        # metadata for explanations) for every scene on every build.
+                        json.dumps(
+                            _classification_payload(score.components),
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ),
                         json.dumps(score.eligibility, sort_keys=True, separators=(",", ":")),
                     )
                     for score in scores

--- a/curator/model/store.py
+++ b/curator/model/store.py
@@ -39,6 +39,32 @@ class RecommendationModelStore:
         ).fetchone()
         return str(row[0]) if row else None
 
+    def _neighbors_by_scene(
+        self, model_id: str, scene_ids: Collection[str] | None = None
+    ) -> dict[str, list[dict[str, object]]]:
+        where = "model_id=?"
+        parameters: list[object] = [model_id]
+        if scene_ids is not None:
+            where += f" AND scene_id IN ({','.join('?' for _ in scene_ids)})"
+            parameters.extend(scene_ids)
+        neighbors_by_scene: dict[str, list[dict[str, object]]] = {}
+        for row in self.connection.execute(
+            f"""
+            SELECT scene_id, neighbor_scene_id, similarity, weight, outcome
+            FROM model_scene_neighbor WHERE {where} ORDER BY scene_id, rank
+            """,
+            parameters,
+        ):
+            neighbors_by_scene.setdefault(str(row["scene_id"]), []).append(
+                {
+                    "scene_id": str(row["neighbor_scene_id"]),
+                    "similarity": float(row["similarity"]),
+                    "weight": float(row["weight"]),
+                    "outcome": float(row["outcome"]),
+                }
+            )
+        return neighbors_by_scene
+
     def scores(
         self, model_id: str, scene_ids: Collection[str] | None = None
     ) -> dict[str, ModelSceneScore]:
@@ -61,22 +87,7 @@ class RecommendationModelStore:
         # Assembled in Python rather than via SQL json_object(): SQLite's JSON1 serializes
         # REAL values with only ~15 significant digits, silently losing precision on the
         # last one or two digits compared to Python's full float64 round-trip.
-        neighbors_by_scene: dict[str, list[dict[str, object]]] = {}
-        for row in self.connection.execute(
-            f"""
-            SELECT scene_id, neighbor_scene_id, similarity, weight, outcome
-            FROM model_scene_neighbor WHERE {where} ORDER BY scene_id, rank
-            """,
-            parameters,
-        ):
-            neighbors_by_scene.setdefault(str(row["scene_id"]), []).append(
-                {
-                    "scene_id": str(row["neighbor_scene_id"]),
-                    "similarity": float(row["similarity"]),
-                    "weight": float(row["weight"]),
-                    "outcome": float(row["outcome"]),
-                }
-            )
+        neighbors_by_scene = self._neighbors_by_scene(model_id, scene_ids)
         return {
             str(row["scene_id"]): ModelSceneScore(
                 model_id=str(row["model_id"]),
@@ -90,6 +101,46 @@ class RecommendationModelStore:
                 metadata_confidence=float(row["metadata_confidence"]),
                 recovery=float(row["recovery"]),
                 components=json.loads(row["components_json"]),
+                neighbors=tuple(neighbors_by_scene.get(str(row["scene_id"]), ())),
+                eligibility=json.loads(row["eligibility_json"]),
+            )
+            for row in rows
+        }
+
+    def classification_data(self, model_id: str) -> dict[str, ModelSceneScore]:
+        """Lean scene scores for lane classification.
+
+        Classification reads only the six family values and the direct signals, so this
+        avoids parsing the full components_json (which carries top-contributor metadata
+        for runtime explanations) for every scene. Falls back to the full scores for
+        artifacts published before the classification_json column existed.
+        """
+        try:
+            rows = self.connection.execute(
+                """
+                SELECT model_id, scene_id, direct_appeal, direct_confidence,
+                    appeal, current_fit, confidence, metadata_confidence, recovery,
+                    classification_json, eligibility_json
+                FROM model_scene_score WHERE model_id=? ORDER BY scene_id
+                """,
+                (model_id,),
+            )
+        except sqlite3.OperationalError:
+            return self.scores(model_id)
+        neighbors_by_scene = self._neighbors_by_scene(model_id)
+        return {
+            str(row["scene_id"]): ModelSceneScore(
+                model_id=str(row["model_id"]),
+                scene_id=str(row["scene_id"]),
+                general_appeal=0.0,
+                direct_appeal=float(row["direct_appeal"]),
+                direct_confidence=float(row["direct_confidence"]),
+                appeal=float(row["appeal"]),
+                current_fit=float(row["current_fit"]),
+                confidence=float(row["confidence"]),
+                metadata_confidence=float(row["metadata_confidence"]),
+                recovery=float(row["recovery"]),
+                components=json.loads(row["classification_json"]),
                 neighbors=tuple(neighbors_by_scene.get(str(row["scene_id"]), ())),
                 eligibility=json.loads(row["eligibility_json"]),
             )

--- a/curator/optional_deps.py
+++ b/curator/optional_deps.py
@@ -1,0 +1,19 @@
+"""Optional accelerated dependencies with a pure-Python fallback.
+
+The plugin ships without third-party packages. When the "Install optional
+dependencies" task has installed numpy into the plugin-local venv, the accelerated
+model stages use it; every other environment keeps the pure-Python implementations.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+try:
+    import numpy as _np
+except ImportError:  # pragma: no cover - exercised only in numpy-less environments
+    _np = None  # type: ignore[assignment]
+
+NUMPY_AVAILABLE: bool = _np is not None
+# Module alias stays untyped so accelerated code can call np.array(...) freely.
+np: Any = _np if NUMPY_AVAILABLE else cast(Any, None)

--- a/curator/ranking/policy.py
+++ b/curator/ranking/policy.py
@@ -8,6 +8,7 @@ import sqlite3
 from collections.abc import Callable, Collection
 from dataclasses import dataclass
 
+from curator import optional_deps
 from curator.config import DEFAULT_CONFIG, CuratorConfig
 from curator.events.contracts import OBSERVED_PLAYBACK_SQL
 from curator.features import FeatureStore
@@ -41,6 +42,28 @@ def _number(value: object) -> float:
 def _percentiles(values: dict[str, float]) -> dict[str, float]:
     if not values:
         return {}
+    np = optional_deps.np
+    if np is not None:
+        ids = np.fromiter(values.keys(), dtype=object)
+        sorted_values = np.fromiter(values.values(), dtype=np.float64)
+        order = np.lexsort((ids, sorted_values))
+        sorted_values = sorted_values[order]
+        sorted_ids = ids[order]
+        count = len(sorted_values)
+        denominator = max(1, count - 1)
+        # Group boundaries where the value changes; percentiles use the midpoint of
+        # each tied group's positions, matching the pure-Python loop below.
+        groups = np.flatnonzero(
+            np.concatenate(([True], sorted_values[1:] != sorted_values[:-1], [True]))
+        )
+        starts = groups[:-1]
+        ends = groups[1:]
+        mids = (starts + ends - 1) / 2
+        percentiles = np.repeat(mids / denominator, ends - starts)
+        return {
+            str(scene_id): float(value)
+            for scene_id, value in zip(sorted_ids, percentiles, strict=True)
+        }
     ordered = sorted(values.items(), key=lambda item: (item[1], item[0]))
     denominator = max(1, len(ordered) - 1)
     result: dict[str, float] = {}
@@ -71,7 +94,7 @@ class LanePolicy:
         *,
         progress: Callable[[int, int], None] | None = None,
     ) -> tuple[LaneClassification, ...]:
-        scores = RecommendationModelStore(self.connection).scores(model_id)
+        scores = RecommendationModelStore(self.connection).classification_data(model_id)
         eligible_scores = {
             scene_id: score
             for scene_id, score in scores.items()

--- a/curator/storage/artifacts.py
+++ b/curator/storage/artifacts.py
@@ -175,6 +175,14 @@ def create_artifact(
     connection.row_factory = sqlite3.Row
     connection.execute("PRAGMA foreign_keys=ON")
     connection.execute(f"PRAGMA user_version={ARTIFACT_SCHEMA_VERSION}")
+    # Publication writes hundreds of thousands of rows and then creates indexes over
+    # a file that grows to hundreds of MiB through this connection. SQLite's 2 MiB
+    # default cache turns that into cold random I/O; a 256 MiB cache plus memory
+    # mapping keeps the index builds and the attached feature-generation reads in
+    # memory. The temporary file is exclusively owned by this process, so mapping it
+    # is safe: nothing else can modify or replace it while it is open.
+    connection.execute("PRAGMA cache_size = -262144")
+    connection.execute("PRAGMA mmap_size = 1073741824")
     connection.executescript(FEATURE_SCHEMA if kind == "feature" else MODEL_SCHEMA)
     connection.execute(
         "INSERT INTO artifact_meta(kind, generation_id, schema_version) VALUES (?, ?, ?)",

--- a/curator/storage/artifacts.py
+++ b/curator/storage/artifacts.py
@@ -11,8 +11,8 @@ from uuid import uuid4
 
 from curator.storage.database import StorageError
 
-ARTIFACT_SCHEMA_VERSION = 2
-SUPPORTED_ARTIFACT_SCHEMA_VERSIONS = frozenset({1, 2})
+ARTIFACT_SCHEMA_VERSION = 3
+SUPPORTED_ARTIFACT_SCHEMA_VERSIONS = frozenset({1, 2, 3})
 _FINAL_NAME = re.compile(r"(feature-fv-[0-9a-f]{20}|model-[0-9a-f]{20})\.sqlite3")
 _TEMP_NAME = re.compile(r"\.(feature-fv-[0-9a-f]{20}|model-[0-9a-f]{20})\.[0-9a-f]{32}\.tmp")
 FEATURE_TABLES = ("feature_definition", "entity_feature", "scene_content_search")
@@ -79,6 +79,7 @@ CREATE TABLE model_scene_score (
     metadata_confidence REAL NOT NULL CHECK (metadata_confidence BETWEEN 0 AND 1),
     recovery REAL NOT NULL CHECK (recovery BETWEEN 0 AND 1),
     components_json TEXT NOT NULL,
+    classification_json TEXT NOT NULL DEFAULT '{}',
     eligibility_json TEXT NOT NULL DEFAULT '{}', PRIMARY KEY (model_id, scene_id)
 ) STRICT, WITHOUT ROWID;
 CREATE TABLE model_scene_neighbor (

--- a/curator/storage/database.py
+++ b/curator/storage/database.py
@@ -130,6 +130,16 @@ def connect_database(
     connection.row_factory = sqlite3.Row
     connection.execute("PRAGMA foreign_keys = ON")
     connection.execute("PRAGMA busy_timeout = 30000")
+    # A 128 MiB page cache turns the repeated full scans of the hundreds-of-MiB
+    # generation artifacts during a model build from cold disk reads into page-cache
+    # hits. Read-only connections additionally memory-map the file: that is safe and
+    # read-only connections see the same coherent pages via the unified OS buffer
+    # cache. Writable connections stay on the pager because the sidecar is shared
+    # with other processes and the files can be replaced by maintenance operations
+    # (for example VACUUM), where a stale mapping could serve obsolete data.
+    connection.execute("PRAGMA cache_size = -131072")
+    if readonly:
+        connection.execute("PRAGMA mmap_size = 536870912")
     if not readonly:
         if str(connection.execute("PRAGMA journal_mode").fetchone()[0]).casefold() != "wal":
             connection.execute("PRAGMA journal_mode = WAL")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,9 @@ permalink: /architecture/
 # Architecture
 
 Curator is a self-contained external raw plugin with no runtime dependencies beyond
-Python 3.12+. Stash loads `plugin/backend.py`; the browser UI is one JavaScript file
+Python 3.12+. Optional numpy acceleration is provisioned on demand into a
+plugin-local venv (see Runtime components); without it, the same code paths run in
+pure Python. Stash loads `plugin/backend.py`; the browser UI is one JavaScript file
 and one CSS file, and model code lives in the packaged `curator` module.
 
 ```text
@@ -41,6 +43,13 @@ source cache ──► normalized events                  StashDB
   orders.
 - `curator/similarity.py`, `curator/expand.py`, and `curator/explanations/` serve
   Similar, StashDB discovery, and factual reasons.
+- `curator/optional_deps.py` and the **Install optional dependencies** task provide
+  the optional numpy acceleration: the task creates a versioned venv beside the
+  plugin and pip-installs `plugin/packages/curator-tools.txt`; `backend.py` adds the
+  venv's site-packages to `sys.path` when present. The content-neighbor and
+  performer-similarity stages use numpy (BLAS matmuls) when importable and fall back
+  to their pure-Python implementations otherwise, so builds are deterministic and
+  correct in either mode.
 - `curator/storage/sql/` contains ordered, checksummed, transactional migrations.
 
 ## Data flow and failure boundaries

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,6 +30,24 @@ A full reconciliation is available as **Full sync and build recommendations** on
 Tasks page. Use it when source records were deleted or an incremental sync appears
 out of date; it is not required for routine refreshes.
 
+## Optional acceleration
+
+Curator runs entirely on the Python standard library, and everything works without
+any extra packages. Model builds get measurably faster when **numpy** is available,
+so a one-shot task installs it for you:
+
+1. In Stash, open **Tasks** and run **Install optional dependencies** once.
+2. The task creates a plugin-local virtual environment and pip-installs the pinned
+   requirements from `packages/curator-tools.txt` into it.
+3. Then run **Sync and build recommendations** as usual.
+
+The numpy paths accelerate the two similarity stages (content neighbors and
+performer similarity), which are the largest part of a first build. Without it, the
+model builder falls back to its pure-Python implementations, so skipping the task is
+always safe. The venv lives in the plugin directory and survives plugin updates;
+re-run the task only if the Python interpreter Stash uses for plugins changes
+version.
+
 ## Configure
 
 Curator's settings live with Stash's plugin settings. Useful early choices are:

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -6,14 +6,29 @@ from __future__ import annotations
 import json
 import re
 import sqlite3
+import subprocess
 import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
+from venv import create as create_venv
 
 PLUGIN_DIR = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else Path(__file__).parent.resolve()
+# Optional dependencies (numpy) installed by the "Install optional dependencies"
+# task into a versioned venv kept beside the plugin. The venv lives on the plugin
+# volume, so it survives plugin updates and container recreations; the pure-Python
+# fallbacks keep every path working when it is absent.
+_venv_site_packages = (
+    PLUGIN_DIR
+    / "venv"
+    / "lib"
+    / f"python{sys.version_info.major}.{sys.version_info.minor}"
+    / "site-packages"
+)
+if _venv_site_packages.is_dir():
+    sys.path.insert(0, str(_venv_site_packages))
 for package_root in (PLUGIN_DIR, PLUGIN_DIR.parent):
     if str(package_root) not in sys.path:
         sys.path.insert(0, str(package_root))
@@ -1406,7 +1421,44 @@ def _profiled[T](
             _log("w", f"Could not save Curator profile: {save_error}")
 
 
+def _install_optional_deps() -> dict[str, object]:
+    """Install the plugin's optional Python dependencies into a local venv.
+
+    Mirrors the community Python Tools Installer pattern: a venv created inside the
+    plugin directory persists on the plugin volume across container recreations, and
+    the backend sys.path shim makes its site-packages importable. Runs without the
+    sidecar database so it works on a fresh install.
+    """
+    venv_dir = PLUGIN_DIR / "venv"
+    requirements = PLUGIN_DIR / "packages" / "curator-tools.txt"
+    if not requirements.is_file():
+        raise RuntimeError(f"missing optional dependency manifest: {requirements}")
+    _log("i", f"Installing optional Curator dependencies from {requirements.name}")
+    _progress(0.05)
+    if not (venv_dir / "pyvenv.cfg").is_file():
+        _log("i", f"Creating virtual environment at {venv_dir}")
+        create_venv(venv_dir, with_pip=True)
+    _progress(0.30)
+    pip = venv_dir / "bin" / "pip"
+    _log("i", "Running " + " ".join([str(pip), "install", "-r", str(requirements)]))
+    completed = subprocess.run(
+        [str(pip), "install", "-r", str(requirements)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    _progress(0.95)
+    if completed.returncode != 0:
+        detail = (completed.stderr or completed.stdout).strip().splitlines()
+        raise RuntimeError(f"pip install failed: {detail[-1] if detail else 'unknown error'}")
+    _log("i", "Optional Curator dependencies installed")
+    _progress(1.0)
+    return {"status": "ok", "venv": str(venv_dir), "requirements": str(requirements)}
+
+
 def _run_task(payload: dict[str, Any], mode: str) -> dict[str, object]:
+    if mode == "install-deps":
+        return _install_optional_deps()
     return _profiled(
         payload,
         mode,

--- a/plugin/packages/curator-tools.txt
+++ b/plugin/packages/curator-tools.txt
@@ -1,0 +1,5 @@
+# Optional Curator dependencies installed by the "Install optional dependencies"
+# task into a plugin-local venv. Pin exact versions: pip resolves the wheel that
+# matches the runtime Python and platform at install time. The model builder falls
+# back to its pure-Python implementations when these are not importable.
+numpy==2.5.1

--- a/plugin/stash-curator.yml
+++ b/plugin/stash-curator.yml
@@ -126,3 +126,7 @@ tasks:
     description: Refresh promising StashDB scenes and performers without affecting library sync.
     execArgs:
       - expand-refresh
+  - name: Install optional dependencies
+    description: Install numpy acceleration into a plugin-local virtual environment. The model builder falls back to pure Python when this is not run.
+    execArgs:
+      - install-deps

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ curator = "curator.cli:main"
 [dependency-groups]
 dev = [
   "mypy>=1.14",
+  "numpy>=2.5,<3",
   "pytest>=8.3",
   "ruff>=0.9",
 ]

--- a/tests/features/test_builder.py
+++ b/tests/features/test_builder.py
@@ -98,6 +98,29 @@ def _database(path: Path) -> sqlite3.Connection:
     return connection
 
 
+def test_fingerprint_table_is_deterministic_and_change_sensitive(tmp_path: Path) -> None:
+    import hashlib
+
+    from curator.features.builder import _fingerprint_table
+
+    connection = _database(tmp_path / "curator.sqlite3")
+
+    def fingerprint() -> str:
+        digest = hashlib.sha256()
+        _fingerprint_table(
+            connection,
+            digest,
+            "source_tag",
+            "SELECT tag_id, name FROM source_tag ORDER BY tag_id",
+        )
+        return digest.hexdigest()
+
+    first = fingerprint()
+    assert fingerprint() == first
+    connection.execute("UPDATE source_tag SET name='Changed' WHERE tag_id='parent'")
+    assert fingerprint() != first
+
+
 def test_feature_build_is_deterministic_versioned_and_explainable(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     progress: list[tuple[int, int]] = []

--- a/tests/features/test_profiles.py
+++ b/tests/features/test_profiles.py
@@ -1,5 +1,7 @@
 from unittest.mock import Mock
 
+import pytest
+
 import curator.features.profiles as profiles_module
 from curator.features.profiles import PerformerProfile, ProfileValue, performer_similarity
 
@@ -62,6 +64,30 @@ def test_cup_and_augmentation_conflicts_reduce_similarity() -> None:
         performer_similarity(close, close, WEIGHTS).similarity
         > performer_similarity(close, conflict, WEIGHTS).similarity
     )
+
+
+def test_cosine_via_cached_keys_matches_fresh_set_math() -> None:
+    left = PerformerProfile(
+        "left",
+        {"eyes": {"eye:blue": ProfileValue(1, 0.9), "eye:brown": ProfileValue(0.2, 0.7)}},
+    )
+    right = PerformerProfile(
+        "right",
+        {"eyes": {"eye:blue": ProfileValue(0.8, 0.8), "eye:green": ProfileValue(1, 1)}},
+    )
+    cached = profiles_module.block_similarity(left, right, "eyes")
+    shared = set(left.blocks["eyes"]) & set(right.blocks["eyes"])
+    assert shared == {"eye:blue"}
+    dot = sum(left.blocks["eyes"][key].value * right.blocks["eyes"][key].value for key in shared)
+    confidence = sum(
+        min(left.blocks["eyes"][key].confidence, right.blocks["eyes"][key].confidence)
+        for key in shared
+    ) / len(shared)
+    expected = max(
+        0.0,
+        min(1.0, dot / (left.norms["eyes"] * right.norms["eyes"]) * confidence),
+    )
+    assert cached == pytest.approx(expected, rel=1e-12)
 
 
 def test_cosine_norms_are_computed_once(monkeypatch) -> None:

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -1,4 +1,5 @@
 import json
+import math
 import sqlite3
 from dataclasses import replace
 from pathlib import Path
@@ -125,6 +126,120 @@ def _database(path: Path) -> sqlite3.Connection:
         (REFERENCE_MS - 100 * DAY_MS,),
     )
     return connection
+
+
+def test_satiation_content_dots_match_naive_recent_loop() -> None:
+    reference = REFERENCE_MS
+    candidate = {"shared_a": 0.8, "shared_b": 0.6, "unique_c": 0.4}
+    recents = [
+        ("candidate", reference, {"shared_a": 5.0}),
+        ("recent-1", reference - DAY_MS, {"shared_a": 1.0, "other": 0.2}),
+        ("recent-2", reference - 3 * DAY_MS, {"shared_a": 0.3, "shared_b": 0.5}),
+    ]
+    context = {
+        "reference": reference,
+        "performers": {},
+        "studios": {},
+        "scene_performers": {},
+        "scene_studios": {},
+        "not_now": {},
+        "recent_by_name": {
+            "shared_a": [(0, 5.0), (1, 1.0), (2, 0.3)],
+            "shared_b": [(2, 0.5)],
+        },
+        "recent_scene_ids": ["candidate", "recent-1", "recent-2"],
+        "recent_played": [reference, reference - DAY_MS, reference - 3 * DAY_MS],
+        "scene_vectors": {"candidate": candidate},
+    }
+    builder = PreferenceModelBuilder(None)
+
+    naive = 0.0
+    for recent_scene, played_at, vector in recents:
+        if recent_scene == "candidate":
+            continue
+        cosine = sum(value * vector.get(name, 0.0) for name, value in candidate.items())
+        days = max(0.0, (reference - played_at) / DAY_MS)
+        naive = max(naive, 0.04 * cosine * math.exp(-days / 7))
+
+    result = builder._satiation("candidate", 1.0, context)
+    assert result == pytest.approx(min(builder.config.model.satiation_bound, naive), rel=1e-12)
+
+
+def test_content_neighbors_numpy_matches_python() -> None:
+    builder = PreferenceModelBuilder(None)
+    vectors = {
+        "s1": {"a": 1.0, "b": 0.5},
+        "s2": {"a": 0.8, "c": 0.3},
+        "s3": {"d": 1.0},
+        "s4": {"a": 0.6, "b": 0.7, "c": 0.2},
+    }
+    labels = {
+        "s1": builder_module._SceneLabel(0.8, 0.9, 1.0, ("o",)),
+        "s2": builder_module._SceneLabel(-0.4, 0.7, 0.8, ("o",)),
+        "s3": builder_module._SceneLabel(0.1, 0.5, 0.6, ("o",)),
+    }
+    if not builder_module.optional_deps.NUMPY_AVAILABLE:
+        pytest.skip("numpy is not installed")
+    numpy_result = builder._content_neighbors_numpy(vectors, labels, 0.2, 8)
+    python_result = builder._content_neighbors_python(vectors, labels, 0.2, 8)
+    assert set(numpy_result) == set(python_result)
+    for scene_id in vectors:
+        numpy_evidence = numpy_result[scene_id]
+        python_evidence = python_result[scene_id]
+        assert numpy_evidence.value == pytest.approx(python_evidence.value, rel=1e-9)
+        assert numpy_evidence.outcome_mean == pytest.approx(python_evidence.outcome_mean, rel=1e-9)
+        assert numpy_evidence.lift == pytest.approx(python_evidence.lift, rel=1e-9)
+        assert numpy_evidence.confidence == pytest.approx(python_evidence.confidence, rel=1e-9)
+        assert numpy_evidence.total_weight == pytest.approx(python_evidence.total_weight, rel=1e-9)
+        assert [n["scene_id"] for n in numpy_evidence.neighbors] == [
+            n["scene_id"] for n in python_evidence.neighbors
+        ]
+        for numpy_neighbor, python_neighbor in zip(
+            numpy_evidence.neighbors, python_evidence.neighbors, strict=True
+        ):
+            assert numpy_neighbor["similarity"] == pytest.approx(
+                python_neighbor["similarity"], rel=1e-9
+            )
+            assert numpy_neighbor["weight"] == pytest.approx(python_neighbor["weight"], rel=1e-9)
+            assert numpy_neighbor["outcome"] == pytest.approx(python_neighbor["outcome"], rel=1e-9)
+
+
+def test_performer_similarity_numpy_matches_python(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    builder = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS)
+    built = builder.build()
+    scene_features = builder_module.FeatureStore(connection).entity_features(
+        built.feature_version, "scene"
+    )
+    labels = builder._scene_labels()
+    training_labels = builder._training_labels(labels)
+    label_mean = builder._label_mean(training_labels)
+    affinities = builder._affinities(scene_features, training_labels, label_mean)
+    if not builder_module.optional_deps.NUMPY_AVAILABLE:
+        pytest.skip("numpy is not installed")
+    numpy_result = builder._performer_similarity_scores_numpy(
+        built.feature_version, scene_features, affinities
+    )
+    python_result = builder._performer_similarity_scores_python(
+        built.feature_version, scene_features, affinities
+    )
+    assert set(numpy_result) == set(python_result)
+    for performer_id in numpy_result:
+        assert numpy_result[performer_id]["value"] == pytest.approx(
+            python_result[performer_id]["value"], rel=1e-6
+        )
+        assert numpy_result[performer_id]["confidence"] == pytest.approx(
+            python_result[performer_id]["confidence"], rel=1e-6
+        )
+        assert [m["performer_id"] for m in numpy_result[performer_id]["matches"]] == [
+            m["performer_id"] for m in python_result[performer_id]["matches"]
+        ]
+        for numpy_match, python_match in zip(
+            numpy_result[performer_id]["matches"],
+            python_result[performer_id]["matches"],
+            strict=True,
+        ):
+            assert numpy_match["similarity"] == pytest.approx(python_match["similarity"], rel=1e-6)
 
 
 def test_complete_model_is_bounded_reproducible_and_applies_cooldown(tmp_path: Path) -> None:
@@ -374,6 +489,9 @@ def test_model_compares_known_performer_pairs_once(
     connection = _database(tmp_path / "curator.sqlite3")
     counted = Mock(wraps=builder_module.performer_similarity)
     monkeypatch.setattr(builder_module, "performer_similarity", counted)
+    # The pair-count contract belongs to the pure-Python implementation; the numpy
+    # path never calls performer_similarity and is covered by its own parity tests.
+    monkeypatch.setattr(builder_module.optional_deps, "NUMPY_AVAILABLE", False)
     PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
 
     assert counted.call_count == 3
@@ -402,6 +520,7 @@ def test_model_ignores_negligible_performer_similarity_seeds(
     }
     counted = Mock(wraps=builder_module.performer_similarity)
     monkeypatch.setattr(builder_module, "performer_similarity", counted)
+    monkeypatch.setattr(builder_module.optional_deps, "NUMPY_AVAILABLE", False)
 
     builder._performer_similarity_scores(built.feature_version, scene_features, affinities)
 

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -242,6 +242,81 @@ def test_performer_similarity_numpy_matches_python(tmp_path: Path) -> None:
             assert numpy_match["similarity"] == pytest.approx(python_match["similarity"], rel=1e-6)
 
 
+def test_classification_data_matches_full_scores_for_lane_values(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    builder = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS)
+    model_id = builder.build().model_id
+    store = RecommendationModelStore(connection)
+    full = store.scores(model_id)
+    lean = store.classification_data(model_id)
+    assert set(lean) == set(full)
+    for scene_id, lean_score in lean.items():
+        full_score = full[scene_id]
+        assert lean_score.current_fit == full_score.current_fit
+        assert lean_score.confidence == full_score.confidence
+        assert lean_score.metadata_confidence == full_score.metadata_confidence
+        assert lean_score.recovery == full_score.recovery
+        assert lean_score.direct_appeal == full_score.direct_appeal
+        assert lean_score.direct_confidence == full_score.direct_confidence
+        assert lean_score.appeal == full_score.appeal
+        assert lean_score.eligibility == full_score.eligibility
+        assert lean_score.neighbors == full_score.neighbors
+        for family in (
+            "content",
+            "content_neighbor",
+            "performer_identity",
+            "performer_similarity",
+            "studio",
+            "structure",
+        ):
+            assert lean_score.components[family]["value"] == pytest.approx(
+                full_score.components[family]["value"], rel=1e-12
+            )
+        assert (
+            lean_score.components["direct"]["signals"] == full_score.components["direct"]["signals"]
+        )
+
+
+def test_classification_data_falls_back_for_pre_classification_artifacts(
+    tmp_path: Path,
+) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    # The migrated core model_scene_score predates the classification_json column;
+    # classification_data must fall back to the full scores read for such artifacts.
+    connection.execute("PRAGMA foreign_keys=OFF")
+    try:
+        connection.execute(
+            """
+            INSERT INTO model_scene_score(
+                model_id, scene_id, general_appeal, direct_appeal, direct_confidence,
+                appeal, current_fit, confidence, metadata_confidence, recovery,
+                components_json, neighbors_json, eligibility_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "model",
+                "scene",
+                0.0,
+                0.1,
+                0.2,
+                0.3,
+                0.4,
+                0.5,
+                0.6,
+                0.7,
+                '{"content": {"value": 0.25}}',
+                "[]",
+                '{"eligible": true, "reasons": []}',
+            ),
+        )
+    finally:
+        connection.execute("PRAGMA foreign_keys=ON")
+    store = RecommendationModelStore(connection)
+    lean = store.classification_data("model")
+    assert lean["scene"].components["content"]["value"] == 0.25
+    assert lean["scene"].appeal == 0.3
+
+
 def test_complete_model_is_bounded_reproducible_and_applies_cooldown(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     statements: list[str] = []

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -74,6 +74,8 @@ def test_plugin_archive_contains_runtime_and_core(tmp_path: Path) -> None:
     assert "Prepare recommendation pages" in (installed / "stash-curator.yml").read_text()
     assert "Compact legacy Curator data" in (installed / "stash-curator.yml").read_text()
     assert "Vacuum compacted Curator data" in (installed / "stash-curator.yml").read_text()
+    assert "Install optional dependencies" in (installed / "stash-curator.yml").read_text()
+    assert "numpy==2.5.1" in (installed / "packages" / "curator-tools.txt").read_text()
     javascript = (installed / "stash-curator.js").read_text()
     assert "data:image/png;base64" in javascript
     assert "curator-whisparr-fallback" in javascript
@@ -297,6 +299,90 @@ def test_backup_controls_validate_ids_refuse_jobs_and_restore_with_safety_copy(
         == "superseded"
     )
     connection.close()
+
+
+def test_install_optional_deps_creates_venv_and_installs_requirements(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
+    spec = importlib.util.spec_from_file_location("curator_plugin_install_deps", backend)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    plugin_dir = tmp_path / "stash-curator"
+    (plugin_dir / "packages").mkdir(parents=True)
+    requirements = plugin_dir / "packages" / "curator-tools.txt"
+    requirements.write_text("numpy==2.5.1\n", encoding="utf-8")
+    monkeypatch.setattr(module, "PLUGIN_DIR", plugin_dir)
+    created: list[tuple[object, ...]] = []
+    monkeypatch.setattr(
+        module,
+        "create_venv",
+        lambda path, with_pip: created.append((path, with_pip)),
+    )
+    installed: list[list[str]] = []
+    monkeypatch.setattr(
+        module,
+        "subprocess",
+        SimpleNamespace(
+            run=lambda command, **_: (
+                installed.append(command)
+                or SimpleNamespace(returncode=0, stderr="", stdout="installed numpy")
+            )
+        ),
+    )
+
+    result = module._install_optional_deps()
+
+    assert created == [(plugin_dir / "venv", True)]
+    assert installed[0][-3:] == ["install", "-r", str(requirements)]
+    assert result == {
+        "status": "ok",
+        "venv": str(plugin_dir / "venv"),
+        "requirements": str(requirements),
+    }
+
+
+def test_install_optional_deps_refuses_missing_manifest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
+    spec = importlib.util.spec_from_file_location("curator_plugin_install_deps_missing", backend)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "PLUGIN_DIR", tmp_path)
+
+    with pytest.raises(RuntimeError, match="missing optional dependency manifest"):
+        module._install_optional_deps()
+
+
+def test_install_optional_deps_surfaces_pip_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
+    spec = importlib.util.spec_from_file_location("curator_plugin_install_deps_failure", backend)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    plugin_dir = tmp_path / "stash-curator"
+    (plugin_dir / "packages").mkdir(parents=True)
+    (plugin_dir / "packages" / "curator-tools.txt").write_text("numpy\n", encoding="utf-8")
+    (plugin_dir / "venv").mkdir()
+    (plugin_dir / "venv" / "pyvenv.cfg").write_text("home = /usr\n", encoding="utf-8")
+    monkeypatch.setattr(module, "PLUGIN_DIR", plugin_dir)
+    monkeypatch.setattr(
+        module,
+        "subprocess",
+        SimpleNamespace(
+            run=lambda command, **_: SimpleNamespace(
+                returncode=1, stderr="no matching distribution", stdout=""
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="pip install failed"):
+        module._install_optional_deps()
 
 
 def test_reset_removes_only_core_and_recognized_artifacts(tmp_path: Path) -> None:

--- a/tests/ranking/test_policy.py
+++ b/tests/ranking/test_policy.py
@@ -2,6 +2,8 @@
 _component_value()'s defensive fallbacks.
 """
 
+import pytest
+
 from curator.model import ModelSceneScore
 from curator.ranking.policy import _component_value, _percentiles
 
@@ -58,6 +60,29 @@ def test_tie_break_by_scene_id_does_not_affect_percentile() -> None:
     # value itself must be identical for every member of the tie regardless of scene_id.
     result = _percentiles({"z": 1.0, "a": 1.0, "m": 1.0})
     assert result["z"] == result["a"] == result["m"]
+
+
+def test_numpy_and_python_percentiles_agree(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from curator import optional_deps
+
+    values = {
+        "a": 1.0,
+        "b": 1.0,
+        "c": 2.0,
+        "d": 3.0,
+        "e": 3.0,
+        "f": -0.5,
+        "g": 0.0,
+        "h": 0.0,
+    }
+    if optional_deps.NUMPY_AVAILABLE:
+        accelerated = _percentiles(values)
+        monkeypatch.setattr(optional_deps, "NUMPY_AVAILABLE", False)
+        monkeypatch.setattr(optional_deps, "np", None)
+        fallback = _percentiles(values)
+        assert accelerated == fallback
 
 
 def test_component_value_missing_family_is_zero() -> None:

--- a/tests/storage/test_artifacts.py
+++ b/tests/storage/test_artifacts.py
@@ -9,6 +9,7 @@ from curator.storage.artifacts import (
     ARTIFACT_SCHEMA_VERSION,
     artifact_path,
     cache_directory,
+    create_artifact,
     validate_artifact,
 )
 
@@ -17,6 +18,17 @@ def _database(path: Path):
     connection = connect_database(path)
     MigrationRunner(connection).migrate(applied_at_ms=1)
     return connection
+
+
+def test_artifact_connection_uses_build_sized_cache_and_mmap(tmp_path: Path) -> None:
+    core = _database(tmp_path / "curator.sqlite3")
+    artifact, temporary, _ = create_artifact(core, "feature", "fv-" + "a" * 20)
+    try:
+        assert artifact.execute("PRAGMA cache_size").fetchone()[0] == -262144
+        assert artifact.execute("PRAGMA mmap_size").fetchone()[0] == 1073741824
+    finally:
+        artifact.close()
+        temporary.unlink(missing_ok=True)
 
 
 def test_artifact_paths_reject_escape_and_symlinks(tmp_path: Path) -> None:

--- a/tests/storage/test_database.py
+++ b/tests/storage/test_database.py
@@ -22,8 +22,19 @@ def test_connection_enables_required_pragmas(tmp_path: Path) -> None:
         assert connection.execute("PRAGMA foreign_keys").fetchone()[0] == 1
         assert connection.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
         assert connection.execute("PRAGMA busy_timeout").fetchone()[0] == 30000
+        assert connection.execute("PRAGMA cache_size").fetchone()[0] == -131072
     finally:
         connection.close()
+
+
+def test_readonly_connection_memory_maps_the_database(tmp_path: Path) -> None:
+    database = tmp_path / "curator.sqlite3"
+    connect_database(database).close()
+    readonly = connect_database(database, readonly=True)
+    try:
+        assert readonly.execute("PRAGMA mmap_size").fetchone()[0] == 536870912
+    finally:
+        readonly.close()
 
 
 def test_transaction_rolls_back_on_failure(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -182,6 +182,57 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/7b/14687aa674250e5e546f616f486b0d56d3631cd5b2415739141ce40bdcea/numpy-2.5.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2c889b56fe48b1018f764b0eec8df59ab654e9148aa91faa12596043500de277", size = 16801574, upload-time = "2026-07-04T17:06:12.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/19/cc5bb2a3f2913d27d6dbb2c78d25921fabaedc6741d4a5a615a11f3c5bf3/numpy-2.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab451b59c5643c570974c43aef780703ef1d3b4965d2be07afd530615a9358d1", size = 11772250, upload-time = "2026-07-04T17:06:15.726Z" },
+    { url = "https://files.pythonhosted.org/packages/42/77/fdf34a71dd30f54979b18603bee915e0aaf825b07afe79acd60b04b691e2/numpy-2.5.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:78798bd5b9ad744056af8efa90e3b9ddaa53272a0848a483084a1cc0a13b2dc0", size = 5331516, upload-time = "2026-07-04T17:06:17.913Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/e2/eb7efa015b4cce41e2517bf182a7fce0d7d5b9d9ed76a29bfa0f4fe4505c/numpy-2.5.1-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:2ae0ca40bcb22d6ba59c1dfd5446f49940b0f2d821fde133f10dda11f816b84e", size = 6664863, upload-time = "2026-07-04T17:06:20.02Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/4b/a2b32dd94ee9ffbeecb28152240042a3949db33b1c834d44090b80e1b3b8/numpy-2.5.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:61ac47e772e6b8ea489e1d2f441a34c5c3ac17327e7ce294cbdf535795ad4e75", size = 15167977, upload-time = "2026-07-04T17:06:21.621Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a9/6e73d68500f80773f65f0654ea932019d6694329a0eb0ed0533de38df376/numpy-2.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:59fda5e192b570217ec2580c96f00e9a7e12ef6866a900eb089b62c1a32545ca", size = 16672469, upload-time = "2026-07-04T17:06:24.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/7d/ad3e59015135f5261c95fd4cafeff159c955febd83a99a1d9250c4233815/numpy-2.5.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f7119ebff1a9829e9f431a4f9d28e703023bb6b9fe7c8f724467dbfc27c94ab3", size = 16527531, upload-time = "2026-07-04T17:06:26.69Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d0/a39b2fbcde9cb17a1dac678f254b33a6336298af9df338824c685425d5e8/numpy-2.5.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e824c2acf8862052246be5a44c15da1777940c60d010dd2aab897824d9c430f9", size = 18431940, upload-time = "2026-07-04T17:06:29.521Z" },
+    { url = "https://files.pythonhosted.org/packages/04/12/cff070947791c1ed425ff76413189adbdc2fbe215eba7ce7fa454a03c7f8/numpy-2.5.1-cp312-cp312-win32.whl", hash = "sha256:08d60c810432eb83360958dea0999ac4cfb94531ea8efcbf0b7f277c2068aeb2", size = 6066764, upload-time = "2026-07-04T17:06:32.571Z" },
+    { url = "https://files.pythonhosted.org/packages/65/66/53f31807a48a750f9d748da273bc3fcedd12b27ff1f3e373bfec55ef2dc0/numpy-2.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:f7d60026c0bdb1380e83bfa7a0419c4577ee4b9a08880afcb6dadeb74c649fa2", size = 12430966, upload-time = "2026-07-04T17:06:34.926Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/2a/d1a88066b1c14186f5d3c0d18c94f17b064511982bab0578d49ee9d43c29/numpy-2.5.1-cp312-cp312-win_arm64.whl", hash = "sha256:17a25e09640602e10bc8de0e6fa2b3fd68eedd84ba6d7842dc8f32f9ab87bd0b", size = 10350488, upload-time = "2026-07-04T17:06:37.785Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/07/ec2a3f0c91761581d4b7104a740791800025983f9a4dc4e73f91a99aeac4/numpy-2.5.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0bfebd8695f9863592fe744be833a258120b14a9f39da255e8aa8fade2c0ddd1", size = 16796419, upload-time = "2026-07-04T17:06:40.37Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ab/ddb499fc4f8780354395face5b65c7fd107bcd6e1d667a5f07d046956f6f/numpy-2.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:30b44a6b53a7ae63c54c089a8726e5563ed302716c5b7ccc85afade40b0e7ff6", size = 11765832, upload-time = "2026-07-04T17:06:42.768Z" },
+    { url = "https://files.pythonhosted.org/packages/88/b3/3c28c558a09fc72100c646dac6d2fce8e834c471b0edca01a29996706117/numpy-2.5.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:6165343f81b56ef8f514f396989e529b61d9dc709b99421b07e9f3e698e2287d", size = 5325143, upload-time = "2026-07-04T17:06:45.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/0e/ce19b985bb15c596f4f05954e76cccc77c845083b3b8f938a6c68e523128/numpy-2.5.1-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:4939237038ada79308dda3204ac6462df056b5672b2e25db1149cf873668b3e1", size = 6659749, upload-time = "2026-07-04T17:06:47.288Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd", size = 15164716, upload-time = "2026-07-04T17:06:49.494Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a", size = 16661440, upload-time = "2026-07-04T17:06:52.061Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d7/a41e3310c886fe457d36e670bbf24fae411aca8a7b6ad92a32afd924077c/numpy-2.5.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3935f3b419b244a02732676fa5317a9193cc596a4c0646db07e5b421229ac9f7", size = 16526305, upload-time = "2026-07-04T17:06:54.605Z" },
+    { url = "https://files.pythonhosted.org/packages/53/75/4333a9a707c1edd3a4e1a0c58eca52c0f31e55089fa80db02b5565b24df7/numpy-2.5.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dc932a65ded7ce9013d120845a2514dcccb1a67bfc8deb8d37633762951904a6", size = 18423008, upload-time = "2026-07-04T17:06:57.54Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/e314a32b1c11a2ffe818ddad3a57b50b4b6e1b6c487192eb50cdef0415d0/numpy-2.5.1-cp313-cp313-win32.whl", hash = "sha256:4b4ff1608417eb7a59da7b967bbb798cacfe071d2caf526a24281cd562072ed9", size = 6063885, upload-time = "2026-07-04T17:07:00.14Z" },
+    { url = "https://files.pythonhosted.org/packages/10/70/800b3fca480af32df9e8ea9f3d4a0c8feb4b32d7f195d174eabbda4829ad/numpy-2.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:6c3fe51bc6a16453d452997053454f309e8e0ed7b42d6b361ce4ac8c32913d74", size = 12425674, upload-time = "2026-07-04T17:07:02.387Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0b/196350c122f50f6ca56846f2d71efd5e0d24b7b2e07355e019b2e2c7a11e/numpy-2.5.1-cp313-cp313-win_arm64.whl", hash = "sha256:f7feb014281029e628ba2d5a007407443b06e418b6fe451d1e2adcbc8eba0107", size = 10350256, upload-time = "2026-07-04T17:07:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f4/731b6085a83faf6ca843394cbd5e217280c214399f7e8b21b9f552af0ae2/numpy-2.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:7c786fe9a5bbe360022e584c5a34cf6b54265c71bd7ec8ac3d8fec38968071f8", size = 16795063, upload-time = "2026-07-04T17:07:07.374Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/64/0e215f2048dd11a55bb989ed41b3585ef57452404e638d703a211a3e4157/numpy-2.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:32985c896d897419ef8da6917872d80b78ad0ea26d85b23245c7366ffde76d75", size = 11776652, upload-time = "2026-07-04T17:07:09.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/59/2b844c7a6e9deff69b404a66221e1542937734f65d5e6e39411876053862/numpy-2.5.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:efd736408cc97c79b9e6917338dfc8f06013b2274f992e96b1d9a81a71e2a2c2", size = 5335944, upload-time = "2026-07-04T17:07:12.227Z" },
+    { url = "https://files.pythonhosted.org/packages/86/51/9bf7cb2cabcebc9e017e4ec7e6322b378317a542c08b4cb68479c1efc716/numpy-2.5.1-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:ab84dc6b074fa881cae55bea94cc4f68e285181ba7f32497bf7dee6b1496165b", size = 6656266, upload-time = "2026-07-04T17:07:14.368Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3e/fb7615b211b82a32f44d5180a6d421b61f84d4fadd578b48ba4ac34e189f/numpy-2.5.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caf3e317d33d60c37986b452613f4ab51246d0691350c03d0cb4a898627f4a95", size = 15179720, upload-time = "2026-07-04T17:07:16.272Z" },
+    { url = "https://files.pythonhosted.org/packages/41/5f/0f992cb24560673496c5d68de61913b57166ce530ffda07c1f280e0cc464/numpy-2.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54ad769f17bc2d833b620851989f62054fb9ab93c969d9e1dc3c8e3d56beea21", size = 16664835, upload-time = "2026-07-04T17:07:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/2f/97d6475ee91afe2587797d09446f9d3e475ad4cb681662d824809327b75a/numpy-2.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c12afb53450fa976d4c681c50a7423729a4c51c0465ed9f32b8a9cabbc472373", size = 16539135, upload-time = "2026-07-04T17:07:22.015Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/5b/4db81e4ba0be7e2776b1de68c82aa862c7f8ec27e1b4927d4ae075e20678/numpy-2.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e8c11c405efc5ff6816d5983c96cdfa215bab3428961243af3ff59b228490438", size = 18426684, upload-time = "2026-07-04T17:07:24.941Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/64/c0ba2d90724d450279a7df8f32057241070250a26a7e2b5337d77347f481/numpy-2.5.1-cp314-cp314-win32.whl", hash = "sha256:f2479a47f8d5932d1718168a681ad6e536a9df484c83cfcf9de365e164537ace", size = 6116103, upload-time = "2026-07-04T17:07:27.622Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/1a/837f9ed7405adcd7a40538792eb169eddd8fa5630c16a1ef49dae71a30f4/numpy-2.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:24d0eb82c0541d3415a33425db64ae439dffccd7b4dbcb30e7c35120205c506a", size = 12562177, upload-time = "2026-07-04T17:07:29.887Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/49707938b6dd0a78a9178dd93227dc89e4c11af47f5c798d70366e8d0483/numpy-2.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:5a4c988b38d261deeeaad9954e3deb091ad905c94e8bb6708654ef1d97f286b0", size = 10627739, upload-time = "2026-07-04T17:07:32.568Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/c7/bb4b882cfe7f299cbc8b66e42e7dd78cf9d14e40f9469fc5e3db7e15b3bd/numpy-2.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a33276be12fa045805f477f22482088b66bb758ffbe89a9d21457de863a32e22", size = 11894709, upload-time = "2026-07-04T17:07:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/40/3f/5af7f4a7f6224aef48017aa82bb6174c7a659d724be0c75017b7e64a55b4/numpy-2.5.1-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f089d7b00756190aacf1f5d34bdf38c3c430ac82b4f868f8cede73380460fce7", size = 5453810, upload-time = "2026-07-04T17:07:37.495Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c9/3474309bc94d634d3f9c3eddf03250ecb8c22cd948ef16fef69a77cc5d7b/numpy-2.5.1-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:09e9bfd8d2cf479c7d174804fb3811c53a8e9f20a37444008606b57d6b7a826d", size = 6761189, upload-time = "2026-07-04T17:07:39.563Z" },
+    { url = "https://files.pythonhosted.org/packages/90/8a/558ae39fdd55d7e7f7fef9a84a6e964ac6b23edbd2a07e52bb084500507d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e68d8dd1e7eba712948f2053a29ec86917bc70ba1358df869d9f06649ef9cf09", size = 15225039, upload-time = "2026-07-04T17:07:41.682Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/ca7392b2d030277bdf0273e7d23255b3ee57d57a7c170a6f4fb3981e1e5d/numpy-2.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:99d5095fa265a0c4152e7bb12759e14381ef5496152f1ce58f44bdf55c44beb4", size = 16701306, upload-time = "2026-07-04T17:07:44.611Z" },
+    { url = "https://files.pythonhosted.org/packages/02/42/03d53ae7996c44d4374a8262e9dc41671fd56cbb98f7d47ef85cf5da4c6b/numpy-2.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ab87a91b3cc3382b8956095bd8f95e00cf679bb81554339be1a2ba404a1473c1", size = 16589955, upload-time = "2026-07-04T17:07:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/15/6c1784ae469640e65db111e9a34b3d0f14d91e8a38b9ce34810ced370dbb/numpy-2.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:224ca51130ef7da85bea2191625181cb4f337f9cb64b471f10c1a12aa8b60077", size = 18464252, upload-time = "2026-07-04T17:07:50.684Z" },
+    { url = "https://files.pythonhosted.org/packages/94/a8/f98e50356cf167df656c526c2dfeec2d7dde182f2a3da4b458a5938e2776/numpy-2.5.1-cp314-cp314t-win32.whl", hash = "sha256:6eab239876581b2b3c5a242281b6007bbdbcd1c7085d7709bb57c5929b11e6bf", size = 6263298, upload-time = "2026-07-04T17:07:53.445Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ac/96ae880cdecad0b3275d9359fcec72667b49a4863c9f12942e43679dda02/numpy-2.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:83ce9c80d5b521b0d77ddcbe5447c218d247929b6cc056ca5351342accfff0af", size = 12748623, upload-time = "2026-07-04T17:07:55.384Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/5a/4d2b1601df3602dba7a14f3348ba9bfe94a18adb428e693df6154c293831/numpy-2.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:5a6db61f9aaa57e369905c67d852045d3c4f7126405b29d09b19dec118e9c9cb", size = 10697674, upload-time = "2026-07-04T17:07:58.506Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -266,6 +317,7 @@ source = { editable = "." }
 [package.dev-dependencies]
 dev = [
     { name = "mypy" },
+    { name = "numpy" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -275,6 +327,7 @@ dev = [
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.14" },
+    { name = "numpy", specifier = ">=2.5,<3" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "ruff", specifier = ">=0.9" },
 ]


### PR DESCRIPTION
## Summary

The model build on a 23.9K-scene library went from **~450s to ~110s (4.1x)** through five measured changes, all verified on the installed instance (Python 3.14 container, numpy 2.5.1 in a plugin-local venv):

### 1. SQLite I/O tuning
Core connections: page cache 8 MiB -> 128 MiB, read-only connections memory-map (512 MiB). Generation-artifact build connections: 256 MiB cache + 1 GiB mapping (were SQLite's 2 MiB default). Writable core stays on the pager (sidecar is shared with other processes; maintenance can replace the file).

### 2. Performer profile caching
PerformerProfile precomputes frozenset block keys; _cosine/_numeric use them single-pass with bit-identical math instead of rebuilding sets per call.

### 3. Satiation transpose
Recent-content dots transpose from per-(feature, recent-scene) pairs to per-feature accumulation - same sums, same penalties, fewer operations.

### 4. Optional numpy acceleration
numpy is never a runtime dependency. A new "Install optional dependencies" task (mirroring the community Python Tools Installer) creates a plugin-local venv and pip-installs the pinned plugin/packages/curator-tools.txt; a backend.py sys.path shim picks it up. With numpy present, _content_neighbors and _performer_similarity_scores use BLAS matmuls (float64 dot + float32-exact shared counts, exact top-12 selection with tiebreaks); the pure-Python implementations remain the fallback everywhere else.

### 5. Lean classification payload + batched fingerprints
- model_scene_score carries a small classification_json (six family values + direct signals) so lane classification no longer parses the 108 MiB components_json (artifact schema v3, MODEL_BUILD_VERSION bumped; classification_data() falls back for pre-v3 artifacts). _percentiles gains a numpy path with an identical pure-Python fallback.
- Source fingerprints hash rows in batches of a thousand (one digest update per batch) instead of per-row json.dumps + hashlib.update (1.39M calls); _feature_id no longer computes a sha256 per feature via eager setdefault.

## Measured (installed, 23.9K-scene library, full-sync-build)

| Stage | pure Python (450s build) | now (110s build) | |
|---|---|---|---|
| content neighbors | 75.9s | 5.8s | 13x |
| performer similarity | 31.1s | 7.1s | 4.4x |
| lane_classification | 34.3s | 9.5s | 3.6x |
| features | 61.4s | 27.0s | 2.3x |
| varied_ordering | 40.0s | 19.4s | 2.1x |
| model build total | ~450s | ~110s | ~4.1x |

scripts/verify full: 272 tests, mypy, ruff, plugin build - all green. Parity tests prove the numpy paths match the pure-Python implementations within float tolerance, with the fallback covering numpy-less environments. A NFS write benchmark confirmed the remaining ordering-stage cost is CPU/contention, not the storage path.

## Notes
- numpy is pinned in plugin/packages/curator-tools.txt; pip resolves the wheel matching the runtime Python/platform at install time. Re-run the install task if the container's Python changes; the fallback keeps everything working meanwhile.
- The fingerprint encoding change rotates feature versions once; reuse is stable afterwards.
- Includes the related scene-neighbor normalization commit (ca173a1) already on this lineage.