### PR TITLE
fix: let release-please bump the runtime __version__

### DIFF
--- a/curator/__init__.py
+++ b/curator/__init__.py
@@ -1,3 +1,4 @@
 """Stash Curator recommendation and discovery tools."""
 
-__version__ = "0.1.0"
+# x-release-please-version keeps this in sync with pyproject.toml on releases.
+__version__ = "0.1.0"  # x-release-please-version

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,13 @@
 {
   "packages": {
     ".": {
-      "release-type": "python"
+      "release-type": "python",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "curator/__init__.py"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Release-please's first run (on the merge of #50) found the release and created its branch, but two things were off:

1. **Repo setting blocked PR creation** — 'Allow GitHub Actions to create and approve pull requests' was disabled. I've enabled it via the API (default workflow permissions stay read-only; only workflows that declare `pull-requests: write` — the release workflow — can create PRs).
2. **`curator/__init__.py` would never be bumped** — the python strategy derives package paths from the project name (`stash_curator/...`), which misses `curator/`. This PR adds a generic extra-files updater with the `x-release-please-version` marker so the release PR bumps the runtime version in lockstep with `pyproject.toml`.

Merging this PR triggers the release workflow on the push; it will open the `chore(main): release v0.2.0` PR automatically. No other action needed.