### PR TITLE
chore: enforce Conventional Commits subjects locally

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Commit-msg hook: keep subjects in Conventional Commits format.
+
+release-please derives versions and the changelog from commit subjects, and
+the PR-title workflow enforces the same format at pull-request time. This hook
+catches local commits before they are made so non-conventional subjects cannot
+slip past the changelog. Bypass with --no-verify if a subject is truly exempt.
+"""
+
+import re
+import sys
+
+TYPES = ("feat", "fix", "docs", "style", "refactor", "perf", "test", "build", "ci", "chore", "revert")
+PATTERN = re.compile(rf"^(?:{'|'.join(TYPES)})(?:\([a-z0-9-]+\))?!?: .+$")
+# Git-generated or machine subjects that are not authored by hand.
+EXEMPT_PREFIXES = ("Merge ", "Revert ", "fixup! ", "squash! ", "amend! ", "Initial commit")
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        return 0
+    try:
+        with open(sys.argv[1], encoding="utf-8") as source:
+            subject = source.readline().strip()
+    except OSError:
+        return 0
+    if not subject or subject.startswith(EXEMPT_PREFIXES) or PATTERN.match(subject):
+        return 0
+    print("commit-msg: subject must be Conventional Commits for release-please changelogs.")
+    print(f"  got:      {subject}")
+    print("  expected: <type>(<scope>): <description>   e.g. 'feat: add lane ordering'")
+    print(f"  types:    {' '.join(TYPES)}")
+    print("  breaking: 'feat!: ...' or a 'BREAKING CHANGE:' footer")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,9 @@ Do not commit or push merely because implementation is complete.
    from an earlier turn.
 4. Before committing, verify the staged diff with `git diff --cached --check` and
    `git diff --cached`.
-5. Use a short imperative commit subject describing the outcome.
+5. Use a short Conventional Commits subject (`feat:`, `fix:`, `docs:`, `perf:`, ...)
+   describing the outcome; the `.githooks/commit-msg` hook enforces it because
+   release-please derives the changelog and version bumps from those subjects.
 6. Run `git push` without force. Never rewrite shared history.
 
 A push to `main` triggers both CI and GitHub Pages. Pages rebuilds the plugin archive

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -68,10 +68,13 @@ for the deployment rationale.
 ## Releases
 
 Releases are automated with [release-please](https://github.com/googleapis/release-please)
-and Conventional Commits. The one thing to keep consistent is **PR titles**: prefix
-them with a conventional type (`feat:`, `fix:`, `docs:`, `perf:`, `chore:`, ...) and
-merge with squash so the title becomes the commit subject. A workflow checks every
-PR title and fails otherwise.
+and Conventional Commits. The one thing to keep consistent is **commit subjects**:
+prefix them with a conventional type (`feat:`, `fix:`, `docs:`, `perf:`, `chore:`, ...)
+and merge with squash so the PR title becomes the commit subject. A workflow checks
+every PR title, and a local `.githooks/commit-msg` hook checks commits before they
+are made (the same hook directory as the pre-push verifier; enable it with
+`git config core.hooksPath .githooks`). Use `--no-verify` only when a subject is
+truly exempt.
 
 On every push to `main`, release-please compares the merged commits against the last
 release, opens a `chore(main): release vX.Y.Z` pull request that bumps


### PR DESCRIPTION
Release-please derives the changelog and version bumps from commit subjects; the PR-title workflow enforces the format at pull-request time, but local commits could bypass it.

- Adds a zero-dependency `.githooks/commit-msg` hook (same directory as the pre-push verifier) accepting `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, with optional scope and `!` breaking marker; Git-generated subjects (Merge, Revert, fixup!/squash!/amend!, Initial commit) stay exempt.
- AGENTS.md and docs/contributing.md now state the convention.
- Verified: conventional subjects pass, plain subjects are rejected with a hint, Git-generated ones pass.