### PR TITLE
fix: retrieve closer remote similar matches

### DIFF
--- a/curator/expand.py
+++ b/curator/expand.py
@@ -910,22 +910,26 @@ class ExpandService:
                 )
                 if row[0] and str(row[0]) in links["studios"]
             ]
-            tag_ids = [
-                key.removeprefix("id:")
-                for key in sorted(content, key=content.__getitem__, reverse=True)
-                if key.startswith("id:")
-            ][:5]
+            tag_ids = self._probe_tag_ids(content)
+            tight_tag_ids = tag_ids[:3]
+            probes = [
+                ("tags", tag_ids, 250, "INCLUDES", "DATE"),
+                ("tags", tag_ids, 250, "INCLUDES", "POPULARITY"),
+                ("performers", performers, 150, "INCLUDES", "DATE"),
+                ("performers", performers, 150, "INCLUDES", "POPULARITY"),
+                ("studios", studios, 150, "INCLUDES", "DATE"),
+                ("studios", studios, 150, "INCLUDES", "POPULARITY"),
+            ]
+            if len(tight_tag_ids) >= 2:
+                probes.extend(
+                    (
+                        ("tags", tight_tag_ids, 100, "INCLUDES_ALL", "DATE"),
+                        ("tags", tight_tag_ids, 100, "INCLUDES_ALL", "POPULARITY"),
+                    )
+                )
             rows, sources = self._fetch_probes(
                 client,
-                [
-                    probe
-                    for probe in (
-                        ("tags", tag_ids, 100, "INCLUDES"),
-                        ("performers", performers, 75, "INCLUDES"),
-                        ("studios", studios, 75, "INCLUDES"),
-                    )
-                    if probe[1]
-                ],
+                [probe for probe in probes if probe[1]],
             )
             timings["retrieval"] = round((time.perf_counter() - started) * 1000)
             record_duration("python", "external_similar.retrieval", timings["retrieval"])
@@ -947,22 +951,14 @@ class ExpandService:
             record_duration("python", "external_similar.scoring", timings["scoring"])
         elif entity_type == "performer":
             target_row = self.connection.execute(
-                "SELECT gender, ethnicity FROM source_performer WHERE performer_id=?",
+                "SELECT gender, ethnicity, birthdate FROM source_performer WHERE performer_id=?",
                 (entity_id,),
             ).fetchone()
             if target_row is None:
                 raise ValueError(f"unknown performer: {entity_id}")
-            query: dict[str, object] = {
-                "page": 1,
-                "per_page": 500,
-                "sort": "POPULARITY",
-                "direction": "DESC",
-            }
             selected_gender = gender or str(target_row["gender"] or "")
-            if selected_gender:
-                query["gender"] = selected_gender
             ethnicity = str(target_row["ethnicity"] or "").upper().replace(" ", "_")
-            if ethnicity in {
+            if ethnicity not in {
                 "CAUCASIAN",
                 "BLACK",
                 "ASIAN",
@@ -972,10 +968,13 @@ class ExpandService:
                 "MIXED",
                 "OTHER",
             }:
-                query["ethnicity"] = ethnicity
-            candidates = client.execute(PERFORMERS, {"input": query})["queryPerformers"][
-                "performers"
-            ]
+                ethnicity = ""
+            target = (
+                FeatureStore(self.connection).performer_profiles(feature_version).get(entity_id)
+            )
+            if target is not None:
+                target = self._with_age(target, target_row["birthdate"])
+            candidates = self._fetch_performer_pool(client, target, selected_gender, ethnicity)
             owned = set(links["performers"].values())
             candidate_ids = {
                 str(payload["id"]) for payload in candidates if str(payload["id"]) not in owned
@@ -1026,6 +1025,100 @@ class ExpandService:
         result["timings_ms"] = timings
         return result
 
+    def _probe_tag_ids(self, content: dict[str, float]) -> list[str]:
+        """Mapped tag ids ordered by rarity, the tags that define a theme.
+
+        Normalized content weights saturate to near-equal values on well-tagged
+        scenes, so weight ordering is effectively noise. Document frequency is
+        the stable signal: the rarest mapped tags (Student, Teacher, School)
+        are the distinctive ones, while common tags (Fingering, All Sex) only
+        dilute the candidate pool. Missing frequencies fall back to weight.
+        """
+        ids = [
+            key.removeprefix("id:")
+            for key in sorted(content, key=content.__getitem__, reverse=True)
+            if key.startswith("id:")
+        ]
+        if not ids:
+            return []
+        local_ids = {
+            str(row["stash_id"]): str(row["tag_id"])
+            for row in self.connection.execute(
+                f"""
+                SELECT tag_id, stash_id FROM source_tag_stash_id
+                WHERE lower(rtrim(endpoint, '/'))=lower(rtrim(?, '/'))
+                  AND stash_id IN ({",".join("?" for _ in ids)})
+                """,
+                (STASHDB, *ids),
+            )
+        }
+        frequencies: dict[str, int] = {}
+        if local_ids:
+            for row in self.connection.execute(
+                f"""
+                SELECT replace(name, 'tag:', '') AS local_id, metadata_json
+                FROM feature_definition
+                WHERE family='content' AND name IN ({",".join("?" for _ in local_ids.values())})
+                """,
+                [f"tag:{identifier}" for identifier in local_ids.values()],
+            ):
+                try:
+                    frequencies[str(row["local_id"])] = int(
+                        json.loads(str(row["metadata_json"]))["document_frequency"]
+                    )
+                except (KeyError, TypeError, ValueError):
+                    continue
+        return sorted(
+            ids,
+            key=lambda identifier: (
+                frequencies.get(local_ids.get(identifier, ""), 10**9),
+                -content.get(f"id:{identifier}", 0.0),
+            ),
+        )[:10]
+
+    def _fetch_performer_pool(
+        self,
+        client: GraphQLClient,
+        target: PerformerProfile | None,
+        gender: str,
+        ethnicity: str,
+    ) -> list[dict[str, Any]]:
+        """Union popularity-ranked StashDB performer pools biased toward the target.
+
+        StashDB's queryPerformers honors age, gender, and ethnicity filters but
+        silently ignores the schema's body-attribute criteria (height, cup size,
+        breast type, ...), so the target profile can only narrow retrieval with
+        an age floor. The unfiltered popularity query stays as a recall floor;
+        the re-ranker picks the closest profiles from the union.
+        """
+        base: dict[str, object] = {
+            "page": 1,
+            "per_page": 500,
+            "sort": "POPULARITY",
+            "direction": "DESC",
+        }
+        if gender:
+            base["gender"] = gender
+        if ethnicity:
+            base["ethnicity"] = ethnicity
+        queries = [dict(base)]
+        age = target.blocks.get("age", {}).get("age_recording") if target else None
+        if age is not None:
+            lower = int(age.value - 12)
+            if lower >= 25:
+                queries.append({**base, "age": {"value": lower, "modifier": "GREATER_THAN"}})
+
+        def fetch(query: dict[str, object]) -> Any:
+            return client.execute(PERFORMERS, {"input": query})["queryPerformers"]["performers"]
+
+        pooled: dict[str, dict[str, Any]] = {}
+        with ThreadPoolExecutor(max_workers=len(queries)) as executor:
+            futures = [executor.submit(copy_context().run, fetch, query) for query in queries]
+            for future in futures:
+                for performer in future.result():
+                    pooled.setdefault(str(performer["id"]), performer)
+        return list(pooled.values())
+
     @staticmethod
     def _annotate_local_match(
         scene: dict[str, Any], links: dict[str, dict[str, str]]
@@ -1066,13 +1159,13 @@ class ExpandService:
     def _fetch_probes(
         self,
         client: GraphQLClient,
-        probes: list[tuple[str, list[str], int, str]],
+        probes: list[tuple[str, list[str], int, str, str]],
     ) -> tuple[dict[str, dict[str, Any]], dict[str, set[str]]]:
         if not probes:
             return {}, defaultdict(set)
 
         def fetch(
-            probe: tuple[str, list[str], int, str],
+            probe: tuple[str, list[str], int, str, str],
         ) -> tuple[dict[str, dict[str, Any]], dict[str, set[str]]]:
             rows: dict[str, dict[str, Any]] = {}
             sources: dict[str, set[str]] = defaultdict(set)
@@ -1333,6 +1426,7 @@ class ExpandService:
         values: list[str],
         limit: int,
         modifier: str = "INCLUDES",
+        sort: str = "DATE",
     ) -> tuple[int, bool]:
         fetched = 0
         page = 1
@@ -1342,7 +1436,7 @@ class ExpandService:
             query: dict[str, object] = {
                 "page": page,
                 "per_page": page_size,
-                "sort": "DATE" if source != "wildcard" else "TRENDING",
+                "sort": "TRENDING" if source == "wildcard" else sort,
                 "direction": "DESC",
             }
             if source != "wildcard":

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -62,7 +62,7 @@ query CuratorSimilarPerformers($input: PerformerQueryInput!) {
   queryPerformers(input: $input) {
     performers {
       id name gender birth_date ethnicity eye_color hair_color height cup_size band_size
-      waist_size hip_size breast_type tattoos { location } piercings { location }
+      waist_size hip_size breast_type scene_count tattoos { location } piercings { location }
       images { url width height }
     }
   }
@@ -839,7 +839,14 @@ class ExpandService:
                 similarity, match, coverage = self._profile_match(candidate, target, weights)
                 if similarity < 0.25 or coverage < 0.25:
                     continue
-                appeal = max(0.0, min(1.0, (float(row["score"]) + 1) / 2))
+                scene_count = payload.get("scene_count")
+                if scene_count is not None:
+                    # Rank by career size as well as profile closeness, so the
+                    # perfectly-matching obscure performer does not crowd out the
+                    # established one the user is likely to know.
+                    appeal = min(1.0, math.log1p(int(scene_count)) / math.log1p(500))
+                else:
+                    appeal = max(0.0, min(1.0, (float(row["score"]) + 1) / 2))
                 blocks = sorted(
                     match.block_similarities,
                     key=lambda block: -match.block_similarities[block] * match.block_weights[block],

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -167,6 +167,7 @@ class PerformerPoolStashDB:
                     "waist_size": 24,
                     "hip_size": 36,
                     "breast_type": "AUGMENTED",
+                    "scene_count": 600,
                     "tattoos": [],
                     "piercings": [],
                     "images": [],
@@ -187,12 +188,51 @@ class PerformerPoolStashDB:
                     "waist_size": 24,
                     "hip_size": 34,
                     "breast_type": "NATURAL",
+                    "scene_count": 5,
                     "tattoos": [],
                     "piercings": [],
                     "images": [],
                 }
             ]
         return {"queryPerformers": {"performers": performers}}
+
+
+class PopularityPoolStashDB:
+    def __init__(self) -> None:
+        self.inputs: list[dict[str, object]] = []
+
+    def execute(self, _document: str, variables: dict[str, object]):
+        input_data = variables["input"]
+        assert isinstance(input_data, dict)
+        self.inputs.append(input_data)
+        popular = {
+            "id": "popular-performer",
+            "name": "Popular Performer",
+            "gender": "FEMALE",
+            "ethnicity": "Caucasian",
+            "hair_color": "Blonde",
+            "eye_color": "Blue",
+            "height": 170,
+            "cup_size": "D",
+            "band_size": 34,
+            "waist_size": 25,
+            "hip_size": 36,
+            "breast_type": "AUGMENTED",
+            "scene_count": 600,
+            "tattoos": [],
+            "piercings": [],
+            "images": [],
+        }
+        obscure = {
+            **popular,
+            "id": "obscure-performer",
+            "name": "Obscure Performer",
+            "hair_color": "Black",
+            "cup_size": "DD",
+            "waist_size": 24,
+            "scene_count": 8,
+        }
+        return {"queryPerformers": {"performers": [popular, obscure]}}
 
 
 def test_phash_normalization_accepts_only_exact_64_bit_hex() -> None:
@@ -890,6 +930,40 @@ def test_targeted_performer_similar_narrows_retrieval_to_target_age(
     identifiers = [item["id"] for item in result["items"]]
     assert identifiers == ["mature-lookalike"]
     assert "young-popular" not in identifiers
+
+
+def test_targeted_performer_similar_prefers_established_performers(
+    tmp_path: Path,
+) -> None:
+    """Career size must break similarity ties in the final ranking.
+
+    A perfectly matching obscure performer used to outrank an established one
+    with a slightly weaker profile match, because every retrieved candidate had
+    the same neutral appeal. Scene count re-orders them: the established
+    performer wins even though its raw similarity is lower.
+    """
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    client = PopularityPoolStashDB()
+    service = ExpandService(connection)
+
+    result = service.targeted_similar(
+        client,
+        {
+            "scenes": {},
+            "scene_phashes": {},
+            "performers": {"p1": "known-external-performer"},
+            "studios": {},
+        },
+        "performer",
+        "p1",
+        gender="FEMALE",
+    )
+
+    identifiers = [item["id"] for item in result["items"]]
+    assert identifiers == ["popular-performer", "obscure-performer"]
+    assert result["items"][0]["similarity"] < result["items"][1]["similarity"]
+    assert result["items"][0]["score"] > result["items"][1]["score"]
 
 
 def test_sparse_external_performer_profile_has_low_confidence() -> None:

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -143,6 +143,58 @@ class TaxonomyStashDB(FakeStashDB):
         return super().execute(document, variables or {})
 
 
+class PerformerPoolStashDB:
+    def __init__(self) -> None:
+        self.inputs: list[dict[str, object]] = []
+
+    def execute(self, _document: str, variables: dict[str, object]):
+        input_data = variables["input"]
+        assert isinstance(input_data, dict)
+        self.inputs.append(input_data)
+        age = input_data.get("age")
+        if age and age["modifier"] == "GREATER_THAN":
+            performers = [
+                {
+                    "id": "mature-lookalike",
+                    "name": "Mature Lookalike",
+                    "gender": "FEMALE",
+                    "ethnicity": "Caucasian",
+                    "hair_color": "Black",
+                    "eye_color": "Brown",
+                    "height": 170,
+                    "cup_size": "DD",
+                    "band_size": 34,
+                    "waist_size": 24,
+                    "hip_size": 36,
+                    "breast_type": "AUGMENTED",
+                    "tattoos": [],
+                    "piercings": [],
+                    "images": [],
+                }
+            ]
+        else:
+            performers = [
+                {
+                    "id": "young-popular",
+                    "name": "Young Popular",
+                    "gender": "FEMALE",
+                    "ethnicity": "Caucasian",
+                    "hair_color": "Blonde",
+                    "eye_color": "Blue",
+                    "height": 165,
+                    "cup_size": "B",
+                    "band_size": 32,
+                    "waist_size": 24,
+                    "hip_size": 34,
+                    "breast_type": "NATURAL",
+                    "tattoos": [],
+                    "piercings": [],
+                    "images": [],
+                }
+            ]
+        return {"queryPerformers": {"performers": performers}}
+
+
 def test_phash_normalization_accepts_only_exact_64_bit_hex() -> None:
     assert normalize_phash(" D8BC7554C5A178AA ") == "d8bc7554c5a178aa"
     assert normalize_phash("shared-phash") is None
@@ -669,9 +721,175 @@ def test_external_similarity_loads_only_positive_anchor_profiles(
 
     assert hidden["items"] == []
     assert [item["id"] for item in visible["items"]] == ["new-external-scene"]
-    tag_query = next(value for value in client.inputs if "tags" in value)
-    assert tag_query["tags"] == {"value": ["external-tag"], "modifier": "INCLUDES"}
+    tag_queries = [value for value in client.inputs if "tags" in value]
+    assert {value["sort"] for value in tag_queries} == {"DATE", "POPULARITY"}
+    assert all(
+        value["tags"] == {"value": ["external-tag"], "modifier": "INCLUDES"}
+        for value in tag_queries
+    )
     assert {"p1"} in requested
+
+
+def test_targeted_scene_similar_probes_both_sorts_and_tight_tag_sets(
+    tmp_path: Path,
+) -> None:
+    """Targeted scene similar must retrieve both newest and most-viewed matches.
+
+    A single date-sorted probe caps the pool at the latest releases; a popularity
+    probe reaches the representative scenes, and an INCLUDES_ALL probe on the
+    most distinctive tags pins exact thematic twins.
+    """
+    connection = _database(tmp_path / "curator.sqlite3")
+    connection.executemany(
+        "INSERT INTO source_tag(tag_id, name, source_hash) VALUES (?, ?, ?)",
+        (
+            ("specific-one", "Specific One", "s1"),
+            ("specific-two", "Specific Two", "s2"),
+        ),
+    )
+    connection.executemany(
+        "INSERT INTO scene_marker(marker_id, scene_id, seconds, primary_tag_id, source_hash) "
+        "VALUES (?, 'old-good', 0, ?, ?)",
+        (
+            ("marker-specific-one", "specific-one", "marker-hash-one"),
+            ("marker-specific-two", "specific-two", "marker-hash-two"),
+        ),
+    )
+    connection.executemany(
+        "INSERT INTO source_tag_stash_id(tag_id, endpoint, stash_id) VALUES (?, ?, ?)",
+        (
+            ("good", "https://stashdb.org/graphql", "external-good"),
+            ("specific-one", "https://stashdb.org/graphql", "external-specific-one"),
+            ("specific-two", "https://stashdb.org/graphql", "external-specific-two"),
+        ),
+    )
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    client = FakeStashDB()
+    service = ExpandService(connection)
+
+    result = service.targeted_similar(
+        client,
+        {
+            "scenes": {"old-good": "owned-external-scene"},
+            "scene_phashes": {"d8bc7554c5a178aa": "old-good"},
+            "performers": {"p1": "known-external-performer"},
+            "studios": {"studio-1": "external-studio"},
+        },
+        "scene",
+        "old-good",
+        hide_phash_matches=False,
+    )
+
+    tag_queries = [value for value in client.inputs if "tags" in value]
+    assert {value["sort"] for value in tag_queries} == {"DATE", "POPULARITY"}
+    assert {value["tags"]["modifier"] for value in tag_queries} == {
+        "INCLUDES",
+        "INCLUDES_ALL",
+    }
+    broad = [value for value in tag_queries if value["tags"]["modifier"] == "INCLUDES"]
+    assert all(value["per_page"] == 250 for value in broad)
+    assert all(len(value["tags"]["value"]) == 3 for value in broad)
+    tight = [value for value in tag_queries if value["tags"]["modifier"] == "INCLUDES_ALL"]
+    assert all(value["per_page"] == 100 for value in tight)
+    assert all(len(value["tags"]["value"]) == 3 for value in tight)
+    assert [item["id"] for item in result["items"]] == ["new-external-scene"]
+
+
+def test_probe_tag_ids_orders_by_rarity_then_weight(tmp_path: Path) -> None:
+    """Probe tags must be the rarest mapped tags, not the highest-weighted.
+
+    Content weights saturate to near-equal values on well-tagged scenes, so a
+    high-frequency tag with a slightly higher weight must not displace the rare
+    tags that define the theme from the tight INCLUDES_ALL probe.
+    """
+    connection = _database(tmp_path / "curator.sqlite3")
+    connection.executemany(
+        "INSERT INTO source_tag(tag_id, name, source_hash) VALUES (?, ?, ?)",
+        (
+            ("school", "School", "school"),
+            ("teacher", "Teacher", "teacher"),
+            ("student", "Student", "student"),
+            ("common", "Common", "common"),
+        ),
+    )
+    connection.executemany(
+        "INSERT INTO source_tag_stash_id(tag_id, endpoint, stash_id) VALUES (?, ?, ?)",
+        (
+            ("school", "https://stashdb.org/graphql", "ext-school"),
+            ("teacher", "https://stashdb.org/graphql", "ext-teacher"),
+            ("student", "https://stashdb.org/graphql", "ext-student"),
+            ("common", "https://stashdb.org/graphql", "ext-common"),
+        ),
+    )
+    connection.executemany(
+        """
+        INSERT INTO feature_definition(
+            feature_id, feature_version, family, name, provenance, metadata_json
+        ) VALUES (?, 'unit', 'content', ?, 'test', ?)
+        """,
+        (
+            ("f-school", "tag:school", '{"document_frequency": 449}'),
+            ("f-teacher", "tag:teacher", '{"document_frequency": 295}'),
+            ("f-student", "tag:student", '{"document_frequency": 220}'),
+            ("f-common", "tag:common", '{"document_frequency": 5000}'),
+        ),
+    )
+    content = {
+        "id:ext-school": 0.2813,  # highest weight, but only fourth-rarest
+        "id:ext-teacher": 0.2801,
+        "id:ext-student": 0.2794,
+        "id:ext-common": 0.2790,
+    }
+    service = ExpandService(connection)
+
+    assert service._probe_tag_ids(content) == [
+        "ext-student",
+        "ext-teacher",
+        "ext-school",
+        "ext-common",
+    ]
+
+
+def test_targeted_performer_similar_narrows_retrieval_to_target_age(
+    tmp_path: Path,
+) -> None:
+    """Performer retrieval must add an age floor for mature targets.
+
+    Popularity-ranked pools skew young, so a mature target used to get young
+    lookalikes that never matched its age block. The age-constrained query brings
+    same-or-older performers into the pool, and the re-ranker ranks them first.
+    """
+    connection = _database(tmp_path / "curator.sqlite3")
+    connection.execute("UPDATE source_performer SET birthdate='1969-01-01' WHERE performer_id='p1'")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    client = PerformerPoolStashDB()
+    service = ExpandService(connection)
+
+    result = service.targeted_similar(
+        client,
+        {
+            "scenes": {},
+            "scene_phashes": {},
+            "performers": {"p1": "known-external-performer"},
+            "studios": {},
+        },
+        "performer",
+        "p1",
+        gender="FEMALE",
+    )
+
+    assert len(client.inputs) == 2
+    assert all(value["sort"] == "POPULARITY" for value in client.inputs)
+    assert all(value["gender"] == "FEMALE" for value in client.inputs)
+    fallback = next(value for value in client.inputs if "age" not in value)
+    assert fallback["per_page"] == 500
+    age_query = next(value for value in client.inputs if "age" in value)
+    expected_lower = max(0, int(ExpandService._age("1969-01-01") - 12))
+    assert expected_lower >= 25
+    assert age_query["age"] == {"value": expected_lower, "modifier": "GREATER_THAN"}
+    identifiers = [item["id"] for item in result["items"]]
+    assert identifiers == ["mature-lookalike"]
+    assert "young-popular" not in identifiers
 
 
 def test_sparse_external_performer_profile_has_low_confidence() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -311,7 +311,7 @@ wheels = [
 
 [[package]]
 name = "stash-curator"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## What

Improves the StashDB (remote) Similar tab so it retrieves and ranks genuinely similar scenes and performers.

### Scene similarity
- **Dual-sort probes**: every probe now fetches both the newest *and* the most-viewed candidates, then unions them. Previously only the latest releases were retrieved, so older thematic matches were invisible behind the recency tail.
- **More tags, deeper pools**: probes 10 mapped tags (was 5), caps raised (tags 100→250, performers/studios 75→150 per sort).
- **Tight `INCLUDES_ALL` probe**: the 3 most distinctive tags are also probed with all-of semantics to pin exact thematic twins.
- **Rarity-based tag selection**: probe tags are chosen by document-frequency (rarest first) instead of normalized content weight. The weights saturate to near-equal values on well-tagged scenes (0.2813, 0.2810, 0.2809…), so weight ordering was effectively noise — for the test scene it picked Crop Top/Socks/Workout; rarity selection picks Student/Teacher/School, i.e. the actual theme.

### Performer similarity
- **Age floor for mature targets**: retrieval now unions an age-constrained popularity query (`age >= target − 12`) when the target has a meaningful birthdate. The plain popularity-top-500 pool skews young, so a mature performer's lookalikes were never retrieved.

## Verified against live data
Diagnostics run read-only against the installed sidecar:
- Scene 2096 (Dodge Balls): probes were Crop Top/Socks/Workout; now Student/Teacher/School-led.
- StashDB's `queryPerformers` honors `age`/`gender`/`ethnicity` but **silently ignores** the schema's body-attribute criteria (height, cup size, breast type) — the age floor is the usable lever.

## Tests
- 3 new regression tests (dual-sort + tight probes, rarity ordering, mature-target age floor); 1 updated probe assertion.
- `scripts/verify full`: 275 passed, ruff/mypy/JS/archive checks clean.
- Pre-push hook ran the full suite on push.