### PR TITLE
chore(release): keep uv.lock in sync with release versions

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,11 @@
         {
           "type": "generic",
           "path": "curator/__init__.py"
+        },
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='stash-curator')].version"
         }
       ]
     }


### PR DESCRIPTION
## What

`release-please` bumps the version in `pyproject.toml` for the python release-type, but leaves the root package version in `uv.lock` stale. Every release PR therefore fails the CI `uv sync --locked` step and needs a manual lockfile fix before it can merge (the 0.3.0 release PR had to be fixed by hand).

This adds a `toml` extra-file updater targeting the `stash-curator` entry inside `uv.lock`:

```json
{
  "type": "toml",
  "path": "uv.lock",
  "jsonpath": "$.package[?(@.name.value=='stash-curator')].version"
}
```

## Validation

Replicated release-please's `GenericToml` updater (tagged TOML parser + `jsonpath-plus` pointer + value replacement) against the repository's real `uv.lock` and confirmed it changes exactly the root package version line, producing valid TOML — no other lines touched.

## Effect

Future release PRs will carry the `uv.lock` version bump alongside `pyproject.toml`, and `uv sync --locked` will pass without manual intervention.