### PR TITLE
feat: expand tag filters to include child tags (descendants) in Expand, Similar, and Performer Hunt (#65)

### DIFF
--- a/curator/expand.py
+++ b/curator/expand.py
@@ -322,6 +322,8 @@ class ExpandService:
         performer_id: str,
         *,
         limit: int = PERFORMER_HUNT_LIMIT,
+        include_tags: tuple[str, ...] = (),
+        exclude_tags: tuple[str, ...] = (),
     ) -> dict[str, object]:
         local = self.connection.execute(
             "SELECT name FROM source_performer WHERE performer_id=?", (performer_id,)
@@ -374,6 +376,8 @@ class ExpandService:
             multi_hop_seed=performer_id,
         )
         self._merge_external("scene", scenes)
+        include_groups = equivalent_tag_names(self.connection, include_tags)
+        exclude_groups = equivalent_tag_names(self.connection, exclude_tags)
         shortlisted = {
             str(row[0])
             for row in self.connection.execute(
@@ -391,6 +395,13 @@ class ExpandService:
                 "shortlisted": scene["id"] in shortlisted,
             }
             for scene in scenes
+            if self._scene_matches(
+                scene["payload"],
+                include_tags,
+                exclude_tags,
+                include_groups=include_groups,
+                exclude_groups=exclude_groups,
+            )
         ]
         items.sort(
             key=lambda item: (

--- a/curator/taxonomy/store.py
+++ b/curator/taxonomy/store.py
@@ -206,39 +206,120 @@ def _normalize(value: str) -> str:
 def equivalent_tag_names(
     connection: sqlite3.Connection, values: tuple[str, ...]
 ) -> tuple[frozenset[str], ...]:
-    """Expand selected tag names through the active StashDB alias taxonomy."""
+    """Expand selected tag names through taxonomy aliases and the local tag hierarchy.
+
+    Each input name resolves to the matching local tag ids, any taxonomy
+    (StashDB) ids that map back to local tags, and — transitively — every
+    descendant in the local ``tag_parent`` hierarchy.  The returned groups
+    include local names and taxonomy names/aliases for all of those tags so
+    both local and external filtering surfaces see the full subtree.
+    """
     snapshot = connection.execute(
         "SELECT value FROM application_meta WHERE key='taxonomy_snapshot_id'"
     ).fetchone()
-    groups = []
+    groups: list[frozenset[str]] = []
     for value in values:
         normalized = _normalize(value)
-        names = {normalized}
+        local_ids: set[str] = set()
+        # 1 ─ direct local name match
+        local_ids.update(
+            str(row[0])
+            for row in connection.execute(
+                "SELECT tag_id FROM source_tag WHERE lower(name)=?", (normalized,)
+            )
+        )
+        taxonomy_names: set[str] = set()
         if snapshot:
-            tag_ids = {
+            # 2 ─ taxonomy (StashDB) resolution + map back to local ids
+            taxonomy_ids = {
                 str(row[0])
                 for row in connection.execute(
                     """
                     SELECT tag_id FROM taxonomy_tag WHERE snapshot_id=? AND lower(name)=?
                     UNION
-                    SELECT tag_id FROM taxonomy_tag_alias WHERE snapshot_id=? AND lower(alias)=?
+                    SELECT tag_id FROM taxonomy_tag_alias
+                    WHERE snapshot_id=? AND lower(alias)=?
                     """,
                     (snapshot[0], normalized, snapshot[0], normalized),
                 )
             }
-            for tag_id in tag_ids:
-                names.update(
+            if taxonomy_ids:
+                local_from_taxonomy = {
+                    str(row[0])
+                    for row in connection.execute(
+                        f"""SELECT local_tag_id FROM tag_taxonomy_match
+                        WHERE snapshot_id=? AND external_tag_id IN
+                        ({",".join("?" for _ in taxonomy_ids)})""",
+                        (snapshot[0], *sorted(taxonomy_ids)),
+                    )
+                    if row[0]
+                }
+                local_ids.update(local_from_taxonomy)
+            # Taxonomy names / aliases (covers external-only tags and aliases
+            # that differ from the local name).
+            for tag_id in taxonomy_ids:
+                taxonomy_names.update(
                     _normalize(str(row[0]))
                     for row in connection.execute(
                         """
                         SELECT name FROM taxonomy_tag WHERE snapshot_id=? AND tag_id=?
                         UNION ALL
-                        SELECT alias FROM taxonomy_tag_alias WHERE snapshot_id=? AND tag_id=?
+                        SELECT alias FROM taxonomy_tag_alias
+                        WHERE snapshot_id=? AND tag_id=?
                         """,
                         (snapshot[0], tag_id, snapshot[0], tag_id),
                     )
                 )
-        groups.append(frozenset(names))
+        # 3 ─ walk tag_parent for all descendants
+        if local_ids:
+            queue = list(local_ids)
+            while queue:
+                parent = queue.pop()
+                for (child,) in connection.execute(
+                    "SELECT tag_id FROM tag_parent WHERE parent_tag_id=?", (parent,)
+                ):
+                    child = str(child)
+                    if child not in local_ids:
+                        local_ids.add(child)
+                        queue.append(child)
+        # 4 ─ collect local names for every resolved id
+        if local_ids:
+            local_names = {
+                _normalize(str(row[0]))
+                for row in connection.execute(
+                    f"""SELECT name FROM source_tag WHERE tag_id IN
+                    ({",".join("?" for _ in local_ids)})""",
+                    sorted(local_ids),
+                )
+            }
+            taxonomy_names.update(local_names)
+        # 5 ─ taxonomy names/aliases for every local id
+        if snapshot and local_ids:
+            external_ids = {
+                str(row[0])
+                for row in connection.execute(
+                    f"""SELECT external_tag_id FROM tag_taxonomy_match
+                    WHERE snapshot_id=? AND local_tag_id IN
+                    ({",".join("?" for _ in local_ids)})""",
+                    (snapshot[0], *sorted(local_ids)),
+                )
+                if row[0]
+            }
+            for ext_id in external_ids:
+                taxonomy_names.update(
+                    _normalize(str(row[0]))
+                    for row in connection.execute(
+                        """
+                        SELECT name FROM taxonomy_tag WHERE snapshot_id=? AND tag_id=?
+                        UNION ALL
+                        SELECT alias FROM taxonomy_tag_alias
+                        WHERE snapshot_id=? AND tag_id=?
+                        """,
+                        (snapshot[0], ext_id, snapshot[0], ext_id),
+                    )
+                )
+        taxonomy_names.add(normalized)
+        groups.append(frozenset(taxonomy_names))
     return tuple(groups)
 
 

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -766,6 +766,8 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
                 _external_links(payload, connection),
                 str(args.get("performer_id") or ""),
                 limit=PERFORMER_HUNT_LIMIT,
+                include_tags=_string_list(args.get("include_tags")),
+                exclude_tags=_string_list(args.get("exclude_tags")),
             )
         if operation == "get_shortlist":
             config = api.config()["config"]

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -1513,7 +1513,7 @@
       const request = entityType === "shortlist"
         ? { operation: "get_shortlist", page }
         : entityType === "hunt"
-          ? { operation: "get_performer_hunt", performer_id: String(huntPerformer.id) }
+          ? { operation: "get_performer_hunt", performer_id: String(huntPerformer.id), include_tags: includeTags.map((item) => item.name), exclude_tags: excludeTags.map((item) => item.name) }
           : { operation: "get_expand", page, entity_type: entityType, sort, performer_id: performerId, favorite_only: favoriteOnly, hide_phash_matches: hidePhashMatches, gender, include_tags: includeTags.map((item) => item.name), exclude_tags: excludeTags.map((item) => item.name), performer_names: performers.map((item) => item.name), studio_names: studios.map((item) => item.name), minimum_score: minimumScore };
       operation(request, entityType === "hunt" ? 60000 : 30000).then(
         (result) => {
@@ -1576,21 +1576,16 @@
       } catch (failure) { setError(failure.message); }
     }
     const sendWhisparr = (id) => operation({ operation: "send_whisparr", external_id: id });
-    const tagFilteredHuntItems = entityType === "hunt"
-      ? (data?.items || []).filter((item) => {
-        const tags = new Set((item.payload.tags || []).map((tag) => String(tag.name || "").toLocaleLowerCase()));
-        return (!hidePhashMatches || item.match_type !== "phash")
-          && includeTags.every((tag) => tags.has(tag.name.toLocaleLowerCase()))
-          && excludeTags.every((tag) => !tags.has(tag.name.toLocaleLowerCase()));
-      })
+    const huntItemsRaw = entityType === "hunt"
+      ? (data?.items || []).filter((item) => !hidePhashMatches || item.match_type !== "phash")
       : [];
     const huntCounts = {
-      all: tagFilteredHuntItems.length,
-      linked: tagFilteredHuntItems.filter((item) => item.linked_locally).length,
-      unlinked: tagFilteredHuntItems.filter((item) => !item.linked_locally).length,
+      all: huntItemsRaw.length,
+      linked: huntItemsRaw.filter((item) => item.linked_locally).length,
+      unlinked: huntItemsRaw.filter((item) => !item.linked_locally).length,
     };
     const huntItems = entityType === "hunt"
-      ? tagFilteredHuntItems
+      ? huntItemsRaw
         .filter((item) => huntView === "all" || item.linked_locally === (huntView === "linked"))
         .sort((left, right) => huntSort === "score"
           ? right.score - left.score || left.id.localeCompare(right.id)

--- a/tests/taxonomy/test_store.py
+++ b/tests/taxonomy/test_store.py
@@ -92,3 +92,40 @@ def test_snapshot_is_immutable_reusable_and_resolves_by_id_then_unique_alias(
 def test_physical_category_allowlist_is_stable() -> None:
     assert BODY_TYPE_ID in PERFORMER_ATTRIBUTE_CATEGORY_IDS
     assert CLOTHING_ID not in PERFORMER_ATTRIBUTE_CATEGORY_IDS
+
+
+def test_equivalent_tag_names_includes_descendants(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    try:
+        connection.execute(
+            "INSERT INTO tag_parent(tag_id, parent_tag_id) VALUES (?, ?)",
+            ("local-clothing", "local-id"),
+        )
+        connection.execute(
+            "INSERT INTO tag_parent(tag_id, parent_tag_id) VALUES (?, ?)",
+            ("local-trimmed", "local-id"),
+        )
+        # Grandchild
+        connection.execute(
+            "INSERT INTO tag_parent(tag_id, parent_tag_id) VALUES (?, ?)",
+            ("local-ambiguous", "local-clothing"),
+        )
+        from curator.taxonomy.store import equivalent_tag_names
+
+        groups = equivalent_tag_names(connection, ("Wrong Local Name",))
+        assert len(groups) == 1
+        names = groups[0]
+        # Original name + descendants (no taxonomy snapshot, so names are local)
+        assert "wrong local name" in names
+        assert "stockings" in names  # local-clothing, child
+        assert "trimmed" in names  # local-trimmed, child
+        assert "ambiguous" in names  # local-ambiguous, grandchild via local-clothing
+        # Unrelated tag should not be included
+        assert "athletic body" not in names  # local-alias, not a descendant
+
+        # Tag with no hierarchy returns only itself
+        groups = equivalent_tag_names(connection, ("Bubble Butt",))
+        assert len(groups) == 1
+        assert groups[0] == {"bubble butt"}
+    finally:
+        connection.close()


### PR DESCRIPTION
Closes #65.

Tag filters (Include/Exclude) now expand to include child tags via the local `tag_parent` hierarchy:

- **`equivalent_tag_names()`**: Walks `tag_parent` transitively for descendants; resolves via both local names and taxonomy (StashDB) names/aliases. One choke-point covers Expand browse, local Similar, and StashDB Similar.
- **Performer Hunt**: Moved tag filtering from client-side JS to the backend `performer_hunt()` so it benefits from descendant expansion and the StashDB alias taxonomy.
- **JS**: Hunt request now sends `include_tags`/`exclude_tags` to the backend; removed redundant client-side `tagFilteredHuntItems` filter.
- **Test**: `test_equivalent_tag_names_includes_descendants` covers parent→child→grandchild expansion and no-hierarchy fallback.