### PR TITLE
feat: add hard Block / Never level for tag sentiment preferences (#64)

### DIFF
--- a/curator/api.py
+++ b/curator/api.py
@@ -471,10 +471,11 @@ class CuratorAPI:
                 "SELECT feature_version FROM model_version WHERE model_id=?", (model_id,)
             ).fetchone()[0]
         )
-        direct = {
-            str(row["tag_id"]): float(row["value"])
-            for row in self.connection.execute("SELECT tag_id, value FROM direct_tag_preference")
-        }
+        direct: dict[str, tuple[float | None, bool]] = {}
+        for row in self.connection.execute(
+            "SELECT tag_id, value, blocked FROM direct_tag_preference"
+        ):
+            direct[str(row["tag_id"])] = (float(row["value"]), bool(row["blocked"]))
         items: list[dict[str, object]] = []
         config_version = f"cfg-{DEFAULT_CONFIG.feature_fingerprint()[:20]}"
         for row in self.connection.execute(
@@ -500,7 +501,7 @@ class CuratorAPI:
             scene_count = int(row["scene_count"])
             affinity = float(row["affinity"] or 0)
             confidence = float(row["confidence"] or 0)
-            direct_value = direct.get(tag_id)
+            direct_value, direct_blocked = direct.get(tag_id, (None, False))
             prompt = None
             if direct_value is None and row["role"] == "content" and scene_count >= 2:
                 prompt = "belief" if confidence >= 0.35 and abs(affinity) >= 0.15 else "uncertain"
@@ -513,6 +514,7 @@ class CuratorAPI:
                     "support": float(row["effective_support"] or 0),
                     "scene_count": scene_count,
                     "direct_value": direct_value,
+                    "direct_blocked": direct_blocked,
                     "prompt": prompt,
                 }
             )
@@ -544,7 +546,8 @@ class CuratorAPI:
             dict(row)
             for row in self.connection.execute(
                 """
-                SELECT t.tag_id, t.name, p.value AS direct_value, ids.stash_id
+                SELECT t.tag_id, t.name, p.value AS direct_value,
+                       p.blocked AS direct_blocked, ids.stash_id
                 FROM source_tag t
                 JOIN tag_role r
                   ON r.tag_id=t.tag_id AND r.config_version=?
@@ -579,6 +582,7 @@ class CuratorAPI:
                         if matched["direct_value"] is not None
                         else None
                     ),
+                    "direct_blocked": bool(matched["direct_blocked"]),
                 }
             )
         return {"schema_version": API_SCHEMA_VERSION, "items": choices}

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -378,6 +378,7 @@ class ExpandService:
         self._merge_external("scene", scenes)
         include_groups = equivalent_tag_names(self.connection, include_tags)
         exclude_groups = equivalent_tag_names(self.connection, exclude_tags)
+        blocked_groups = self._blocked_tag_name_groups()
         shortlisted = {
             str(row[0])
             for row in self.connection.execute(
@@ -401,6 +402,7 @@ class ExpandService:
                 exclude_tags,
                 include_groups=include_groups,
                 exclude_groups=exclude_groups,
+                blocked_groups=blocked_groups,
             )
         ]
         items.sort(
@@ -475,6 +477,7 @@ class ExpandService:
         rows = []
         include_groups = equivalent_tag_names(self.connection, include_tags)
         exclude_groups = equivalent_tag_names(self.connection, exclude_tags)
+        blocked_groups = self._blocked_tag_name_groups()
         for row in self.connection.execute(
             "SELECT * FROM external_entity WHERE entity_type=? AND pool='candidate'",
             (entity_type,),
@@ -515,6 +518,7 @@ class ExpandService:
                 studio_query,
                 include_groups,
                 exclude_groups,
+                blocked_groups=blocked_groups,
             ):
                 continue
             rows.append(
@@ -559,6 +563,7 @@ class ExpandService:
         studio_query: str = "",
         include_groups: tuple[frozenset[str], ...] = (),
         exclude_groups: tuple[frozenset[str], ...] = (),
+        blocked_groups: tuple[frozenset[str], ...] = (),
     ) -> bool:
         tags = {str(item.get("name") or "").casefold() for item in payload.get("tags", [])}
         cast = {
@@ -567,12 +572,35 @@ class ExpandService:
         }
         studio = str((payload.get("studio") or {}).get("name") or "").casefold()
         return (
-            (not include_tags or all(group & tags for group in include_groups))
+            not any(group & tags for group in blocked_groups)
+            and (not include_tags or all(group & tags for group in include_groups))
             and not any(group & tags for group in exclude_groups)
             and (not performer_names or all(value.casefold() in cast for value in performer_names))
             and (not studio_names or studio in {value.casefold() for value in studio_names})
             and (not performer_query or performer_query.casefold() in " ".join(cast))
             and (not studio_query or studio_query.casefold() in studio)
+        )
+
+    def _blocked_tag_name_groups(self) -> tuple[frozenset[str], ...]:
+        """Resolve every blocked local tag to its local name and taxonomy aliases."""
+        blocked_ids = {
+            str(row[0])
+            for row in self.connection.execute(
+                "SELECT tag_id FROM direct_tag_preference WHERE blocked=1"
+            )
+        }
+        if not blocked_ids:
+            return ()
+        return equivalent_tag_names(
+            self.connection,
+            tuple(
+                str(row[0])
+                for row in self.connection.execute(
+                    f"""SELECT name FROM source_tag WHERE tag_id IN
+                    ({",".join("?" for _ in blocked_ids)})""",
+                    sorted(blocked_ids),
+                )
+            ),
         )
 
     @staticmethod
@@ -1082,11 +1110,19 @@ class ExpandService:
         )
         raw_items = result["items"]
         assert isinstance(raw_items, list)
+        blocked_groups = self._blocked_tag_name_groups()
         filtered_items = [
             item
             for item in raw_items
             if not gender or self._payload_matches_gender(item["payload"], entity_type, gender)
-        ][:count]
+        ]
+        if entity_type == "scene":
+            filtered_items = [
+                item
+                for item in filtered_items
+                if self._scene_matches(item["payload"], blocked_groups=blocked_groups)
+            ]
+        filtered_items = filtered_items[:count]
         if entity_type == "performer":
             # Mark results that are already in the library so the cards can
             # badge them and link to the local profile instead of StashDB.

--- a/curator/interactions.py
+++ b/curator/interactions.py
@@ -30,6 +30,7 @@ FEEDBACK_TYPES = {
     "metadata_wrong",
 }
 TAG_SENTIMENT_VALUES = {-1.0, -0.5, 0.0, 0.5, 1.0}
+BLOCKED_TAG_VALUE = -1.0  # Stored value when blocked=1; the blocked flag drives exclusion.
 
 
 class InteractionStore:
@@ -270,13 +271,14 @@ class InteractionStore:
                 cursor = self.connection.execute(
                     """
                     INSERT OR IGNORE INTO direct_tag_preference_history(
-                        preference_id, tag_id, value, occurred_at_ms
-                    ) VALUES (?, ?, ?, ?)
+                        preference_id, tag_id, value, blocked, occurred_at_ms
+                    ) VALUES (?, ?, ?, ?, ?)
                     """,
                     (
                         entry["preference_id"],
                         entry["tag_id"],
                         entry["value"],
+                        int(entry["blocked"]),
                         entry["occurred_at_ms"],
                     ),
                 )
@@ -311,17 +313,19 @@ class InteractionStore:
                     self.connection.execute(
                         """
                         INSERT INTO direct_tag_preference(
-                            tag_id, preference_id, value, occurred_at_ms
-                        ) VALUES (?, ?, ?, ?)
+                            tag_id, preference_id, value, blocked, occurred_at_ms
+                        ) VALUES (?, ?, ?, ?, ?)
                         ON CONFLICT(tag_id) DO UPDATE SET
                             preference_id=excluded.preference_id,
                             value=excluded.value,
+                            blocked=excluded.blocked,
                             occurred_at_ms=excluded.occurred_at_ms
                         """,
                         (
                             entry["tag_id"],
                             entry["preference_id"],
                             entry["value"],
+                            int(entry["blocked"]),
                             entry["occurred_at_ms"],
                         ),
                     )
@@ -522,12 +526,15 @@ class InteractionStore:
         tag_id = str(entry.get("tag_id") or "")
         occurred_at_ms = int(entry.get("occurred_at_ms", -1))
         value = entry.get("value")
+        blocked = bool(entry.get("blocked", False))
         if value is not None:
             if isinstance(value, bool) or not isinstance(value, (int, float)):
                 raise ValueError("tag sentiment must be numeric or null")
             value = float(value)
             if value not in TAG_SENTIMENT_VALUES:
                 raise ValueError("tag sentiment must use the fixed five-point scale")
+        if blocked:
+            value = BLOCKED_TAG_VALUE
         if not preference_id or not tag_id or occurred_at_ms < 0:
             raise ValueError("preference_id, tag_id, and occurred_at_ms are required")
         config_version = f"cfg-{DEFAULT_CONFIG.feature_fingerprint()[:20]}"
@@ -546,6 +553,7 @@ class InteractionStore:
             "preference_id": preference_id,
             "tag_id": tag_id,
             "value": value,
+            "blocked": blocked,
             "occurred_at_ms": occurred_at_ms,
         }
 

--- a/curator/model/boundaries.py
+++ b/curator/model/boundaries.py
@@ -70,6 +70,10 @@ def scene_eligibility(
             else set()
         )
     not_now_ms = int(config.model.not_now_days * 86_400_000)
+    blocked_tag_ids = {
+        str(row[0])
+        for row in connection.execute("SELECT tag_id FROM direct_tag_preference WHERE blocked=1")
+    }
     result: dict[str, dict[str, object]] = {}
     for scene_id in scenes:
         reasons: list[str] = []
@@ -83,5 +87,14 @@ def scene_eligibility(
             reasons.append("current_thumb_down")
         if include_temporary and reference_at_ms - not_now.get(scene_id, -not_now_ms) < not_now_ms:
             reasons.append("not_now")
+        if blocked_tag_ids and not reasons:
+            scene_blocked = connection.execute(
+                f"""SELECT 1 FROM scene_tag WHERE scene_id=?
+                AND tag_id IN ({",".join("?" for _ in blocked_tag_ids)})
+                LIMIT 1""",
+                (scene_id, *sorted(blocked_tag_ids)),
+            ).fetchone()
+            if scene_blocked:
+                reasons.append("blocked_tag")
         result[scene_id] = {"eligible": not reasons, "reasons": reasons}
     return result

--- a/curator/similarity.py
+++ b/curator/similarity.py
@@ -173,10 +173,26 @@ class SimilarityService:
             if favorite_only
             else set()
         )
+        blocked_tag_ids = {
+            str(row[0])
+            for row in self.connection.execute(
+                "SELECT tag_id FROM direct_tag_preference WHERE blocked=1"
+            )
+        }
+        blocked_scenes: set[str] = set()
+        if blocked_tag_ids:
+            for row in self.connection.execute(
+                f"""SELECT scene_id FROM scene_tag WHERE tag_id IN
+                ({",".join("?" for _ in blocked_tag_ids)})""",
+                sorted(blocked_tag_ids),
+            ):
+                blocked_scenes.add(str(row["scene_id"]))
         results: list[SimilarityResult] = []
         for candidate_id in candidate_ids:
             candidate_appeal = self.appeals[candidate_id]
             if candidate_id == scene_id:
+                continue
+            if candidate_id in blocked_scenes:
                 continue
             candidate_performers = performers.get(candidate_id, set())
             if gender and not any(genders.get(value) == gender for value in candidate_performers):

--- a/curator/storage/sql/0026_tag_preference_blocked.sql
+++ b/curator/storage/sql/0026_tag_preference_blocked.sql
@@ -1,0 +1,5 @@
+-- Add a `blocked` flag to direct tag preferences so a Block / Never level
+-- can hard-exclude scenes carrying the tag while leaving the five-point weight
+-- scale (-1, -0.5, 0, 0.5, 1) untouched.
+ALTER TABLE direct_tag_preference_history ADD COLUMN blocked INTEGER NOT NULL DEFAULT 0 CHECK (blocked IN (0, 1));
+ALTER TABLE direct_tag_preference ADD COLUMN blocked INTEGER NOT NULL DEFAULT 0 CHECK (blocked IN (0, 1));

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -422,14 +422,15 @@
     [1, "Strong like"],
   ];
 
-  function TagSentimentControl({ tag, value, onChange }) {
+  function TagSentimentControl({ tag, value, blocked, onChange }) {
     return React.createElement(
       "div",
       { className: "curator-sentiment", role: "group", "aria-label": `Sentiment for ${tag.name}` },
+      React.createElement(Button, { size: "sm", variant: blocked ? "danger" : "secondary", "aria-pressed": blocked, title: "Block: never show scenes with this tag", onClick: () => onChange({ blocked: true }) }, "Block"),
       SENTIMENTS.map(([score, label]) =>
-        React.createElement(Button, { key: score, size: "sm", variant: value === score ? "primary" : "secondary", "aria-pressed": value === score, title: label, onClick: () => onChange(score) }, label)
+        React.createElement(Button, { key: score, size: "sm", variant: !blocked && value === score ? "primary" : "secondary", "aria-pressed": !blocked && value === score, title: label, onClick: () => onChange({ value: score, blocked: false }) }, label)
       ),
-      value !== null && value !== undefined && React.createElement(Button, { size: "sm", variant: "link", onClick: () => onChange(null) }, "Clear answer")
+      (value !== null && value !== undefined || blocked) && React.createElement(Button, { size: "sm", variant: "link", onClick: () => onChange({ value: null, blocked: false }) }, "Clear answer")
     );
   }
 
@@ -461,9 +462,9 @@
     }
   }
 
-  function submitTagPreference(tagId, value) {
+  function submitTagPreference(tagId, {value, blocked}) {
     const queue = readTagPreferenceQueue();
-    queue.push({ preference_id: uuid(), tag_id: tagId, value, occurred_at_ms: Date.now() });
+    queue.push({ preference_id: uuid(), tag_id: tagId, value, blocked: !!blocked, occurred_at_ms: Date.now() });
     localStorage.setItem(TAG_PREFERENCE_QUEUE_KEY, JSON.stringify(queue));
     flushTagPreferenceQueue();
   }
@@ -482,9 +483,9 @@
       );
       return () => { active = false; };
     }, []);
-    function answer(tagId, value) {
-      submitTagPreference(tagId, value);
-      setData((current) => ({ ...current, items: current.items.map((item) => item.tag_id === tagId ? { ...item, direct_value: value, prompt: null } : item) }));
+    function answer(tagId, {value, blocked}) {
+      submitTagPreference(tagId, {value, blocked});
+      setData((current) => ({ ...current, items: current.items.map((item) => item.tag_id === tagId ? { ...item, direct_value: value, direct_blocked: !!blocked, prompt: null } : item) }));
     }
     const visibleItems = data
       ? data.items
@@ -537,7 +538,7 @@
               item.prompt && React.createElement("span", { className: "badge badge-info" }, item.prompt === "belief" ? `I think you ${item.inferred_value >= 0 ? "like" : "dislike"} this` : "I'm unsure"),
               React.createElement("small", null, `Inferred ${item.inferred_value.toFixed(2)} · confidence ${item.confidence.toFixed(2)} · support ${item.support.toFixed(1)} · ${item.scene_count} local scene${item.scene_count === 1 ? "" : "s"}`)
             ),
-            React.createElement(TagSentimentControl, { tag: item, value: item.direct_value, onChange: (value) => answer(item.tag_id, value) })
+            React.createElement(TagSentimentControl, { tag: item, value: item.direct_value, blocked: item.direct_blocked, onChange: (value) => answer(item.tag_id, value) })
           )
         )
       )
@@ -549,9 +550,9 @@
     const [answers, setAnswers] = React.useState({});
     const [status, setStatus] = React.useState("");
     const [busy, setBusy] = React.useState(false);
-    function answer(tag, value) {
-      submitTagPreference(tag.tag_id, value);
-      setAnswers((current) => ({ ...current, [tag.tag_id]: value }));
+    function answer(tag, {value, blocked}) {
+      submitTagPreference(tag.tag_id, {value, blocked});
+      setAnswers((current) => ({ ...current, [tag.tag_id]: {value, blocked} }));
       setSelected(null);
       setStatus(`${tag.name} answer queued`);
     }
@@ -589,8 +590,8 @@
           "div",
           { key: tag.tag_id, className: "curator-tag-follow-up-item" },
           React.createElement(Button, { size: "sm", variant: selected === tag.tag_id ? "primary" : "secondary", onClick: () => setSelected(selected === tag.tag_id ? null : tag.tag_id) }, tag.name),
-          Object.hasOwn(answers, tag.tag_id) && React.createElement("small", null, `Answered: ${SENTIMENTS.find(([value]) => value === answers[tag.tag_id])?.[1]}`),
-          selected === tag.tag_id && React.createElement(TagSentimentControl, { tag, value: answers[tag.tag_id], onChange: (value) => answer(tag, value) })
+          Object.hasOwn(answers, tag.tag_id) && React.createElement("small", null, `Answered: ${answers[tag.tag_id]?.blocked ? "Blocked" : SENTIMENTS.find(([value]) => value === answers[tag.tag_id]?.value)?.[1]}`),
+          selected === tag.tag_id && React.createElement(TagSentimentControl, { tag, value: answers[tag.tag_id]?.value, blocked: answers[tag.tag_id]?.blocked, onChange: (value) => answer(tag, value) })
         )
       ),
       React.createElement(
@@ -668,9 +669,9 @@
         setTagLoading(false);
       }
     }
-    function answerTag(tag, value) {
-      submitTagPreference(tag.tag_id, value);
-      setTagChoices((current) => current.map((item) => item.tag_id === tag.tag_id ? { ...item, direct_value: value } : item));
+    function answerTag(tag, {value, blocked}) {
+      submitTagPreference(tag.tag_id, {value, blocked});
+      setTagChoices((current) => current.map((item) => item.tag_id === tag.tag_id ? { ...item, direct_value: value, direct_blocked: !!blocked } : item));
     }
     return React.createElement(
       "article",
@@ -681,7 +682,7 @@
       React.createElement("div", { className: `curator-external-thumbnail thumbnail-section ${kind === "scene" ? "video-section" : ""}` }, React.createElement("a", { className: `${kind}-card-link`, href, target: "_blank", rel: "noreferrer" }, image && React.createElement("img", { className: `${kind}-card-image`, src: image, loading: "lazy", alt: "" })), kind === "scene" && payload.studio?.name && React.createElement("span", { className: "curator-external-studio-overlay" }, payload.studio.name)),
       React.createElement("div", { className: "card-section" }, React.createElement(TitleLink, localProfile, React.createElement("h5", { className: "card-section-title flex-aligned" }, title)), React.createElement("div", { className: kind === "scene" ? "scene-card__details" : "curator-external-details" }, React.createElement("span", null, payload.release_date || payload.birth_date || ""), metadataControls), kind === "scene" && payload.description && React.createElement("p", { className: "curator-card-description" }, payload.description)),
       React.createElement("div", { className: "curator-card-body" }, (() => { let scoreDetail; if (item.similarity === undefined) { scoreDetail = `Match ${item.score.toFixed(2)} · found via ${item.sources.join(", ")}`; } else { scoreDetail = `Similarity ${item.similarity.toFixed(2)} · appeal ${item.appeal.toFixed(2)}`; const mh = item.details && item.details.score_breakdown && item.details.score_breakdown.multi_hop; if (mh > 0) scoreDetail += " + multi-hop " + mh.toFixed(4); } return React.createElement("div", { className: "curator-card-details" }, payload.why?.length && React.createElement("details", { className: "curator-evidence" }, React.createElement("summary", null, "Why this?"), React.createElement("p", { className: "curator-explanation" }, payload.why.join(" · "))), React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, `Score · ${item.score.toFixed(2)}`), scoreBar(item), React.createElement("p", null, scoreDetail))); })()),
-      kind === "scene" && tagChoices !== null && React.createElement("div", { className: "curator-external-tag-rating" }, tagLoading && React.createElement("small", { role: "status" }, "Matching local tags…"), tagError && React.createElement("small", { className: "text-danger", role: "status" }, tagError), !tagLoading && !tagError && tagChoices.length === 0 && React.createElement("small", null, "No matching local tags."), tagChoices.map((tag) => React.createElement("div", { key: tag.tag_id }, React.createElement("strong", null, tag.name), React.createElement(TagSentimentControl, { tag, value: tag.direct_value, onChange: (value) => answerTag(tag, value) })))),
+      kind === "scene" && tagChoices !== null && React.createElement("div", { className: "curator-external-tag-rating" }, tagLoading && React.createElement("small", { role: "status" }, "Matching local tags…"), tagError && React.createElement("small", { className: "text-danger", role: "status" }, tagError), !tagLoading && !tagError && tagChoices.length === 0 && React.createElement("small", null, "No matching local tags."), tagChoices.map((tag) => React.createElement("div", { key: tag.tag_id }, React.createElement("strong", null, tag.name), React.createElement(TagSentimentControl, { tag, value: tag.direct_value, blocked: tag.direct_blocked, onChange: (value) => answerTag(tag, value) })))),
       React.createElement("div", { className: "curator-prune-actions" }, React.createElement("a", { className: "btn btn-secondary btn-sm curator-icon-action", href, target: "_blank", rel: "noreferrer", title: "Open on StashDB", "aria-label": "Open on StashDB" }, React.createElement(FontAwesomeIcon, { icon: faExternalLinkAlt })), React.createElement(Button, { className: "curator-icon-action", size: "sm", title: copied ? "Copied" : "Copy StashDB ID", "aria-label": copied ? "Copied" : "Copy StashDB ID", onClick: async () => { try { await copyText(item.id); setCopied(true); setTimeout(() => setCopied(false), 1500); } catch (_) { setCopied(false); } } }, React.createElement(FontAwesomeIcon, { icon: copied ? faCheckCircle : faCopy })), onShortlist && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: item.shortlisted ? "primary" : "secondary", title: item.shortlisted ? "Remove from shortlist" : "Add to shortlist", "aria-label": item.shortlisted ? "Remove from shortlist" : "Add to shortlist", onClick: () => onShortlist(item, kind) }, React.createElement(FontAwesomeIcon, { icon: faList })), kind === "scene" && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: tagChoices !== null ? "primary" : "secondary", disabled: tags.length === 0 || tagLoading, title: "Rate matching local tags", "aria-label": "Rate matching local tags", onClick: rateTags }, React.createElement(FontAwesomeIcon, { icon: faTag })), kind === "performer" && onShowScenes && React.createElement(Button, { className: "curator-icon-action", size: "sm", title: "Show this performer's scenes", "aria-label": "Show this performer's scenes", onClick: () => onShowScenes(item) }, React.createElement(FontAwesomeIcon, { icon: faFilm })), kind === "scene" && onWhisparr && React.createElement(Button, { className: "curator-icon-action curator-whisparr-action", size: "sm", variant: "primary", disabled: !whisparrEnabled || whisparr?.status === "adding" || whisparr?.status === "sent" || whisparr?.status === "already_exists", title: !whisparrEnabled ? "Configure Whisparr in plugin settings" : whisparr?.status === "error" ? "Retry sending to Whisparr" : "Send to Whisparr", "aria-label": !whisparrEnabled ? "Whisparr is not configured" : whisparr?.status === "error" ? "Retry sending to Whisparr" : "Send to Whisparr", onClick: addToWhisparr }, React.createElement("span", { className: "curator-whisparr-logo", "aria-hidden": "true" }, React.createElement("span", { className: "curator-whisparr-fallback" }, "W"), React.createElement("img", { src: WHISPARR_LOGO, alt: "", onError: (event) => event.currentTarget.remove() }))), whisparr && React.createElement("small", { className: `curator-whisparr-status ${whisparr.status === "error" ? "text-danger" : ""}`, role: "status" }, whisparr.message))
     );
   });

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -497,7 +497,7 @@ def test_thumb_down_follow_up_is_optional_and_survives_card_removal() -> None:
     assert '"Metadata is wrong"' in source
     assert '"Skip"' in source
     assert "onClick: onDismiss" in source
-    assert "submitTagPreference(tag.tag_id, value);" in source
+    assert "submitTagPreference(tag.tag_id, {value, blocked});" in source
 
 
 def test_feedback_history_can_undo_or_replace_append_only_actions() -> None:
@@ -532,7 +532,7 @@ def test_external_scene_cards_can_rate_matching_local_tags() -> None:
     assert 'operation: "get_external_tag_choices"' in source
     assert '"Rate matching local tags"' in source
     assert '"No matching local tags."' in source
-    assert "submitTagPreference(tag.tag_id, value);" in source
+    assert "submitTagPreference(tag.tag_id, {value, blocked});" in source
 
 
 def test_curator_external_components_are_public_and_patchable() -> None:

--- a/tests/storage/test_artifacts.py
+++ b/tests/storage/test_artifacts.py
@@ -217,6 +217,6 @@ def test_attach_skips_tables_missing_from_older_artifact(tmp_path: Path) -> None
         assert "model_performer_edge" not in views
         # Migration 25 creates and indexes model_performer_edge; the shadowing view
         # used to make its CREATE INDEX fail with "views may not be indexed".
-        assert MigrationRunner(attached).migrate(applied_at_ms=2).current_version == 25
+        assert MigrationRunner(attached).migrate(applied_at_ms=2).current_version == 26
     finally:
         attached.close()

--- a/tests/storage/test_cli_db.py
+++ b/tests/storage/test_cli_db.py
@@ -15,7 +15,7 @@ def test_database_cli_migrate_status_and_backup(
 
     assert run(["--db", str(database), "db", "migrate", "--json"]) == 0
     migrated = json.loads(capsys.readouterr().out)
-    assert migrated["current_version"] == migrated["latest_version"] == 25
+    assert migrated["current_version"] == migrated["latest_version"] == 26
 
     assert run(["--db", str(database), "db", "status", "--json"]) == 0
     status = json.loads(capsys.readouterr().out)

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -37,10 +37,11 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
             23,
             24,
             25,
+            26,
         )
 
         after = runner.migrate(applied_at_ms=1234)
-        assert after.current_version == 25
+        assert after.current_version == 26
         assert after.pending_versions == ()
         assert runner.migrate(applied_at_ms=5678) == after
 
@@ -332,7 +333,7 @@ def test_status_stays_read_only_after_migrations(tmp_path: Path) -> None:
     reader.execute("PRAGMA busy_timeout=1")
     try:
         writer.execute("BEGIN IMMEDIATE")
-        assert MigrationRunner(reader).status().current_version == 25
+        assert MigrationRunner(reader).status().current_version == 26
     finally:
         writer.rollback()
         reader.close()
@@ -358,7 +359,7 @@ def test_stale_concurrent_migrator_rechecks_after_writer_lock(
 
     monkeypatch.setattr(second_runner, "status", status)
     try:
-        assert second_runner.migrate(applied_at_ms=2).current_version == 25
+        assert second_runner.migrate(applied_at_ms=2).current_version == 26
     finally:
         second.close()
         first.close()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -230,7 +230,7 @@ def test_taste_profile_exposes_inference_and_direct_answer(tmp_path: Path) -> No
     )
     assert api.external_tag_choices([{"id": "external-unused", "name": "External name"}])[
         "items"
-    ] == [{"tag_id": "unused", "name": "Unused", "direct_value": -1.0}]
+    ] == [{"tag_id": "unused", "name": "Unused", "direct_value": -1.0, "direct_blocked": False}]
     assert (
         api.submit_tag_preferences(
             [
@@ -245,7 +245,7 @@ def test_taste_profile_exposes_inference_and_direct_answer(tmp_path: Path) -> No
         == 1
     )
     assert api.external_tag_choices([{"name": "Black Man"}])["items"] == [
-        {"tag_id": "attribute", "name": "Black Man", "direct_value": -1.0}
+        {"tag_id": "attribute", "name": "Black Man", "direct_value": -1.0, "direct_blocked": False}
     ]
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_doctor_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
     assert result["status"] == "ok"
     assert result["stash"] == "not_configured"
     assert result["schema_current"] == 0
-    assert result["schema_latest"] == 25
+    assert result["schema_latest"] == 26
 
 
 def test_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -83,6 +83,21 @@ def test_tag_preferences_validate_replace_clear_and_ignore_stale_retries(tmp_pat
     with pytest.raises(ValueError, match="unsupported"):
         store.submit_tag_preferences([{**positive, "preference_id": "unknown", "tag_id": "x"}])
 
+    blocked = {
+        "preference_id": "blocked",
+        "tag_id": "good",
+        "value": -1,
+        "blocked": True,
+        "occurred_at_ms": 40,
+    }
+    assert store.submit_tag_preferences([blocked]) == 1
+    row = connection.execute(
+        "SELECT value, blocked FROM direct_tag_preference WHERE tag_id='good'"
+    ).fetchone()
+    assert row is not None
+    assert float(row[0]) == -1.0
+    assert bool(row[1]) is True
+
 
 def test_direct_sessions_record_views_and_quick_replacement(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")


### PR DESCRIPTION
Closes #64.

Adds a hard "Block" level to tag sentiment controls that unconditionally excludes scenes carrying the tag, while keeping the existing five-point scale as soft weights:

- **Schema (0026)**: `blocked` column on `direct_tag_preference` and `direct_tag_preference_history`.
- **`scene_eligibility()`**: Checks for blocked tags — scenes with any blocked tag are ineligible across all lanes (Best Bets, Revisit, Discover, Adventure, For You).
- **Local Similar**: Filters out scenes carrying blocked tags.
- **External results (Expand, StashDB Similar, Performer Hunt)**: `_blocked_tag_name_groups()` resolves blocked local tags to names and taxonomy aliases; `_scene_matches()` excludes them.
- **Taste Profile API**: Returns `direct_blocked` alongside `direct_value`; tag search includes the blocked state.
- **UI**: `TagSentimentControl` now has a "Block" button (danger variant) alongside the five sentiment levels; "Clear answer" works for both.
- **Test**: Covers blocked preference submission + retrieval.