### PR TITLE
fix: shorten Block button label and sort taste profile by sign then magnitude

### DIFF
--- a/curator/api.py
+++ b/curator/api.py
@@ -522,6 +522,7 @@ class CuratorAPI:
             key=lambda item: (
                 item["prompt"] is None,
                 item["prompt"] == "uncertain",
+                not (float(str(item["inferred_value"])) > 0),
                 -abs(float(str(item["inferred_value"]))),
                 str(item["name"]).casefold(),
                 str(item["tag_id"]),

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -265,6 +265,18 @@
   gap: 0.25rem;
 }
 
+.curator-sentiment .btn-sm {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.4rem;
+}
+
+@media (max-width: 480px) {
+  .curator-sentiment .btn-sm {
+    font-size: 0.7rem;
+    padding: 0.15rem 0.3rem;
+  }
+}
+
 .curator-tag-follow-up {
   margin: 0.5rem 0;
 }

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -426,7 +426,7 @@
     return React.createElement(
       "div",
       { className: "curator-sentiment", role: "group", "aria-label": `Sentiment for ${tag.name}` },
-      React.createElement(Button, { size: "sm", variant: blocked ? "danger" : "secondary", "aria-pressed": blocked, title: "Block: never show scenes with this tag", onClick: () => onChange({ blocked: true }) }, "Block"),
+      React.createElement(Button, { size: "sm", variant: blocked ? "danger" : "secondary", "aria-pressed": blocked, title: "Block: never show scenes with this tag", onClick: () => onChange({ blocked: true }) }, "✕"),
       SENTIMENTS.map(([score, label]) =>
         React.createElement(Button, { key: score, size: "sm", variant: !blocked && value === score ? "primary" : "secondary", "aria-pressed": !blocked && value === score, title: label, onClick: () => onChange({ value: score, blocked: false }) }, label)
       ),


### PR DESCRIPTION
Two fixes:

- **Block button**: Uses "✕" instead of "Block" so it fits on one row on mobile. Added compact button sizing via CSS.
- **Taste profile sort**: Changed from `-abs(inferred_value)` to `(not positive, -abs(...))` so liked tags appear before disliked ones of equal strength, rather than mixing positive and negative guesses.