### PR TITLE
fix: sentiment button colors, expand setup button, and StashDB details field

### DIFF
--- a/curator/expand.py
+++ b/curator/expand.py
@@ -44,7 +44,7 @@ query CuratorExpandScenes($input: SceneQueryInput!) {
   queryScenes(input: $input) {
     count
     scenes {
-      id title release_date production_date duration description
+      id title release_date production_date duration details
       studio { id name }
       tags { id name }
       images { url width height }

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -270,6 +270,34 @@
   padding: 0.15rem 0.4rem;
 }
 
+.curator-sentiment-never,
+.curator-sentiment-danger,
+.curator-sentiment-warning,
+.curator-sentiment-neutral,
+.curator-sentiment-like,
+.curator-sentiment-love {
+  background: transparent;
+  color: #fff;
+}
+
+.curator-sentiment-never            { --sc: #212529; border-color: var(--sc); }
+.curator-sentiment-danger           { --sc: #dc3545; border-color: var(--sc); }
+.curator-sentiment-warning          { --sc: #fd7e14; border-color: var(--sc); }
+.curator-sentiment-neutral          { --sc: #6c757d; border-color: var(--sc); }
+.curator-sentiment-like             { --sc: #6b8e23; border-color: var(--sc); }
+.curator-sentiment-love             { --sc: #198754; border-color: var(--sc); }
+
+.curator-sentiment-never.curator-sentiment-active,
+.curator-sentiment-danger.curator-sentiment-active,
+.curator-sentiment-warning.curator-sentiment-active,
+.curator-sentiment-neutral.curator-sentiment-active,
+.curator-sentiment-like.curator-sentiment-active,
+.curator-sentiment-love.curator-sentiment-active {
+  background: var(--sc);
+  border-color: var(--sc);
+  color: #fff;
+}
+
 @media (max-width: 480px) {
   .curator-sentiment .btn-sm {
     font-size: 0.7rem;

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -415,21 +415,22 @@
   }
 
   const SENTIMENTS = [
-    [-1, "Strong dislike"],
-    [-0.5, "Slight dislike"],
-    [0, "Neutral"],
-    [0.5, "Slight like"],
-    [1, "Strong like"],
+    [-1, "Strong dislike", "curator-sentiment-danger"],
+    [-0.5, "Slight dislike", "curator-sentiment-warning"],
+    [0, "Neutral", "curator-sentiment-neutral"],
+    [0.5, "Slight like", "curator-sentiment-like"],
+    [1, "Strong like", "curator-sentiment-love"],
   ];
 
   function TagSentimentControl({ tag, value, blocked, onChange }) {
     return React.createElement(
       "div",
       { className: "curator-sentiment", role: "group", "aria-label": `Sentiment for ${tag.name}` },
-      React.createElement(Button, { size: "sm", variant: blocked ? "danger" : "secondary", "aria-pressed": blocked, title: "Block: never show scenes with this tag", onClick: () => onChange({ blocked: true }) }, "✕"),
-      SENTIMENTS.map(([score, label]) =>
-        React.createElement(Button, { key: score, size: "sm", variant: !blocked && value === score ? "primary" : "secondary", "aria-pressed": !blocked && value === score, title: label, onClick: () => onChange({ value: score, blocked: false }) }, label)
-      ),
+      React.createElement(Button, { size: "sm", className: `curator-sentiment-never${blocked ? " curator-sentiment-active" : ""}`, "aria-pressed": blocked, title: "Never show scenes with this tag", onClick: () => onChange({ blocked: true }) }, "Never"),
+      SENTIMENTS.map(([score, label, cls]) => {
+        const selected = !blocked && value === score;
+        return React.createElement(Button, { key: score, size: "sm", className: `${cls}${selected ? " curator-sentiment-active" : ""}`, "aria-pressed": selected, title: label, onClick: () => onChange({ value: score, blocked: false }) }, label);
+      }),
       (value !== null && value !== undefined || blocked) && React.createElement(Button, { size: "sm", variant: "link", onClick: () => onChange({ value: null, blocked: false }) }, "Clear answer")
     );
   }
@@ -680,7 +681,7 @@
       payload.curator_local && React.createElement("span", { className: "curator-local-badge", title: "Already in your local library" }, "In library"),
       payload.curator_local_match?.type === "phash" && React.createElement("span", { className: "curator-phash-badge", title: "A local scene has the same exact PHash. This is strong matching evidence, not guaranteed identity." }, "Likely local · exact PHash"),
       React.createElement("div", { className: `curator-external-thumbnail thumbnail-section ${kind === "scene" ? "video-section" : ""}` }, React.createElement("a", { className: `${kind}-card-link`, href, target: "_blank", rel: "noreferrer" }, image && React.createElement("img", { className: `${kind}-card-image`, src: image, loading: "lazy", alt: "" })), kind === "scene" && payload.studio?.name && React.createElement("span", { className: "curator-external-studio-overlay" }, payload.studio.name)),
-      React.createElement("div", { className: "card-section" }, React.createElement(TitleLink, localProfile, React.createElement("h5", { className: "card-section-title flex-aligned" }, title)), React.createElement("div", { className: kind === "scene" ? "scene-card__details" : "curator-external-details" }, React.createElement("span", null, payload.release_date || payload.birth_date || ""), metadataControls), kind === "scene" && payload.description && React.createElement("p", { className: "curator-card-description" }, payload.description)),
+      React.createElement("div", { className: "card-section" }, React.createElement(TitleLink, localProfile, React.createElement("h5", { className: "card-section-title flex-aligned" }, title)), React.createElement("div", { className: kind === "scene" ? "scene-card__details" : "curator-external-details" }, React.createElement("span", null, payload.release_date || payload.birth_date || ""), metadataControls), kind === "scene" && payload.details && React.createElement("p", { className: "curator-card-description" }, payload.details)),
       React.createElement("div", { className: "curator-card-body" }, (() => { let scoreDetail; if (item.similarity === undefined) { scoreDetail = `Match ${item.score.toFixed(2)} · found via ${item.sources.join(", ")}`; } else { scoreDetail = `Similarity ${item.similarity.toFixed(2)} · appeal ${item.appeal.toFixed(2)}`; const mh = item.details && item.details.score_breakdown && item.details.score_breakdown.multi_hop; if (mh > 0) scoreDetail += " + multi-hop " + mh.toFixed(4); } return React.createElement("div", { className: "curator-card-details" }, payload.why?.length && React.createElement("details", { className: "curator-evidence" }, React.createElement("summary", null, "Why this?"), React.createElement("p", { className: "curator-explanation" }, payload.why.join(" · "))), React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, `Score · ${item.score.toFixed(2)}`), scoreBar(item), React.createElement("p", null, scoreDetail))); })()),
       kind === "scene" && tagChoices !== null && React.createElement("div", { className: "curator-external-tag-rating" }, tagLoading && React.createElement("small", { role: "status" }, "Matching local tags…"), tagError && React.createElement("small", { className: "text-danger", role: "status" }, tagError), !tagLoading && !tagError && tagChoices.length === 0 && React.createElement("small", null, "No matching local tags."), tagChoices.map((tag) => React.createElement("div", { key: tag.tag_id }, React.createElement("strong", null, tag.name), React.createElement(TagSentimentControl, { tag, value: tag.direct_value, blocked: tag.direct_blocked, onChange: (value) => answerTag(tag, value) })))),
       React.createElement("div", { className: "curator-prune-actions" }, React.createElement("a", { className: "btn btn-secondary btn-sm curator-icon-action", href, target: "_blank", rel: "noreferrer", title: "Open on StashDB", "aria-label": "Open on StashDB" }, React.createElement(FontAwesomeIcon, { icon: faExternalLinkAlt })), React.createElement(Button, { className: "curator-icon-action", size: "sm", title: copied ? "Copied" : "Copy StashDB ID", "aria-label": copied ? "Copied" : "Copy StashDB ID", onClick: async () => { try { await copyText(item.id); setCopied(true); setTimeout(() => setCopied(false), 1500); } catch (_) { setCopied(false); } } }, React.createElement(FontAwesomeIcon, { icon: copied ? faCheckCircle : faCopy })), onShortlist && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: item.shortlisted ? "primary" : "secondary", title: item.shortlisted ? "Remove from shortlist" : "Add to shortlist", "aria-label": item.shortlisted ? "Remove from shortlist" : "Add to shortlist", onClick: () => onShortlist(item, kind) }, React.createElement(FontAwesomeIcon, { icon: faList })), kind === "scene" && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: tagChoices !== null ? "primary" : "secondary", disabled: tags.length === 0 || tagLoading, title: "Rate matching local tags", "aria-label": "Rate matching local tags", onClick: rateTags }, React.createElement(FontAwesomeIcon, { icon: faTag })), kind === "performer" && onShowScenes && React.createElement(Button, { className: "curator-icon-action", size: "sm", title: "Show this performer's scenes", "aria-label": "Show this performer's scenes", onClick: () => onShowScenes(item) }, React.createElement(FontAwesomeIcon, { icon: faFilm })), kind === "scene" && onWhisparr && React.createElement(Button, { className: "curator-icon-action curator-whisparr-action", size: "sm", variant: "primary", disabled: !whisparrEnabled || whisparr?.status === "adding" || whisparr?.status === "sent" || whisparr?.status === "already_exists", title: !whisparrEnabled ? "Configure Whisparr in plugin settings" : whisparr?.status === "error" ? "Retry sending to Whisparr" : "Send to Whisparr", "aria-label": !whisparrEnabled ? "Whisparr is not configured" : whisparr?.status === "error" ? "Retry sending to Whisparr" : "Send to Whisparr", onClick: addToWhisparr }, React.createElement("span", { className: "curator-whisparr-logo", "aria-hidden": "true" }, React.createElement("span", { className: "curator-whisparr-fallback" }, "W"), React.createElement("img", { src: WHISPARR_LOGO, alt: "", onError: (event) => event.currentTarget.remove() }))), whisparr && React.createElement("small", { className: `curator-whisparr-status ${whisparr.status === "error" ? "text-danger" : ""}`, role: "status" }, whisparr.message))
@@ -1634,7 +1635,7 @@
       error && React.createElement("div", { className: "alert alert-danger" }, error),
       message && React.createElement("p", { role: "status" }, message),
       entityType === "hunt" && !huntPerformer && React.createElement("div", { className: "alert alert-info" }, "Select a local performer linked to StashDB."),
-      data && !data.ready && React.createElement("div", { className: "alert alert-info" }, "Expand has not been prepared yet. Use refresh to collect candidates from StashDB."),
+      data && !data.ready && React.createElement("div", { className: "alert alert-info" }, React.createElement("p", null, "Expand has not been prepared yet — StashDB candidates need to be collected first."), React.createElement(Button, { size: "sm", variant: "primary", onClick: refresh }, React.createElement(FontAwesomeIcon, { icon: faSync }), " Prepare now")),
       data?.ready && visibleItems.length === 0 && React.createElement("div", { className: "alert alert-info" }, entityType === "hunt" ? "No scenes match this view." : "No external candidates match these filters."),
       data?.ready && React.createElement(
         "div",
@@ -2206,13 +2207,13 @@
           React.createElement("span", null, loading ? `Preparing ${laneOption?.label || "recommendations"}…` : "Loading scene cards…"),
           React.createElement("div", { className: "curator-progress", "aria-hidden": "true" })
         ),
-      error && React.createElement("div", { className: "alert alert-danger" }, error, React.createElement("p", null, "Run “Sync and build recommendations” from Tasks if no model exists yet.")),
+      error && React.createElement("div", { className: "alert alert-danger" }, error, React.createElement("p", null, "Run “Sync and build recommendations” from Tasks if no model exists yet."), React.createElement(Button, { size: "sm", variant: "primary", onClick: () => start("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync }), " Sync and build now")),
       scenesQuery.error && React.createElement("div", { className: "alert alert-danger" }, scenesQuery.error.message),
       laneByValue.has(lane) && slate && !loading &&
         React.createElement(
           React.Fragment,
           null,
-          visibleItems.length === 0 && React.createElement("div", { className: "alert alert-info" }, "Nothing qualifies for this lane right now."),
+          visibleItems.length === 0 && React.createElement("div", { className: "alert alert-info" }, React.createElement("p", null, "Nothing qualifies for this lane right now."), React.createElement(Button, { size: "sm", variant: "secondary", onClick: () => start("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench }), " Rebuild model")),
           React.createElement(
             "section",
             { className: "curator-grid", role: "tabpanel", "aria-live": "polite" },

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -454,8 +454,8 @@ def test_taste_profile_uses_fixed_durable_tag_sentiment_control() -> None:
     assert 'operation: "get_taste_profile"' in source
     assert 'operation: "submit_tag_preferences"' in source
     assert "TAG_PREFERENCE_QUEUE_KEY" in source
-    assert '[-1, "Strong dislike"]' in source
-    assert '[1, "Strong like"]' in source
+    assert '[-1, "Strong dislike", "curator-sentiment-danger"]' in source
+    assert '[1, "Strong like", "curator-sentiment-love"]' in source
     assert '"Clear answer"' in source
     assert '"Search taste profile tags"' in source
     assert '"Filter taste profile tags"' in source


### PR DESCRIPTION
Post-#73 follow-up fixes:

- **Sentiment buttons**: Color-coded with custom CSS — outline style with white text, solid fill when active. Red → orange → grey → olive → green scale. "Never" label for block with black border. Compact on mobile.
- **Taste profile sort**: Likes appear before dislikes of equal strength (sign-then-magnitude).
- **Expand setup**: "Prepare now" button when no candidates exist, instead of just a static message.
- **Recommendation setup**: "Sync and build now" button on error, "Rebuild model" on empty lanes.
- **StashDB query fix**: Use `details` instead of `description` (the correct StashDB field name).