### PR TITLE
test: add coverage for user-visible empty-state and error messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,30 @@ jobs:
           path: |
             dist/stash-curator.zip
             dist/index.yml
+
+  integration:
+    name: Integration (Playwright)
+    runs-on: ubuntu-latest
+    needs: quality
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "0.11.21"
+          python-version: "3.12"
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync --locked --group integration
+      - name: Install Playwright browsers
+        run: uv run playwright install chromium --with-deps
+      - name: Build plugin
+        run: uv run --frozen python scripts/build_plugin.py
+      - name: Run integration tests
+        run: scripts/verify integration
+      - uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: integration-artifacts
+          path: /tmp/stash-curator-integration-test-output/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dev = [
   "ruff>=0.9",
   "scipy>=1.14",
 ]
+integration = [
+  "pytest-playwright>=0.7",
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["curator"]
@@ -47,3 +50,6 @@ warn_unreachable = true
 [tool.pytest.ini_options]
 addopts = "-ra --strict-config --strict-markers"
 testpaths = ["tests"]
+markers = [
+  "integration: browser integration tests (requires Stash + Docker)",
+]

--- a/scripts/verify
+++ b/scripts/verify
@@ -72,7 +72,7 @@ case "${1:-}" in
     # ── run playwright tests ──
     echo "[verify] running integration tests …"
     uv run --group integration --frozen pytest tests/integration/ -m integration -v \
-      --stash-url "$STASH_URL" \
+      --base-url "$STASH_URL" \
       --video=retain-on-failure \
       --screenshot=only-on-failure \
       --output=/tmp/stash-curator-integration-test-output

--- a/scripts/verify
+++ b/scripts/verify
@@ -12,6 +12,10 @@ pytest() (
   uv run --frozen pytest -q --basetemp="$temporary" "$@"
 )
 
+pytest_not_integration() (
+  pytest -m "not integration" "$@"
+)
+
 case "${1:-}" in
   changed)
     shift
@@ -29,20 +33,52 @@ case "${1:-}" in
     ((${#python[@]} == 0)) || uv run --frozen ruff format "${python[@]}"
     ((${#python[@]} == 0)) || uv run --frozen ruff check "${python[@]}"
     [[ "$javascript" == false ]] || node --check plugin/stash-curator.js
-    (($# == 0)) || pytest "$@"
+    (($# == 0)) || pytest_not_integration "$@"
     git diff --check
     ;;
   full)
     uv run --frozen ruff check .
     uv run --frozen ruff format --check .
     uv run --frozen mypy curator plugin/backend.py
-    pytest
+    pytest_not_integration
     node --check plugin/stash-curator.js
     uv run --frozen python scripts/build_plugin.py
     git diff --check
     ;;
+  integration)
+    # ── build plugin ──
+    uv run --frozen python scripts/build_plugin.py
+    compose_file="tests/integration/docker-compose.yml"
+    plugin_dir="/tmp/stash-curator-integration/plugins/stash-curator"
+    mkdir -p "$plugin_dir"
+    unzip -oq dist/stash-curator.zip -d "$plugin_dir"
+    # copy config
+    cp tests/integration/stash-config.yml /tmp/stash-curator-integration/config.yml
+    # ── start stash ──
+    cleanup() {
+      echo "[verify] tearing down Stash …"
+      cd "$(dirname "$0")/.."
+      STASH_CONFIG=/tmp/stash-curator-integration \
+        docker compose -f "$compose_file" down --volumes 2>/dev/null || true
+    }
+    trap cleanup EXIT
+    echo "[verify] starting Stash …"
+    STASH_CONFIG=/tmp/stash-curator-integration \
+      docker compose -f "$compose_file" up -d --wait
+    # ── seed ──
+    echo "[verify] seeding data …"
+    STASH_URL="${STASH_URL:-http://localhost:9999}"
+    uv run --frozen python tests/integration/seed.py --stash-url "$STASH_URL"
+    # ── run playwright tests ──
+    echo "[verify] running integration tests …"
+    uv run --group integration --frozen pytest tests/integration/ -m integration -v \
+      --stash-url "$STASH_URL" \
+      --video=retain-on-failure \
+      --screenshot=only-on-failure \
+      --output=/tmp/stash-curator-integration-test-output
+    ;;
   *)
-    echo "usage: scripts/verify {changed [pytest-target ...]|full}" >&2
+    echo "usage: scripts/verify {changed [pytest-target ...]|full|integration}" >&2
     exit 2
     ;;
 esac

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,1 +1,0 @@
-"""Integration tests."""

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,109 @@
+"""Fixtures for Curator browser integration tests.
+
+Lifecycle:
+  1. docker compose -f tests/integration/docker-compose.yml up -d
+  2. python tests/integration/seed.py --stash-url http://localhost:9999
+  3. pytest tests/integration/ --stash-url http://localhost:9999
+
+The plugin must be pre-installed into the Stash config volume before start:
+  scripts/build_plugin.py
+  unzip -oq dist/stash-curator.zip -d <stash-config>/plugins/stash-curator/
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, cast
+
+import pytest
+
+INTEGRATION_DIR = Path(__file__).resolve().parent
+PROJECT_ROOT = INTEGRATION_DIR.parents[1]
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--stash-url",
+        default=os.environ.get("STASH_URL", "http://localhost:9999"),
+        help="Stash base URL for integration tests",
+    )
+
+
+def _gql(stash_url: str, query: str, variables: dict[str, object] | None = None) -> dict[str, Any]:
+    """Helper: make a GraphQL request to Stash."""
+    payload = json.dumps({"query": query, "variables": variables or {}}).encode()
+    req = urllib.request.Request(
+        f"{stash_url}/graphql",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        raise RuntimeError(f"Stash returned {exc.code}: {body[:500]}") from exc
+    if "errors" in data:
+        raise RuntimeError(f"GraphQL error: {data['errors']}")
+    return cast(dict[str, Any], data["data"])
+
+
+def _wait_for_stash(url: str, timeout: float = 120) -> None:
+    """Poll until Stash serves HTTP 200."""
+    deadline = time.monotonic() + timeout
+    last: str = ""
+    while time.monotonic() < deadline:
+        try:
+            req = urllib.request.Request(url, method="HEAD")
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                if resp.status == 200:
+                    return
+        except Exception as exc:
+            last = str(exc)
+            time.sleep(2)
+    raise RuntimeError(f"Stash not ready at {url} after {timeout}s: {last}")
+
+
+# ── session-scoped fixtures ──────────────────────────────────────────────────
+
+
+@pytest.fixture(scope="session")
+def stash_url(request: pytest.FixtureRequest) -> str:
+    url: str = request.config.getoption("--stash-url").rstrip("/")
+    _wait_for_stash(url)
+    return url
+
+
+@pytest.fixture(scope="session")
+def seeded(stash_url: str) -> str:
+    """Ensure Stash has seed data. Idempotent — skips if already present."""
+    try:
+        data = _gql(
+            stash_url,
+            (
+                "query Find($n: String!) { "
+                "findTags(tag_filter: {name: {value: $n, modifier: EQUALS}}) "
+                "{ count } }"
+            ),
+            {"n": "Blowjob"},
+        )
+        if data["findTags"]["count"] > 0 and os.environ.get("FORCE_SEED") != "1":
+            print("[conftest] seed data already present, skipping")
+            return stash_url
+    except Exception:
+        pass
+
+    print("[conftest] seeding Stash …")
+    subprocess.run(
+        [sys.executable, str(INTEGRATION_DIR / "seed.py"), "--stash-url", stash_url],
+        check=True,
+        cwd=PROJECT_ROOT,
+    )
+    return stash_url

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,13 +1,10 @@
 """Fixtures for Curator browser integration tests.
 
 Lifecycle:
-  1. docker compose -f tests/integration/docker-compose.yml up -d
-  2. python tests/integration/seed.py --stash-url http://localhost:9999
-  3. pytest tests/integration/ --stash-url http://localhost:9999
+  1. scripts/verify integration     (handles build, start, seed, test, teardown)
+  2. pytest --base-url http://localhost:9999 tests/integration/
 
-The plugin must be pre-installed into the Stash config volume before start:
-  scripts/build_plugin.py
-  unzip -oq dist/stash-curator.zip -d <stash-config>/plugins/stash-curator/
+The `base_url` fixture is provided by pytest-playwright.
 """
 
 from __future__ import annotations
@@ -26,14 +23,6 @@ import pytest
 
 INTEGRATION_DIR = Path(__file__).resolve().parent
 PROJECT_ROOT = INTEGRATION_DIR.parents[1]
-
-
-def pytest_addoption(parser: pytest.Parser) -> None:
-    parser.addoption(
-        "--stash-url",
-        default=os.environ.get("STASH_URL", "http://localhost:9999"),
-        help="Stash base URL for integration tests",
-    )
 
 
 def _gql(stash_url: str, query: str, variables: dict[str, object] | None = None) -> dict[str, Any]:
@@ -71,19 +60,12 @@ def _wait_for_stash(url: str, timeout: float = 120) -> None:
     raise RuntimeError(f"Stash not ready at {url} after {timeout}s: {last}")
 
 
-# ── session-scoped fixtures ──────────────────────────────────────────────────
-
-
 @pytest.fixture(scope="session")
-def stash_url(request: pytest.FixtureRequest) -> str:
-    url: str = request.config.getoption("--stash-url").rstrip("/")
-    _wait_for_stash(url)
-    return url
+def seeded() -> None:
+    """Seed Stash with test data. Uses STASH_URL or defaults to localhost:9999."""
+    stash_url = os.environ.get("STASH_URL", "http://localhost:9999").rstrip("/")
+    _wait_for_stash(stash_url)
 
-
-@pytest.fixture(scope="session")
-def seeded(stash_url: str) -> str:
-    """Ensure Stash has seed data. Idempotent — skips if already present."""
     try:
         data = _gql(
             stash_url,
@@ -95,15 +77,12 @@ def seeded(stash_url: str) -> str:
             {"n": "Blowjob"},
         )
         if data["findTags"]["count"] > 0 and os.environ.get("FORCE_SEED") != "1":
-            print("[conftest] seed data already present, skipping")
-            return stash_url
+            return
     except Exception:
         pass
 
-    print("[conftest] seeding Stash …")
     subprocess.run(
         [sys.executable, str(INTEGRATION_DIR / "seed.py"), "--stash-url", stash_url],
         check=True,
         cwd=PROJECT_ROOT,
     )
-    return stash_url

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  stash:
+    image: stashapp/stash:latest
+    ports:
+      - "${STASH_PORT:-9999}:9999"
+    environment:
+      STASH_CONFIG_FILE: /root/.stash/config.yml
+    volumes:
+      - "${STASH_CONFIG:-/tmp/stash-curator-integration}:/root/.stash"
+      - stash-media:/media
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:9999/"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 10s
+
+volumes:
+  stash-media:

--- a/tests/integration/seed.py
+++ b/tests/integration/seed.py
@@ -1,0 +1,257 @@
+"""Seed a Stash instance with minimal data for Curator integration tests.
+
+Creates tags, performers, and scenes via Stash's GraphQL API, then
+triggers a Curator sync and model build.
+
+Usage:
+  python tests/integration/seed.py --stash-url http://localhost:9999
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+import urllib.request
+from typing import Any, cast
+
+MUTATION_TAG_CREATE = """
+mutation TagCreate($input: TagCreateInput!) {
+  tagCreate(input: $input) {
+    id
+    name
+  }
+}
+"""
+
+MUTATION_PERFORMER_CREATE = """
+mutation PerformerCreate($input: PerformerCreateInput!) {
+  performerCreate(input: $input) {
+    id
+    name
+  }
+}
+"""
+
+MUTATION_SCENE_CREATE = """
+mutation SceneCreate($input: SceneCreateInput!) {
+  sceneCreate(input: $input) {
+    id
+    title
+  }
+}
+"""
+
+QUERY_FIND_TAG = """
+query FindTag($name: String!) {
+  findTags(tag_filter: {name: {value: $name, modifier: EQUALS}}) {
+    tags { id name }
+  }
+}
+"""
+
+QUERY_FIND_PERFORMER = """
+query FindPerformer($name: String!) {
+  findPerformers(performer_filter: {name: {value: $name, modifier: EQUALS}}) {
+    performers { id name }
+  }
+}
+"""
+
+SEED_TAGS = [
+    {"name": "Blowjob"},
+    {"name": "Anal"},
+    {"name": "Outdoor"},
+    {"name": "Threesome"},
+    {"name": "Creampie"},
+    {"name": "Solo"},
+    {"name": "Lesbian"},
+    {"name": "BDSM"},
+    {"name": "Cosplay"},
+    {"name": "MILF"},
+]
+
+SEED_PERFORMERS = [
+    {"name": "Test Performer One", "gender": "FEMALE"},
+    {"name": "Test Performer Two", "gender": "FEMALE"},
+    {"name": "Test Performer Male", "gender": "MALE"},
+]
+
+SEED_SCENES = [
+    {
+        "title": "Test Scene Outdoor Fun",
+        "details": "A test scene filmed outdoors.",
+        "date": "2025-01-15",
+        "tag_names": ["Blowjob", "Outdoor"],
+        "performer_names": ["Test Performer One", "Test Performer Male"],
+    },
+    {
+        "title": "Test Scene Threesome Party",
+        "details": "Two performers and a guest star.",
+        "date": "2025-02-20",
+        "tag_names": ["Threesome", "Creampie"],
+        "performer_names": ["Test Performer One", "Test Performer Two", "Test Performer Male"],
+    },
+    {
+        "title": "Test Scene Solo Stretch",
+        "details": "Solo performance.",
+        "date": "2025-03-10",
+        "tag_names": ["Solo", "Cosplay"],
+        "performer_names": ["Test Performer Two"],
+    },
+    {
+        "title": "Test Scene Anal Adventure",
+        "details": "Anal-focused scene.",
+        "date": "2025-04-05",
+        "tag_names": ["Anal", "Creampie", "MILF"],
+        "performer_names": ["Test Performer One"],
+    },
+    {
+        "title": "Test Scene Lesbian Encounter",
+        "details": "Girl-on-girl action.",
+        "date": "2025-05-18",
+        "tag_names": ["Lesbian", "BDSM"],
+        "performer_names": ["Test Performer One", "Test Performer Two"],
+    },
+]
+
+
+def stash_request(
+    stash_url: str, query: str, variables: dict[str, object] | None = None
+) -> dict[str, Any]:
+    """Make a GraphQL request to the Stash instance."""
+    payload = json.dumps({"query": query, "variables": variables or {}}).encode()
+    req = urllib.request.Request(
+        f"{stash_url}/graphql",
+        data=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as response:
+        data = json.loads(response.read())
+    if "errors" in data:
+        raise RuntimeError(f"GraphQL error: {data['errors']}")
+    return cast(dict[str, Any], data["data"])
+
+
+def create_tags(stash_url: str) -> dict[str, str]:
+    """Create seed tags and return a {name: id} mapping."""
+    tag_ids: dict[str, str] = {}
+    for tag_def in SEED_TAGS:
+        data = stash_request(stash_url, MUTATION_TAG_CREATE, {"input": tag_def})
+        tag_id = data["tagCreate"]["id"]
+        tag_ids[tag_def["name"]] = tag_id
+        print(f"  tag: {tag_def['name']} ({tag_id})")
+    return tag_ids
+
+
+def create_performers(stash_url: str) -> dict[str, str]:
+    """Create seed performers and return a {name: id} mapping."""
+    performer_ids: dict[str, str] = {}
+    for perf in SEED_PERFORMERS:
+        data = stash_request(stash_url, MUTATION_PERFORMER_CREATE, {"input": perf})
+        perf_id = data["performerCreate"]["id"]
+        performer_ids[perf["name"]] = perf_id
+        print(f"  performer: {perf['name']} ({perf_id})")
+    return performer_ids
+
+
+def create_scenes(
+    stash_url: str, tag_ids: dict[str, str], performer_ids: dict[str, str]
+) -> list[str]:
+    """Create seed scenes with tag and performer links."""
+    scene_ids: list[str] = []
+    for scene in SEED_SCENES:
+        tag_list = [tag_ids[n] for n in scene["tag_names"]]
+        perf_list = [performer_ids[n] for n in scene["performer_names"]]
+        data = stash_request(
+            stash_url,
+            MUTATION_SCENE_CREATE,
+            {
+                "input": {
+                    "title": scene["title"],
+                    "details": scene["details"],
+                    "date": scene["date"],
+                    "tag_ids": tag_list,
+                    "performer_ids": perf_list,
+                }
+            },
+        )
+        scene_id = data["sceneCreate"]["id"]
+        scene_ids.append(scene_id)
+        print(f"  scene: {scene['title']} ({scene_id})")
+    return scene_ids
+
+
+def trigger_curator_sync(stash_url: str) -> None:
+    """Trigger a Curator sync and wait for it to finish."""
+    print("  triggering curator sync …")
+    try:
+        stash_request(
+            stash_url,
+            """
+            mutation CuratorSync($args: Map!) {
+              runPluginTask(
+                plugin_id: "stash-curator"
+                task_name: "Sync and build recommendations"
+                args: $args
+              )
+            }
+            """,
+            {"args": {}},
+        )
+    except Exception as exc:
+        print(f"  sync trigger failed (may need manual setup): {exc}", file=sys.stderr)
+        return
+
+    # Wait for sync to complete by polling health endpoint
+    print("  waiting for sync to finish …")
+    for _attempt in range(60):
+        try:
+            data = stash_request(
+                stash_url,
+                """
+                query Health($args: Map!) {
+                  runPluginOperation(
+                    plugin_id: "stash-curator"
+                    args: $args
+                  )
+                }
+                """,
+                {"args": {"operation": "health"}},
+            )
+            if not data.get("runPluginOperation", {}).get("error"):
+                print("  sync complete")
+                return
+        except Exception:
+            pass
+        time.sleep(2)
+
+    print("  warning: sync may not have completed within timeout", file=sys.stderr)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Seed Stash for Curator integration tests")
+    parser.add_argument(
+        "--stash-url",
+        default="http://localhost:9999",
+        help="Stash base URL (default: http://localhost:9999)",
+    )
+    args = parser.parse_args()
+    stash_url = args.stash_url.rstrip("/")
+
+    print(f"Seeding {stash_url} …")
+    print("Creating tags …")
+    tag_ids = create_tags(stash_url)
+    print("Creating performers …")
+    performer_ids = create_performers(stash_url)
+    print("Creating scenes …")
+    scene_ids = create_scenes(stash_url, tag_ids, performer_ids)
+    print(f"Done — {len(tag_ids)} tags, {len(performer_ids)} performers, {len(scene_ids)} scenes.")
+    print("Triggering curator sync …")
+    trigger_curator_sync(stash_url)
+    print("Seed complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/stash-config.yml
+++ b/tests/integration/stash-config.yml
@@ -1,0 +1,4 @@
+# Minimal Stash configuration for integration tests
+plugins:
+  stash-curator:
+    enabled: true

--- a/tests/integration/stash-config.yml
+++ b/tests/integration/stash-config.yml
@@ -1,4 +1,11 @@
 # Minimal Stash configuration for integration tests
+generated: /root/.stash/generated
+cache: /root/.stash/cache
+blobs:
+  path: /root/.stash/blobs
+  storage: FILESYSTEM
+database: /root/.stash/stash-go.sqlite
+dangerous_allow_public_without_auth: true
 plugins:
   stash-curator:
     enabled: true

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -6,6 +6,7 @@ Start with: docker compose -f tests/integration/docker-compose.yml up -d
 
 from __future__ import annotations
 
+import contextlib
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -29,10 +30,8 @@ def _dismiss_modals(page: Page) -> None:
         ):
             btn = page.locator(sel)
             if btn.count() > 0:
-                try:
+                with contextlib.suppress(Exception):
                     btn.first.click(force=True, timeout=2000)
-                except Exception:
-                    pass
         page.keyboard.press("Escape")
         page.wait_for_timeout(300)
         if page.locator("div.modal.show").count() == 0:

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -1,0 +1,122 @@
+"""Smoke tests: every Curator page and tab must render without JavaScript errors.
+
+These tests require a Stash instance with the plugin installed.
+Start with: docker compose -f tests/integration/docker-compose.yml up -d
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+pytestmark = pytest.mark.integration
+
+
+CURATOR_PATH = "/plugins/stash-curator"
+
+
+def _collect_errors(page: Page) -> list[str]:
+    """Return any JS errors that have occurred on the page so far."""
+    errors: list[Any] = getattr(page, "_errors", [])
+    return [str(e.message) for e in errors]
+
+
+@pytest.fixture(autouse=True)
+def _track_errors(page: Page) -> None:
+    """Capture all unhandled JS errors for the lifetime of the page."""
+    tracked: list[Any] = []
+    page.on("pageerror", lambda err: tracked.append(err))
+    page.__dict__["_errors"] = tracked
+
+
+def _wait_stable(page: Page, ms: int = 1500) -> None:
+    """Wait for React rendering to settle."""
+    page.wait_for_timeout(ms)
+
+
+def test_curator_page_loads_without_errors(page: Page) -> None:
+    """The Curator plugin main page loads without JS errors."""
+    page.goto(CURATOR_PATH, wait_until="domcontentloaded")
+    _wait_stable(page)
+    errors = _collect_errors(page)
+    assert not errors, f"JS errors on page load: {errors}"
+
+
+# ── Tab names and expected content ──
+
+TABS = [
+    ("For You", ["No qualified recommendations"]),
+    ("Similar", ["No scenes cross this prediction threshold"]),
+    ("Expand", ["Expand has not been prepared yet", "Prepare now"]),
+    ("Taste Profile", ["No supported tags"]),
+    ("Performer Hunt", ["Select a local performer linked to StashDB"]),
+    ("Feedback", ["No feedback has been recorded yet"]),
+    ("Backups", ["No Curator backups found"]),
+]
+
+
+@pytest.mark.parametrize("tab_name,expected_phrases", TABS)
+def test_curator_tab_renders_without_errors(
+    page: Page, tab_name: str, expected_phrases: list[str]
+) -> None:
+    """Each Curator tab renders its empty-state content without JS errors."""
+    page.goto(CURATOR_PATH, wait_until="domcontentloaded")
+    _wait_stable(page)
+
+    # Click the tab
+    link = page.locator("a.nav-link", has_text=re.compile(tab_name))
+    if link.count() > 0:
+        link.first.click()
+    else:
+        # Tab may be directly accessible
+        tab_id = tab_name.lower().replace(" ", "-")
+        page.click(f"#{tab_id}")
+
+    _wait_stable(page)
+
+    # Verify at least one expected phrase is visible
+    content = page.content()
+    found = any(phrase in content for phrase in expected_phrases)
+    assert found, f"Tab '{tab_name}' did not show expected content: {expected_phrases}"
+
+    errors = _collect_errors(page)
+    assert not errors, f"JS errors on tab '{tab_name}': {errors}"
+
+
+def test_curator_tasks_page_renders(page: Page) -> None:
+    """The Tasks sub-tab renders without errors."""
+    page.goto(CURATOR_PATH, wait_until="domcontentloaded")
+    _wait_stable(page)
+
+    tasks_link = page.locator("a.nav-link", has_text="Tasks")
+    if tasks_link.count() > 0:
+        tasks_link.first.click()
+        _wait_stable(page)
+
+        content = page.content()
+        assert "Tasks" in content or "Clone" in content or "Downloads" in content
+
+        errors = _collect_errors(page)
+        assert not errors, f"JS errors on Tasks: {errors}"
+
+
+def test_curator_settings_page_renders(page: Page) -> None:
+    """The Settings sub-tab renders without errors."""
+    page.goto(CURATOR_PATH, wait_until="domcontentloaded")
+    _wait_stable(page)
+
+    settings_link = page.locator("a.nav-link", has_text="Settings")
+    if settings_link.count() > 0:
+        settings_link.first.click()
+        _wait_stable(page)
+
+        content = page.content()
+        assert "Settings" in content or "Profiling" in content
+
+        errors = _collect_errors(page)
+        assert not errors, f"JS errors on Settings: {errors}"

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -6,7 +6,6 @@ Start with: docker compose -f tests/integration/docker-compose.yml up -d
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -16,8 +15,28 @@ if TYPE_CHECKING:
 
 pytestmark = pytest.mark.integration
 
-
 CURATOR_PATH = "/plugins/stash-curator"
+
+
+def _dismiss_modals(page: Page) -> None:
+    """Dismiss Stash release notes and setup modals that block clicks."""
+    for _ in range(5):
+        for sel in (
+            "div.modal.show button.btn-close",
+            "div.modal.show .close",
+            "div.modal.show [aria-label='Close']",
+            "div.modal.show .btn-primary",
+        ):
+            btn = page.locator(sel)
+            if btn.count() > 0:
+                try:
+                    btn.first.click(force=True, timeout=2000)
+                except Exception:
+                    pass
+        page.keyboard.press("Escape")
+        page.wait_for_timeout(300)
+        if page.locator("div.modal.show").count() == 0:
+            break
 
 
 def _collect_errors(page: Page) -> list[str]:
@@ -34,89 +53,82 @@ def _track_errors(page: Page) -> None:
     page.__dict__["_errors"] = tracked
 
 
-def _wait_stable(page: Page, ms: int = 1500) -> None:
-    """Wait for React rendering to settle."""
+def _wait(page: Page, ms: int = 2000) -> None:
     page.wait_for_timeout(ms)
 
 
-def test_curator_page_loads_without_errors(page: Page) -> None:
+def test_curator_page_loads_without_errors(page: Page, base_url: str) -> None:
     """The Curator plugin main page loads without JS errors."""
-    page.goto(CURATOR_PATH, wait_until="domcontentloaded")
-    _wait_stable(page)
+    page.goto(base_url + CURATOR_PATH, wait_until="domcontentloaded")
+    _wait(page)
+    _dismiss_modals(page)
     errors = _collect_errors(page)
-    assert not errors, f"JS errors on page load: {errors}"
+    assert not errors, f"JS errors: {errors}"
 
 
-# ── Tab names and expected content ──
+# ── Tab URLs → expected content ──
 
-TABS = [
-    ("For You", ["No qualified recommendations"]),
-    ("Similar", ["No scenes cross this prediction threshold"]),
-    ("Expand", ["Expand has not been prepared yet", "Prepare now"]),
-    ("Taste Profile", ["No supported tags"]),
-    ("Performer Hunt", ["Select a local performer linked to StashDB"]),
-    ("Feedback", ["No feedback has been recorded yet"]),
-    ("Backups", ["No Curator backups found"]),
+TABS: list[tuple[str, list[str]]] = [
+    ("", ["no published model", "Sync and build now", "Preparing For You"]),
+    ("?view=similar", ["Choose a scene or performer", "Library", "StashDB"]),
+    ("?view=expand", ["External metadata candidates", "Loading Expand cache"]),
+    ("?view=taste", ["Loading taste profile", "No supported tags"]),
+    ("?view=hunt", ["Select a local performer linked to StashDB"]),
+    ("?view=feedback", ["Loading feedback history", "No feedback has been recorded yet"]),
+    ("?view=backups", ["Create backup", "No Curator backups found"]),
 ]
 
 
-@pytest.mark.parametrize("tab_name,expected_phrases", TABS)
+@pytest.mark.parametrize("view_param,expected_phrases", TABS)
 def test_curator_tab_renders_without_errors(
-    page: Page, tab_name: str, expected_phrases: list[str]
+    page: Page, base_url: str, view_param: str, expected_phrases: list[str]
 ) -> None:
     """Each Curator tab renders its empty-state content without JS errors."""
-    page.goto(CURATOR_PATH, wait_until="domcontentloaded")
-    _wait_stable(page)
+    page.goto(f"{base_url}{CURATOR_PATH}{view_param}", wait_until="domcontentloaded")
+    _wait(page)
+    _dismiss_modals(page)
 
-    # Click the tab
-    link = page.locator("a.nav-link", has_text=re.compile(tab_name))
-    if link.count() > 0:
-        link.first.click()
-    else:
-        # Tab may be directly accessible
-        tab_id = tab_name.lower().replace(" ", "-")
-        page.click(f"#{tab_id}")
-
-    _wait_stable(page)
-
-    # Verify at least one expected phrase is visible
     content = page.content()
     found = any(phrase in content for phrase in expected_phrases)
-    assert found, f"Tab '{tab_name}' did not show expected content: {expected_phrases}"
+
+    if not found:
+        body_text = page.locator("body").inner_text()
+        assert found, (
+            f"View '{view_param or '/'}' missing expected phrases: {expected_phrases}\n"
+            f"Body (first 800): {body_text[:800]}"
+        )
 
     errors = _collect_errors(page)
-    assert not errors, f"JS errors on tab '{tab_name}': {errors}"
+    assert not errors, f"JS errors on '{view_param or '/'}': {errors}"
 
 
-def test_curator_tasks_page_renders(page: Page) -> None:
+def test_curator_tasks_page_renders(page: Page, base_url: str) -> None:
     """The Tasks sub-tab renders without errors."""
-    page.goto(CURATOR_PATH, wait_until="domcontentloaded")
-    _wait_stable(page)
+    page.goto(base_url + CURATOR_PATH, wait_until="domcontentloaded")
+    _wait(page)
+    _dismiss_modals(page)
 
     tasks_link = page.locator("a.nav-link", has_text="Tasks")
     if tasks_link.count() > 0:
-        tasks_link.first.click()
-        _wait_stable(page)
-
+        tasks_link.first.click(force=True)
+        _wait(page)
         content = page.content()
-        assert "Tasks" in content or "Clone" in content or "Downloads" in content
-
+        assert "Tasks" in content or "Clone" in content
         errors = _collect_errors(page)
         assert not errors, f"JS errors on Tasks: {errors}"
 
 
-def test_curator_settings_page_renders(page: Page) -> None:
+def test_curator_settings_page_renders(page: Page, base_url: str) -> None:
     """The Settings sub-tab renders without errors."""
-    page.goto(CURATOR_PATH, wait_until="domcontentloaded")
-    _wait_stable(page)
+    page.goto(base_url + CURATOR_PATH, wait_until="domcontentloaded")
+    _wait(page)
+    _dismiss_modals(page)
 
     settings_link = page.locator("a.nav-link", has_text="Settings")
     if settings_link.count() > 0:
-        settings_link.first.click()
-        _wait_stable(page)
-
+        settings_link.first.click(force=True)
+        _wait(page)
         content = page.content()
         assert "Settings" in content or "Profiling" in content
-
         errors = _collect_errors(page)
         assert not errors, f"JS errors on Settings: {errors}"

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -71,10 +71,31 @@ TABS: list[tuple[str, list[str]]] = [
     ("", ["no published model", "Sync and build now", "Preparing For You"]),
     ("?view=similar", ["Choose a scene or performer", "Library", "StashDB"]),
     ("?view=expand", ["External metadata candidates", "Loading Expand cache"]),
-    ("?view=taste", ["Loading taste profile", "No supported tags"]),
+    (
+        "?view=taste",
+        [
+            "Loading taste profile",
+            "No supported tags",
+            "Declared answers are strong evidence",
+        ],
+    ),
     ("?view=hunt", ["Select a local performer linked to StashDB"]),
-    ("?view=feedback", ["Loading feedback history", "No feedback has been recorded yet"]),
-    ("?view=backups", ["Create backup", "No Curator backups found"]),
+    (
+        "?view=feedback",
+        [
+            "Loading feedback history",
+            "No feedback has been recorded yet",
+            "Review recent feedback",
+        ],
+    ),
+    (
+        "?view=backups",
+        [
+            "Create backup",
+            "No Curator backups found",
+            "Create, inspect",
+        ],
+    ),
 ]
 
 

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -1156,3 +1156,48 @@ def test_external_links_reuse_the_last_scan_until_stash_reports_a_change(
     state["count"] = 2
     module._external_links({}, connection)
     assert scanned == 4, "an added or deleted link must invalidate the cache"
+
+
+def test_every_user_visible_empty_and_error_message_is_defensive() -> None:
+    """Every empty-state, error, and guidance message must remain in the source.
+
+    These are the strings users see when something is missing, broken, or
+    needs action.  Removing or rewording one silently breaks the UX.
+    """
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
+
+    # ── empty / not-ready states ──
+    assert '"No supported tags are available yet."' in source
+    assert '"No tags match that search."' in source
+    assert '"No matching local tags."' in source
+    assert '"No matches found."' in source
+    assert '"No feedback has been recorded yet."' in source
+    assert '"No qualified recommendations have been recorded yet."' in source
+    assert '"Nothing in this view."' in source
+    assert '"No Curator backups found."' in source
+    assert '"No scenes match this view."' in source
+    assert '"No external candidates match these filters."' in source
+    assert '"No profiles have been recorded yet."' in source
+
+    # ── guidance prompts ──
+    assert '"Select a local performer linked to StashDB."' in source
+    assert "Expand has not been prepared yet" in source
+    assert '" Prepare now"' in source
+    assert '" Sync and build now"' in source
+    assert '" Rebuild model"' in source
+    assert '"Nothing qualifies for this lane right now."' in source
+    assert "no model exists yet" in source
+
+    # ── warnings ──
+    assert "Showing the first" in source
+    assert "StashDB scenes; the safety cap is" in source
+    assert "Profiling is disabled." in source
+    assert '"Initial sync failed: "' in source
+    assert "Open Tasks for the full log" in source
+
+    # ── external card tag rating states ──
+    assert '"Matching local tags…"' in source
+    assert '"Rate matching local tags"' in source
+    assert '"Configure Whisparr in plugin settings"' in source
+    assert '"Retry sending to Whisparr"' in source
+    assert '"Send to Whisparr"' in source

--- a/uv.lock
+++ b/uv.lock
@@ -48,12 +48,158 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0327fcd59a935777d83410750c50600ee9571af2846f71ce40f25b13da1ef380", size = 317253, upload-time = "2026-07-07T14:33:54.994Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a79d9f4d8001473a30c163556b3c3bfebec837495a412dde78b51672f6134f9", size = 215898, upload-time = "2026-07-07T14:33:56.334Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/e7/5ddfd76fc061eb52de219658a4aa431cbacadf0a0219c8854f00da50d289/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:33bdcc2a32c0a0e861f60841a512c8acc658c87c2ac59d89e3a46dacf7d866e4", size = 236718, upload-time = "2026-07-07T14:33:57.9Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ba/768fa3f36048d81c477a0ce61f813bc1454d80917ccfe550abd9f44f5e24/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f840ed6d8ecba8255df8c42b87fadeda98ddfc6eeec05e2dc66e26d46dd6f58a", size = 232519, upload-time = "2026-07-07T14:33:59.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c25fe15c70c59eb7c5ce8c06a1f3fa1da0ecc5ea1e7a5922c40fd2fa9b0d5046", size = 223143, upload-time = "2026-07-07T14:34:01.517Z" },
+    { url = "https://files.pythonhosted.org/packages/19/79/55c32d06d76ae4feafe053f061f3e3ab70bcf19f4007797ce8c3efda7830/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:f7fb7d750cfa0a070d2c24e831fd3481019a60dd317ea2b39acbcebc08b6ed81", size = 206742, upload-time = "2026-07-07T14:34:03.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e0/47c079dd82d217c807479cd59ffd30af56307ea31c108b75758970459ad3/charset_normalizer-3.4.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1c96a7a18b9690a4d46df09e3e3382406ae3213727cd1019ebade1c4a81917", size = 219191, upload-time = "2026-07-07T14:34:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/42/ab/b9bc2e77d6b44a7e46ef62ec5cac1c9a6ba7b9135a5d560f002696ec9995/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a4cfde78a9f2880208d16a93b795726a3017d5977e08d1e162a7a31322479c41", size = 218328, upload-time = "2026-07-07T14:34:06.115Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/78/c9c71d599f5aa2d42bcdd35cbbd46d7f535351a57e40ff7d8e5a7e219401/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:d4d6fcde76f94f5cb9e43e9e9a61f16dacefd228cbbf6f1a09bd9b219a92f1a1", size = 207406, upload-time = "2026-07-07T14:34:07.554Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/39/c914445c321a845097ce4f6ac7de9a18228a77b766272125a1ce00d851eb/charset_normalizer-3.4.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:898f0e9068ca27d37f8e83a5b962821df851532e6c4a7d615c1c033f9da6eedf", size = 225157, upload-time = "2026-07-07T14:34:09.061Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f2/c0d4b8508565a36bc5c624e88ed297f5b0b1095011034d7f5b83a69908b5/charset_normalizer-3.4.9-cp314-cp314-win32.whl", hash = "sha256:c1c948747b03be832dceed96ca815cef7360de9aa19d37c730f8e3f6101aca48", size = 151095, upload-time = "2026-07-07T14:34:10.901Z" },
+    { url = "https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl", hash = "sha256:16b65ea0f2465b6fb52aa22de5eca612aa964ddfec00a912e26f4656cbef890b", size = 162796, upload-time = "2026-07-07T14:34:12.47Z" },
+    { url = "https://files.pythonhosted.org/packages/20/95/d75e82f8ce9fd323ebf059c16c9aadefb22a1ecde13b7840b35835e4886c/charset_normalizer-3.4.9-cp314-cp314-win_arm64.whl", hash = "sha256:40a126142a56b2dfc0aacbad1de8310cbf60da7656db0e6b16eebd48e3e93519", size = 153334, upload-time = "2026-07-07T14:34:14.044Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/17398df3a139985ba9d11ed072531986f408c8fca952835ef1ab1820c02b/charset_normalizer-3.4.9-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:609b3ba8fcc0fb5ab7af00719d0fb6ad0cb518e48e7712d12fd68f1327951198", size = 338848, upload-time = "2026-07-07T14:34:15.688Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/91/7253a32e86b7e1d1239b1b36ba6dd0f021a21107ab33054b53119cc083b9/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:51447e9aa2684679af07ca5021c3db526e0284347ebf4ffcec1154c3350cfe32", size = 223022, upload-time = "2026-07-07T14:34:17.248Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/2e64bd2be10e89c61e57ebe6a93fd98ae88eb7ebe414b5121f22c96c69eb/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc1b0fff8ead343dae06305f954eb8468ba0ec1a97881f42489d198e4ce3c632", size = 241590, upload-time = "2026-07-07T14:34:18.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ef/d96ec496cfea0c21db43b0ad03891308b02388d054cc902cf0e5a1ad6a88/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:fa36ec09ef71d158186bc79e359ff5fdd6e7996fe8ab638f00d6b93139ba4fcf", size = 239584, upload-time = "2026-07-07T14:34:20.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ce/9af95f7876194bd7a14e3dfe4a4de2e0bff02666a3910d72beafd06cc297/charset_normalizer-3.4.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:df115d4d83168fdf2cae48ef1ff6d1cb4c466364e30861b37121de0f3bf1b990", size = 230224, upload-time = "2026-07-07T14:34:22.189Z" },
+    { url = "https://files.pythonhosted.org/packages/52/94/af74dde74a3996bd959c350709bfe50e297823d70a8c1cbd54b838880863/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:f86c6358749bd4fda175388691e3ba8c46e24c5347d0afd20f9b7edfc9faf07d", size = 212667, upload-time = "2026-07-07T14:34:23.857Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f0/f1c4fe746c395922961b5916ed1d7d6e7d4c84851d19ed43cc89980ec953/charset_normalizer-3.4.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:32286a2c8d167e897177b673176c1e3e00d4057caf5d2b64eef9a3666b03018e", size = 227179, upload-time = "2026-07-07T14:34:25.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/56/6c745619ac397e8871e2bcd3cea1eec86b877488f33888b3aef5c3ed506e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:83aed2c10721ddd90f68140685391b50811a880af20654c59af6b6c66c40513c", size = 225372, upload-time = "2026-07-07T14:34:27.212Z" },
+    { url = "https://files.pythonhosted.org/packages/78/ad/98aae8630ac71f16711968e38a5acfecce41b778bf2f0312851020f565a8/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cd6c3d4b783c556fa00bf540854e42f135e2f256abd29669fcd0da0f2dec79c2", size = 215222, upload-time = "2026-07-07T14:34:28.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/40/9593d54209765207a7f11073c06494c1721e4ca4a0a426c597679bf7f91e/charset_normalizer-3.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ee2f2a527e3c1a6e6411eb4209642e138b544a2d72fe5d0d76daf77b24063534", size = 231958, upload-time = "2026-07-07T14:34:30.345Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/27/693ee5e8a18191eb38647360c51cd505013e2bd3b366aa43fd5344c21e3c/charset_normalizer-3.4.9-cp314-cp314t-win32.whl", hash = "sha256:0d861473f743244d349b50f850d10eb87aeb22bbdcc8e64f79273c94af5a8226", size = 155580, upload-time = "2026-07-07T14:34:31.884Z" },
+    { url = "https://files.pythonhosted.org/packages/80/3f/bd97d3d9c613013d07cb7733d299385b41df37f0471310f5a73dc359f0b8/charset_normalizer-3.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:9b8e0f3107e2200b76f6054de99016eac3ee6762713587b36baaa7e4bd2ae177", size = 167620, upload-time = "2026-07-07T14:34:33.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c6/eee9dca4439b1061f76373f06ea855678cc4a64c1c3c90b50e479edbb8eb/charset_normalizer-3.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:19ac87f93086ce37b86e098888555c4b4bc48102279bae3350098c0ed664b501", size = 158037, upload-time = "2026-07-07T14:34:35.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/74/b13368064b09053253555d3f2839cc2684d22d5aed0d2ccffbf7a6736558/greenlet-3.5.4.tar.gz", hash = "sha256:0232ae1de90a8e07867bb127d7a6ba2301e859145489f25cda8a6096dabe1d20", size = 206538, upload-time = "2026-07-22T12:47:14.468Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/04/81bd731d6d1e3a469d9a4c36f5eb069bcf0cbb2d5d342c9fec22245b91fc/greenlet-3.5.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3d66250e8b09f182ede05490998c818b5961f7a3640332d44c4927caec7bbfe4", size = 295909, upload-time = "2026-07-22T11:38:09.261Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/dd/f5f22903a6ae70f5ea328ed0beaec92ad903f0e3b7d2845133b354abc4b8/greenlet-3.5.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c90e930c9c192e5b3ee9fb8bcd920ea3926155e2e3ded39fc697323addecee17", size = 612011, upload-time = "2026-07-22T12:26:40.69Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/10/92a4a88d12b915d74ea5b6d288e4afefda4771647caa34442c156f7a454f/greenlet-3.5.4-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:791fdfeeb9c6e0c7b10fa151bf110d2a6974866f13dcb5b1c7efae698245893a", size = 624299, upload-time = "2026-07-22T12:29:02.089Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/f9/03e26be3487c5238e81f2b84714959a86ea8515a869828cf41f4fc54b34e/greenlet-3.5.4-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b7c895310363f310361e0fe2072af85269d2a2a285cd04c0c59e79a5e3670dcf", size = 629603, upload-time = "2026-07-22T12:43:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6d/0b14bb9db2989f32cd9fe7f76afedea01ee8bee3f87c07e69f24adfe7e63/greenlet-3.5.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f88193799d43dbf8c8a806d6405c9c52fe2af40bf75072a606357b33cc336c7f", size = 621541, upload-time = "2026-07-22T11:51:09.464Z" },
+    { url = "https://files.pythonhosted.org/packages/57/6b/7c55ca72ef80d57c16c4a55210f82582622462dc4485799a30f4ec6f3372/greenlet-3.5.4-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:13b980043cb1b3134e81ea469da1250ddcc6bfe6d245bbaa59168d9cdc8f228f", size = 432554, upload-time = "2026-07-22T12:39:51.379Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/25e9a2d9eb6b2e8b7ca4e80a3a26cb887cce6c8e0a87c921164f11bc5574/greenlet-3.5.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7a5f095767c4493afcd06067f2bb3b8716e3f3f9e92b99c88e7e99f885b3d4d", size = 1581444, upload-time = "2026-07-22T12:25:03.818Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/96/4c9bf2e2c408dcc0556edce69efa9f802e82223573c53240136a086821f1/greenlet-3.5.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:42afdc1ab5f66da8c586c32af9224a74a706b4f0ea0dc3a4188a0860a09c65c9", size = 1645842, upload-time = "2026-07-22T11:51:12.295Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/41/303ecb26a3a56122c0f4d4073ee078881847bd6b6f463ae0ec57ec20223b/greenlet-3.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:60149df8f462d1b230038e6590c23c3b4768bb5d6c022b3b6e82532b34b0b8a3", size = 247169, upload-time = "2026-07-22T11:38:19.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e3/ef56864b4c35fcb3eb3b41b869f6cc46f4cd3f5e2c68e74acde8ac433951/greenlet-3.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:77d6ce04fed0d9aeed42e0f37923cc43eba9b027bdd9c34546bb4ccd143d0fe0", size = 245565, upload-time = "2026-07-22T11:38:27.061Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/9a/e51225dcd58713f16ccbdcc501a8da21098ea14515b7870f1f94459e5ff5/greenlet-3.5.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:24e61b88cb7e1b1d794b32a10cc346ac779681d6d74ff137a3e0a444d2bf1f02", size = 294831, upload-time = "2026-07-22T11:38:53.389Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ea/de50a50fadf979713ab18b46f22ad5ff5f2dcfc637a3ebdecf669801e1a5/greenlet-3.5.4-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:870d730fec833f5a06906a32596cc099b9161594642a92a520b7a88911c95356", size = 614619, upload-time = "2026-07-22T12:26:42.282Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c7/2aae27fea41205b8650294c301f042a2a4bb6155eea48c995b890a92f2c1/greenlet-3.5.4-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ec5ff0d1878df6af3bf9b638a5a92a7d5693291de77c91bff10fa48519c604ef", size = 627021, upload-time = "2026-07-22T12:29:03.445Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/80/fb4d4788bbc8e54761f1fc88533af9523a6e86299fa113d6e8a8503ed9fc/greenlet-3.5.4-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:07bd44616608d873d06735b63ef1a88191d6ca57c8d291d6559c71bc14c0893c", size = 632845, upload-time = "2026-07-22T12:43:45.19Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/79fd826f9ccaae0b84e1b4ef68dabba5e105bb044ffcd448a0b782fcba9a/greenlet-3.5.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d84d993f6e575c950d91a23c1345d18fe1a4310d447bf630849d7809196b52f0", size = 624002, upload-time = "2026-07-22T11:51:11.391Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e3/6086fa578ebb72772722cdc4bcd628459814b42e0c2db1e3cbd6552b3271/greenlet-3.5.4-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:3529a8a933582ad19e224792cac7372489526576b75b4c124e8e4f29948f4861", size = 435053, upload-time = "2026-07-22T12:39:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/1a/27319f97e731298513dcba1a2e91b63e9d8811d9de22130f960b129b1bf1/greenlet-3.5.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:58023945f421093de5e6fa108c0985a8659d43f49e0216da25099369a121bcbd", size = 1581533, upload-time = "2026-07-22T12:25:05.322Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/6d/24240bf562e9786dd2799ee0a4a4dadb4ded22510f41b20245099159ac8c/greenlet-3.5.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bae2728e1897aa8df8cb1af38cd48b3a743aefe29372de7b8b7a9f532501e69f", size = 1645781, upload-time = "2026-07-22T11:51:14.805Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/5a/442ab1a9ef7ca6bf7210e5397a95972206a91a31033a03c8900866a10039/greenlet-3.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:ca5726c0b08ca35ae873557266a78b2c3f3b2b7d7401aa5ff886c2045dd0111c", size = 247133, upload-time = "2026-07-22T11:39:20.661Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/e6/9160210222386b1a378ff94db846b9508ca24a121cf684991561fdb69280/greenlet-3.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:7c1303791d603080cac6fc3b34df51c3b75b723739c282c8029e48a0d241672f", size = 245500, upload-time = "2026-07-22T11:40:22.185Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/a7/6ab1d4f9cd548d15ab90da29947f2076100130bb179b0bde59f795a459e3/greenlet-3.5.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:7e8afa5eac028f8140ceafe5ceec66e6aa127ddcb21452d2a564dcd2900b5f22", size = 295410, upload-time = "2026-07-22T11:40:35.747Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7a/422f63b4715cbc0b24385305407adf38b48f6bb68b3e6b04090e994d0f5a/greenlet-3.5.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:73b37afe369021423ea53dd3123e04bffa7e93ac64429b9f50835b2e4fcae7cf", size = 661286, upload-time = "2026-07-22T12:26:43.8Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/31/5a1cac663bf5582190c5a714ef81364f03cde232227f39748f8ae4c11da5/greenlet-3.5.4-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3ef964f56dfcb6f9bbef2a190d9126795eac408716aeae47b5e7c73c32aafca9", size = 673517, upload-time = "2026-07-22T12:29:04.815Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/bf/250c2921c7b585dde12f5239e313ca2dcbc464d161ecca36e4e6ef21762d/greenlet-3.5.4-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:cef589bc65fae02d10bca2ac341191c5b33acc2967892ebf4fcbd10eabb7a74c", size = 677968, upload-time = "2026-07-22T12:43:46.788Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4a/2a82a1e3f8aaca020853ac8d12211280ca2b231aa08ea39f636f1060c319/greenlet-3.5.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c53ff01a5c53a40f2c16820ebc56d7c61a77f5fbe009dadd96292d5682f80f8", size = 670917, upload-time = "2026-07-22T11:51:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/18/40/10bfcf6513558d82f7b95dd728001c63bd388259fe27d3e30ae01f103430/greenlet-3.5.4-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:dfc41ae893d9ceaf22c824f2153a88b30651b20e8758c2cd9ac143f23640563c", size = 480643, upload-time = "2026-07-22T12:39:54.149Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b0/e379a152b17bfdfa95795af4049e37c0fd1b4d81f020d426db104ed07c77/greenlet-3.5.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecca4d80d55a01ad6b23b33262662956149fbb7b2c6be2910f1705921958cbf3", size = 1628478, upload-time = "2026-07-22T12:25:06.678Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/43/bffdfa64f7317f954c5c1230b5dd5922676ce198689a68c1ac1ed4b1b1a5/greenlet-3.5.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2ffbc533e0eaf8e80d8471411646ab88fe58f641d508c0b02b24494479f4d9ec", size = 1692021, upload-time = "2026-07-22T11:51:17.008Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/11/f799f9637e2c6e9b0b716015e339040598b058cf7654dfc0d67468b177ed/greenlet-3.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:305f69e6c4523d7f6979ed001cff4e5853c063e5da04880296603aa0227e544c", size = 248031, upload-time = "2026-07-22T11:40:11.007Z" },
+    { url = "https://files.pythonhosted.org/packages/05/75/625bcdd74d5e6b2dca1ecba3c3ac77bcf8a026c21a649a46cef23e421f97/greenlet-3.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:f260930bbbbcf9caee661211235a5111c86dfe5832fdf6ae4570da1e0995320f", size = 246892, upload-time = "2026-07-22T11:40:27.357Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/69/35c62ed49c320cb4d98e14698ccca5467d3bfe683984172be9cb564d9ce3/greenlet-3.5.4-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:41ddab54e4b238f4a6c323f39b4e59e176affd5a94d461a9fb7583dac74240a3", size = 305571, upload-time = "2026-07-22T11:40:31.659Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6c/64d60216b3640dcb0b62d913dd9e0d80030c09115bb2e4ba70c95d10ca45/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b3dabe3e2809013052c68bdf0b7fa5f5f2859c43a80803131ad61af9cabd7867", size = 672568, upload-time = "2026-07-22T12:26:45.298Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/de/ba3ab0a96292e53039530333b0d2ae18d9e508f3a325cd7bf15f8172944c/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:27d3f00718634d4520a3a150154ac5da36f257869d41321953375b90bfbbc72c", size = 680076, upload-time = "2026-07-22T12:29:06.125Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/db/24a10af12bf8e639cec46c38b9ce1a282543ba42ff4fb0b31a970f1ab603/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:39169a11d87a6a263afda3e9a27d1df16d0f919d40a4837cc73986c9884c0dd8", size = 681690, upload-time = "2026-07-22T12:43:48.109Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/aeada79083c6f1c15f45d77a332f9c441af263ee298e3eb17522cd337d22/greenlet-3.5.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cbd60b5763c6543c1827e48faaf14ea9bfbad245f52b1a4d76a2a2d8884c6c66", size = 676733, upload-time = "2026-07-22T11:51:16.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/60/44a2eca7b9fd71ae0fae7ff184da1cd3169d176652b97aa1cffcbb0ef961/greenlet-3.5.4-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:bd3d1145f603b2db19feb9078c2e6855eb7c67e15580c010ed815cee519b86fd", size = 510263, upload-time = "2026-07-22T12:39:55.678Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/10/2392fc3a98948652ef5fd1e7275c04f861dd13f74b78a2b4309f4ee4d090/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f00f910f0e7b35416c63b23ad78b769aeccfc1775f712b43c4ee525624a2eef7", size = 1637327, upload-time = "2026-07-22T12:25:07.879Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c6/e7237a3dfa1f205ed0d9ea1e46d70bd2811b32d516266399fb59d28ab90a/greenlet-3.5.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:91c26423753b92caf41ab3f98fd547d7374d4d9fc2d85be041886c1579d9255e", size = 1697493, upload-time = "2026-07-22T11:51:19.214Z" },
+    { url = "https://files.pythonhosted.org/packages/55/e3/4ba8154ba2a3d43729e499f72471b4b5c993f3826d3e24da81d5f06d6572/greenlet-3.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:ee032b91fd8ec29ec6c4cea2b8c561b178435134bd0752c7334b94e9c736c132", size = 251637, upload-time = "2026-07-22T11:40:37.44Z" },
+    { url = "https://files.pythonhosted.org/packages/90/03/e3f96dfc100261a29545ddc8270cafe58f9195b6651466910e820910de77/greenlet-3.5.4-cp315-cp315-macosx_11_0_universal2.whl", hash = "sha256:178111881dd7a6c946471fda85485ec796e1043c2b939f694b096e2ecf986809", size = 296076, upload-time = "2026-07-22T11:39:38.364Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/3d/da52d208e5c977bce8667e784729e584e38b5785f4c1ec0f4c836e9a1c42/greenlet-3.5.4-cp315-cp315-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d92df08dd65fede97fc37aad36c2e9dcda3b31c467f8e0c2c096456cb818e927", size = 666870, upload-time = "2026-07-22T12:26:46.691Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/8a/7e6dee25cb8a8cf9b362c8e597cc269593378bd916f16c736c059a52e85a/greenlet-3.5.4-cp315-cp315-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:99e8f8c4ebc4fd80aa26c1280ae9ad43a0976e786349703a181cf0bae60413e5", size = 677678, upload-time = "2026-07-22T12:29:07.508Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a7/dafc7415d430b0a43a16396eb49ecb3b62fd720877fb259cc4dcfaf5f31e/greenlet-3.5.4-cp315-cp315-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1f17e362d78e37559e0506c5a7d066bdd45073c36a0127a543e8a0df27242ff3", size = 681428, upload-time = "2026-07-22T12:43:49.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/21/5a38699fa45de749e3857d93b8f07e4c20489e77c2d35d915a2e1c456606/greenlet-3.5.4-cp315-cp315-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:394de08dad5ffcb1f50c2159d93e398d9d2da3ed437645eaa54771fa720db9f0", size = 676067, upload-time = "2026-07-22T11:51:18.163Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/d9/6298f3432de301d4718766cf934bd73c418c73f81fbb77247319364b0d96/greenlet-3.5.4-cp315-cp315-manylinux_2_39_riscv64.whl", hash = "sha256:cd320d998cbaa032932830448e39abf3c6a12901295e386e8114db926e10cffb", size = 487446, upload-time = "2026-07-22T12:39:57.044Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/ba/863116ab8ff1ca7a729e327800268939d182db47aa433db70e216e7d9194/greenlet-3.5.4-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:c883d61f2282d72c767a14936641b3efcbde9d82f1080712aaea0b1d3126cb88", size = 1633489, upload-time = "2026-07-22T12:25:09.605Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/06/7466ced82818d6132462d7f26b3f83c66ea15d2b193a6c0088d558ed7d95/greenlet-3.5.4-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:2a924f15d17957e252a810acefcb5942f5ca712298e8b6fcaed9a307d357522c", size = 1696584, upload-time = "2026-07-22T11:51:21.304Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/4d/55b638489260065de9ffce606c8b5d04507bef705de4b212a0c3d6a1a0df/greenlet-3.5.4-cp315-cp315-win_amd64.whl", hash = "sha256:ed17e5f3420360d5b459de8462efb52060399a5326a613d4cde31cef63ef95da", size = 248297, upload-time = "2026-07-22T11:42:04.055Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/08/9dd4ae635da93d41dc268bc34bd62a9d711ed8b8825c5d22ac910c7d6e6d/greenlet-3.5.4-cp315-cp315-win_arm64.whl", hash = "sha256:f908898d6fa484ce4b6f447ce70ea99b52c503fee419e53cf74d60a16bc9e667", size = 247423, upload-time = "2026-07-22T11:44:00.764Z" },
+    { url = "https://files.pythonhosted.org/packages/19/66/7c87ed9cdbf1d49c2c6cd1c7b9dd4d16c33b24235ca03972293a1876b30c/greenlet-3.5.4-cp315-cp315t-macosx_11_0_universal2.whl", hash = "sha256:1833637f17d5e7472548a48575c394fe39f1b1890d676d162d86593610f44d8c", size = 306487, upload-time = "2026-07-22T11:41:25.118Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/05/0a4201e7c0054866eefc05da234f236dd4c950d0fbf9ca0517141f01b269/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12cda9122e03341f1cb6b8207a19d7a9d375e52f1b4e9243918375f40fd7b4b9", size = 676479, upload-time = "2026-07-22T12:26:48.129Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c0/4b6b8c5a3aec70f0649cd89662d120fdd6421e2bdc8e3b15c3ab5ec568d8/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d83ae0e32d14957ab7170785a20f582635c8474deab1bfbb552b17e769a6ce25", size = 684321, upload-time = "2026-07-22T12:29:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/88/15/0b167aeea95285b0e654ddce651922f666c089363c2ec528ca8b9a9ba74f/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:123aa379c962ed5fe90a880327e0c3066124ac64ec99e12a238be9fd8eb3db3d", size = 685995, upload-time = "2026-07-22T12:43:50.993Z" },
+    { url = "https://files.pythonhosted.org/packages/24/c9/b49c31c9a972eee91e260445770e922244a7efc542697f51a012ec046d0f/greenlet-3.5.4-cp315-cp315t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9f1467de1bb767f75db0aa34c195e3a496d8d1278c796e70c24ce205d3e99cde", size = 681293, upload-time = "2026-07-22T11:51:20.43Z" },
+    { url = "https://files.pythonhosted.org/packages/de/90/c023ec337f32ff505be7db759c80d98f0532bb94d0c6fa13645efe9bee2e/greenlet-3.5.4-cp315-cp315t-manylinux_2_39_riscv64.whl", hash = "sha256:adf2244d7f69409925a8f22ed22cc5f93cdfe5c9dc87ff3476be2c2aaae61a05", size = 516928, upload-time = "2026-07-22T12:39:58.359Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6f/7f2d4653770500eee667866016d42d7a68e3d3462f80df6b8e3fcd48a0eb/greenlet-3.5.4-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:0fa53040b78b578120eecdc0265e3f1051487cc425d11a2b7c761daadf4feaa8", size = 1642474, upload-time = "2026-07-22T12:25:10.819Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/d8/8cba31036a4caae448087ba5d150660ab03b4a0f54d9150f6495a3be7262/greenlet-3.5.4-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:60e0bc961d367df506660e9ac0177a76bc6d81305300704b0977d1634f76efe2", size = 1701012, upload-time = "2026-07-22T11:51:23.17Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cd/3f77a4cce3bae631b08eb52f53a82a976669600337e21dfdba811cb50267/greenlet-3.5.4-cp315-cp315t-win_amd64.whl", hash = "sha256:f680e549edb3eaf21eea4e7fe101e15ec180c74b7879ab46adc080f22d4015d2", size = 251977, upload-time = "2026-07-22T11:41:38.125Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e8/65e8707d00fe2a49bf12f609a9b2b39ba6dd23c2810eacad877c4fc94bfe/greenlet-3.5.4-cp315-cp315t-win_arm64.whl", hash = "sha256:08fc36de8442d5c3e95b044550dbea9bf144d31ec0cc58e36fb241cb6ef6a994", size = 250538, upload-time = "2026-07-22T11:40:17.985Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.18"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -260,12 +406,43 @@ wheels = [
 ]
 
 [[package]]
+name = "playwright"
+version = "1.62.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet" },
+    { name = "pyee" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/5b/ca2abcf3aa69f9fb510215e3064f30b57fe57657c8d04ede45bb966d5606/playwright-1.62.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:d8da938f3748841a8754f2e1f0216902c1c8f8ae3720de8b32ccf8e6913a7c4f", size = 43732091, upload-time = "2026-07-31T17:00:44.178Z" },
+    { url = "https://files.pythonhosted.org/packages/af/1a/0bfbe9904350961f4dbb713f04342e40d548c5fc26c8157bd13617c81492/playwright-1.62.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:db755ab27db21a04186f1fe8169888e42356086e439b1059b923ef417f0b6034", size = 42510842, upload-time = "2026-07-31T17:00:48.596Z" },
+    { url = "https://files.pythonhosted.org/packages/66/dc/c0486b407ad0699a250f6bbe3066fca95344009a99ca66e88ca175c69dc1/playwright-1.62.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:5108bd5b3e87169ddf269feee097da5893af7f8aea4634dfc840518d64c1f1da", size = 43732093, upload-time = "2026-07-31T17:00:52.218Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6b/b24aebc2b04bffcb342bccf96e287c78b363e1615bed5cea97500cc0393a/playwright-1.62.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:ba33bae6a13b3d9d354c751cb618af357d20fe1d57767cbcce52079bbef17ad3", size = 47748926, upload-time = "2026-07-31T17:00:56.438Z" },
+    { url = "https://files.pythonhosted.org/packages/36/43/b4b18bdc87e1949568fffdcde3ff9a0456266b2d0c6d4432cc34d89ea6eb/playwright-1.62.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:db2d76613a57ad844362ce42f7d0c2fa26b19a4f7a46d4f76b891c631e6e5aff", size = 47441423, upload-time = "2026-07-31T17:01:00.404Z" },
+    { url = "https://files.pythonhosted.org/packages/81/22/af5d926fc2c32a339eec00a443644bc40ab9db1dd2dd9017873c59773c0c/playwright-1.62.0-py3-none-win32.whl", hash = "sha256:e5614fa89355d7081457680324bb219f79f69c423c5cb6fa250e30b0d8aebf1c", size = 38164450, upload-time = "2026-07-31T17:01:04.187Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/a9/4160c1033c07af98bf841ad079457dd78408a5ee0dd56cbfe50b8b6a1c22/playwright-1.62.0-py3-none-win_amd64.whl", hash = "sha256:92c0d98ed04eb35af557b709875edba415b1f548bdb22ddb5bb3e1e6c835c2f1", size = 38164458, upload-time = "2026-07-31T17:01:08.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ec/06b55d619a7082a766aa04f2c6bb31435c87f02930087d8a0517119408fa/playwright-1.62.0-py3-none-win_arm64.whl", hash = "sha256:ea8d3055aa9d5a9f1832ac82517bd8b42c78fac7ebcbebb0107116735c8cb6a1", size = 34208868, upload-time = "2026-07-31T17:01:11.818Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
 ]
 
 [[package]]
@@ -291,6 +468,61 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/1a/b64ac368de6b993135cb70ca4e5d958a5c268094a3a2a4cac6f0021b6c4f/pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45", size = 6702, upload-time = "2024-01-31T22:43:00.81Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/1c/b00940ab9eb8ede7897443b771987f2f4a76f06be02f1b3f01eb7567e24a/pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6", size = 5302, upload-time = "2024-01-31T22:42:58.897Z" },
+]
+
+[[package]]
+name = "pytest-playwright"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-base-url" },
+    { name = "python-slugify" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/ef/172eb8e23c80491fc72f1401c72f9305663873649351306a38b18406b0c9/pytest_playwright-0.8.0.tar.gz", hash = "sha256:7888d4a2443160c82e0c506c437076679f86b36d1910427250d90fbf1843a981", size = 17132, upload-time = "2026-05-18T10:16:15.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/71/1c545fac6a9054b52b3771238fb2dc6e8f1d0ccec116e1c7786ec191887c/pytest_playwright-0.8.0-py3-none-any.whl", hash = "sha256:856aae6efd4bc055f2ef229c647768760bcaad5cd3a5983c314ac260a974a933", size = 17143, upload-time = "2026-05-18T10:16:18.226Z" },
+]
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "text-unidecode" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/87/c7/5e1547c44e31da50a460df93af11a535ace568ef89d7a811069ead340c4a/python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856", size = 10921, upload-time = "2024-02-08T18:32:45.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/62/02da182e544a51a5c3ccf4b03ab79df279f9c60c5e82d5e8bec7ca26ac11/python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8", size = 10051, upload-time = "2024-02-08T18:32:43.911Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -383,6 +615,9 @@ dev = [
     { name = "ruff" },
     { name = "scipy" },
 ]
+integration = [
+    { name = "pytest-playwright" },
+]
 
 [package.metadata]
 
@@ -395,6 +630,16 @@ dev = [
     { name = "ruff", specifier = ">=0.9" },
     { name = "scipy", specifier = ">=1.14" },
 ]
+integration = [{ name = "pytest-playwright", specifier = ">=0.7" }]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ab/e2/e9a00f0ccb71718418230718b3d900e71a5d16e701a3dae079a21e9cd8f8/text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93", size = 76885, upload-time = "2019-08-30T21:36:45.405Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a5/c0b6468d3824fe3fde30dbb5e1f687b291608f9473681bbf7dabbf5a87d7/text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8", size = 78154, upload-time = "2019-08-30T21:37:03.543Z" },
+]
 
 [[package]]
 name = "typing-extensions"
@@ -403,4 +648,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]


### PR DESCRIPTION
Adds a defensive test that verifies every empty-state, error, and guidance message is present in the plugin source. Covers:\n\n- Empty/not-ready states (no tags, no feedback, no recommendations, no backups, no profiles, no matches)\n- Guidance prompts (select performer, prepare expand, sync and build, rebuild model)\n- Warnings (truncated results, profiling disabled, initial sync failed)\n- External card states (matching tags, whisper configuration)\n\nThis catches accidental removal or rewording of user-facing messages.