### PR TITLE
docs: clarify product behavior and onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,18 @@
 <p align="center"><strong>Navigate your library, guided by your taste.</strong></p>
 
 Stash Curator is a local-first recommendation and discovery plugin for
-[Stash](https://github.com/stashapp/stash). It learns from viewing history and direct
-feedback, explains why an item appears, and keeps the model in a sidecar SQLite
-database you control.
+[Stash](https://github.com/stashapp/stash). It uses library metadata, viewing history,
+and direct feedback to recommend scenes from your library, explains why an item
+appears, and keeps the preference model in a separate SQLite database you control.
 
 ![Stash Curator's For You lane showing varied recommendations](docs/assets/showcase-recommendations.png)
 
 ## Install
 
 Preview requirements: **Stash v0.31** and **Python 3.12+** available to Stash's
-plugin runtime (no third-party packages required; an optional numpy acceleration
-is installed by one Stash task). Add this source under
+plugin runtime. Local recommendations do not require StashDB. No third-party
+packages are required; optional NumPy acceleration is installed by one Stash task.
+Add this source under
 **Settings → Plugins → Available Plugins**:
 
 ```text
@@ -23,19 +24,20 @@ https://mrx-31415.github.io/stash-curator/index.yml
 ```
 
 Install **Stash Curator**, reload plugins, open the compass in Stash's navigation,
-then select **Sync library** once. See [Getting started](docs/getting-started.md) for
-configuration, updates, and backups.
+then run **Sync library** once to build the first model. See [Getting started](docs/getting-started.md)
+for first-build expectations, configuration, updates, and backups.
 
 ## What it does
 
-- **Recommendations:** For You balances dependable matches, timely revisits, and a
-  little discovery; four dedicated lanes let you choose the mood.
-- **Explanations:** “Why this?” shows the evidence, confidence, and timing behind a
-  recommendation.
-- **Similar:** find related scenes and performers using content and learned preference.
-- **Expand:** optionally discover external StashDB candidates scored against your
-  local model.
-- **Prune:** review poor matches and apply a reversible tag; Curator never deletes media.
+- **Recommendations:** For You balances dependable matches, revisits, and discovery;
+  Best Bets, Revisit, Discover, and Adventure let you choose the kind of slate.
+- **Explanations:** “Why this?” shows why an item fits, how strong the evidence is,
+  and whether timing changed its place.
+- **Similar:** find related scenes and performers in your library or compare separate
+  external StashDB candidates.
+- **Expand:** optionally browse StashDB metadata, scored against your local model.
+- **Prune:** review poor matches and add or remove a reversible tag; Curator never
+  deletes media.
 
 Curator separates long-term **Appeal** from **Current Fit**, then builds varied lanes
 instead of sorting everything by one opaque score. Read [how recommendations work](docs/recommendations.md)
@@ -46,14 +48,14 @@ or browse the complete [documentation site](https://mrx-31415.github.io/stash-cu
 Preference history, learned weights, and explanations stay local. StashDB discovery
 is opt-in and sends bounded read-only metadata queries, never your preference model.
 The only intentional Stash mutation is an explicit Prune action that adds or removes
-the configured tag. Back up the sidecar before uninstalling; see [Privacy](docs/privacy.md).
+the configured tag. Whisparr receives only an item you explicitly send. See [Privacy](docs/privacy.md).
 
 ## Status
 
-Stash Curator is **Preview / pre-1.0**. Core recommendation, Similar, Expand, Prune,
-backup, and packaging flows are implemented; installed-system compatibility and
-performance testing continue. The runtime is dependency-free. Development uses
-[uv](https://docs.astral.sh/uv/); see [Contributing](docs/contributing.md).
+Stash Curator is **Preview / pre-1.0**. The first sync/model build can take several
+minutes on a large library. StashDB discovery is optional, and Curator has no built-in
+background scheduler. The runtime is dependency-free; NumPy is optional. Development
+uses [uv](https://docs.astral.sh/uv/); see [Contributing](docs/contributing.md).
 
 ## Project provenance
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,6 +8,9 @@ permalink: /getting-started/
 Stash Curator is preview software for **Stash v0.31**. Stash must be able to run
 **Python 3.12 or newer** for external raw plugins.
 
+Curator can build local recommendations from your library metadata. StashDB is not
+required; viewing history and feedback make the model more personal over time.
+
 ## Install
 
 In Stash, open **Settings → Plugins → Available Plugins**, add this source, and refresh:
@@ -29,6 +32,21 @@ orders. Progress and errors appear in Curator and on Stash's Tasks page.
 A full reconciliation is available as **Full sync and build recommendations** on the
 Tasks page. Use it when source records were deleted or an incremental sync appears
 out of date; it is not required for routine refreshes.
+
+The first sync and model build may take several minutes on a large library and can
+use significant CPU, memory, and disk space. Leave the Stash task running until
+Curator reports that the model is ready. Progress and the full task log are available
+from the Curator status indicator and Stash's Tasks page.
+
+## Choose the right refresh
+
+| Action | Use it when | Contacts Stash? |
+| --- | --- | --- |
+| **Sync library** | Stash metadata or viewing history changed | Yes, then rebuilds if needed |
+| **Full sync and build recommendations** | Records were deleted or incremental sync is stale | Yes, reads the complete library |
+| **Rebuild recommendation model** | You changed Curator settings or want to rebuild synced data | No |
+| **Apply recent Curator feedback** | You want to publish queued playback or feedback sooner | No |
+| **Refresh Expand cache** | You want new StashDB candidates | Stash and StashDB |
 
 ## Optional acceleration
 
@@ -64,13 +82,18 @@ Curator's settings live with Stash's plugin settings. Useful early choices are:
 StashDB discovery requires a configured StashDB stash-box in Stash. It is optional;
 local recommendations do not depend on it.
 
+Whisparr is also optional. Configure its URL and API key only if you want the
+explicit **Send to Whisparr** action on external scene cards. Curator sends an item
+only after you select that action; it does not send candidates automatically.
+
 ## Refresh and update
 
 Use **Sync library** after Stash metadata or history changes. It fetches only changed
 records and refreshes recommendations when needed. Use **Rebuild model** to force a
 refresh from Curator's already-synced data; it does not contact Stash. Playback and
-Curator feedback already request a smaller preference rebuild, so neither command is
-normally needed for them.
+Curator feedback request a smaller preference rebuild automatically. Those updates
+are batched, so a recommendation may not change immediately after one action. Use
+**Apply recent Curator feedback** when you want to publish pending changes now.
 
 Stash does not give plugins a reliable background scheduler or startup hook, so
 unattended syncs must call **Sync and build recommendations** through Stash's task API
@@ -84,6 +107,10 @@ database migrations to finish, then load Curator and confirm the model is ready.
 Run **Backup Curator data** from Stash's Tasks page. The timestamped SQLite backup is
 written beside the sidecar. Keep a copy outside the plugin directory before an
 update or uninstall if that directory may be replaced.
+
+The Curator **Backups** view can also create, restore, and delete recognized backups.
+Restoring first creates a safety copy of the current sidecar, then invalidates the
+current recommendation model. Run **Rebuild recommendation model** after restoring.
 
 Removing Curator does not alter Stash-owned scenes, performers, studios, tags, or
 history. A Prune tag already applied to scenes remains ordinary Stash metadata and

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,14 +1,14 @@
 ---
 title: Local-first recommendations for Stash
-description: Explainable recommendations, discovery, and reversible library review for Stash.
+description: A local Stash plugin for personalized recommendations, discovery, and reversible library review.
 wide: true
 ---
 
 <section class="hero">
   <div>
-    <p class="eyebrow">Preview · local-first · explainable</p>
-    <h1>Find the right scene without giving up control.</h1>
-    <p class="lede">Stash Curator learns from your library history and feedback, builds varied recommendation lanes, and shows the evidence behind every choice. Your preference model stays on your machine.</p>
+    <p class="eyebrow">Preview · Stash plugin · local-first</p>
+    <h1>Personalized recommendations for your Stash library.</h1>
+    <p class="lede">Curator uses your library metadata, viewing history, and feedback to recommend scenes from your library. Each recommendation includes a reason. Similar, optional StashDB discovery, and reversible Prune review help you explore without giving up control.</p>
     <div class="actions"><a class="button" href="#install">Install the preview</a><a class="button secondary" href="{{ '/recommendations/' | relative_url }}">How it recommends</a></div>
   </div>
   <img class="hero-mark" src="{{ '/assets/stash-curator.svg' | relative_url }}" alt="Blue-violet Stash Curator compass">
@@ -17,15 +17,15 @@ wide: true
 <section class="install" id="install">
   <p class="eyebrow">Install</p>
   <h2>One plugin source</h2>
-  <p>Requires Stash v0.31 and Python 3.12+ in Stash's plugin runtime. Add this URL under <strong>Settings → Plugins → Available Plugins</strong>:</p>
+  <p>Requires Stash v0.31 and Python 3.12+ in Stash's plugin runtime. Local recommendations do not require StashDB. Add this URL under <strong>Settings → Plugins → Available Plugins</strong>:</p>
   <pre><code>https://mrx-31415.github.io/stash-curator/index.yml</code></pre>
-  <p>Install <strong>Stash Curator</strong>, reload plugins, open the compass, and select <strong>Sync library</strong> once. <a href="{{ '/getting-started/' | relative_url }}">Read the setup guide →</a></p>
+  <p>Install <strong>Stash Curator</strong>, reload plugins, open the compass, and run <strong>Sync library</strong> once to build the first model. <a href="{{ '/getting-started/' | relative_url }}">Read the setup guide →</a></p>
 </section>
 
 ## A recommendation you can inspect
 
 <section class="showcase">
-  <div class="showcase-copy"><span class="pill">For You</span><h3>Reasons, not mystery scores</h3><p>Every card can open “Why this?” to show Appeal, Current Fit, confidence, supporting evidence, and any timing adjustment.</p></div>
+  <div class="showcase-copy"><span class="pill">For You</span><h3>Reasons, not mystery scores</h3><p>Open “Why this?” to see why a scene fits your taste, how well-supported the estimate is, and whether timing or recent repetition changed its place.</p></div>
   <div class="recommendation-captures">
     <div class="capture"><img src="{{ '/assets/showcase-recommendations.png' | relative_url }}" alt="Curator For You lane showing varied recommendations and source-lane icons" width="1909" height="730" loading="lazy" decoding="async"></div>
     <div class="capture capture-detail"><img src="{{ '/assets/showcase-explanation.png' | relative_url }}" alt="Why this panel with a plain-language reason and readable model evidence" width="455" height="686" loading="lazy" decoding="async"></div>
@@ -33,35 +33,42 @@ wide: true
 </section>
 
 <section class="showcase">
-  <div class="showcase-copy"><span class="pill">Discover + Expand</span><h3>Explore locally—or look beyond it</h3><p>Discover tests one explainable edge of your learned taste. Optional Expand searches StashDB metadata without uploading preference history.</p></div>
+  <div class="showcase-copy"><span class="pill">Discover + Expand</span><h3>Explore locally—or look beyond it</h3><p>Discover stays inside your library while testing one explained boundary of your taste. Optional Expand browses StashDB metadata and scores candidates locally; external results are leads, not proof that a scene is available to you.</p></div>
   <div class="capture-pair"><div class="capture"><img src="{{ '/assets/showcase-discover.png' | relative_url }}" alt="Local Discover lane explaining that it gently challenges one learned boundary" width="1919" height="722" loading="lazy" decoding="async"></div><div class="capture"><img src="{{ '/assets/showcase-expand.png' | relative_url }}" alt="External Expand view with locally scored StashDB candidates and a Wildcard result" width="1907" height="934" loading="lazy" decoding="async"></div></div>
 </section>
 
 <section class="showcase">
-  <div class="showcase-copy"><span class="pill">Similar</span><h3>Similarity informed by preference</h3><p>Find related scenes or performers through shared content and missing-aware profiles, with local and StashDB results kept distinct.</p></div>
+  <div class="showcase-copy"><span class="pill">Similar</span><h3>Find related scenes and performers</h3><p>Compare preference-aware matches from your library or separate StashDB results. Missing metadata is treated as unknown, not as a dislike.</p></div>
   <div class="capture"><img src="{{ '/assets/showcase-similar.png' | relative_url }}" alt="Similar view comparing a reference scene with preference-aware local matches" width="1919" height="944" loading="lazy" decoding="async"></div>
 </section>
 
 <section class="showcase">
-  <div class="showcase-copy"><span class="pill">Prune</span><h3>Review, tag, reverse</h3><p>Curator can surface explicit dislikes and uncertain candidates for review. It never deletes media; applying or removing the configured tag is deliberate and reversible.</p></div>
+  <div class="showcase-copy"><span class="pill">Prune</span><h3>Review, tag, reverse</h3><p>Review explicit dislikes, suspected poor fits, and exploration candidates. Prune only adds or removes a configurable Stash tag; it never deletes media.</p></div>
   <div class="capture"><img src="{{ '/assets/showcase-prune.png' | relative_url }}" alt="Prune review queue with reversible tag actions and no delete control" width="1919" height="944" loading="lazy" decoding="async"></div>
 </section>
 
 ## Local by design
 
 <div class="grid">
-  <article class="card"><h3>Your model stays yours</h3><p>History, feedback, features, scores, and explanations live in a plugin-owned SQLite sidecar.</p></article>
-  <article class="card"><h3>Remote discovery is optional</h3><p>StashDB access uses bounded read-only metadata queries. It does not receive your learned preferences.</p></article>
-  <article class="card"><h3>Library changes stay reversible</h3><p>Prune only adds or removes a configurable tag. Curator never deletes scenes or other media.</p></article>
+  <article class="card"><h3>Private by default</h3><p>Your history, feedback, and preference model stay in a separate plugin-owned SQLite database.</p></article>
+  <article class="card"><h3>Remote discovery is optional</h3><p>StashDB receives only bounded, read-only metadata queries. Your learned preferences are scored locally.</p></article>
+  <article class="card"><h3>No delete action</h3><p>Prune changes only the configured tag, and you can remove that tag from Curator or Stash.</p></article>
 </div>
+
+## What Curator does not do
+
+- It does not delete scenes or other media.
+- It does not upload your viewing history, feedback, or preference model to StashDB.
+- It does not require StashDB for local recommendations.
+- It does not synchronize automatically in the background; use the Stash task or a host scheduler.
 
 ## Preview status
 
-Curator targets **Stash v0.31** and **Python 3.12+**. Recommendation lanes, feedback,
-Similar, Expand, Prune, backup, and packaging are implemented. It remains pre-1.0
-while installed-system compatibility, accessibility, and performance validation
-continue. Start with [Using Curator]({{ '/using-curator/' | relative_url }}) or inspect
-the [architecture]({{ '/architecture/' | relative_url }}).
+Curator targets **Stash v0.31** and **Python 3.12+**. It remains preview software and
+pre-1.0. The first sync/model build can take several minutes on a large library;
+NumPy acceleration is optional. External discovery needs a configured StashDB
+connection, and Curator has no built-in background scheduler. Start with [Getting
+started]({{ '/getting-started/' | relative_url }}), then read [Using Curator]({{ '/using-curator/' | relative_url }}).
 
 ## Acknowledgements and project provenance
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -5,10 +5,11 @@ permalink: /privacy/
 
 # Privacy and data safety
 
-Curator is local-first: its sidecar SQLite database stores synchronized Stash facts,
-normalized viewing and feedback events, feature/model versions, impressions,
-shortlists, and explanation evidence. The browser temporarily keeps an idempotent
-feedback/playback queue so navigation or a short failure does not lose an action.
+Curator is local-first. A separate plugin-owned SQLite database stores the Stash
+metadata needed for recommendations, viewing and feedback events, tag preferences,
+recommendation history, shortlists, model versions, and explanation evidence. The
+browser temporarily keeps an idempotent feedback/playback queue so navigation or a
+short failure does not lose an action.
 
 ## Stash and StashDB boundaries
 
@@ -20,7 +21,7 @@ StashDB discovery is opt-in. Curator sends bounded, read-only metadata searches 
 public tags, performers, and scenes. Scoring happens locally. Viewing history,
 feedback, learned weights, local URLs, and the preference model are not uploaded to
 StashDB. Whisparr is a separate optional integration and receives only an item you
-explicitly send.
+explicitly send with **Send to Whisparr**; it is never sent automatically.
 
 ## Retention and diagnostics
 
@@ -40,6 +41,10 @@ The default sidecar is `{pluginDir}/data/curator.sqlite3`. Configure another pat
 before first use if plugin lifecycle operations may replace that directory. The
 **Backup Curator data** task creates a timestamped SQLite backup. Copy it somewhere
 safe before updates or uninstalling.
+
+The Curator **Backups** view can restore a recognized backup. It first creates a
+safety copy of the current sidecar, then invalidates the current recommendation
+model; run **Rebuild recommendation model** after restoring.
 
 Removing Curator leaves Stash-owned entities and history intact. Applied Prune tags
 remain in Stash until you remove them. Deleting the sidecar discards Curator's learned

--- a/docs/recommendations.md
+++ b/docs/recommendations.md
@@ -5,26 +5,28 @@ permalink: /recommendations/
 
 # How recommendations work
 
-Curator uses a deterministic, inspectable pipeline. It treats missing metadata as
-unknown rather than negative and never assumes an unplayed scene is disliked.
+Curator uses a deterministic, inspectable pipeline. You do not need to understand
+the scoring to use it, but every score and explanation can be inspected. Missing
+metadata is treated as unknown rather than negative, and an unplayed scene is never
+assumed to be disliked.
 
-## The three numbers that matter
+## Understand the scores
 
-**Appeal** estimates how satisfying an item is likely to be in general. It combines
-bounded evidence from content, performers, studios, similar scenes, and direct item
-history. Strong direct outcomes can override weaker inferences.
+**Appeal** is the long-term estimate of how satisfying an item is likely to be. It
+combines bounded evidence from content, performers, studios, similar scenes, and
+direct item history. Strong direct outcomes can override weaker inferences.
 
-**Current Fit** starts from Appeal and adjusts for timing: exact-scene cooldown,
-recent performer or content repetition, and **Not now** feedback. Time changes
-whether something fits today; it does not erase learned taste.
+**Current Fit** is how suitable the item is right now. It starts from Appeal and
+adjusts for exact-scene cooldown, recent performer or content repetition, and **Not
+now** feedback. Time changes today's fit; it does not erase learned taste.
 
-**Confidence** describes how much independent, relevant evidence supports the
-estimate. It is not another preference score. A high estimate with thin evidence
-belongs in a different lane than a high estimate backed by varied outcomes.
+**Confidence** is the strength and variety of the evidence behind the estimate. It is
+not another preference score. A high estimate with thin evidence belongs in a
+different lane than a high estimate backed by varied outcomes.
 
 ## Lane policy
 
-- **Best Bets** requires strong fit and enough corroborating evidence, and excludes
+- **Best Bets** requires strong fit and enough independent supporting evidence, and excludes
   anything with recorded viewing history.
 - **Revisit** requires a prior strong positive and enough cooldown recovery.
 - **Discover** keeps a familiar anchor while testing one named uncertainty or mild
@@ -39,15 +41,15 @@ checked before lane scoring.
 
 ## Variety is presentation, not taste
 
-After candidates qualify, Curator builds the page one card at a time. Shared
-performers are avoided in adjacent cards; repeated studios and very similar content
-receive soft penalties. These choices alter the slate, not Appeal. A page can
-therefore be varied without pretending your preferences changed.
+After candidates qualify, Curator builds the page one card at a time. It avoids
+adjacent performer repeats and softly varies studios and very similar content. These
+choices alter the slate, not Appeal. A page can therefore be varied without changing
+your learned preferences.
 
 ## Why the explanation is trustworthy
 
 Every explanation is planned from reason codes derived from published model evidence.
 Curator derives it when you expand **Why this?**, keeping the recommendation page
-fast. Deterministic prose combines the strongest facts, while the expanded score tree
-exposes the underlying contributions, confidence, timing changes, exploration reason,
-and final lane choice. The wording may vary; the evidence cannot invent new facts.
+fast. The plain-language summary names the strongest facts; the score tree exposes
+the contributions, confidence, timing changes, exploration reason, and final lane.
+The wording may vary, but it cannot invent evidence that is not in the model.

--- a/docs/using-curator.md
+++ b/docs/using-curator.md
@@ -9,11 +9,11 @@ permalink: /using-curator/
 
 | Lane | Best used for |
 | --- | --- |
-| **For You** | A varied everyday slate drawn from the other recommendation policies |
-| **Best Bets** | Reliable unseen matches with enough supporting evidence |
-| **Revisit** | Previously enjoyed scenes whose cooldown has recovered |
-| **Discover** | Familiar appeal plus one explained unknown or stretch |
-| **Adventure** | Deliberate model-gap probes where more misses are expected |
+| **For You** | A varied everyday mix of dependable matches, revisits, and a little discovery |
+| **Best Bets** | Strong unseen matches with enough independent supporting evidence |
+| **Revisit** | Scenes you previously enjoyed, shown again after enough time away |
+| **Discover** | Mostly familiar recommendations plus one explained test of your taste |
+| **Adventure** | Deliberate probes into uncertain or under-covered parts of the model |
 
 Cards are arranged as a slate. Curator avoids adjacent performer repetition and
 softly varies studios and content, so the page is not merely the top 20 scores.
@@ -31,8 +31,9 @@ The structured evidence—not generated prose—is authoritative.
 
 Use thumbs up or down for direct feedback. The detail menu also supports **Not now**,
 **Never show**, **Review for pruning**, and **Metadata is wrong**. New feedback is
-queued durably in the browser during transient failures and applied in a small model
-update. A later explicit action can reverse earlier feedback.
+queued durably in the browser during transient failures and applied in a batched
+model update. A later explicit action can reverse earlier feedback; one action may
+not change the next recommendation immediately.
 
 Open **Taste Profile** to review tag beliefs and answer with a fixed sentiment
 from strong dislike to strong like. A direct answer is strong evidence rather than a
@@ -54,6 +55,12 @@ Open Similar from Curator or the compass action on a Stash scene or performer.
 Library results use content overlap and preference-aware performer profiles. Switch
 to StashDB only when you want external candidates; local and remote results remain
 separate and the reference entity stays visible.
+
+| Source | What you get | Requirement |
+| --- | --- | --- |
+| **Library** | Related scenes or performers already in Stash | A synced Curator model |
+| **StashDB** | External metadata candidates, ranked with local preferences | A configured StashDB stash-box |
+
 Local matches use the configured page size. StashDB Similar keeps up to 100 matches
 from one remote search and pages that stable result locally.
 
@@ -62,8 +69,9 @@ from one remote search and pages that stable result locally.
 Expand is optional StashDB discovery. Refresh its cache from Curator or with the
 **Refresh Expand cache** task, then browse scenes and performers, save filters, or
 shortlist candidates. External results are metadata leads, not proof that a scene is
-available locally. Filters and ordering are applied before paging. Optional Whisparr
-actions require separate settings.
+available locally. Filters and ordering are applied before paging. If Whisparr is
+configured, **Send to Whisparr** appears on external scene cards; it sends only the
+scene you explicitly select.
 Use the tag action on an external scene to rate its tags that map exactly to local
 tags; this does not create scene-level feedback for media outside the library.
 
@@ -84,12 +92,14 @@ identity.
 ## Prune
 
 Prune groups explicit dislikes, suspected poor fits, and candidates surfaced during
-exploration. Review each item before applying the configured tag. Curator never
-deletes media, and the tag can be removed from the same view or in Stash.
+exploration. Review each item before applying the configured tag. Applying or removing
+the tag changes Stash metadata only; it does not delete a file or rewrite your feedback.
+Curator never deletes media, and the tag can be removed from the same view or in Stash.
 
 ## Routine maintenance
 
 - Sync after meaningful library or metadata changes.
+- Run the first sync/build before expecting recommendation lanes to contain results.
 - Back up before plugin updates and before uninstalling.
 - Treat Adventure and external results as exploration, not guaranteed matches.
 - If Curator feels stale, check task status and run the normal sync before a full one.


### PR DESCRIPTION
## Summary

- make the landing page and README explicit about what Curator recommends, what is optional, and what it never does
- document first-build cost, refresh task choices, batched feedback, and background-sync limitations
- clarify local versus StashDB discovery, Whisparr behavior, and Prune semantics
- document backup restoration and simplify the recommendation score explanations

## Verification

- scripts/verify changed
- local documentation link and asset checks
- pre-push verification: 295 passed, 10 deselected
