### PR TITLE
feat: sync recent plays automatically after playback

### DIFF
--- a/curator/sync/service.py
+++ b/curator/sync/service.py
@@ -105,14 +105,28 @@ class SyncService:
         self.id_factory = id_factory or (lambda: str(uuid.uuid4()))
         self.progress = progress
 
-    def sync(self, *, full: bool = False) -> SyncResult:
-        mode = "full" if full else "incremental"
+    def sync(self, *, full: bool = False, plays_only: bool = False) -> SyncResult:
+        if full and plays_only:
+            raise ValueError("full and plays_only are mutually exclusive")
+        if plays_only:
+            # The play pass is a cheap, targeted follow-up after playback: plays never bump
+            # scenes.updated_at, so the scene pass cannot observe them. It shares the
+            # incremental run ledger (the mode column only allows 'incremental' and 'full'),
+            # which is safe because the cursor machinery keys resumption by run_id and the
+            # backend never runs two sidecar jobs at once.
+            run_mode = "incremental"
+            mode = "plays"
+        else:
+            run_mode = "full" if full else "incremental"
+            mode = run_mode
         capabilities = probe_capabilities(self.client)
-        existing = self.repository.resumable_run(mode)
+        existing = self.repository.resumable_run(run_mode)
         resumed = existing is not None
         if existing is None:
             run_id = self.id_factory()
-            self.repository.start_run(run_id, mode, capabilities.server_version, self.clock_ms())
+            self.repository.start_run(
+                run_id, run_mode, capabilities.server_version, self.clock_ms()
+            )
         else:
             run_id = str(existing["run_id"])
             self.repository.resume_run(run_id)
@@ -128,6 +142,8 @@ class SyncService:
             for operation in ENTITY_OPERATIONS
             if not (full and operation.incremental_only)
         )
+        if plays_only:
+            operations = tuple(operation for operation in operations if operation.incremental_only)
         try:
             for position, operation in enumerate(operations):
                 current_entity = operation.entity_type
@@ -145,7 +161,9 @@ class SyncService:
             current_entity = None
             if full:
                 self.repository.reconcile(run_id)
-            else:
+            elif not plays_only:
+                # The play pass has no id sweep (its ids_document is None), so pruning would
+                # be a no-op; skip it explicitly so a later play-only pass can never grow one.
                 for operation in operations:
                     current_entity = operation.entity_type
                     deleted = self._prune_deleted(operation)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,7 +66,8 @@ indexes and return stable IDs; the browser fetches current display metadata from
 Stash.
 
 Feedback and playback increment a durable generation counter and trigger a smaller
-preference rebuild after a short debounce. They do not rerun library sync. Full
+preference rebuild after a short debounce. They do not rerun library sync; after playback a
+lightweight play-only sync keeps cooldown and recovery context current between full syncs. Full
 sync/build and Expand refresh remain one-shot tasks because Stash provides no plugin
 background scheduler/startup hook.
 

--- a/docs/using-curator.md
+++ b/docs/using-curator.md
@@ -100,6 +100,8 @@ Curator never deletes media, and the tag can be removed from the same view or in
 
 - Sync after meaningful library or metadata changes.
 - Run the first sync/build before expecting recommendation lanes to contain results.
+- Plays recorded by Stash are imported automatically after Curator playback so cooldown and
+  recovery stay current; the **Sync recent plays** task can also be run manually.
 - Back up before plugin updates and before uninstalling.
 - Treat Adventure and external results as exploration, not guaranteed matches.
 - If Curator feels stale, check task status and run the normal sync before a full one.

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -568,6 +568,7 @@ def _health(payload: dict[str, Any]) -> dict[str, object]:
         "Rebuild recommendation model",
         "Apply recent Curator feedback",
         "Prepare recommendation pages",
+        "Sync recent plays",
         "Backup Curator data",
         "Compact legacy Curator data",
         "Vacuum compacted Curator data",
@@ -1027,6 +1028,7 @@ def _job_status(connection: Any) -> dict[str, object]:
 DIAGNOSTIC_JOB_TYPES = {
     "sync-build",
     "full-sync-build",
+    "sync-plays",
     "build",
     "update-model",
     "prepare",
@@ -1338,6 +1340,27 @@ def _run_task_body(
                     "lane_candidate_caches": lane_caches,
                     "stage_timings_ms": model.stage_timings_ms,
                 }
+        elif mode == "sync-plays":
+            _progress(0.05)
+            sidecar_config = CuratorAPI(connection).config()["config"]
+            assert isinstance(sidecar_config, dict)
+            _log("i", "Synchronizing recent plays")
+            with span("python", "task.sync_plays"):
+                synced = SyncService(
+                    _client(payload),
+                    SyncRepository(connection),
+                    page_size=int(sidecar_config["sync_page_size"]),
+                ).sync(plays_only=True)
+            _progress(0.95)
+            changed_plays = int(synced.changed_entity_counts.get("scene_play", 0))
+            if changed_plays:
+                _log("i", f"Imported {changed_plays} recently played scenes")
+            _progress(0.99)
+            summary = {
+                "sync_run_id": synced.run_id,
+                "changed_play_scenes": changed_plays,
+                "scene_ids": synced.scene_ids,
+            }
         elif mode == "prepare":
             _progress(0.05)
             prepared_model_id = RecommendationModelStore(connection).current_model_id()

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -134,6 +134,7 @@
   let cachedConfigUpdatedAtMs = restoredCache.configUpdatedAtMs;
   let cacheGeneration = 0;
   let modelUpdateTimer = null;
+  let playSyncTimer = null;
   const localActivities = new Map();
   const activityListeners = new Set();
 
@@ -393,6 +394,18 @@
         .catch(() => {}),
       delay
     );
+  }
+
+  // Stash records plays without bumping scenes.updated_at, so only the play pass can bring
+  // cooldown and recovery context up to date. It is cheap (a watermark query since the last
+  // sync) and runs as an async Stash job, so coalesce bursts before firing it.
+  function schedulePlaySync() {
+    clearTimeout(playSyncTimer);
+    playSyncTimer = setTimeout(() => {
+      runTask("Sync recent plays").catch(() => {
+        // Retry on the next play, route change, or online event.
+      });
+    }, 8000);
   }
 
   function idFilter(ids) {
@@ -2377,6 +2390,7 @@
       if (entries.some((entry) => entry.event_type !== "qualified_impression")) {
         clearSlateCache();
         scheduleModelUpdate();
+        schedulePlaySync();
       }
       const sent = new Set(entries.map(queueId));
       localStorage.setItem(EVENT_QUEUE_KEY, JSON.stringify(readQueue().filter((entry) => !sent.has(queueId(entry)))));

--- a/plugin/stash-curator.yml
+++ b/plugin/stash-curator.yml
@@ -107,6 +107,10 @@ tasks:
     description: Publish pending feedback and playback signals without blocking the Curator page.
     execArgs:
       - update-model
+  - name: Sync recent plays
+    description: Import plays Stash recorded since the last sync so cooldown and recovery reflect your latest viewing. Runs automatically after Curator playback.
+    execArgs:
+      - sync-plays
   - name: Prepare recommendation pages
     description: Warm the fast page cache for the current model without rebuilding it.
     execArgs:

--- a/scripts/verify
+++ b/scripts/verify
@@ -52,6 +52,13 @@ case "${1:-}" in
     plugin_dir="/tmp/stash-curator-integration/plugins/stash-curator"
     mkdir -p "$plugin_dir"
     unzip -oq dist/stash-curator.zip -d "$plugin_dir"
+    # The sidecar database is created inside the container (as root) in WAL mode. Host
+    # tests read it read-only, and a WAL read needs to create the -shm file, so the data
+    # directory must be owned/writable by the test user. Reset it every run so the
+    # integration environment starts from a clean sidecar instead of leftover state.
+    rm -rf "$plugin_dir/data"
+    mkdir -p "$plugin_dir/data"
+    chmod 777 "$plugin_dir/data"
     # copy config
     cp tests/integration/stash-config.yml /tmp/stash-curator-integration/config.yml
     # ── start stash ──

--- a/tests/integration/seed.py
+++ b/tests/integration/seed.py
@@ -59,6 +59,15 @@ query FindPerformer($name: String!) {
 }
 """
 
+QUERY_FIND_SCENE = """
+query FindScene($title: String!) {
+  findScenes(
+    scene_filter: {title: {value: $title, modifier: EQUALS}}
+    filter: {page: 1, per_page: 1}
+  ) { scenes { id } }
+}
+"""
+
 SEED_TAGS = [
     {"name": "Blowjob"},
     {"name": "Anal"},
@@ -135,33 +144,63 @@ def stash_request(
 
 
 def create_tags(stash_url: str) -> dict[str, str]:
-    """Create seed tags and return a {name: id} mapping."""
+    """Find-or-create seed tags and return a {name: id} mapping.
+
+    The integration harness reuses the Stash config directory between runs, so the
+    database outlives a container teardown; re-seeding must not collide.
+    """
     tag_ids: dict[str, str] = {}
     for tag_def in SEED_TAGS:
-        data = stash_request(stash_url, MUTATION_TAG_CREATE, {"input": tag_def})
-        tag_id = data["tagCreate"]["id"]
+        existing = stash_request(stash_url, QUERY_FIND_TAG, {"name": tag_def["name"]})["findTags"][
+            "tags"
+        ]
+        match = next((item for item in existing if str(item.get("name")) == tag_def["name"]), None)
+        if match is not None:
+            tag_id = str(match["id"])
+            print(f"  tag: {tag_def['name']} ({tag_id}) [exists]")
+        else:
+            data = stash_request(stash_url, MUTATION_TAG_CREATE, {"input": tag_def})
+            tag_id = data["tagCreate"]["id"]
+            print(f"  tag: {tag_def['name']} ({tag_id})")
         tag_ids[tag_def["name"]] = tag_id
-        print(f"  tag: {tag_def['name']} ({tag_id})")
     return tag_ids
 
 
 def create_performers(stash_url: str) -> dict[str, str]:
-    """Create seed performers and return a {name: id} mapping."""
+    """Find-or-create seed performers and return a {name: id} mapping."""
     performer_ids: dict[str, str] = {}
     for perf in SEED_PERFORMERS:
-        data = stash_request(stash_url, MUTATION_PERFORMER_CREATE, {"input": perf})
-        perf_id = data["performerCreate"]["id"]
+        existing = stash_request(stash_url, QUERY_FIND_PERFORMER, {"name": perf["name"]})[
+            "findPerformers"
+        ]["performers"]
+        match = next((item for item in existing if str(item.get("name")) == perf["name"]), None)
+        if match is not None:
+            perf_id = str(match["id"])
+            print(f"  performer: {perf['name']} ({perf_id}) [exists]")
+        else:
+            data = stash_request(stash_url, MUTATION_PERFORMER_CREATE, {"input": perf})
+            perf_id = data["performerCreate"]["id"]
+            print(f"  performer: {perf['name']} ({perf_id})")
         performer_ids[perf["name"]] = perf_id
-        print(f"  performer: {perf['name']} ({perf_id})")
     return performer_ids
 
 
 def create_scenes(
     stash_url: str, tag_ids: dict[str, str], performer_ids: dict[str, str]
 ) -> list[str]:
-    """Create seed scenes with tag and performer links."""
+    """Find-or-create seed scenes with tag and performer links."""
     scene_ids: list[str] = []
     for scene in SEED_SCENES:
+        existing = stash_request(
+            stash_url,
+            QUERY_FIND_SCENE,
+            {"title": scene["title"]},
+        )["findScenes"]["scenes"]
+        if existing:
+            scene_id = str(existing[0]["id"])
+            scene_ids.append(scene_id)
+            print(f"  scene: {scene['title']} ({scene_id}) [exists]")
+            continue
         tag_list = [tag_ids[n] for n in scene["tag_names"]]
         perf_list = [performer_ids[n] for n in scene["performer_names"]]
         data = stash_request(

--- a/tests/integration/test_plays.py
+++ b/tests/integration/test_plays.py
@@ -1,0 +1,186 @@
+"""End-to-end tests for the Sync recent plays task and its browser trigger.
+
+These exercise the real plugin against live Stash and the sidecar database:
+
+- test_sync_recent_plays_task_imports_a_stash_recorded_play: the task imports a
+  play Stash recorded (via sceneAddPlay) into source_play and advances the play
+  watermark, without running any other sync pass.
+- test_playing_a_scene_schedules_the_automatic_play_sync: visiting a scene page
+  finishes a tracker session, and the resident plugin then fires the Sync recent
+  plays task on its own.
+
+Each test is self-sufficient: it records a play through Stash's own play API and
+runs the play sync, so the scene exists in the sidecar without depending on the
+seed-time sync/build having completed. The tests never trigger a model build, so
+they do not disturb the no-model state the smoke suite expects. The sidecar lives
+in the bind-mounted plugin directory, so the host can read it.
+
+Start with: scripts/verify integration
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from curator.storage import connect_database
+from tests.integration.conftest import _gql
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+pytestmark = pytest.mark.integration
+
+CURATOR_TASK = "Sync recent plays"
+
+
+def _stash_url() -> str:
+    return os.environ.get("STASH_URL", "http://localhost:9999").rstrip("/")
+
+
+def _sidecar_path() -> Path:
+    config = os.environ.get("STASH_CONFIG", "/tmp/stash-curator-integration")
+    return Path(config) / "plugins" / "stash-curator" / "data" / "curator.sqlite3"
+
+
+def _plugin_operation(operation: str, **args: object) -> dict[str, Any]:
+    # runPluginOperation is a mutation, matching the plugin frontend's own usage.
+    return _gql(
+        _stash_url(),
+        'mutation Op($args: Map!) { runPluginOperation(plugin_id: "stash-curator", args: $args) }',
+        {"args": {"operation": operation, **args}},
+    )["runPluginOperation"]
+
+
+def _run_task(name: str) -> str:
+    return str(
+        _gql(
+            _stash_url(),
+            (
+                "mutation Task($task: String!, $args: Map!) { "
+                'runPluginTask(plugin_id: "stash-curator", task_name: $task, args_map: $args) }'
+            ),
+            {"task": name, "args": {}},
+        )["runPluginTask"]
+    )
+
+
+def _first_scene_id() -> str:
+    data = _gql(
+        _stash_url(),
+        "query Scenes { findScenes(filter: {page: 1, per_page: 1}) { scenes { id } } }",
+    )
+    return str(data["findScenes"]["scenes"][0]["id"])
+
+
+def _wait_curator_idle(timeout: float = 180) -> None:
+    """Wait until no Curator job is running (e.g. a seed-time sync/build)."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        jobs = _plugin_operation("get_job_status")["jobs"]
+        if not any(job["state"] == "running" for job in jobs):
+            return
+        time.sleep(2)
+    raise RuntimeError("Curator jobs did not finish within the timeout")
+
+
+def _wait_sync_plays_job(after_ms: int, timeout: float = 60) -> dict[str, Any]:
+    """Wait for a completed sync-plays job started after the given time."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        for job in _plugin_operation("get_job_status")["jobs"]:
+            if (
+                job["job_type"] == "sync-plays"
+                and int(job["started_at_ms"]) >= after_ms
+                and job["state"] == "complete"
+            ):
+                return job
+        time.sleep(2)
+    raise AssertionError("Sync recent plays job did not complete")
+
+
+def _import_play(scene_id: str) -> dict[str, Any]:
+    """Record a play in Stash and import it through the play sync.
+
+    Also populates the scene in source_scene (the play pass upserts full scene
+    data), which play_session rows need to satisfy their foreign key.
+    """
+    played_at = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+    _gql(
+        _stash_url(),
+        (
+            "mutation Play($id: ID!, $times: [Timestamp!]) { "
+            "sceneAddPlay(id: $id, times: $times) { count } }"
+        ),
+        {"id": scene_id, "times": [played_at]},
+    )
+    started_ms = time.time_ns() // 1_000_000
+    _run_task(CURATOR_TASK)
+    job = _wait_sync_plays_job(started_ms)
+    assert int(job["summary"]["changed_play_scenes"]) >= 1
+    return job
+
+
+def _open_sidecar() -> Any:
+    return connect_database(_sidecar_path(), readonly=True, attach_artifacts=False)
+
+
+def test_sync_recent_plays_task_imports_a_stash_recorded_play() -> None:
+    """The task imports a Stash-recorded play into source_play and advances the watermark."""
+    _wait_curator_idle()
+    scene_id = _first_scene_id()
+    _import_play(scene_id)
+
+    connection = _open_sidecar()
+    try:
+        rows = connection.execute(
+            "SELECT played_at_ms FROM source_play WHERE scene_id=?", (scene_id,)
+        ).fetchall()
+        assert rows, "the recorded play was not imported into source_play"
+        latest = max(int(row[0]) for row in rows)
+        assert abs(time.time_ns() // 1_000_000 - latest) < 5 * 60_000
+        watermark = connection.execute(
+            "SELECT watermark FROM sync_cursor WHERE entity_type='scene_play'"
+        ).fetchone()
+        assert watermark and watermark[0], "the play pass did not advance its watermark"
+        # Plays-only runs never record a full-snapshot seen set.
+        assert connection.execute("SELECT count(*) FROM sync_seen").fetchone()[0] == 0
+    finally:
+        connection.close()
+
+
+def test_playing_a_scene_schedules_the_automatic_play_sync(page: Page, base_url: str) -> None:
+    """Visiting a scene page and leaving it triggers the play sync on its own."""
+    _wait_curator_idle()
+    scene_id = _first_scene_id()
+    _import_play(scene_id)
+    started_ms = time.time_ns() // 1_000_000
+
+    # The resident tracker attaches on the scene page and finishes on navigation away,
+    # which flushes the session and schedules the automatic play sync.
+    page.goto(f"{base_url}/scenes/{scene_id}", wait_until="domcontentloaded")
+    page.wait_for_timeout(1500)
+    page.goto(base_url + "/", wait_until="domcontentloaded")
+    page.wait_for_timeout(1500)
+
+    job = _wait_sync_plays_job(started_ms)
+    assert "changed_play_scenes" in job["summary"], "the completed job was not a plays-only sync"
+
+    connection = _open_sidecar()
+    try:
+        session = connection.execute(
+            """
+            SELECT session_id FROM play_session
+            WHERE scene_id=? AND provenance='direct_player' AND started_at_ms>=?
+            LIMIT 1
+            """,
+            (scene_id, started_ms),
+        ).fetchone()
+        assert session, "the tracker session was not ingested into play_session"
+    finally:
+        connection.close()

--- a/tests/integration/test_sync.py
+++ b/tests/integration/test_sync.py
@@ -324,6 +324,86 @@ def test_play_pass_resumes_from_its_own_watermark(connection: sqlite3.Connection
     )
 
 
+def test_plays_only_sync_imports_plays_and_nothing_else(
+    connection: sqlite3.Connection,
+) -> None:
+    client = SyntheticClient(_entities())
+    result = SyncService(client, SyncRepository(connection), page_size=10).sync(plays_only=True)
+
+    # Only the capability probe and the play pass ran: no metadata passes, no id sweeps.
+    assert [entity for entity, _ in client.calls] == ["capabilities", "scene_play"]
+    assert result.mode == "plays"
+    assert result.entity_counts == {"scene_play": 2}
+    assert result.changed_entity_counts == {"scene_play": 2}
+    assert result.scene_ids == ("1", "2")
+    assert [
+        row[0] for row in connection.execute("SELECT scene_id FROM source_play ORDER BY scene_id")
+    ] == ["1", "2"]
+    assert connection.execute("SELECT count(*) FROM source_scene").fetchone()[0] == 2
+    # The play pass shares the incremental run ledger and never records a full-snapshot seen set.
+    assert connection.execute("SELECT mode FROM sync_run").fetchone()[0] == "incremental"
+    assert connection.execute("SELECT count(*) FROM sync_seen").fetchone()[0] == 0
+
+
+def test_plays_only_sync_advances_its_own_watermark(
+    connection: sqlite3.Connection,
+) -> None:
+    entities = _entities()
+    client = SyntheticClient(entities)
+    service = SyncService(client, SyncRepository(connection), page_size=10)
+    service.sync(plays_only=True)
+
+    # Stash records a new play without touching scenes.updated_at.
+    scene = entities["scene"][1]
+    history = scene["play_history"]
+    assert isinstance(history, list)
+    history.append("2026-03-01T08:00:00Z")
+    scene["play_count"] = 2
+    client.calls.clear()
+    client.variables.clear()
+
+    result = service.sync(plays_only=True)
+
+    assert result.mode == "plays"
+    assert [entity for entity, _ in client.calls if entity == "scene_play"] == ["scene_play"]
+    assert result.changed_entity_counts == {"scene_play": 1}
+    assert result.scene_ids == ("2",)
+    assert (
+        connection.execute("SELECT count(*) FROM source_play WHERE scene_id='2'").fetchone()[0] == 2
+    )
+    assert (
+        connection.execute(
+            "SELECT watermark FROM sync_cursor WHERE entity_type='scene_play'"
+        ).fetchone()[0]
+        == "2026-03-01T08:00:00Z"
+    )
+
+
+def test_plays_only_sync_after_incremental_sync_keeps_entity_cursors(
+    connection: sqlite3.Connection,
+) -> None:
+    client = SyntheticClient(_entities())
+    service = SyncService(client, SyncRepository(connection), page_size=10)
+    service.sync()
+    client.calls.clear()
+    client.variables.clear()
+
+    result = service.sync(plays_only=True)
+
+    assert result.mode == "plays"
+    assert result.changed_entity_counts == {"scene_play": 0}
+    assert [entity for entity, _ in client.calls] == ["capabilities", "scene_play"]
+    # A fresh play run joins the incremental ledger; metadata cursors keep their state.
+    assert (
+        connection.execute("SELECT count(*) FROM sync_run WHERE mode='incremental'").fetchone()[0]
+        == 2
+    )
+    assert (
+        connection.execute("SELECT state FROM sync_cursor WHERE entity_type='tag'").fetchone()[0]
+        == "complete"
+    )
+
+
 def test_full_sync_skips_the_play_pass(connection: sqlite3.Connection) -> None:
     client = SyntheticClient(_entities())
     SyncService(client, SyncRepository(connection), page_size=10).sync(full=True)


### PR DESCRIPTION
## What

Stash records plays without bumping `scenes.updated_at`, so cooldown/recovery context only reaches the model through the play pass. This PR:

1. **New `SyncService.sync(plays_only=True)` pass** — runs only the `SCENE_PLAYS` watermark pass (no metadata passes, no deletion sweeps, no `sync_seen` rows). It shares the incremental run ledger, which is safe because the cursor machinery keys resumption by run id and the backend never runs two sidecar jobs at once. It deliberately does **not** request a model update, so `modelUpdateEventThreshold` keeps its meaning (the ingest path already bumps the generation once per signaled play).
2. **New "Sync recent plays" task** (`plugin/backend.py` + `stash-curator.yml`) — surfaced in health task detection and diagnostics.
3. **Automatic browser trigger** — after play-session flush, an 8s-debounced `runTask("Sync recent plays")`, so `source_play` stays current between full syncs.
4. **Tests** — 3 unit tests for the plays-only pass, plus 2 Playwright tests (task imports a Stash-recorded play into `source_play`; visiting a scene page fires the automatic sync).
5. **Harness fixes** to make `scripts/verify integration` re-runnable: `seed.py` now finds-or-creates tags/performers/scenes (the Stash config dir persists across container teardowns, so re-seeding previously collided), and the verify script resets the sidecar data dir to be writable by the test user (host read-only WAL reads need to create `-shm`).

## Verification

- `scripts/verify full` — 298 passed, 12 deselected (integration), ruff/mypy/node clean, plugin builds.
- `scripts/verify integration` — **12 passed** (2 new + 10 smoke) against live Stash.

## Notes

Pre-existing, out of scope: `seed.py`'s Curator sync trigger fails GraphQL validation (deprecated `args:` param + a query used for a mutation), so the seed-time sync has never run — the suite happens to rely on that no-model state. Fixing it means switching to `args_map` and rebalancing the smoke expectations.