### PR TITLE
feat: sync changed entities immediately via Stash hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ AGENTS.override.md
 
 # Curator private and generated state
 *.private.*
+.tmp/
 data/
 private/
 reports/

--- a/curator/graphql/operations.py
+++ b/curator/graphql/operations.py
@@ -184,6 +184,43 @@ query CuratorScenePlays(
 )
 
 ENTITY_OPERATIONS = (TAGS, STUDIOS, PERFORMERS, SCENES, SCENE_PLAYS)
+
+# Single-entity lookups for hook-triggered targeted syncs. They mirror the field lists
+# of the list operations above so the same adapters apply unchanged.
+FIND_SCENE = f"""
+query CuratorFindScene($id: ID!) {{
+  findScene(id: $id) {{{SCENE_FIELDS}}}
+}}
+"""
+
+FIND_PERFORMER = """
+query CuratorFindPerformer($id: ID!) {
+  findPerformer(id: $id) {
+    id name gender favorite rating100 birthdate ethnicity country eye_color hair_color
+    height_cm weight measurements fake_tits tattoos piercings updated_at
+    tags { id name updated_at }
+  }
+}
+"""
+
+FIND_TAG = """
+query CuratorFindTag($id: ID!) {
+  findTag(id: $id) {
+    id name updated_at stash_ids { endpoint stash_id }
+    parents { id name updated_at }
+  }
+}
+"""
+
+FIND_STUDIO = """
+query CuratorFindStudio($id: ID!) {
+  findStudio(id: $id) {
+    id name favorite rating100 updated_at
+    parent_studio { id name updated_at }
+  }
+}
+"""
+
 ALL_DOCUMENTS = (
     CAPABILITIES,
     *(operation.document for operation in ENTITY_OPERATIONS),
@@ -192,4 +229,8 @@ ALL_DOCUMENTS = (
         for operation in ENTITY_OPERATIONS
         if operation.ids_document is not None
     ),
+    FIND_SCENE,
+    FIND_PERFORMER,
+    FIND_TAG,
+    FIND_STUDIO,
 )

--- a/curator/storage/sql/0027_pending_entity_changes.sql
+++ b/curator/storage/sql/0027_pending_entity_changes.sql
@@ -1,0 +1,14 @@
+-- Entity hooks enqueue the changed entity instead of fetching it inline: Stash fires
+-- hooks inside the mutation path, and a per-edit GraphQL fetch plus upsert added latency
+-- to every edit (and minutes to bulk edits). The hook records the change here, and the
+-- preference-rebuild task drains the queue before rebuilding, so the model always sees
+-- fresh source data. The row keeps the latest operation (an update followed by a destroy
+-- becomes a delete), and the queue is superseded by any full sync.
+
+CREATE TABLE pending_entity_change (
+    entity_type TEXT NOT NULL CHECK (entity_type IN ('tag', 'studio', 'performer', 'scene')),
+    entity_id TEXT NOT NULL,
+    operation TEXT NOT NULL CHECK (operation IN ('upsert', 'delete')),
+    created_at_ms INTEGER NOT NULL CHECK (created_at_ms >= 0),
+    PRIMARY KEY (entity_type, entity_id)
+) STRICT, WITHOUT ROWID;

--- a/curator/sync/repository.py
+++ b/curator/sync/repository.py
@@ -173,6 +173,20 @@ class SyncRepository:
         row = self.connection.execute(f"SELECT count(*) FROM {table}").fetchone()
         return int(row[0])
 
+    def upsert_entity(self, entity: SourceEntity) -> bool:
+        """Upsert one already-fetched entity, e.g. a hook-triggered targeted sync.
+
+        Dependencies (tag parents, studio parents, a scene's tags and performers) are
+        upserted by the same write path the page sync uses, so the row is never a stub.
+        """
+        with transaction(self.connection):
+            return self._upsert(entity)
+
+    def delete_entity(self, entity_type: str, entity_id: str) -> None:
+        """Remove one entity, releasing the references SQLite will not cascade."""
+        with transaction(self.connection):
+            self._delete_entities(entity_type, (entity_id,))
+
     def delete_absent(self, entity_type: str, present_ids: set[str]) -> tuple[str, ...]:
         """Remove entities Stash no longer has, given a complete id sweep."""
         table, column = ENTITY_TABLES[entity_type]

--- a/curator/sync/service.py
+++ b/curator/sync/service.py
@@ -8,12 +8,48 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from typing import Protocol
 
-from curator.graphql.adapters import adapt_id_page, adapt_page
-from curator.graphql.operations import CAPABILITIES, ENTITY_OPERATIONS, EntityOperation
+from curator.graphql.adapters import (
+    SourceEntity,
+    adapt_id_page,
+    adapt_page,
+    adapt_performer,
+    adapt_scene,
+    adapt_studio,
+    adapt_tag,
+)
+from curator.graphql.operations import (
+    CAPABILITIES,
+    ENTITY_OPERATIONS,
+    FIND_PERFORMER,
+    FIND_SCENE,
+    FIND_STUDIO,
+    FIND_TAG,
+    EntityOperation,
+)
 from curator.sync.repository import SyncRepository
 
 # Id-only rows are small, and the sweep cost is dominated by per-request overhead.
 SWEEP_PAGE_SIZE = 5_000
+
+# Single-entity lookup documents and their response keys for hook-triggered targeted syncs.
+_FIND_DOCUMENTS = {
+    "tag": FIND_TAG,
+    "studio": FIND_STUDIO,
+    "performer": FIND_PERFORMER,
+    "scene": FIND_SCENE,
+}
+_FIND_ROOTS = {
+    "tag": "findTag",
+    "studio": "findStudio",
+    "performer": "findPerformer",
+    "scene": "findScene",
+}
+_FIND_ADAPTERS: dict[str, Callable[[object], SourceEntity]] = {
+    "tag": adapt_tag,
+    "studio": adapt_studio,
+    "performer": adapt_performer,
+    "scene": adapt_scene,
+}
 
 
 class QueryClient(Protocol):
@@ -221,6 +257,28 @@ class SyncService:
             # An empty library is indistinguishable from a broken response; never act on it.
             return ()
         return self.repository.delete_absent(operation.entity_type, present)
+
+    def upsert_entity(self, entity_type: str, entity_id: str) -> bool:
+        """Fetch one entity from Stash by id and upsert it into the sidecar.
+
+        Hook-triggered targeted sync: a create or update hook carries just the entity id,
+        and the full row (including dependencies such as tag parents or a scene's cast) is
+        fetched and persisted with the same write path the page sync uses.
+        """
+        document = _FIND_DOCUMENTS.get(entity_type)
+        if document is None:
+            raise ValueError(f"unsupported entity type: {entity_type}")
+        data = self.client.execute(document, {"id": entity_id})
+        root = data.get(_FIND_ROOTS[entity_type])
+        if not isinstance(root, Mapping):
+            raise RuntimeError(f"Stash did not return {_FIND_ROOTS[entity_type]}")
+        return self.repository.upsert_entity(_FIND_ADAPTERS[entity_type](root))
+
+    def delete_entity(self, entity_type: str, entity_id: str) -> None:
+        """Remove one entity from the sidecar, cascading like the reconcile pass."""
+        if entity_type not in _FIND_DOCUMENTS:
+            raise ValueError(f"unsupported entity type: {entity_type}")
+        self.repository.delete_entity(entity_type, entity_id)
 
     def _sync_entity(
         self,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -67,7 +67,10 @@ Stash.
 
 Feedback and playback increment a durable generation counter and trigger a smaller
 preference rebuild after a short debounce. They do not rerun library sync; after playback a
-lightweight play-only sync keeps cooldown and recovery context current between full syncs. Full
+lightweight play-only sync keeps cooldown and recovery context current between full syncs.
+Stash entity hooks (scene, performer, studio, and tag create/update/destroy) import or remove
+the single changed entity inline, so metadata edits reach the sidecar immediately and mark the
+model dirty without building it. Full
 sync/build and Expand refresh remain one-shot tasks because Stash provides no plugin
 background scheduler/startup hook.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,9 +68,10 @@ Stash.
 Feedback and playback increment a durable generation counter and trigger a smaller
 preference rebuild after a short debounce. They do not rerun library sync; after playback a
 lightweight play-only sync keeps cooldown and recovery context current between full syncs.
-Stash entity hooks (scene, performer, studio, and tag create/update/destroy) import or remove
-the single changed entity inline, so metadata edits reach the sidecar immediately and mark the
-model dirty without building it. Full
+Stash entity hooks (scene, performer, studio, and tag create/update/destroy) record each
+changed entity in a pending queue, and the preference-rebuild task drains that queue
+(fetching the entity by id or removing it on destroy) before rebuilding, so the model
+always sees fresh source data while bulk edits pay no inline fetch cost. Full
 sync/build and Expand refresh remain one-shot tasks because Stash provides no plugin
 background scheduler/startup hook.
 

--- a/docs/decisions/002-runtime-swap-planning.md
+++ b/docs/decisions/002-runtime-swap-planning.md
@@ -1,0 +1,307 @@
+# Planning: compiled runtime swap (Go/Rust core)
+
+Status: **planning** — no decision made. Record of evidence, the equality-coverage
+strategy, the RPC plan pointer, and the release/dev workflow for the compiled-core
+direction. Complements ADR 001 (backend runtime, accepted) and
+`docs/handover-rpc-plugin.md` (resident RPC conversion, planned).
+
+Updated: 2026-08-09.
+
+## 1. Goals restated
+
+- Runtime speed for the expensive stages (model build, per-call latency).
+- Dependencies pulled in at **build time**, with no separate install task at
+  runtime (the current "Install optional dependencies" numpy/networkx pip task).
+
+## 2. Banked findings (evidence)
+
+### 2.1 Constraints that shape every option
+
+- Stash's plugin index (`index.yml`) has **no platform/architecture field**: one
+  zip per plugin id. A compiled-only plugin is one architecture unless the zip
+  carries several binaries or the plugin downloads one at first run.
+- Stash's official Docker image **does not ship Python**; community issues and
+  forum threads document Python plugins as effectively locked out of default
+  Docker installs unless users install Python themselves (and reinstall it after
+  every Stash update). Curator's docs require Python 3.12+ today.
+- Stash supports `raw` (spawn per call — Curator today) and `rpc` (resident
+  process, JSON-RPC over stdio; Go reference implementation `pkg/plugin/examples/
+  gorpc`, `pkg/plugin/common.ServePlugin`). The Python RPC conversion is already
+  designed in `docs/handover-rpc-plugin.md`.
+- Current runtime profile (measured, ~24k-scene library, numpy): 409s model build;
+  132s similarity (76s content neighbors + 56s performer); 243s publication
+  (144s classification/order/reason/index; the 88s validation scan was removed).
+- Per-call Python spawn + import measured at ~630-860 ms (with numpy) in the RPC
+  handover; ~730 ms for the full import stack on this dev host. Every interactive
+  operation, task, and entity hook pays it.
+- The pure-Python fallback is ~870x slower per element than numpy BLAS on the
+  cosine workload — effectively unusable at production library sizes, which is
+  why the numpy acceleration task exists.
+
+### 2.2 Language comparison (Rust vs Go vs Python)
+
+| Axis | Go | Rust | Python (current) |
+| --- | --- | --- | --- |
+| Deps at build time | stdlib covers http/json/zip/testing; sqlite via module | crates | runtime pip task for numpy/networkx |
+| Per-call startup | ~3-8 ms | ~2-5 ms | ~630-860 ms |
+| Multi-arch distribution | cheap (`CGO_ENABLED=0`+modernc, or native CI runners per arch) | expensive (musl/OpenSSL/cross-toolchain per target) | n/a (source ships everywhere) |
+| Port cost (~31k LOC + 10.5k LOC tests) | lower (simpler language, fast compile loop) | higher (borrow checker) | n/a |
+| Hot-loop ceiling | below numpy unless fused/sparse (see 2.3) | ndarray+SIMD closer to numpy | numpy = OpenBLAS |
+| SQLite | mattn (CGO, C-speed) or modernc (pure Go, slower) | rusqlite bundled | stdlib sqlite3 |
+| Ecosystem fit | Stash is Go; RPC example is Go | n/a | no runtime deps today |
+
+**Lean:** Go over Rust for this project (Stash's own stack, cheap distribution,
+faster port). But see the decision framework in 3 — the *size* of the change is
+the bigger question than the language.
+
+### 2.3 Benchmark evidence (banked POC)
+
+Location: `poc/golang-similarity-benchmark/` (tracked; README has full numbers and
+how to run). Kernels mirror production `_content_neighbors_numpy` exactly and were
+cross-verified against a Python replica on shared data: **0 mismatched rows**,
+max weight error 1.4e-17.
+
+| Scenario | numpy (prod algo) | Go dense 4t | Go sparse fused 4t |
+| --- | --- | --- | --- |
+| N=6 000, d=120, nnz=12 | 24.3s | 13.8s (1.8x) | 6.3s (3.9x) |
+| N=3 000, d=600, nnz=30 | 18.0s | 4.5s (4.0x) | 1.45s (12.4x) |
+| N=24 000, d=120 (prod size) | ~400s extrapolated | — | 44.8s |
+| N=24 000, d=600 (tag-heavy) | ~19 min extrapolated | — | 51.6s |
+
+Machine context: 4-core x86_64, 7 GB RAM, numpy 2.5.1 + scipy-openblas 0.3.33
+(~4-6 GFLOPS raw matmul — a slow BLAS environment), Go 1.26.5.
+
+Key structural results:
+
+- numpy densifies: O(N^2 d) arithmetic, paid twice (float64 dot + float32 binary
+  matmul), plus a Python per-row `flatnonzero`/`partition` loop. Go sparse-fused
+  is O(N * nnz * col-nnz) and **immune to feature-column count `d`** — and real
+  Curator vectors include description-token columns, so production `d` is likely
+  in the hundreds-to-thousands.
+- numpy allocates ~3 * block * N * 8B per block (sim/weights/shared — >1 GB at
+  production block sizes; this box swapped at N=24 000). Go streams per-row
+  top-k with O(N + k) scratch — no big matrices.
+- Both implementations pay an O(N^2) per-row selection scan; at N=24 000 that is
+  the remaining ~20-40s floor for Go and ~24k Python-level numpy calls for numpy.
+- Go kernels are deterministic (1t vs 4t identical outputs, verified).
+- Caveats: synthetic data only; production feature-column count and sparsity are
+  **not yet measured**; numpy ratios will narrow on servers with fast BLAS at
+  low `d` (the selection scan becomes the common floor).
+
+## 2.4 Phase 0 benchmark results (measured 2026-08-09, automated harness)
+
+Harness: `scripts/benchmark.py` — drives a Docker Stash (v0.31.1, plugin 0.5.1)
+with the plugin installed, runs the operation battery and tasks through
+`runPluginOperation`/`runPluginTask`, and pulls profiling traces from a copied
+sidecar. Sidecar: copy of the live 23,917-scene sidecar (published model, 200
+traces, 73 jobs). Run: `uv run python scripts/benchmark.py --db PATH
+[--cold-build]`; report written to `.tmp/benchmark-report/` (gitignored).
+
+Interactive operations (client wall time, 4 reps, numpy installed):
+
+- every operation pays ~1.1 s median spawn+import (numpy import dominates);
+  actual work is 55-250 ms median for everything except Similar;
+- `get_similar` scene: 2.5 s wall (1.6 s work); performer: 8.3 s wall (7.2 s work);
+- without numpy in the container the same ops were ~500-700 ms wall — the
+  acceleration task adds ~400-700 ms to every spawn;
+- one rep of `get_config` crashed the plugin process (`signal: bus error`)
+  after numpy import; the next rep succeeded (self-healing, but a real defect
+  candidate to investigate).
+
+Tasks (fresh copies of the sidecar, so warm paths):
+
+- `prepare`: 2.0 s wall, 96 ms trace — caches already materialized (no-op);
+- `backup`: 2.0 s wall, 718 ms trace — 105 MB sidecar via the backup API;
+- `build` (cold, `--cold-build` invalidates the published model first):
+  **278 s wall / 276 s trace** with numpy, stage breakdown: similarity 74.5 s
+  (content) + 57.3 s (performer) = 132 s, feature build 54 s, indexing 86 s,
+  varied ordering 52 s, score-first ordering 10 s, lane classification 15 s,
+  scoring 22 s, affinities 20 s, publication 0.1 s (validation scan already
+  removed). `install-deps` (numpy/networkx venv) completes in ~1-2 min
+  (needs network).
+
+Real workload shape (from the sidecar's feature artifact, counts only):
+**N = 23,917 scenes, d = 10,245 content features, ~33 content features per
+scene (0.3% sparsity)**. The POC's d=600 scenario was already ~17x below real
+d, so the Go sparse advantage (immune to d; numpy pays O(N^2 d) twice) is
+larger in production than the 12.4x measured at d=600: numpy ~11.7T MACs vs
+Go ~61M + the O(N^2) selection scan both pay.
+
+### Phase 0 conclusions
+
+- **Interactive latency is spawn-dominated, not work-dominated**: the RPC
+  conversion (per-call spawn -> resident process) is the fix for interactive
+  ops, and it also removes the numpy-import tax the acceleration task adds to
+  every call.
+- **Build time breaks down as similarity (132 s) + indexing (86 s) + varied
+  ordering (52 s)**: the compiled-core hybrid's ceiling on this workload is
+  similarity + the Python-loop stages; indexing/varied-ordering are SQLite
+  write-bound and would move less.
+- **The real d ~ 10k validates the d-immunity argument** for the compiled
+  core; numpy's dense work scales with d, Go's sparse work does not.
+- **One observed crash** (bus error on numpy import) is worth a defect ticket
+  regardless of the language decision.
+
+## 3. Decision framework
+
+The fix depends on which pain dominates; the options are nearly disjoint:
+
+| Observed pain | Cheapest fix | Notes |
+| --- | --- | --- |
+| Interactive latency (pages/hooks feel slow) | RPC conversion (Python stays) | Kills ~0.7s spawn + per-call migrate/settings overhead. Designed in `docs/handover-rpc-plugin.md`. |
+| Optional-deps install task friction | Vendor wheels into the zip | Offline, pinned, deterministic; still a task, no network. ~0.5 day. |
+| Build wall-time / scaling | Compiled core (Go) in numpy's role | Validated 4-12x on the similarity stage on this box; ~2-3x on the whole build. ~2-4 days for a sidecar-wired slice. |
+| Full rewrite of everything | Not justified | 31k LOC + 10.5k LOC tests for a ~2-3x win on a background task with progress bars. |
+
+**Recommended shape if the compiled direction is chosen:** the binary replaces
+numpy's *role* — optional acceleration with the pure-Python fallback retained, so
+the plugin never depends on it and equality guarantees are the same as today's
+"deterministic and correct in either mode" promise. This sidesteps the
+single-zip/arch constraint (see 5) and gives a clean rollback path.
+
+## 4. Equality-coverage plan
+
+Goal: any compiled implementation must produce outputs the existing Python
+implementation accepts, under a defined tolerance policy, with the 10.5k LOC test
+corpus as the oracle (not ported — *driven*).
+
+### 4.1 What "equal" means, by artifact
+
+- **SQLite sidecar**: identical schema; the ordered, checksummed migration chain
+  (`curator/storage/sql/`) must be implemented with the same checksums so a
+  sidecar built by either implementation is accepted by the other. Migration
+  status and `PRAGMA integrity_check` must match.
+- **Published artifacts**: byte-identical (hash-equal) for the same input corpus —
+  the artifact model already checksums and validates generations.
+- **JSON API responses**: byte-identical (the frontend contract is the JSON
+  payloads; the JS does not change).
+- **Floats**: exact for integer/hash/count domains (ids, shared counts, checksums,
+  hashes); 1e-9 relative tolerance for similarity/weight/affinity floats; selection
+  and ordering tie-breaking **identical by construction** — sort keys must match
+  production exactly (e.g. `(-weight, id)`).
+- The float32 shared-count exactness trick (counts <= feature count, exact in
+  float32; BLAS matmul path) must be replicated or proven equivalent; Go uses
+  integer counts, which are exact.
+
+### 4.2 Layers of coverage
+
+1. **Kernel differential tests** (already proven in the POC): Python owns the
+   data, the binary reads it and must reproduce outputs within tolerance. Promote
+   the POC's verify mode into a fixture-based permanent test.
+2. **Corpus differential tests**: seeded synthetic corpora varying N, d, nnz, and
+   sparsity; run the full pipeline (not just the kernel) through both
+   implementations and diff every output artifact (neighbor selections, weights,
+   classifications, lane orders, reasons, published artifacts). Synthetic corpora
+   only in-repo — never a sidecar snapshot (private data). A local, uncommitted
+   sidecar may be used for manual runs.
+3. **Schema/migration parity**: build a sidecar with Python migrations, run the
+   compiled implementation against it and vice versa; assert status + checksums
+   match. This is the integration-surprise surface the POC cannot probe.
+4. **Existing tests as acceptance**: the current 39 test files (e.g.
+   `tests/model/test_builder.py` reference values) define the behavioral oracle;
+   the compiled implementation must pass them via its process boundary.
+5. **CI differential gate**: a job that builds both implementations, runs the
+   corpus differential tests, and fails on any mismatch beyond tolerance; runs on
+   every PR touching the core. Determinism is enforced by the corpus test (both
+   implementations must be deterministic; Go: no map-iteration-order dependence,
+   fixed chunking — verified in the POC).
+
+### 4.3 Harness shape
+
+Keep pytest as the single harness. The compiled core is exercised through its
+process boundary (argv/stdin + JSON), exactly like the POC's `verify` mode, so the
+10.5k LOC suite stays the oracle without porting. Integration tests (Playwright +
+real Stash) remain for end-to-end behavior; profiling (`curator/profiling.py`)
+remains the timing oracle.
+
+## 5. Release and dev workflow (compiled direction)
+
+### 5.1 Dev loop
+
+- Python harness + pytest unchanged; the core is built and driven via IPC.
+- `scripts/verify` gains: build the core (if changed), run the differential gate.
+- Go toolchain is a dev/build dependency only — never a runtime one.
+
+### 5.2 Build and CI
+
+- Per-arch binaries on native GitHub runners (linux amd64/arm64, darwin,
+  windows). CGO decision for SQLite: `mattn/go-sqlite3` (C-speed, per-arch builds)
+  vs `modernc.org/sqlite` (pure Go, one-machine cross-compile, slower on the
+  540 MiB artifact stage — lean mattn + native runners).
+- The archive test (`tests/plugin/test_runtime.py`) extends to assert the binary
+  is present in the zip for each shipped platform.
+
+### 5.3 Distribution (the single-zip constraint)
+
+Three options, with the recommended one first:
+
+1. **One zip, all supported-arch binaries; runtime selects.** Plugin probes
+   `runtime.GOOS/GOARCH`-style detection and runs the matching binary; pure-Python
+   fallback if none. Zip grows by ~15 MB per arch. Simple, offline, no download —
+   at the cost of zip size. Mirrors the optional-acceleration role (3).
+2. **Universal launcher downloads the binary at first run.** Smallest zip, but
+   reintroduces a runtime download (more robust than pip, still a network step).
+3. **Per-arch plugin ids in the index.** Cleanest per-arch UX in Stash, but three
+   release lines and confusing updates.
+
+### 5.4 Versioning and release
+
+- Keep release-please; the version source stays `pyproject.toml` (release-type
+  python), injected into the binary at build time (same pattern as
+  `curator/__init__.py` today). The pages workflow rebuilds the zip and index
+  from main.
+- Rollout: the binary ships as optional acceleration; rollback = remove it
+  (fallback active). Measure on the installed sidecar with the existing profiling
+  page and stage timings before/after.
+
+## 6. RPC plan
+
+Already designed in detail in `docs/handover-rpc-plugin.md` (transport, resident
+server, concurrency, lifecycle, steps, risks, acceptance criteria). Additions from
+this planning round:
+
+- The RPC conversion is **language-independent and independent of the core swap**:
+  the handover's Python resident server works unchanged as the shell for a
+  compiled core (each call stays a short JSON-RPC dispatch; the core is invoked
+  per call or per task).
+- If the backend itself ever becomes Go, Stash's `gorpc` example and
+  `pkg/plugin/common` are the reference implementation for the same wire contract.
+- Sequencing: do the RPC conversion first if interactive latency is the pain; it
+  also removes the per-call `_open()` cost (migrations + settings application run
+  on every call today).
+- Open items: verify hook behavior under RPC on the target Stash version;
+  concurrent `Run` calls (bulk-edit hooks); crash-reconnect semantics via `pie`
+  (queue in the sidecar is the safety net).
+
+## 7. Open questions (must resolve before committing)
+
+Phase 0 answered the first two:
+
+1. ~~Which pain dominates?~~ **Measured**: interactive latency is spawn-dominated
+   (~1.1 s per call, ~55-250 ms of work); the cold build is 278 s here with
+   similarity + indexing + varied ordering as the top stages. Both the RPC
+   conversion (interactive) and the compiled core (build) have measured targets.
+2. ~~Real `d` and sparsity?~~ **Measured**: d = 10,245 content features, ~33 per
+   scene (0.3% sparsity), N = 23,917 — validates the d-immunity argument.
+3. Target Stash version's RPC stability for hooks (v0.31 declared today).
+4. Required platform matrix (windows? arm64? — decides 5.3).
+5. BLAS quality on the actual server (the Go-vs-numpy ratio at the real d ~ 10k
+   is expected to exceed the d=600 measurement of 12.4x).
+6. Root cause of the observed `bus error` crash on numpy import in the
+   container (defect ticket, independent of the language decision).
+
+## 8. Proposed sequencing
+
+- **Phase 0 (done):** POC banked (`poc/golang-similarity-benchmark/`); automated
+  benchmark harness (`scripts/benchmark.py`); interactive latency, cold-build
+  stage breakdown, install-deps cost, and real d/sparsity measured (2.4).
+- **Phase 1:** pick the fix from the table in 3 based on the Phase 0 evidence:
+  the strongest measured case is the RPC conversion for interactive latency
+  (~1.1 s per call), with the compiled core as the build-time lever (278 s
+  build, similarity 132 s of it).
+- **Phase 2 (compiled core, if chosen):** port the content-neighbor and
+  performer-similarity kernels (math already validated), wire to the sidecar via
+  the differential harness (4.2), ship as optional acceleration replacing numpy,
+  pure-Python fallback retained; measure end-to-end on the installed sidecar.
+- **Phase 3 (optional):** full backend in Go behind the RPC shell, if the hybrid
+  proves out and the port budget is available.

--- a/docs/handover-rpc-plugin.md
+++ b/docs/handover-rpc-plugin.md
@@ -1,0 +1,111 @@
+# Resident RPC plugin handover
+
+Updated: 2026-08-09.
+
+## Goal
+
+Remove the per-invocation Python process spawn from the plugin's hot paths (entity
+hooks, operations, tasks) by converting the plugin from Stash's `raw` interface to its
+resident `rpc` interface, so every call is a JSON-RPC message into a process that Stash
+already keeps alive.
+
+## Measured baseline
+
+The entity-hook path was measured on a development host with the same dependencies
+(numpy included) and against a copy of the live sidecar:
+
+| Component | Time |
+| --- | --- |
+| Python process spawn + import (numpy) | 630-860 ms |
+| Sidecar open + migrations + artifact attach | 10-120 ms (cold) / ~10 ms (warm) |
+| GraphQL round trips (settings + find-by-id) | ~60-180 ms |
+| Upsert + model request | ~10 ms |
+
+The spawn is **70-85% of the per-edit cost**. A 500-scene bulk edit therefore blocks
+Stash's mutation path for roughly 6-8 minutes today (the enqueue change in #90 already
+removed the fetch + upsert from that path; the spawn remains the floor for raw hooks).
+Converting to `interface: rpc` removes the spawn: per-edit drops to ~50-200 ms and a
+bulk edit to roughly 30-60 seconds. The enqueue-only hooks (migration 27,
+`pending_entity_change`) are the prerequisite: with RPC, the hook is just one small
+INSERT in a resident process.
+
+Keep private scene, performer, and library identifiers out of tracked files and
+command output.
+
+## What Stash provides (verified against v0.31 source)
+
+- `interface: rpc` (`InterfaceEnumRPC` in `pkg/plugin/config.go`): Stash starts the
+  plugin's exec command once and keeps it alive; every operation, task, and hook is a
+  call into the resident process.
+- The wire protocol is Go `net/rpc` with the JSON codec over the process's stdin/stdout
+  (`pkg/plugin/rpc.go`, `net/rpc/jsonrpc`, lifecycle via the `pie` library, which
+  reconnects on crash). Requests are newline-delimited JSON objects
+  `{"method": "RPCRunner.Run", "params": [<PluginInput>], "id": <n>}` with
+  `{"result": <PluginOutput>, "error": ..., "id": <n>}` responses; `RPCRunner.Stop` is
+  the shutdown call.
+- Hooks execute through the same task path: `executePostHooks` builds a `pluginTask`
+  and `createTask()` dispatches to the interface's task builder, so an RPC plugin
+  receives hook invocations as `RPCRunner.Run` calls with the same
+  `hookContext` payload.
+- Reference implementation: `pkg/plugin/examples/gorpc` (Go). There is no packaged
+  Python RPC example; the Python plugin examples are raw (`pkg/plugin/examples/python`).
+- The yml `exec` stays the same (Stash runs it once, inside its container); only
+  `interface: rpc` changes. Stash restarts the process on crash via `pie`.
+
+## Design
+
+1. **Transport**: a small `net/rpc`-over-jsonrpc server in Python. Read one JSON
+   object per line from stdin, dispatch `RPCRunner.Run` / `RPCRunner.Stop`, write the
+   JSON response line. Keep it dependency-free (stdlib only): the wire format is
+   simple, and the plugin must not gain runtime requirements.
+2. **Entrypoint**: `backend.py` gains a `serve` mode (a flag or first argv) that runs
+   the resident server; the raw stdin/stdout `main()` stays for development and
+   fallback. The per-call bodies (`dispatch`, `_run_entity_hook`, `_run_task`) are
+   unchanged — only the shell around them moves.
+3. **Concurrency**: Stash issues calls concurrently (hooks especially, during bulk
+   edits). The server must handle concurrent `Run` calls (threads or a small worker
+   pool). The sidecar already tolerates this (WAL, busy_timeout); each call opens its
+   own connection and closes it, as today.
+4. **Lifecycle**: handle `RPCRunner.Stop` gracefully (flush/close), and ensure the
+   process exits cleanly when stdin closes. `pie` reconnects if it crashes, but the
+   handler should be defensive: a crashed resident process means hooks are missed
+   until restart, so keep the queue semantics (drain on next rebuild) as the safety
+   net.
+5. **Instrumentation**: keep the existing span/profiling wrapper per call; the trace
+   goes to the same `profile_trace` table.
+
+## Implementation steps
+
+1. Add the jsonrpc-over-stdio server (stdlib), with unit tests against the wire
+   format (feed scripted request lines, assert response lines, including errors and
+   `RPCRunner.Stop`).
+2. Convert `main()` so the same handlers serve both the raw one-shot contract and the
+   resident server; switch `stash-curator.yml` to `interface: rpc` behind a
+   config-controlled choice if a fallback is wanted.
+3. Rework the harness: integration tests currently drive `backend.py` via argv/stdin
+   subprocesses; they must instead run the resident server and talk JSON-RPC (or keep
+   one raw-mode test for the fallback path).
+4. Measure again with the same methodology as the baseline table; target per-edit
+   hook cost below ~300 ms on the integration box and confirm a synthetic bulk edit
+   completes in seconds.
+5. Verify hooks, operations, tasks, and progress reporting all work through RPC on the
+   live install; confirm Stash restarts the process after a forced kill.
+
+## Risks
+
+- The `net/rpc` jsonrpc framing must match exactly (method name, single-value params,
+  id echo). Get the wire protocol wrong and Stash reports the plugin as failing to
+  start; the fallback raw mode limits blast radius during rollout.
+- Concurrency bugs (shared mutable state across calls) would be new to the plugin —
+  today every invocation is a fresh process. The per-call connection model avoids
+  most of it.
+- Stash version compatibility: `interface: rpc` has existed for a long time, but the
+  behavior of hooks under RPC should be re-verified on the target Stash version.
+
+## Acceptance criteria
+
+- Hook per-edit cost < ~300 ms including a resident call (no spawn).
+- A 500-entity bulk edit completes in seconds, not minutes.
+- Full unit + integration suites pass against the RPC transport.
+- Crash recovery: kill the resident process; the next Stash call (or reload)
+  restores it and the pending queue is not lost (it lives in the sidecar).

--- a/docs/handover-rpc-plugin.md
+++ b/docs/handover-rpc-plugin.md
@@ -84,12 +84,55 @@ command output.
    config-controlled choice if a fallback is wanted.
 3. Rework the harness: integration tests currently drive `backend.py` via argv/stdin
    subprocesses; they must instead run the resident server and talk JSON-RPC (or keep
-   one raw-mode test for the fallback path).
+   one raw-mode test for the fallback path). The Phase 0 benchmark
+   (`scripts/benchmark.py`) already drives the plugin through Stash's
+   `runPluginOperation`/`runPluginTask` mutations and reads profiling traces from the
+   sidecar, so it works unchanged over either interface — use it as the before/after
+   measurement tool.
 4. Measure again with the same methodology as the baseline table; target per-edit
    hook cost below ~300 ms on the integration box and confirm a synthetic bulk edit
-   completes in seconds.
+   completes in seconds. The Phase 0 measured interactive medians (~1.1 s wall, of
+   which ~55-250 ms work, 4 reps) are the "before" numbers to beat.
 5. Verify hooks, operations, tasks, and progress reporting all work through RPC on the
    live install; confirm Stash restarts the process after a forced kill.
+
+## Prepared state (2026-08-09, Phase 0 complete)
+
+This work package is decided and prepped; it is the next session's task. What exists:
+
+- `docs/handover-rpc-plugin.md` — this design (goal, baseline, wire protocol,
+  risks, acceptance criteria above).
+- `docs/decisions/002-runtime-swap-planning.md` — the full planning record:
+  language comparison, Go-vs-numpy POC evidence, equality-coverage plan, release/
+  dev workflow, and the Phase 0 measurements.
+- `poc/golang-similarity-benchmark/` — the banked Go kernel benchmark (tracked).
+- `scripts/benchmark.py` — the automated Phase 0 harness: starts Docker Stash with
+  the plugin installed, enables profiling via `configurePlugin`, runs the ops
+  battery + tasks, pulls traces from a copied sidecar, writes a scrubbed report to
+  `.tmp/benchmark-report/`. Run with `uv run python scripts/benchmark.py --db PATH
+  [--cold-build]`. Requires `STASH_CURATOR_DB`/`--db` (the live testing sidecar), a
+  Docker daemon, and the Stash image.
+
+Phase 0 findings that shape this work:
+
+- Interactive operations are spawn-dominated: ~1.1 s median wall per call, of which
+  ~55-250 ms is work (numpy import is ~400-700 ms of the spawn). Removing the spawn
+  is the measured win; a resident process also pays the numpy import once instead of
+  per call.
+- Gotchas learned while building the harness (relevant to step 3 and to validating
+  the RPC conversion): `health` and `round_trip` are intentionally not profiled;
+  profiling enables via `configurePlugin(plugin_id, input: {profilingEnabled: true})`
+  (config.yml alone does not reach the plugin); Stash's `jobQueue` query returns
+  null in v0.31.1 while plugin tasks run, so task completion must be read from the
+  sidecar's `curator_job` rows (filtered by `started_at_ms > submission`); plugin
+  task submission is async (`runPluginTask` returns the job id).
+- Defect to file (independent of this work): one `get_config` rep crashed the plugin
+  process with `signal: bus error` after numpy import in the container
+  (`docker logs integration-stash-1`).
+
+Uncommitted worktree state at handoff (not yet committed): `.gitignore` (+`.tmp/`),
+`docs/decisions/002-runtime-swap-planning.md`, `poc/`, `scripts/benchmark.py`. The
+RPC conversion itself has not started.
 
 ## Risks
 

--- a/docs/handover.md
+++ b/docs/handover.md
@@ -1,6 +1,9 @@
 # Stash Curator handover
 
-Updated: 2026-07-30 after Stage 4 live storage cutover.
+Updated: 2026-08-09. Next work package is the resident RPC plugin conversion
+(see below); Phase 0 planning and measurements are banked in
+`docs/decisions/002-runtime-swap-planning.md` and the RPC design in
+`docs/handover-rpc-plugin.md`.
 
 ## Current state
 
@@ -22,7 +25,16 @@ durable state, all pre-existing backups, and the protected pre-repair copy remai
 
 ## Next work package
 
-Retain these installed UI follow-ups as a separate coherent package:
+**Convert the plugin to Stash's resident RPC interface** (decision from the Phase 0
+planning round). The design, measured baseline, implementation steps, risks, and
+acceptance criteria live in [`handover-rpc-plugin.md`](handover-rpc-plugin.md); the
+full planning record and Phase 0 measurements are in
+`docs/decisions/002-runtime-swap-planning.md`. Validation tooling:
+`scripts/benchmark.py` (automated ops/task battery + trace pull; run before and
+after the conversion). Uncommitted at handoff: `scripts/benchmark.py`, `poc/`,
+`docs/decisions/002-runtime-swap-planning.md`, `.gitignore`.
+
+Deferred UI follow-ups (retain as a separate coherent package):
 
 - Rename the feedback-facing history label to clearer product language, likely
   **Feedback history** or **Review feedback**.

--- a/docs/using-curator.md
+++ b/docs/using-curator.md
@@ -102,10 +102,13 @@ Curator never deletes media, and the tag can be removed from the same view or in
 
 ## Routine maintenance
 
-- Sync after meaningful library or metadata changes.
+- Sync after meaningful library or metadata changes; a full sync reconciles deletions and
+  tag merges that targeted entity hooks do not cover.
 - Run the first sync/build before expecting recommendation lanes to contain results.
 - Plays recorded by Stash are imported automatically after Curator playback so cooldown and
   recovery stay current; the **Sync recent plays** task can also be run manually.
+- Scenes, performers, studios, and tags you create, edit, or delete in Stash are imported
+  immediately through entity hooks, so recommendations pick them up without a manual sync.
 - Back up before plugin updates and before uninstalling.
 - Treat Adventure and external results as exploration, not guaranteed matches.
 - If Curator feels stale, check task status and run the normal sync before a full one.

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -1038,6 +1038,67 @@ DIAGNOSTIC_JOB_TYPES = {
     "expand-refresh",
 }
 
+# Stash entity hooks that trigger a targeted one-entity sync. Tag merges are left to the
+# next regular sync: a merge re-links many scenes that a single tag upsert cannot refresh.
+_HOOK_ENTITY_TYPES = {
+    "Scene.Create.Post": "scene",
+    "Scene.Update.Post": "scene",
+    "Scene.Destroy.Post": "scene",
+    "Performer.Create.Post": "performer",
+    "Performer.Update.Post": "performer",
+    "Performer.Destroy.Post": "performer",
+    "Studio.Create.Post": "studio",
+    "Studio.Update.Post": "studio",
+    "Studio.Destroy.Post": "studio",
+    "Tag.Create.Post": "tag",
+    "Tag.Update.Post": "tag",
+    "Tag.Destroy.Post": "tag",
+}
+
+
+def _run_entity_hook(payload: dict[str, Any]) -> dict[str, object]:
+    """Import or remove one entity after a Stash create/update/destroy hook.
+
+    Hooks run inline inside Stash's mutation path, so this stays small: one lookup, one
+    bounded write, no curator_job row, no model build. Stash logs hook failures without
+    failing the mutation; this logs and returns a neutral result instead of raising.
+    """
+    try:
+        settings = _settings(payload)
+        args = payload.get("args") or {}
+        hook_context = args.get("hookContext")
+        if not isinstance(hook_context, dict):
+            return {"handled": False, "reason": "missing hookContext"}
+        hook_type = str(hook_context.get("type") or "")
+        entity_type = _HOOK_ENTITY_TYPES.get(hook_type)
+        if entity_type is None:
+            return {"handled": False, "hook_type": hook_type}
+        entity_id = str(hook_context.get("id") or "")
+        if not entity_id:
+            return {"handled": False, "hook_type": hook_type, "reason": "missing entity id"}
+        connection = _open(payload, settings)
+        try:
+            service = SyncService(_client(payload), SyncRepository(connection))
+            if hook_type.endswith(".Destroy.Post"):
+                service.delete_entity(entity_type, entity_id)
+                changed = True
+            else:
+                changed = service.upsert_entity(entity_type, entity_id)
+            if changed:
+                ModelUpdateCoordinator(connection).request("entity_hook")
+            return {
+                "handled": True,
+                "hook_type": hook_type,
+                "entity_type": entity_type,
+                "entity_id": entity_id,
+                "changed": changed,
+            }
+        finally:
+            connection.close()
+    except Exception as error:
+        _log("w", f"Curator entity hook failed: {error}")
+        return {"handled": False, "reason": str(error)[:500]}
+
 
 def _diagnostics(connection: Any) -> dict[str, object]:
     migration = MigrationRunner(connection).status()
@@ -1583,7 +1644,12 @@ def main() -> None:
         if not isinstance(payload, dict):
             raise ValueError("plugin input must be an object")
         mode = sys.argv[2] if len(sys.argv) > 2 else None
-        output = _run_task(payload, mode) if mode else dispatch(payload)
+        if mode == "entity-sync":
+            # Stash entity hooks run inline in the mutation path and must never take the
+            # task path: no curator_job row, no single-running-job guard, no model build.
+            output = _run_entity_hook(payload)
+        else:
+            output = _run_task(payload, mode) if mode else dispatch(payload)
         print(json.dumps({"output": output}, separators=(",", ":")))
     except Exception as error:
         print(json.dumps({"error": str(error)}, separators=(",", ":")))

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -87,7 +87,7 @@ from curator.profiling import (  # noqa: E402
     save_trace,
     span,
 )
-from curator.ranking import LanePolicy, SlateBuilder  # noqa: E402
+from curator.ranking import SlateBuilder  # noqa: E402
 from curator.storage import (  # noqa: E402
     MigrationRunner,
     backup_database,
@@ -1247,16 +1247,21 @@ def _classify_lanes(
     model_id: str,
     progress: Callable[[int, int], None] | None = None,
 ) -> int:
+    """Report the published lane count without re-classifying on the core connection.
+
+    The model build classifies straight into the artifact, which this connection reads
+    through attached views; the core-schema copy is shadowed by those views, so writing
+    it would fail (and the runtime never reads it). A zero count is a legitimate outcome
+    for a sparse library, not a signal to rebuild here.
+    """
     count = int(
         connection.execute(
             "SELECT count(*) FROM model_scene_lane WHERE model_id=?", (model_id,)
         ).fetchone()[0]
     )
-    if count:
-        if progress:
-            progress(1, 1)
-        return count
-    return len(LanePolicy(connection).classify(model_id, progress=progress))
+    if progress:
+        progress(1, 1)
+    return count
 
 
 def _prepare_lanes(

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -1057,11 +1057,14 @@ _HOOK_ENTITY_TYPES = {
 
 
 def _run_entity_hook(payload: dict[str, Any]) -> dict[str, object]:
-    """Import or remove one entity after a Stash create/update/destroy hook.
+    """Enqueue a changed entity after a Stash create/update/destroy hook.
 
-    Hooks run inline inside Stash's mutation path, so this stays small: one lookup, one
-    bounded write, no curator_job row, no model build. Stash logs hook failures without
-    failing the mutation; this logs and returns a neutral result instead of raising.
+    Hooks run inline inside Stash's mutation path, so this stays tiny: one bounded write,
+    no GraphQL fetch, no curator_job row, no model build. The fetch and upsert happen in
+    the drain that precedes a preference rebuild, so the model always sees fresh source
+    data while bulk edits pay only the process-spawn cost per entity. Stash logs hook
+    failures without failing the mutation; this logs and returns a neutral result instead
+    of raising.
     """
     try:
         settings = _settings(payload)
@@ -1076,28 +1079,77 @@ def _run_entity_hook(payload: dict[str, Any]) -> dict[str, object]:
         entity_id = str(hook_context.get("id") or "")
         if not entity_id:
             return {"handled": False, "hook_type": hook_type, "reason": "missing entity id"}
-        connection = _open(payload, settings)
+        operation = "delete" if hook_type.endswith(".Destroy.Post") else "upsert"
+        connection = _open(payload, settings, attach_artifacts=False)
         try:
-            service = SyncService(_client(payload), SyncRepository(connection))
-            if hook_type.endswith(".Destroy.Post"):
-                service.delete_entity(entity_type, entity_id)
-                changed = True
-            else:
-                changed = service.upsert_entity(entity_type, entity_id)
-            if changed:
-                ModelUpdateCoordinator(connection).request("entity_hook")
+            with transaction(connection):
+                connection.execute(
+                    """
+                    INSERT INTO pending_entity_change(
+                        entity_type, entity_id, operation, created_at_ms
+                    ) VALUES (?, ?, ?, ?)
+                    ON CONFLICT(entity_type, entity_id) DO UPDATE SET
+                        operation=excluded.operation, created_at_ms=excluded.created_at_ms
+                    """,
+                    (entity_type, entity_id, operation, time.time_ns() // 1_000_000),
+                )
+            ModelUpdateCoordinator(connection).request("entity_hook")
             return {
                 "handled": True,
                 "hook_type": hook_type,
                 "entity_type": entity_type,
                 "entity_id": entity_id,
-                "changed": changed,
+                "enqueued": True,
             }
         finally:
             connection.close()
     except Exception as error:
         _log("w", f"Curator entity hook failed: {error}")
         return {"handled": False, "reason": str(error)[:500]}
+
+
+def _drain_pending_entity_changes(payload: dict[str, Any], connection: Any) -> int:
+    """Fetch and persist every enqueued entity change before a preference rebuild.
+
+    Rows that process cleanly are removed; a row whose entity no longer exists on Stash
+    (deleted after the hook) is dropped as handled, and a transient failure is kept for
+    the next drain. Any full sync supersedes the queue entirely.
+    """
+    rows = list(
+        connection.execute(
+            "SELECT entity_type, entity_id, operation FROM pending_entity_change"
+            " ORDER BY created_at_ms"
+        )
+    )
+    if not rows:
+        return 0
+    service = SyncService(_client(payload), SyncRepository(connection))
+    drained = 0
+    dropped: list[tuple[str, str]] = []
+    for row in rows:
+        entity_type = str(row["entity_type"])
+        entity_id = str(row["entity_id"])
+        try:
+            if row["operation"] == "delete":
+                service.delete_entity(entity_type, entity_id)
+                dropped.append((entity_type, entity_id))
+            else:
+                service.upsert_entity(entity_type, entity_id)
+                dropped.append((entity_type, entity_id))
+            drained += 1
+        except Exception as error:
+            # A missing entity is a destroy that never reached us; a transient failure
+            # stays queued for the next drain.
+            if "did not return" in str(error):
+                dropped.append((entity_type, entity_id))
+            _log("w", f"pending entity change failed for {entity_type} {entity_id}: {error}")
+    if dropped:
+        with transaction(connection):
+            connection.executemany(
+                "DELETE FROM pending_entity_change WHERE entity_type=? AND entity_id=?",
+                dropped,
+            )
+    return drained
 
 
 def _diagnostics(connection: Any) -> dict[str, object]:
@@ -1303,6 +1355,9 @@ def _run_task_body(
                 )
             _progress(0.68)
             coordinator = ModelUpdateCoordinator(connection)
+            # A full sync supersedes the hook queue: everything is refetched anyway.
+            with transaction(connection):
+                connection.execute("DELETE FROM pending_entity_change")
             for entity, removed in sorted(synced.deleted_entity_counts.items()):
                 _log("i", f"Removed {removed} {entity}s deleted from Stash")
             source_changed = (
@@ -1373,6 +1428,11 @@ def _run_task_body(
             coordinator = ModelUpdateCoordinator(connection)
             if mode == "build":
                 coordinator.request("manual_build")
+            _log("i", "Importing entity changes recorded by hooks")
+            with span("python", "task.drain_entity_changes"):
+                drained = _drain_pending_entity_changes(payload, connection)
+            if drained:
+                _log("i", f"Imported {drained} entity changes")
             with span("python", "task.model_build"):
                 models = coordinator.drain(force=True, max_builds=1, progress=report_model)
             if not models:

--- a/plugin/stash-curator.yml
+++ b/plugin/stash-curator.yml
@@ -135,3 +135,21 @@ tasks:
     description: Install numpy and networkx acceleration into a plugin-local virtual environment. The model builder falls back to pure Python when this is not run.
     execArgs:
       - install-deps
+hooks:
+  - name: Sync changed entity
+    description: Import or remove a single entity after a Stash create, update, or delete, so the sidecar stays current without a full sync.
+    triggeredBy:
+      - Scene.Create.Post
+      - Scene.Update.Post
+      - Scene.Destroy.Post
+      - Performer.Create.Post
+      - Performer.Update.Post
+      - Performer.Destroy.Post
+      - Studio.Create.Post
+      - Studio.Update.Post
+      - Studio.Destroy.Post
+      - Tag.Create.Post
+      - Tag.Update.Post
+      - Tag.Destroy.Post
+    execArgs:
+      - entity-sync

--- a/poc/golang-similarity-benchmark/.gitignore
+++ b/poc/golang-similarity-benchmark/.gitignore
@@ -1,0 +1,6 @@
+# Local build artifacts for the POC benchmark; sources are tracked.
+bench
+go/
+*.log
+*.json
+__pycache__/

--- a/poc/golang-similarity-benchmark/README.md
+++ b/poc/golang-similarity-benchmark/README.md
@@ -1,0 +1,82 @@
+# Go similarity-kernel benchmark (POC)
+
+Validates the "fused sparse Go kernel beats numpy on the Curator similarity stage"
+hypothesis. The kernels mirror the production algorithm in
+`curator/model/builder.py::_content_neighbors_numpy` exactly: per row,
+`sim = dot(A_i, B_j)` and `shared = count of co-occurring non-zero features`, then
+
+```
+s = sim * (1 - exp(-shared / 4))
+w = s^3 * labeled_conf[j]
+keep top-12 by (-w, j) among s >= 0.05 (excluding self)
+```
+
+## What is here
+
+- `main.go` — three Go kernels:
+  - `denseStraight`: row-major A x column-major B, all `d` keys per row (a naive
+    dense port; exploits A-side sparsity only).
+  - `sparseFused`: exploits A's non-zeros *and* B's column non-zeros, fuses the
+    sim+shared accumulation into one pass, streams top-k per row (no big matrices),
+    goroutine-parallel over row chunks.
+  - `sparseFusedRef` (in-process): sort-based reference used for self-verification.
+- `ref_numpy.py` — faithful replica of the production numpy path (block 1024 for
+  memory-limited boxes; production uses 4096 — same algorithm, identical results),
+  including the float32 binary matmul for shared counts and the per-row
+  `flatnonzero` + `partition` + sort selection loop.
+
+## How to run
+
+Requires Go >= 1.26 and numpy (the repo's venv has it):
+
+```bash
+# Cross-verify: Python owns the data, Go must reproduce it.
+python3 ref_numpy.py dump 300 120 12 /tmp/cross.json
+go run . verify /tmp/cross.json
+
+# Benchmarks (best-of-3 Go, best-of-2 numpy; OPENBLAS_NUM_THREADS=4).
+go run . 6000 120 12
+OPENBLAS_NUM_THREADS=4 python3 ref_numpy.py 6000 120 12
+```
+
+## Results (4-core x86_64, numpy 2.5.1 + scipy-openblas 0.3.33, Go 1.26.5)
+
+Correctness first: on shared Python-owned data (N=300) all Go kernels select
+identical neighbors to numpy — **0 mismatched rows**, max weight error 1.4e-17
+(float associativity noise only).
+
+| Scenario | numpy (prod algo) | Go dense 4t | Go sparse fused 4t | Go sparse 1t |
+| --- | --- | --- | --- | --- |
+| N=6 000, d=120, nnz=12 | 24.3s | 13.8s (1.8x) | 6.3s (3.9x) | 8.8s |
+| N=3 000, d=600, nnz=30 | 18.0s | 4.5s (4.0x) | 1.45s (12.4x) | 1.8s |
+| N=24 000, d=120 (production size) | ~400s extrapolated | — | 44.8s | 57.0s |
+| N=24 000, d=600 (tag-heavy) | ~19 min extrapolated | — | 51.6s | 51.0s |
+
+Notes:
+
+- This box's OpenBLAS is slow (~4-6 GFLOPS raw matmul; ~0.4-0.6 GFLOPS effective on
+  the full pipeline). On a server with a fast multithreaded BLAS the ratios at
+  d=120 narrow (the O(N^2) per-row selection scan becomes the common floor); at
+  d=600 numpy still performs 20-100x the arithmetic, so the Go win should survive.
+- numpy scales with `d` (it densifies: O(N^2 d), twice - float64 dot + float32
+  binary). Go sparse scales with non-zero counts: O(N * nnz * col-nnz), immune to
+  `d`. Real Curator vectors include description-token columns, so production `d`
+  is likely in the hundreds-to-thousands.
+- numpy allocates ~3 * block * N * 8B per block (sim/weights/shared); Go streams
+  per-row top-k with O(N + k) scratch per worker - no big matrices at all.
+- Both implementations pay an O(N^2) selection scan per row; at N=24 000 that is
+  the remaining ~20-40s floor for Go (next optimization: stamped iteration over
+  only the reachable columns). Production numpy pays the same cost as 24k
+  Python-level numpy calls.
+- Go kernels are deterministic: 1t and 4t produce identical neighbor sets
+  (verified).
+
+## Caveats
+
+- Synthetic data only (seeded; nnz per row fixed, values |N(0,1)|, row-normalized,
+  conf ~ U[0.3, 1]). No real sidecar data was used; the real feature-column count
+  and sparsity are not yet measured.
+- Extrapolations assume numpy's per-MAC cost is constant with N (conservative:
+  selection cost grows too).
+- See `docs/decisions/002-runtime-swap-planning.md` for how this evidence feeds the
+  runtime-swap decision and the equality-coverage plan.

--- a/poc/golang-similarity-benchmark/go.mod
+++ b/poc/golang-similarity-benchmark/go.mod
@@ -1,0 +1,3 @@
+module stashcurator-gobench
+
+go 1.26

--- a/poc/golang-similarity-benchmark/main.go
+++ b/poc/golang-similarity-benchmark/main.go
@@ -1,0 +1,581 @@
+// POC benchmark: Curator content-neighbor similarity stage.
+//
+// Mirrors the production algorithm in curator/model/builder.py
+// (_content_neighbors_numpy): per row, sim = dot(A_i, B_j) and
+// shared = count of co-occurring non-zero features, then
+//
+//	s = sim * (1 - exp(-shared/4))
+//	w = s^3 * labeled_conf[j]
+//	keep top-k by (-w, j) among s >= min_sim (excluding self).
+//
+// Three kernels:
+//
+//	denseStraight : row-major A, column-major B, all d keys per row (naive port)
+//	sparseFused   : exploits A's non-zeros AND B's column non-zeros; fused
+//	                sim+shared in one pass; goroutine-parallel over row chunks
+//	sparseFused1  : same, single thread (core-scaling attribution)
+package main
+
+import (
+	"container/heap"
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/rand"
+	"os"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	minSim        = 0.05
+	neighborCount = 12
+)
+
+type Row struct {
+	Keys   []int
+	Values []float64
+}
+
+// Neighbor mirrors production's evidence tuple (labeled id, similarity, weight).
+type Neighbor struct {
+	J int
+	S float64
+	W float64
+}
+
+// ---------- data generation (matches the Python replica's generator) ----------
+
+func genData(n, d, nnz int, seed int64) ([]Row, [][]float64, [][]float64) {
+	rng := rand.New(rand.NewSource(seed))
+	rows := make([]Row, n)
+	for i := range rows {
+		perm := rng.Perm(d)[:nnz]
+		sort.Ints(perm)
+		keys := make([]int, nnz)
+		vals := make([]float64, nnz)
+		var sumsq float64
+		for k := range perm {
+			keys[k] = perm[k]
+			vals[k] = math.Abs(rng.NormFloat64())
+			sumsq += vals[k] * vals[k]
+		}
+		norm := math.Sqrt(sumsq)
+		for k := range vals {
+			vals[k] /= norm
+		}
+		rows[i] = Row{keys, vals}
+	}
+	// Dense A (row-major) and column-major BT for the straight kernel.
+	a := make([][]float64, n)
+	bt := make([][]float64, d)
+	for k := range bt {
+		bt[k] = make([]float64, n)
+	}
+	for i := range rows {
+		a[i] = make([]float64, d)
+		for k, key := range rows[i].Keys {
+			a[i][key] = rows[i].Values[k]
+			bt[key][i] = rows[i].Values[k]
+		}
+	}
+	conf := make([]float64, n)
+	for i := range conf {
+		conf[i] = 0.3 + rng.Float64()*0.7
+	}
+	return rows, a, bt
+}
+
+// ---------- kernel: sparse, fused ----------
+
+type ColEntry struct {
+	J int
+	V float64
+}
+
+func buildColLists(rows []Row, d int) [][]ColEntry {
+	lists := make([][]ColEntry, d)
+	for i, row := range rows {
+		for k, key := range row.Keys {
+			lists[key] = append(lists[key], ColEntry{i, row.Values[k]})
+		}
+	}
+	return lists
+}
+
+// sparseFused: sim and shared accumulated in one pass over (row nonzeros x column
+// nonzeros); streaming top-k per row. Returns per-row selected neighbors.
+func sparseFused(rows []Row, colLists [][]ColEntry, conf []float64, nthreads int) [][]Neighbor {
+	n := len(rows)
+	results := make([][]Neighbor, n)
+	if nthreads > n {
+		nthreads = n
+	}
+	chunk := (n + nthreads - 1) / nthreads
+	var wg sync.WaitGroup
+	for w := 0; w < nthreads; w++ {
+		start := w * chunk
+		end := start + chunk
+		if end > n {
+			end = n
+		}
+		if start >= end {
+			continue
+		}
+		wg.Add(1)
+		go func(start, end int) {
+			defer wg.Done()
+			sims := make([]float64, n)
+			shared := make([]int32, n)
+			stamps := make([]int32, n)
+			stamp := int32(0)
+			for i := start; i < end; i++ {
+				stamp++
+				row := rows[i]
+				// Accumulate sim and shared for all j reachable from row's keys.
+				for k, key := range row.Keys {
+					val := row.Values[k]
+					for _, ce := range colLists[key] {
+						j := ce.J
+						if stamps[j] != stamp {
+							stamps[j] = stamp
+							sims[j] = val * ce.V
+							shared[j] = 1
+						} else {
+							sims[j] += val * ce.V
+							shared[j]++
+						}
+					}
+				}
+				// Collect valid candidates, stream-select top-k by (-w, j).
+				sel := &neighborHeap{}
+				heap.Init(sel)
+				for j := 0; j < n; j++ {
+					if stamps[j] != stamp || j == i {
+						continue
+					}
+					s := sims[j] * (1 - math.Exp(-float64(shared[j])/4.0))
+					if s < minSim {
+						continue
+					}
+					w := s * s * s * conf[j]
+					if sel.Len() < neighborCount {
+						heap.Push(sel, Neighbor{j, s, w})
+					} else if w > sel.Peek().W || (w == sel.Peek().W && j < sel.Peek().J) {
+						heap.Pop(sel)
+						heap.Push(sel, Neighbor{j, s, w})
+					}
+				}
+				out := make([]Neighbor, 0, sel.Len())
+				for sel.Len() > 0 {
+					out = append(out, heap.Pop(sel).(Neighbor))
+				}
+				// heap.Pop yields worst-first; reverse to (-w, j) order.
+				for l, r := 0, len(out)-1; l < r; l, r = l+1, r-1 {
+					out[l], out[r] = out[r], out[l]
+				}
+				results[i] = out
+			}
+		}(start, end)
+	}
+	wg.Wait()
+	return results
+}
+
+// ---------- kernel: dense straight port (all d keys per row, fused sim+shared) ----------
+
+func denseStraight(a [][]float64, bt [][]float64, conf []float64, nthreads int) [][]Neighbor {
+	n := len(a)
+	d := len(bt)
+	results := make([][]Neighbor, n)
+	if nthreads > n {
+		nthreads = n
+	}
+	chunk := (n + nthreads - 1) / nthreads
+	var wg sync.WaitGroup
+	for w := 0; w < nthreads; w++ {
+		start := w * chunk
+		end := start + chunk
+		if end > n {
+			end = n
+		}
+		if start >= end {
+			continue
+		}
+		wg.Add(1)
+		go func(start, end int) {
+			defer wg.Done()
+			sims := make([]float64, n)
+			shared := make([]int32, n)
+			for i := start; i < end; i++ {
+				row := a[i]
+				for j := range sims {
+					sims[j] = 0
+					shared[j] = 0
+				}
+				for k := 0; k < d; k++ {
+					av := row[k]
+					if av == 0 {
+						continue
+					}
+					col := bt[k]
+					for j := 0; j < n; j++ {
+						bv := col[j]
+						if bv == 0 {
+							continue
+						}
+						sims[j] += av * bv
+						shared[j]++
+					}
+				}
+				sel := &neighborHeap{}
+				heap.Init(sel)
+				for j := 0; j < n; j++ {
+					if j == i || shared[j] == 0 {
+						continue
+					}
+					s := sims[j] * (1 - math.Exp(-float64(shared[j])/4.0))
+					if s < minSim {
+						continue
+					}
+					w := s * s * s * conf[j]
+					if sel.Len() < neighborCount {
+						heap.Push(sel, Neighbor{j, s, w})
+					} else if w > sel.Peek().W || (w == sel.Peek().W && j < sel.Peek().J) {
+						heap.Pop(sel)
+						heap.Push(sel, Neighbor{j, s, w})
+					}
+				}
+				out := make([]Neighbor, 0, sel.Len())
+				for sel.Len() > 0 {
+					out = append(out, heap.Pop(sel).(Neighbor))
+				}
+				for l, r := 0, len(out)-1; l < r; l, r = l+1, r-1 {
+					out[l], out[r] = out[r], out[l]
+				}
+				results[i] = out
+			}
+		}(start, end)
+	}
+	wg.Wait()
+	return results
+}
+
+// ---------- min-heap of the *worst* kept neighbor: worst (smallest w, largest j) at top ----------
+
+type neighborHeap []Neighbor
+
+func (h neighborHeap) Len() int { return len(h) }
+func (h neighborHeap) Less(i, j int) bool {
+	if h[i].W != h[j].W {
+		return h[i].W < h[j].W
+	}
+	return h[i].J > h[j].J
+}
+func (h neighborHeap) Swap(i, j int)  { h[i], h[j] = h[j], h[i] }
+func (h *neighborHeap) Push(x any)    { *h = append(*h, x.(Neighbor)) }
+func (h *neighborHeap) Pop() any      { old := *h; x := old[len(old)-1]; *h = old[:len(old)-1]; return x }
+func (h neighborHeap) Peek() Neighbor { return h[0] }
+
+// candidateStats counts candidates passing the min-sim filter (excluding self).
+func candidateStats(rows []Row, colLists [][]ColEntry, conf []float64) float64 {
+	n := len(rows)
+	sims := make([]float64, n)
+	shared := make([]int32, n)
+	stamps := make([]int32, n)
+	stamp := int32(0)
+	total := 0
+	for i := range rows {
+		stamp++
+		row := rows[i]
+		for k, key := range row.Keys {
+			val := row.Values[k]
+			for _, ce := range colLists[key] {
+				j := ce.J
+				if stamps[j] != stamp {
+					stamps[j] = stamp
+					sims[j] = val * ce.V
+					shared[j] = 1
+				} else {
+					sims[j] += val * ce.V
+					shared[j]++
+				}
+			}
+		}
+		for j := 0; j < n; j++ {
+			if stamps[j] == stamp && j != i {
+				s := sims[j] * (1 - math.Exp(-float64(shared[j])/4.0))
+				if s >= minSim {
+					total++
+				}
+			}
+		}
+	}
+	return float64(total) / float64(n)
+}
+
+// ---------- harness ----------
+
+func timeKernel(name string, fn func()) time.Duration {
+	best := time.Duration(1 << 62)
+	reps := 3
+	if v := os.Getenv("GO_REPS"); v != "" {
+		fmt.Sscanf(v, "%d", &reps)
+	}
+	for r := 0; r < reps; r++ {
+		runtime.GC()
+		t0 := time.Now()
+		fn()
+		el := time.Since(t0)
+		if el < best {
+			best = el
+		}
+	}
+	fmt.Printf("%-22s %10s\n", name, best.Round(time.Millisecond))
+	return best
+}
+
+func main() {
+	if len(os.Args) >= 2 && os.Args[1] == "verify" {
+		// verify PYTHON_DUMP.json  -> compare Go kernels against the Python replica
+		// on data owned by the Python side.
+		raw, err := os.ReadFile(os.Args[2])
+		if err != nil {
+			panic(err)
+		}
+		var dump struct {
+			Values  map[string]map[string]float64 `json:"values"`
+			Conf    []float64                     `json:"conf"`
+			Results map[string][][3]float64       `json:"results"`
+		}
+		if err := json.Unmarshal(raw, &dump); err != nil {
+			panic(err)
+		}
+		n := len(dump.Results)
+		rows := make([]Row, n)
+		for i := 0; i < n; i++ {
+			vec := dump.Values[fmt.Sprint(i)]
+			keys := make([]int, 0, len(vec))
+			for k := range vec {
+				var key int
+				fmt.Sscanf(k, "%d", &key)
+				keys = append(keys, key)
+			}
+			sort.Ints(keys)
+			vals := make([]float64, len(keys))
+			for m, k := range keys {
+				vals[m] = vec[fmt.Sprint(k)]
+			}
+			rows[i] = Row{keys, vals}
+		}
+		d := 0
+		for _, row := range rows {
+			if len(row.Keys) > 0 && row.Keys[len(row.Keys)-1] >= d {
+				d = row.Keys[len(row.Keys)-1] + 1
+			}
+		}
+		colLists := buildColLists(rows, d)
+		for _, kernel := range []struct {
+			name string
+			fn   func() [][]Neighbor
+		}{{"sparseFusedRef", func() [][]Neighbor { return sparseFusedRef(rows, colLists, dump.Conf) }},
+			{"sparseFused(1t)", func() [][]Neighbor { return sparseFused(rows, colLists, dump.Conf, 1) }},
+			{"sparseFused(4t)", func() [][]Neighbor { return sparseFused(rows, colLists, dump.Conf, runtime.GOMAXPROCS(0)) }}} {
+			got := kernel.fn()
+			mismatched, maxWErr := 0, 0.0
+			for i := 0; i < n; i++ {
+				want := dump.Results[fmt.Sprint(i)]
+				if len(want) != len(got[i]) {
+					mismatched++
+					continue
+				}
+				for m := range want {
+					if int(want[m][0]) != got[i][m].J {
+						mismatched++
+						break
+					}
+					if wErr := math.Abs(want[m][2] - got[i][m].W); wErr > maxWErr {
+						maxWErr = wErr
+					}
+				}
+			}
+			fmt.Printf("verify %-16s vs numpy: mismatched rows=%d maxWErr=%.3e\n", kernel.name, mismatched, maxWErr)
+		}
+		return
+	}
+	if len(os.Args) >= 2 && os.Args[1] == "dump" {
+		// dump N D NNZ PATH  -> write reference results as JSON for cross-verification.
+		var n, d, nnz int
+		fmt.Sscanf(os.Args[2], "%d", &n)
+		fmt.Sscanf(os.Args[3], "%d", &d)
+		fmt.Sscanf(os.Args[4], "%d", &nnz)
+		rows, _, _ := genData(n, d, nnz, 7)
+		conf := make([]float64, n)
+		rng := rand.New(rand.NewSource(99))
+		for i := range conf {
+			conf[i] = 0.3 + rng.Float64()*0.7
+		}
+		colLists := buildColLists(rows, d)
+		ref := sparseFusedRef(rows, colLists, conf)
+		buf, _ := json.Marshal(ref)
+		os.WriteFile(os.Args[5], buf, 0o644)
+		fmt.Println("dumped", os.Args[5])
+		return
+	}
+	var n, d, nnz int
+	if len(os.Args) == 4 {
+		fmt.Sscanf(os.Args[1], "%d", &n)
+		fmt.Sscanf(os.Args[2], "%d", &d)
+		fmt.Sscanf(os.Args[3], "%d", &nnz)
+	} else {
+		n, d, nnz = 24000, 120, 12
+	}
+	threads := runtime.GOMAXPROCS(0)
+	reps := 3
+	if v := os.Getenv("GO_REPS"); v != "" {
+		fmt.Sscanf(v, "%d", &reps)
+	}
+	fmt.Printf("n=%d d=%d nnz=%d threads=%d reps=%d\n", n, d, nnz, threads, reps)
+
+	rows, a, bt := genData(n, d, nnz, 7)
+	conf := make([]float64, n)
+	rng := rand.New(rand.NewSource(99))
+	for i := range conf {
+		conf[i] = 0.3 + rng.Float64()*0.7
+	}
+	colLists := buildColLists(rows, d)
+
+	only := os.Getenv("GO_ONLY")
+	if only == "gen" {
+		fmt.Println("generation only")
+		return
+	}
+	if only == "dense" {
+		timeKernel("denseStraight 4t", func() { denseStraight(a, bt, conf, threads) })
+		return
+	}
+	if only == "sparse" {
+		timeKernel("sparseFused 4t", func() { sparseFused(rows, colLists, conf, threads) })
+		return
+	}
+	if only == "sel" {
+		// self-check + selection kernels only (no denseStraight)
+		avgCand := candidateStats(rows, colLists, conf)
+		fmt.Printf("avg valid/row (Go data) ~ %.0f\n", avgCand)
+		ref := sparseFusedRef(rows, colLists, conf)
+		got := sparseFused(rows, colLists, conf, 1)
+		mismatches, maxWErr := 0, 0.0
+		for i := range ref {
+			if len(ref[i]) != len(got[i]) {
+				mismatches++
+				continue
+			}
+			for m := range ref[i] {
+				if ref[i][m].J != got[i][m].J {
+					mismatches++
+					break
+				}
+				if wErr := math.Abs(ref[i][m].W - got[i][m].W); wErr > maxWErr {
+					maxWErr = wErr
+				}
+			}
+		}
+		fmt.Printf("self-check: mismatched rows=%d maxWErr=%.3e\n", mismatches, maxWErr)
+		timeKernel("sparseFused 4t", func() { sparseFused(rows, colLists, conf, threads) })
+		return
+	}
+
+	// Workload fairness: average valid-candidate count per row (>= minSim).
+	avgCand := candidateStats(rows, colLists, conf)
+	fmt.Printf("avg valid/row (Go data) ~ %.0f\n", avgCand)
+
+	// Correctness vs a reference implementation (sort-based top-k, same math).
+	ref := sparseFusedRef(rows, colLists, conf)
+	got := sparseFused(rows, colLists, conf, 1)
+	mismatches := 0
+	maxWErr := 0.0
+	for i := range ref {
+		if len(ref[i]) != len(got[i]) {
+			mismatches++
+			continue
+		}
+		for m := range ref[i] {
+			if ref[i][m].J != got[i][m].J {
+				mismatches++
+				break
+			}
+			if wErr := math.Abs(ref[i][m].W - got[i][m].W); wErr > maxWErr {
+				maxWErr = wErr
+			}
+		}
+	}
+	fmt.Printf("self-check: mismatched rows=%d maxWErr=%.3e\n", mismatches, maxWErr)
+
+	kernels := os.Getenv("GO_KERNELS")
+	run := func(name string) bool {
+		return kernels == "" || strings.Contains(kernels, name)
+	}
+	if run("dense") {
+		timeKernel("denseStraight 4t", func() { denseStraight(a, bt, conf, threads) })
+	}
+	if run("sparse") {
+		timeKernel("sparseFused 4t", func() { sparseFused(rows, colLists, conf, threads) })
+		timeKernel("sparseFused 1t", func() { sparseFused(rows, colLists, conf, 1) })
+	}
+}
+
+// sparseFusedRef: straightforward correct implementation (sort, no heap tricks)
+// used only to validate the optimized kernel.
+func sparseFusedRef(rows []Row, colLists [][]ColEntry, conf []float64) [][]Neighbor {
+	n := len(rows)
+	results := make([][]Neighbor, n)
+	sims := make([]float64, n)
+	shared := make([]int32, n)
+	stamps := make([]int32, n)
+	stamp := int32(0)
+	for i := range rows {
+		stamp++
+		row := rows[i]
+		for k, key := range row.Keys {
+			val := row.Values[k]
+			for _, ce := range colLists[key] {
+				j := ce.J
+				if stamps[j] != stamp {
+					stamps[j] = stamp
+					sims[j] = val * ce.V
+					shared[j] = 1
+				} else {
+					sims[j] += val * ce.V
+					shared[j]++
+				}
+			}
+		}
+		var cand []Neighbor
+		for j := 0; j < n; j++ {
+			if stamps[j] != stamp || j == i {
+				continue
+			}
+			s := sims[j] * (1 - math.Exp(-float64(shared[j])/4.0))
+			if s < minSim {
+				continue
+			}
+			cand = append(cand, Neighbor{j, s, s * s * s * conf[j]})
+		}
+		sort.Slice(cand, func(x, y int) bool {
+			if cand[x].W != cand[y].W {
+				return cand[x].W > cand[y].W
+			}
+			return cand[x].J < cand[y].J
+		})
+		if len(cand) > neighborCount {
+			cand = cand[:neighborCount]
+		}
+		kept := make([]Neighbor, len(cand))
+		copy(kept, cand)
+		results[i] = kept
+	}
+	return results
+}

--- a/poc/golang-similarity-benchmark/ref_numpy.py
+++ b/poc/golang-similarity-benchmark/ref_numpy.py
@@ -1,0 +1,155 @@
+"""Faithful replica of production curator/model/builder.py::_content_neighbors_numpy.
+
+Same math and order: block 2048 (memory-limited box; production uses 4096 — the
+algorithm and results are identical), float64 target @ labeled.T, float32 binary
+matmul for shared counts, sim *= 1-exp(-shared/4), weights = sim^3 * conf,
+per-row flatnonzero + partition + sort, top-12 by (-weight, column).
+
+Usage: OPENBLAS_NUM_THREADS=N python3 ref_numpy.py N D NNZ [verify_go_file]
+"""
+
+import json
+import os
+import sys
+import time
+
+import numpy as np
+
+BLOCK = 1024
+MIN_SIM = 0.05
+NEIGHBOR_COUNT = 12
+
+
+def generate(n, d, nnz, seed=7):
+    rng = np.random.default_rng(seed)
+    values = {}
+    for i in range(n):
+        cols = rng.choice(d, size=nnz, replace=False)
+        vals = np.abs(rng.standard_normal(nnz))
+        vals /= np.linalg.norm(vals)
+        values[i] = {int(c): float(v) for c, v in zip(cols, vals, strict=True)}
+    conf = 0.3 + rng.random(n) * 0.7
+    return values, conf
+
+
+def content_neighbors_numpy(values, conf, min_sim=MIN_SIM, neighbor_count=NEIGHBOR_COUNT):
+    """Returns per-scene list of (labeled_j, similarity, weight) selected neighbors."""
+    scene_ids = sorted(values)
+    column_names = sorted({c for sid in scene_ids for c in values[sid]})
+    col_index = {c: i for i, c in enumerate(column_names)}
+    n = len(scene_ids)
+    d = len(column_names)
+    labeled_values = np.zeros((n, d))
+    for col, sid in enumerate(scene_ids):
+        for c, v in values[sid].items():
+            labeled_values[col, col_index[c]] = v
+    target_values = labeled_values
+    labeled_conf = np.array(conf)
+    labeled_binary = (labeled_values != 0).astype(np.float32)
+    target_binary = (target_values != 0).astype(np.float32)
+    self_column = np.arange(n)
+
+    t_matmul = 0.0
+    t_select = 0.0
+    results = {}
+    for start in range(0, n, BLOCK):
+        end = min(start + BLOCK, n)
+        t0 = time.perf_counter()
+        sim = target_values[start:end] @ labeled_values.T
+        shared = (target_binary[start:end] @ labeled_binary.T).astype(np.float64)
+        sim *= 1.0 - np.exp(-shared / 4.0)
+        weights = sim**3 * labeled_conf[np.newaxis, :]
+        valid = sim >= min_sim
+        for local_row in range(end - start):
+            own = int(self_column[start + local_row])
+            if own >= 0:
+                valid[local_row, own] = False
+        t_matmul += time.perf_counter() - t0
+
+        t1 = time.perf_counter()
+        for local_row in range(end - start):
+            sid = scene_ids[start + local_row]
+            vi = np.flatnonzero(valid[local_row])
+            if len(vi) == 0:
+                results[sid] = []
+                continue
+            rw = weights[local_row, vi]
+            chosen = min(neighbor_count, len(rw))
+            boundary = float(np.partition(rw, len(rw) - chosen)[len(rw) - chosen])
+            candidates = vi[rw >= boundary]
+            ev = sorted(
+                (
+                    (int(c), float(sim[local_row, c]), float(weights[local_row, c]))
+                    for c in candidates
+                ),
+                key=lambda item: (-item[2], item[0]),
+            )[:neighbor_count]
+            results[sid] = ev
+        t_select += time.perf_counter() - t1
+    return results, t_matmul, t_select
+
+
+def main():
+    if sys.argv[1] == "dump":
+        # dump N D NNZ OUT  -> single source of truth for cross-verification.
+        n, d, nnz = (int(x) for x in sys.argv[2:5])
+        out = sys.argv[5]
+        values, conf = generate(n, d, nnz)
+        results, _, _ = content_neighbors_numpy(values, conf)
+        with open(out, "w") as fh:
+            json.dump(
+                {
+                    "values": {str(k): v for k, v in values.items()},
+                    "conf": [float(x) for x in conf],
+                    "results": {str(k): [[j, s, w] for j, s, w in v] for k, v in results.items()},
+                },
+                fh,
+            )
+        print(f"dumped {out}")
+        return
+    n, d, nnz = (int(x) for x in sys.argv[1:4])
+    verify_path = sys.argv[4] if len(sys.argv) > 4 else None
+    reps = int(os.environ.get("NP_REPS", "3"))
+    values, conf = generate(n, d, nnz)
+
+    best = None
+    for _ in range(reps):
+        t0 = time.perf_counter()
+        results, t_mm, t_sel = content_neighbors_numpy(values, conf)
+        el = time.perf_counter() - t0
+        if best is None or el < best[0]:
+            best = (el, results, t_mm, t_sel)
+    el, results, t_mm, t_sel = best
+    macs = n * n * d * 2
+    valid_counts = [len(v) for v in results.values()]
+    print(
+        f"numpy  n={n} d={d} nnz={nnz} "
+        f"threads={os.environ.get('OPENBLAS_NUM_THREADS', '?')} reps={reps}: "
+        f"{el:.2f}s total  (matmul+overlap {t_mm:.2f}s, per-row select {t_sel:.2f}s, "
+        f"dense MACs {macs / 1e9:.1f}G -> {macs / el / 1e9:.1f} GFLOPS effective; "
+        f"avg valid/row {sum(valid_counts) / len(valid_counts):.0f})"
+    )
+    sys.stdout.flush()
+
+    if verify_path:
+        # Compare against Go's output (JSON: per row [[j, s, w], ...]).
+        with open(verify_path) as fh:
+            go_results = json.load(fh)
+        mismatched = 0
+        max_w_err = 0.0
+        for i in range(n):
+            rp = [(j, s, w) for j, s, w in results[i]]
+            gp = [tuple(x) for x in go_results[i]]
+            if len(rp) != len(gp):
+                mismatched += 1
+                continue
+            for (j1, _s1, w1), (j2, _s2, w2) in zip(rp, gp, strict=True):
+                if j1 != j2:
+                    mismatched += 1
+                    break
+                max_w_err = max(max_w_err, abs(w1 - w2))
+        print(f"verify vs Go: mismatched rows={mismatched} maxWErr={max_w_err:.3e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark.py
+++ b/scripts/benchmark.py
@@ -1,0 +1,835 @@
+#!/usr/bin/env python3
+"""Automated Phase 0 benchmark: drive a live Stash running Curator, collect traces.
+
+Runs a battery of plugin operations and tasks against a Stash that has Curator
+installed, pulls the profiling traces from the sidecar copy, and writes a scrubbed
+report (JSON + Markdown) with per-operation latency statistics, the spawn/import
+component, and the stage-level span breakdowns for tasks.
+
+Everything is stdlib-only. The sidecar under test is always copied first (sqlite
+backup API) and the benchmark never touches the original. The report contains only
+operation names, aggregate statistics, and span categories/names - no entity ids or
+library data.
+
+Usage:
+  python scripts/benchmark.py --db /path/to/curator.sqlite3 [--url URL] [--ops ...]
+
+Options:
+  --db PATH        Sidecar to benchmark against (copied before use). Default:
+                   $STASH_CURATOR_DB, else the first candidate found under
+                   data/ and .tmp/.
+  --url URL        Stash base URL. Default http://localhost:PORT with
+                   --port (default 9998; 9999 is often the UI-dev mock).
+  --port PORT      Host port to publish Stash on when starting it.
+  --ops LIST       Comma-separated operations; "all" for the full battery.
+  --tasks LIST     Comma-separated task display names from stash-curator.yml;
+                   "all" for prepare, backup, build.
+  --reps N         Repetitions per operation (default 4).
+  --workspace DIR  Scratch dir for the Stash install + sidecar copy (default
+                   .tmp/benchmark).
+  --report-dir DIR Report output dir (default .tmp/benchmark-report).
+  --keep-stash     Do not tear down Stash after the run.
+  --no-stash       Do not start/stop Stash; use whatever answers at --url.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sqlite3
+import statistics
+import subprocess
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPOSE_FILE = ROOT / "tests" / "integration" / "docker-compose.yml"
+PLUGIN_ZIP = ROOT / "dist" / "stash-curator.zip"
+PLUGIN_ID = "stash-curator"
+
+# Task display names from plugin/stash-curator.yml (what runPluginTask expects).
+TASK_NAMES = {
+    "prepare": "Prepare recommendation pages",
+    "backup": "Backup Curator data",
+    "build": "Rebuild recommendation model",
+    "update-model": "Apply recent Curator feedback",
+    "sync-plays": "Sync recent plays",
+    "compact": "Compact legacy Curator data",
+    "vacuum": "Vacuum compacted Curator data",
+}
+
+OPERATIONS = {
+    "round_trip": {},
+    "health": {},
+    "get_config": {},
+    "get_slate": {"operation": "get_slate", "lane": "for_you", "count": 20, "page": 1},
+    "get_slate_page2": {"operation": "get_slate", "lane": "for_you", "count": 20, "page": 2},
+    "replace_item": {"operation": "replace_item", "exclude_scene_ids": []},
+    "get_similar_scene": {"operation": "get_similar", "entity_type": "scene", "count": 20},
+    "get_similar_performer": {
+        "operation": "get_similar",
+        "entity_type": "performer",
+        "count": 20,
+    },
+    "get_explanation": {"operation": "get_explanation"},
+    "get_expand": {"operation": "get_expand", "entity_type": "performer", "page": 1},
+    "get_shortlist": {"operation": "get_shortlist", "page": 1},
+    "get_taste_profile": {"operation": "get_taste_profile"},
+    "get_feedback_history": {"operation": "get_feedback_history", "page": 1},
+    "get_recommendation_history": {"operation": "get_recommendation_history", "page": 1},
+    "get_job_status": {"operation": "get_job_status"},
+    "get_diagnostics": {"operation": "get_diagnostics"},
+}
+
+# Operations that need a published model in the sidecar.
+MODEL_OPS = {
+    "get_slate",
+    "get_slate_page2",
+    "replace_item",
+    "get_similar_scene",
+    "get_similar_performer",
+    "get_explanation",
+    "get_expand",
+    "get_shortlist",
+    "get_taste_profile",
+    "get_recommendation_history",
+}
+
+
+def _gql(url: str, query: str, variables: dict[str, object] | None = None) -> dict[str, object]:
+    payload = json.dumps({"query": query, "variables": variables or {}}).encode()
+    req = urllib.request.Request(
+        f"{url}/graphql", data=payload, headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=1800) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode(errors="replace")
+        raise RuntimeError(f"Stash returned {exc.code}: {body[:500]}") from exc
+    if "errors" in data:
+        raise RuntimeError(f"GraphQL error: {data['errors']}")
+    return dict(data["data"])
+
+
+def _wait_for_stash(url: str, timeout: float = 180) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            req = urllib.request.Request(url, method="HEAD")
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                if resp.status == 200:
+                    return
+        except Exception:
+            time.sleep(2)
+    raise RuntimeError(f"Stash not ready at {url} after {timeout}s")
+
+
+# --------------------------------------------------------------------------- sidecar
+
+
+def _find_sidecar() -> Path | None:
+    """Pick the first usable sidecar (published model + profiling) under data/ and .tmp/."""
+    candidates = [ROOT / "data"]
+    tmp = ROOT / ".tmp"
+    if tmp.is_dir():
+        candidates.append(tmp)
+    found: list[tuple[float, Path]] = []
+    for base in candidates:
+        for path in sorted(base.rglob("*.sqlite3")):
+            try:
+                con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+                try:
+                    tables = {
+                        row[0]
+                        for row in con.execute("SELECT name FROM sqlite_master WHERE type='table'")
+                    }
+                    if "profile_trace" not in tables:
+                        continue
+                    model = con.execute(
+                        "SELECT count(*) FROM model_version WHERE status='published'"
+                    ).fetchone()[0]
+                    if model == 0:
+                        continue
+                finally:
+                    con.close()
+            except Exception:
+                continue
+            # Prefer cores with their generation-artifact directory present.
+            derived = path.resolve().with_name(f"{path.stem}-derived")
+            if not derived.is_dir():
+                continue
+            found.append((path.stat().st_mtime, path))
+    if not found:
+        return None
+    found.sort(reverse=True)
+    return found[0][1]
+
+
+def _copy_sidecar(source: Path, destination: Path) -> None:
+    """Crash-safe single-file copy via the sqlite backup API (handles WAL).
+
+    Also copies the `<stem>-derived` generation-artifact directory beside the
+    destination, so the copy is self-contained: `attach_active_artifacts`
+    requires the active feature/model artifacts to exist there.
+    """
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    src = sqlite3.connect(f"file:{source}?mode=ro", uri=True)
+    dst = sqlite3.connect(destination)
+    try:
+        src.backup(dst)
+    finally:
+        dst.close()
+        src.close()
+    derived = source.resolve().with_name(f"{source.stem}-derived")
+    if derived.is_dir():
+        target = destination.resolve().with_name(f"{destination.stem}-derived")
+        shutil.copytree(derived, target, dirs_exist_ok=True)
+
+
+def _sidecar_state(path: Path) -> dict[str, object]:
+    """Counts only - never values. Used for the report header."""
+    con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    try:
+        model = con.execute(
+            "SELECT count(*) FROM model_version WHERE status='published'"
+        ).fetchone()[0]
+        traces = con.execute("SELECT count(*) FROM profile_trace").fetchone()[0]
+        jobs = con.execute("SELECT count(*) FROM curator_job").fetchone()[0]
+    finally:
+        con.close()
+    return {"published_models": model, "profile_traces": traces, "curator_jobs": jobs}
+
+
+def _sample_ids(path: Path) -> tuple[str | None, str | None]:
+    """One scene id and one performer id from the copy (used in requests only)."""
+    con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    try:
+        scene = con.execute("SELECT scene_id FROM source_scene ORDER BY rowid LIMIT 1").fetchone()
+        performer = con.execute(
+            "SELECT performer_id FROM source_performer ORDER BY rowid LIMIT 1"
+        ).fetchone()
+    finally:
+        con.close()
+    return (
+        str(scene[0]) if scene else None,
+        str(performer[0]) if performer else None,
+    )
+
+
+# --------------------------------------------------------------------------- Stash
+
+
+def _ensure_plugin_built() -> None:
+    if PLUGIN_ZIP.is_file():
+        return
+    subprocess.run(
+        ["uv", "run", "--frozen", "python", "scripts/build_plugin.py"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _clean_workspace_plugin(workspace: Path) -> None:
+    """Remove the installed plugin tree, falling back to a root container.
+
+    The Stash container runs Python as root and writes __pycache__ into the
+    mounted plugin dir; host removal then hits permission errors. A throwaway
+    alpine container removes those files when plain shutil.rmtree fails.
+    """
+    plugin_dir = workspace / "plugins"
+    if not plugin_dir.exists():
+        return
+    try:
+        shutil.rmtree(plugin_dir)
+        return
+    except PermissionError:
+        pass
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "-v",
+            f"{plugin_dir.resolve()}:/clean",
+            "alpine",
+            "sh",
+            "-c",
+            "rm -rf /clean/*",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    shutil.rmtree(plugin_dir, ignore_errors=True)
+
+
+def _install_plugin(workspace: Path) -> None:
+    plugin_dir = workspace / "plugins" / PLUGIN_ID
+    _clean_workspace_plugin(workspace)
+    plugin_dir.mkdir(parents=True)
+    with zipfile.ZipFile(PLUGIN_ZIP) as archive:
+        archive.extractall(plugin_dir)
+    data_dir = plugin_dir / "data"
+    shutil.rmtree(data_dir, ignore_errors=True)
+    data_dir.mkdir()
+    os.chmod(data_dir, 0o777)  # container writes WAL as root; host reads read-only
+    # The container runs Python as root and writes __pycache__ into the mounted
+    # plugin dir; make the tree writable so host cleanup (and the next install)
+    # can remove it without root.
+    for root, dirs, _ in os.walk(plugin_dir):
+        os.chmod(root, 0o777)
+        for name in dirs:
+            os.chmod(Path(root) / name, 0o777)
+    (workspace / "config.yml").write_text(
+        "\n".join(
+            (
+                "generated: /root/.stash/generated",
+                "cache: /root/.stash/cache",
+                "blobs:",
+                "  path: /root/.stash/blobs",
+                "  storage: FILESYSTEM",
+                "database: /root/.stash/stash-go.sqlite",
+                "dangerous_allow_public_without_auth: true",
+                "plugins:",
+                f"  {PLUGIN_ID}:",
+                "    enabled: true",
+                "    profilingEnabled: true",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    return data_dir
+
+
+def _compose(action: str, workspace: Path, port: int) -> None:
+    env = dict(os.environ, STASH_CONFIG=str(workspace), STASH_PORT=str(port))
+    command = ["docker", "compose", "-f", str(COMPOSE_FILE), action]
+    if action == "up":
+        command += ["-d", "--wait"]
+    else:
+        command += ["--volumes"]
+    subprocess.run(
+        command,
+        cwd=ROOT,
+        check=True,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _introspect(url: str) -> tuple[bool, bool, bool]:
+    data = _gql(url, '{ __type(name: "Mutation") { fields { name } } }')
+    fields = {str(item["name"]) for item in data["__type"]["fields"]}
+    return (
+        "runPluginOperation" in fields,
+        "runPluginTask" in fields,
+        "configurePlugin" in fields,
+    )
+
+
+def _run_operation(url: str, args: dict[str, object]) -> tuple[float, dict[str, object]]:
+    started = time.perf_counter()
+    data = _gql(
+        url,
+        f'mutation($args: Map!) {{ runPluginOperation(plugin_id: "{PLUGIN_ID}", args: $args) }}',
+        {"args": args},
+    )
+    return (time.perf_counter() - started) * 1000, dict(data["runPluginOperation"])
+
+
+def _wait_for_task(
+    sidecar: Path, job_type: str, after_ms: int, timeout_s: float = 3600
+) -> dict[str, object]:
+    """Poll the sidecar copy until a fresh curator_job row for job_type finishes.
+
+    Rows are filtered to those started after the submission timestamp: the
+    source sidecar already contains historical rows for the same job types, and
+    matching those would report instant completion for a task that never ran.
+    Stash's jobQueue query returns null in some versions even while plugin
+    tasks run, so the sidecar row (written by the task itself) is the
+    completion ground truth; it also carries the exact duration and error text.
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        con = sqlite3.connect(f"file:{sidecar}?mode=ro", uri=True)
+        try:
+            row = con.execute(
+                """
+                SELECT state, started_at_ms, finished_at_ms, error
+                FROM curator_job
+                WHERE job_type=? AND started_at_ms>?
+                ORDER BY started_at_ms DESC LIMIT 1
+                """,
+                (job_type, after_ms),
+            ).fetchone()
+        finally:
+            con.close()
+        if row is not None and str(row[0]) != "running":
+            result: dict[str, object] = {"state": str(row[0])}
+            if row[1] is not None and row[2] is not None:
+                result["job_duration_ms"] = int(row[2]) - int(row[1])
+            if row[3] is not None:
+                result["error"] = str(row[3])
+            return result
+        if time.monotonic() > deadline:
+            raise RuntimeError(f"task {job_type} did not finish within {timeout_s}s")
+        time.sleep(2)
+
+
+def _run_task(
+    url: str,
+    sidecar: Path,
+    mode: str,
+    display_name: str,
+    after_ms: int,
+    timeout_s: float = 3600,
+) -> tuple[float, dict[str, object]]:
+    """Start a plugin task and wait for its fresh curator_job row to finish.
+
+    runPluginTask returns the Stash job id immediately; the plugin task runs in
+    Stash's job queue. The returned wall time spans submission to completion.
+    """
+    started = time.perf_counter()
+    data = _gql(
+        url,
+        "mutation($task_name: String!) {"
+        f' runPluginTask(plugin_id: "{PLUGIN_ID}", task_name: $task_name) }}',
+        {"task_name": display_name},
+    )
+    job_id = str(data["runPluginTask"])
+    result = _wait_for_task(sidecar, mode, after_ms, timeout_s)
+    wall_ms = (time.perf_counter() - started) * 1000
+    return wall_ms, {"job_id": job_id, **result}
+
+
+# --------------------------------------------------------------------------- traces
+
+
+def _invalidate_model(sidecar: Path) -> None:
+    """Force a full cold rebuild by dropping the published generations in the copy.
+
+    Deletes the published feature_build and model_version rows (no FK constraints
+    block this) and removes the derived artifact files, so the next build task
+    regenerates features, similarity, and publication from the synced source data.
+    """
+    con = sqlite3.connect(sidecar)
+    try:
+        con.execute("DELETE FROM feature_build")
+        con.execute("DELETE FROM model_version")
+        con.commit()
+    finally:
+        con.close()
+    derived = sidecar.resolve().with_name(f"{sidecar.stem}-derived")
+    if derived.is_dir():
+        shutil.rmtree(derived, ignore_errors=True)
+
+
+def _install_deps(url: str, workspace: Path, timeout_s: float = 900) -> bool:
+    """Run the plugin's optional-deps task and wait for the venv pip to appear.
+
+    The task creates a venv beside the plugin; the host sees it through the
+    bind mount. Returns False on timeout (the cold build then runs pure Python).
+    """
+    print("[benchmark] installing optional dependencies (numpy/networkx) ...")
+    _gql(
+        url,
+        'mutation { runPluginTask(plugin_id: "stash-curator", '
+        'task_name: "Install optional dependencies") }',
+    )
+    marker = workspace / "plugins" / PLUGIN_ID / "venv" / "bin" / "pip"
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if marker.is_file():
+            print("[benchmark] optional dependencies installed")
+            return True
+        time.sleep(3)
+    print(f"[benchmark] WARNING: optional deps did not install within {timeout_s}s")
+    return False
+
+
+def _pull_traces(sidecar: Path, after_ms: int) -> list[dict]:
+    con = sqlite3.connect(f"file:{sidecar}?mode=ro", uri=True)
+    try:
+        rows = con.execute(
+            """
+            SELECT trace_id, kind, operation, started_at_ms, duration_us, status,
+                   span_count, truncated, trace_json
+            FROM profile_trace
+            WHERE started_at_ms >= ?
+            ORDER BY started_at_ms ASC
+            """,
+            (after_ms,),
+        ).fetchall()
+    finally:
+        con.close()
+    traces = []
+    for row in rows:
+        payload = json.loads(row[8])
+        events = payload.get("traceEvents") if isinstance(payload, dict) else None
+        traces.append(
+            {
+                "trace_id": str(row[0]),
+                "kind": str(row[1]),
+                "operation": str(row[2]),
+                "started_at_ms": int(row[3]),
+                "duration_us": int(row[4]),
+                "status": str(row[5]),
+                "spans": [
+                    {
+                        "category": str(event.get("cat", "")),
+                        "name": str(event.get("name", "")),
+                        "duration_us": int(event.get("dur", 0)),
+                    }
+                    for event in (events or [])
+                    if isinstance(event, dict)
+                ],
+            }
+        )
+    return traces
+
+
+def _span_aggregate(traces: list[dict]) -> list[dict[str, object]]:
+    buckets: dict[tuple[str, str], list[int]] = {}
+    for trace in traces:
+        for span in trace["spans"]:
+            key = (span["category"], span["name"])
+            buckets.setdefault(key, []).append(span["duration_us"])
+    rows = [
+        {
+            "category": cat,
+            "name": name,
+            "count": len(values),
+            "median_ms": round(statistics.median(values) / 1000, 1),
+            "total_ms": round(sum(values) / 1000, 1),
+        }
+        for (cat, name), values in sorted(buckets.items(), key=lambda item: -sum(item[1]))
+    ]
+    return rows
+
+
+def _job_summary(sidecar: Path, job_type: str, after_ms: int) -> dict[str, object] | None:
+    con = sqlite3.connect(f"file:{sidecar}?mode=ro", uri=True)
+    try:
+        row = con.execute(
+            """
+            SELECT summary_json, started_at_ms, finished_at_ms
+            FROM curator_job
+            WHERE job_type=? AND state='complete' AND started_at_ms>?
+            ORDER BY started_at_ms DESC LIMIT 1
+            """,
+            (job_type, after_ms),
+        ).fetchone()
+    finally:
+        con.close()
+    if row is None:
+        return None
+    summary = json.loads(row[0])
+    summary["job_duration_ms"] = int(row[2]) - int(row[1]) if row[2] is not None else None
+    return summary
+
+
+# --------------------------------------------------------------------------- report
+
+
+def _stats(values: list[float]) -> dict[str, float]:
+    if not values:
+        return {"n": 0}
+    return {
+        "n": len(values),
+        "min_ms": round(min(values), 1),
+        "median_ms": round(statistics.median(values), 1),
+        "p95_ms": round(sorted(values)[max(0, int(len(values) * 0.95) - 1)], 1),
+        "max_ms": round(max(values), 1),
+    }
+
+
+def _write_report(report_dir: Path, report: dict[str, object]) -> Path:
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_dir = report_dir.resolve()
+    json_path = report_dir / "benchmark-report.json"
+    json_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    lines = [
+        "# Curator Phase 0 benchmark",
+        "",
+        f"- date: {report['generated_at']}",
+        f"- stash: {report.get('stash_version', 'unknown')}",
+        f"- plugin: {report.get('plugin_version', 'unknown')}",
+        f"- sidecar: {report.get('sidecar_state')}",
+        "",
+        "## Operations (client wall time, ms)",
+        "",
+        "| operation | n | min | median | p95 | max | trace median | est spawn |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for name, data in sorted(report["operations"].items()):
+        s = data["wall"]
+        lines.append(
+            "| {} | {} | {} | {} | {} | {} | {} | {} |".format(
+                name,
+                s["n"],
+                s["min_ms"],
+                s["median_ms"],
+                s["p95_ms"],
+                s["max_ms"],
+                data["trace_median_ms"] or "-",
+                data["spawn_estimate_ms"] or "-",
+            )
+        )
+    lines.append("")
+    lines.append("## Tasks")
+    lines.append("")
+    for name, data in sorted(report["tasks"].items()):
+        lines.append(f"### {name}")
+        lines.append("")
+        lines.append(f"- wall: {data['wall_ms']} ms")
+        lines.append(f"- trace: {data['trace_ms']} ms")
+        if data.get("job_summary"):
+            lines.append(f"- job duration: {data['job_summary'].get('job_duration_ms')} ms")
+            stages = data["job_summary"].get("stage_timings_ms") or {}
+            if stages:
+                lines.append("- model stages (ms):")
+                for stage, ms in sorted(stages.items()):
+                    lines.append(f"  - {stage}: {ms}")
+        lines.append("- spans:")
+        for span in data["spans"]:
+            lines.append(
+                f"  - {span['category']}.{span['name']}: count={span['count']} "
+                f"median={span['median_ms']} ms total={span['total_ms']} ms"
+            )
+        lines.append("")
+    markdown = report_dir / "benchmark-report.md"
+    markdown.write_text("\n".join(lines), encoding="utf-8")
+    return json_path
+
+
+# --------------------------------------------------------------------------- main
+
+
+def _select_ops(names: str, has_model: bool) -> dict[str, dict[str, object]]:
+    if names == "all":
+        chosen = set(OPERATIONS)
+    else:
+        chosen = {name.strip() for name in names.split(",") if name.strip()}
+        unknown = chosen - set(OPERATIONS)
+        if unknown:
+            raise SystemExit(f"unknown operations: {sorted(unknown)}")
+    if not has_model:
+        chosen -= MODEL_OPS
+    return {name: OPERATIONS[name] for name in sorted(chosen)}
+
+
+def _select_tasks(names: str) -> list[str]:
+    if names == "all":
+        return ["prepare", "backup", "build"]
+    chosen = [name.strip() for name in names.split(",") if name.strip()]
+    unknown = set(chosen) - set(TASK_NAMES)
+    if unknown:
+        raise SystemExit(f"unknown tasks: {sorted(unknown)}")
+    return chosen
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", help="sidecar to benchmark (copied first)")
+    parser.add_argument("--url", help="Stash base URL")
+    parser.add_argument("--port", type=int, default=9998, help="host port (default 9998)")
+    parser.add_argument("--ops", default="all")
+    parser.add_argument("--tasks", default="all")
+    parser.add_argument("--reps", type=int, default=4)
+    parser.add_argument("--workspace", default=str(ROOT / ".tmp" / "benchmark"))
+    parser.add_argument("--report-dir", default=str(ROOT / ".tmp" / "benchmark-report"))
+    parser.add_argument("--keep-stash", action="store_true")
+    parser.add_argument("--no-stash", action="store_true")
+    parser.add_argument("--cold-build", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--skip-install-deps",
+        action="store_true",
+        help="skip the optional-deps (numpy/networkx) venv task; cold builds then run pure Python",
+    )
+    args = parser.parse_args()
+
+    source: Path | None = None
+    if args.db:
+        source = Path(args.db)
+    elif os.environ.get("STASH_CURATOR_DB"):
+        source = Path(os.environ["STASH_CURATOR_DB"])
+    if source is None or not source.is_file():
+        source = _find_sidecar()
+        if source is None:
+            raise SystemExit("no sidecar found; pass --db PATH or set STASH_CURATOR_DB")
+    print(f"[benchmark] sidecar source: {source}")
+
+    workspace = Path(args.workspace)
+    workspace.mkdir(parents=True, exist_ok=True)
+    if not args.no_stash:
+        _ensure_plugin_built()
+        print(f"[benchmark] installing plugin + config into {workspace}")
+        _install_plugin(workspace)
+    sidecar = workspace / "plugins" / PLUGIN_ID / "data" / "curator.sqlite3"
+    print("[benchmark] copying sidecar (backup API) ...")
+    _copy_sidecar(source, sidecar)
+    state = _sidecar_state(sidecar)
+    print(f"[benchmark] copy state: {state}")
+    scene_id, performer_id = _sample_ids(sidecar)
+    has_model = bool(state["published_models"])
+
+    url = args.url or f"http://localhost:{args.port}"
+    if not args.no_stash:
+        print(f"[benchmark] starting Stash on :{args.port} ...")
+        _compose("up", workspace, args.port)
+        try:
+            _wait_for_stash(url)
+            _run(url, args, workspace, sidecar, state, scene_id, performer_id, has_model)
+        finally:
+            if not args.keep_stash:
+                print("[benchmark] tearing down Stash ...")
+                _compose("down", workspace, args.port)
+                _clean_workspace_plugin(workspace)
+    else:
+        _wait_for_stash(url)
+        _run(url, args, workspace, sidecar, state, scene_id, performer_id, has_model)
+
+
+def _run(
+    url: str,
+    args: argparse.Namespace,
+    workspace: Path,
+    sidecar: Path,
+    state: dict[str, object],
+    scene_id: str | None,
+    performer_id: str | None,
+    has_model: bool,
+) -> None:
+    has_operation, has_task, has_configure = _introspect(url)
+    if not has_operation:
+        raise SystemExit("Stash does not expose runPluginOperation")
+    health = _gql(url, "{ version { version } }")
+    stash_version = health["version"]["version"]
+    _, health_output = _run_operation(url, {"operation": "health"})
+    plugin_version = str(health_output.get("curator_version", "unknown"))
+    if has_configure:
+        _gql(
+            url,
+            'mutation { configurePlugin(plugin_id: "stash-curator", '
+            "input: {profilingEnabled: true}) }",
+        )
+    # Self-check: a profiled operation must record a trace (round_trip and
+    # health are intentionally not profiled).
+    _, _ = _run_operation(url, {"operation": "get_config"})
+    if not _pull_traces(sidecar, int(time.time() * 1000) - 60_000):
+        print(
+            "[benchmark] WARNING: no profiling traces recorded; is "
+            "profilingEnabled: true set under plugins.stash-curator in config.yml?"
+        )
+    if not args.skip_install_deps:
+        _install_deps(url, workspace)
+
+    ops = _select_ops(args.ops, has_model)
+    print(f"[benchmark] operations: {sorted(ops)} (reps={args.reps})")
+    op_results: dict[str, dict[str, object]] = {}
+    for name in sorted(ops):
+        base = dict(ops[name])
+        if name == "get_similar_scene" and scene_id is not None:
+            base["entity_id"] = scene_id
+        elif name == "get_similar_performer" and performer_id is not None:
+            base["entity_id"] = performer_id
+        elif name == "get_explanation" and scene_id is not None:
+            base["scene_id"] = scene_id
+        if name in MODEL_OPS and not has_model:
+            continue
+        wall: list[float] = []
+        traces: list[dict] = []
+        for rep in range(args.reps):
+            before = int(time.time() * 1000)
+            try:
+                elapsed, output = _run_operation(url, base)
+            except RuntimeError as error:
+                print(f"[benchmark] {name} rep {rep} failed: {error}")
+                break
+            wall.append(elapsed)
+            traces.extend(_pull_traces(sidecar, before))
+            if "error" in output:
+                print(f"[benchmark] {name} returned error: {output['error']}")
+                break
+            time.sleep(0.2)
+        op_results[name] = {
+            "wall": _stats(wall),
+            "trace_median_ms": (
+                round(statistics.median(t["duration_us"] for t in traces) / 1000, 1)
+                if traces
+                else None
+            ),
+            "spawn_estimate_ms": (
+                round(
+                    statistics.median(wall)
+                    - statistics.median(t["duration_us"] for t in traces) / 1000,
+                    1,
+                )
+                if traces and wall
+                else None
+            ),
+            "spans": _span_aggregate(traces),
+        }
+        print(f"  {name}: median {op_results[name]['wall']['median_ms']} ms")
+
+    tasks = _select_tasks(args.tasks)
+    if not has_task:
+        print("[benchmark] Stash does not expose runPluginTask; skipping tasks")
+        tasks = []
+    print(f"[benchmark] tasks: {tasks}")
+    task_results: dict[str, dict[str, object]] = {}
+    for name in tasks:
+        before = int(time.time() * 1000)
+        if args.cold_build and name == "build":
+            print("[benchmark] invalidating published model for a cold rebuild ...")
+            _invalidate_model(sidecar)
+        print(f"[benchmark] running task '{TASK_NAMES[name]}' ...")
+        try:
+            wall_ms, output = _run_task(url, sidecar, name, TASK_NAMES[name], before)
+        except RuntimeError as error:
+            print(f"[benchmark] task {name} failed: {error}")
+            task_results[name] = {"error": str(error)}
+            continue
+        traces = _pull_traces(sidecar, before)
+        if str(output.get("state")) == "failed":
+            print(f"[benchmark] task {name} failed: {output.get('error')}")
+        task_results[name] = {
+            "wall_ms": round(wall_ms, 1),
+            "trace_ms": (
+                round(statistics.median(t["duration_us"] for t in traces) / 1000, 1)
+                if traces
+                else None
+            ),
+            "spans": _span_aggregate(traces),
+            "job_summary": _job_summary(sidecar, name, before),
+        }
+        print(f"  {name}: {task_results[name]['wall_ms']} ms wall")
+        time.sleep(0.5)
+
+    report = {
+        "generated_at": time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime()),
+        "stash_version": stash_version,
+        "plugin_version": plugin_version,
+        "cold_build": bool(args.cold_build),
+        "optional_deps_installed": not args.skip_install_deps,
+        "sidecar_state": state,
+        "operations": op_results,
+        "tasks": task_results,
+    }
+    report_path = _write_report(Path(args.report_dir), report)
+    print(f"[benchmark] report: {report_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify
+++ b/scripts/verify
@@ -52,13 +52,6 @@ case "${1:-}" in
     plugin_dir="/tmp/stash-curator-integration/plugins/stash-curator"
     mkdir -p "$plugin_dir"
     unzip -oq dist/stash-curator.zip -d "$plugin_dir"
-    # The sidecar database is created inside the container (as root) in WAL mode. Host
-    # tests read it read-only, and a WAL read needs to create the -shm file, so the data
-    # directory must be owned/writable by the test user. Reset it every run so the
-    # integration environment starts from a clean sidecar instead of leftover state.
-    rm -rf "$plugin_dir/data"
-    mkdir -p "$plugin_dir/data"
-    chmod 777 "$plugin_dir/data"
     # copy config
     cp tests/integration/stash-config.yml /tmp/stash-curator-integration/config.yml
     # ── start stash ──
@@ -72,6 +65,14 @@ case "${1:-}" in
     echo "[verify] starting Stash …"
     STASH_CONFIG=/tmp/stash-curator-integration \
       docker compose -f "$compose_file" up -d --wait
+    # The sidecar database and its artifact directory are created inside the container as
+    # root in WAL mode. Host tests read it read-only, and a WAL read needs to create the
+    # -shm file, so the data directory must be writable by the test user. Reset it with a
+    # root container every run so the integration environment starts from a clean sidecar
+    # instead of leftover state, including root-owned artifact subdirectories.
+    echo "[verify] resetting Curator sidecar …"
+    docker run --rm -v "$plugin_dir":/plugin stashapp/stash:latest \
+      sh -c 'rm -rf /plugin/data && mkdir -p /plugin/data && chmod 777 /plugin/data'
     # ── seed ──
     echo "[verify] seeding data …"
     STASH_URL="${STASH_URL:-http://localhost:9999}"

--- a/tests/integration/seed.py
+++ b/tests/integration/seed.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 import time
 import urllib.request
 from typing import Any, cast
@@ -223,34 +222,37 @@ def create_scenes(
 
 
 def trigger_curator_sync(stash_url: str) -> None:
-    """Trigger a Curator sync and wait for it to finish."""
-    print("  triggering curator sync …")
-    try:
-        stash_request(
-            stash_url,
-            """
-            mutation CuratorSync($args: Map!) {
-              runPluginTask(
-                plugin_id: "stash-curator"
-                task_name: "Sync and build recommendations"
-                args: $args
-              )
-            }
-            """,
-            {"args": {}},
-        )
-    except Exception as exc:
-        print(f"  sync trigger failed (may need manual setup): {exc}", file=sys.stderr)
-        return
+    """Trigger a Curator sync-and-build and wait until a model is published.
 
-    # Wait for sync to complete by polling health endpoint
+    The sync runs as a Stash job; health reports `ready` only after the build
+    has published a model, so polling it gives a deterministic "seeded and
+    built" environment for the integration suite. Failure is loud: a broken
+    env is easier to diagnose at seed time than as a page-render assertion.
+    """
+    print("  triggering curator sync …")
+    stash_request(
+        stash_url,
+        """
+        mutation CuratorSync($args: Map!) {
+          runPluginTask(
+            plugin_id: "stash-curator"
+            task_name: "Sync and build recommendations"
+            args_map: $args
+          )
+        }
+        """,
+        {"args": {}},
+    )
+
+    # Wait for the model to be published by polling the health operation.
     print("  waiting for sync to finish …")
-    for _attempt in range(60):
+    deadline = time.monotonic() + 180
+    while time.monotonic() < deadline:
         try:
             data = stash_request(
                 stash_url,
                 """
-                query Health($args: Map!) {
+                mutation Health($args: Map!) {
                   runPluginOperation(
                     plugin_id: "stash-curator"
                     args: $args
@@ -259,14 +261,17 @@ def trigger_curator_sync(stash_url: str) -> None:
                 """,
                 {"args": {"operation": "health"}},
             )
-            if not data.get("runPluginOperation", {}).get("error"):
+            if data.get("runPluginOperation", {}).get("ready"):
                 print("  sync complete")
                 return
         except Exception:
             pass
         time.sleep(2)
 
-    print("  warning: sync may not have completed within timeout", file=sys.stderr)
+    raise RuntimeError(
+        "Curator sync-and-build did not publish a model within 180s; "
+        "check the plugin logs and the Stash task queue"
+    )
 
 
 def main() -> None:

--- a/tests/integration/stash-config.yml
+++ b/tests/integration/stash-config.yml
@@ -9,3 +9,8 @@ dangerous_allow_public_without_auth: true
 plugins:
   stash-curator:
     enabled: true
+    # Entity hooks mark the model dirty on every create/update/delete; keep the test
+    # environment deterministic by never letting those requests auto-trigger a build.
+    modelUpdateEventThreshold: 100
+    modelUpdateMaxWaitMinutes: 1440
+    modelUpdateMinIntervalMinutes: 1440

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -1,0 +1,171 @@
+"""End-to-end tests for Stash entity hooks: targeted one-entity syncs.
+
+Stash runs plugin hooks inline after every scene/performer/studio/tag
+create, update, and destroy. The Curator hook handler fetches the single
+changed entity (or removes it on destroy) and persists it into the sidecar,
+so metadata changes are reflected immediately without a full sync.
+
+The sidecar lives in the bind-mounted plugin directory, so the host can read it.
+
+Start with: scripts/verify integration
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from curator.storage import connect_database
+from tests.integration.conftest import _gql
+
+pytestmark = pytest.mark.integration
+
+
+def _stash_url() -> str:
+    return os.environ.get("STASH_URL", "http://localhost:9999").rstrip("/")
+
+
+def _sidecar_path() -> Path:
+    config = os.environ.get("STASH_CONFIG", "/tmp/stash-curator-integration")
+    return Path(config) / "plugins" / "stash-curator" / "data" / "curator.sqlite3"
+
+
+def _open_sidecar() -> Any:
+    return connect_database(_sidecar_path(), readonly=True, attach_artifacts=False)
+
+
+def _plugin_operation(operation: str, **args: object) -> dict[str, Any]:
+    return _gql(
+        _stash_url(),
+        'mutation Op($args: Map!) { runPluginOperation(plugin_id: "stash-curator", args: $args) }',
+        {"args": {"operation": operation, **args}},
+    )["runPluginOperation"]
+
+
+def _wait_curator_idle(timeout: float = 180) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        jobs = _plugin_operation("get_job_status")["jobs"]
+        if not any(job["state"] == "running" for job in jobs):
+            return
+        time.sleep(2)
+    raise RuntimeError("Curator jobs did not finish within the timeout")
+
+
+def test_scene_create_update_destroy_reach_the_sidecar_without_a_sync() -> None:
+    """Each Scene.* hook imports or removes exactly that scene, immediately."""
+    _wait_curator_idle()
+    stash = _stash_url()
+
+    # Create: Scene.Create.Post fetches the new scene and upserts it.
+    created = _gql(
+        stash,
+        ("mutation Create($input: SceneCreateInput!) { sceneCreate(input: $input) { id title } }"),
+        {"input": {"title": "Hook Test Scene", "details": "created by hook test"}},
+    )
+    scene_id = str(created["sceneCreate"]["id"])
+    try:
+        connection = _open_sidecar()
+        try:
+            title = connection.execute(
+                "SELECT title FROM source_scene WHERE scene_id=?", (scene_id,)
+            ).fetchone()
+            assert title and title[0] == "Hook Test Scene"
+        finally:
+            connection.close()
+
+        # Update: Scene.Update.Post refetches and replaces the row.
+        _gql(
+            stash,
+            ("mutation Update($input: SceneUpdateInput!) { sceneUpdate(input: $input) { id } }"),
+            {"input": {"id": scene_id, "title": "Hook Test Scene Renamed"}},
+        )
+
+        connection = _open_sidecar()
+        try:
+            title = connection.execute(
+                "SELECT title FROM source_scene WHERE scene_id=?", (scene_id,)
+            ).fetchone()
+            assert title and title[0] == "Hook Test Scene Renamed"
+        finally:
+            connection.close()
+
+        # Destroy: Scene.Destroy.Post removes the row and its dependents.
+        _gql(
+            stash,
+            "mutation Destroy($input: SceneDestroyInput!) { sceneDestroy(input: $input) }",
+            {"input": {"id": scene_id}},
+        )
+
+        connection = _open_sidecar()
+        try:
+            assert (
+                connection.execute(
+                    "SELECT count(*) FROM source_scene WHERE scene_id=?", (scene_id,)
+                ).fetchone()[0]
+                == 0
+            )
+        finally:
+            connection.close()
+    finally:
+        # Keep Stash's own database tidy across runs (only the sidecar is reset each run).
+        with contextlib.suppress(Exception):
+            _gql(
+                stash,
+                "mutation Destroy($input: SceneDestroyInput!) { sceneDestroy(input: $input) }",
+                {"input": {"id": scene_id}},
+            )
+
+
+def test_tag_hook_imports_a_new_tag_and_links_it() -> None:
+    """A tag created and attached to a scene reaches the sidecar without a sync."""
+    _wait_curator_idle()
+    stash = _stash_url()
+
+    # Stash's own database persists across integration runs, so find-or-create.
+    existing = _gql(
+        stash,
+        (
+            "query Find($name: String!) { "
+            "findTags(tag_filter: {name: {value: $name, modifier: EQUALS}}) { tags { id } } }"
+        ),
+        {"name": "Hook Test Tag"},
+    )["findTags"]["tags"]
+    if existing:
+        tag_id = str(existing[0]["id"])
+    else:
+        created = _gql(
+            stash,
+            "mutation Create($input: TagCreateInput!) { tagCreate(input: $input) { id } }",
+            {"input": {"name": "Hook Test Tag"}},
+        )
+        tag_id = str(created["tagCreate"]["id"])
+
+    scenes = _gql(
+        stash,
+        "query Scenes { findScenes(filter: {page: 1, per_page: 1}) { scenes { id } } }",
+    )
+    scene_id = str(scenes["findScenes"]["scenes"][0]["id"])
+    _gql(
+        stash,
+        ("mutation Tag($input: SceneUpdateInput!) { sceneUpdate(input: $input) { id } }"),
+        {"input": {"id": scene_id, "tag_ids": [tag_id]}},
+    )
+
+    connection = _open_sidecar()
+    try:
+        row = connection.execute("SELECT name FROM source_tag WHERE tag_id=?", (tag_id,)).fetchone()
+        assert row and row[0] == "Hook Test Tag"
+        assert (
+            connection.execute(
+                "SELECT count(*) FROM scene_tag WHERE scene_id=? AND tag_id=?", (scene_id, tag_id)
+            ).fetchone()[0]
+            == 1
+        )
+    finally:
+        connection.close()

--- a/tests/integration/test_hooks.py
+++ b/tests/integration/test_hooks.py
@@ -1,9 +1,10 @@
-"""End-to-end tests for Stash entity hooks: targeted one-entity syncs.
+"""End-to-end tests for Stash entity hooks: enqueue-then-drain syncs.
 
 Stash runs plugin hooks inline after every scene/performer/studio/tag
-create, update, and destroy. The Curator hook handler fetches the single
-changed entity (or removes it on destroy) and persists it into the sidecar,
-so metadata changes are reflected immediately without a full sync.
+create, update, and destroy. The Curator hook handler only records the change
+in the sidecar; the preference-rebuild task drains the queue (fetching each
+changed entity by id, or removing it on destroy) before rebuilding, so the
+model always sees fresh source data and bulk edits pay no inline fetch cost.
 
 The sidecar lives in the bind-mounted plugin directory, so the host can read it.
 
@@ -24,6 +25,8 @@ from curator.storage import connect_database
 from tests.integration.conftest import _gql
 
 pytestmark = pytest.mark.integration
+
+REBUILD_TASK = "Apply recent Curator feedback"
 
 
 def _stash_url() -> str:
@@ -47,6 +50,19 @@ def _plugin_operation(operation: str, **args: object) -> dict[str, Any]:
     )["runPluginOperation"]
 
 
+def _run_task(name: str) -> str:
+    return str(
+        _gql(
+            _stash_url(),
+            (
+                "mutation Task($task: String!, $args: Map!) { "
+                'runPluginTask(plugin_id: "stash-curator", task_name: $task, args_map: $args) }'
+            ),
+            {"task": name, "args": {}},
+        )["runPluginTask"]
+    )
+
+
 def _wait_curator_idle(timeout: float = 180) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
@@ -57,12 +73,32 @@ def _wait_curator_idle(timeout: float = 180) -> None:
     raise RuntimeError("Curator jobs did not finish within the timeout")
 
 
-def test_scene_create_update_destroy_reach_the_sidecar_without_a_sync() -> None:
-    """Each Scene.* hook imports or removes exactly that scene, immediately."""
+def _wait_job(job_type: str, after_ms: int, timeout: float = 180) -> dict[str, Any]:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        for job in _plugin_operation("get_job_status")["jobs"]:
+            if (
+                job["job_type"] == job_type
+                and int(job["started_at_ms"]) >= after_ms
+                and job["state"] == "complete"
+            ):
+                return job
+        time.sleep(2)
+    raise AssertionError(f"{job_type} job did not complete")
+
+
+def _run_rebuild() -> None:
+    """Run the preference rebuild, which drains the entity-change queue first."""
+    started_ms = time.time_ns() // 1_000_000
+    _run_task(REBUILD_TASK)
+    _wait_job("update-model", started_ms)
+
+
+def test_scene_changes_reach_the_sidecar_through_the_rebuild_drain() -> None:
+    """Create, update, and destroy each enqueue a change that the rebuild applies."""
     _wait_curator_idle()
     stash = _stash_url()
 
-    # Create: Scene.Create.Post fetches the new scene and upserts it.
     created = _gql(
         stash,
         ("mutation Create($input: SceneCreateInput!) { sceneCreate(input: $input) { id title } }"),
@@ -70,6 +106,7 @@ def test_scene_create_update_destroy_reach_the_sidecar_without_a_sync() -> None:
     )
     scene_id = str(created["sceneCreate"]["id"])
     try:
+        _run_rebuild()
         connection = _open_sidecar()
         try:
             title = connection.execute(
@@ -79,13 +116,12 @@ def test_scene_create_update_destroy_reach_the_sidecar_without_a_sync() -> None:
         finally:
             connection.close()
 
-        # Update: Scene.Update.Post refetches and replaces the row.
         _gql(
             stash,
             ("mutation Update($input: SceneUpdateInput!) { sceneUpdate(input: $input) { id } }"),
             {"input": {"id": scene_id, "title": "Hook Test Scene Renamed"}},
         )
-
+        _run_rebuild()
         connection = _open_sidecar()
         try:
             title = connection.execute(
@@ -95,13 +131,12 @@ def test_scene_create_update_destroy_reach_the_sidecar_without_a_sync() -> None:
         finally:
             connection.close()
 
-        # Destroy: Scene.Destroy.Post removes the row and its dependents.
         _gql(
             stash,
             "mutation Destroy($input: SceneDestroyInput!) { sceneDestroy(input: $input) }",
             {"input": {"id": scene_id}},
         )
-
+        _run_rebuild()
         connection = _open_sidecar()
         try:
             assert (
@@ -122,8 +157,8 @@ def test_scene_create_update_destroy_reach_the_sidecar_without_a_sync() -> None:
             )
 
 
-def test_tag_hook_imports_a_new_tag_and_links_it() -> None:
-    """A tag created and attached to a scene reaches the sidecar without a sync."""
+def test_tag_hook_enqueues_and_links_through_the_rebuild_drain() -> None:
+    """A tag created and attached to a scene reaches the sidecar via the drain."""
     _wait_curator_idle()
     stash = _stash_url()
 
@@ -156,6 +191,7 @@ def test_tag_hook_imports_a_new_tag_and_links_it() -> None:
         ("mutation Tag($input: SceneUpdateInput!) { sceneUpdate(input: $input) { id } }"),
         {"input": {"id": scene_id, "tag_ids": [tag_id]}},
     )
+    _run_rebuild()
 
     connection = _open_sidecar()
     try:

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -7,6 +7,7 @@ Start with: docker compose -f tests/integration/docker-compose.yml up -d
 from __future__ import annotations
 
 import contextlib
+import time
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -68,7 +69,9 @@ def test_curator_page_loads_without_errors(page: Page, base_url: str) -> None:
 # ── Tab URLs → expected content ──
 
 TABS: list[tuple[str, list[str]]] = [
-    ("", ["no published model", "Sync and build now", "Preparing For You"]),
+    # The seed runs a sync-and-build and waits for the published model, so the
+    # main route shows the ready recommendation UI, not the fresh-install state.
+    ("", ["For You", "Best Bets", "Ready"]),
     ("?view=similar", ["Choose a scene or performer", "Library", "StashDB"]),
     ("?view=expand", ["External metadata candidates", "Loading Expand cache"]),
     (
@@ -108,8 +111,16 @@ def test_curator_tab_renders_without_errors(
     _wait(page)
     _dismiss_modals(page)
 
-    content = page.content()
-    found = any(phrase in content for phrase in expected_phrases)
+    # Poll for the expected phrases: some depend on an async health round trip
+    # (the ready status), so a fixed wait would be flaky on slow runners.
+    found = False
+    deadline = time.monotonic() + 20
+    while time.monotonic() < deadline:
+        content = page.content()
+        if any(phrase in content for phrase in expected_phrases):
+            found = True
+            break
+        page.wait_for_timeout(500)
 
     if not found:
         body_text = page.locator("body").inner_text()

--- a/tests/integration/test_sync.py
+++ b/tests/integration/test_sync.py
@@ -147,6 +147,21 @@ class SyntheticClient:
         sweep = next((value for name, value in id_names.items() if name in document), None)
         if sweep is not None:
             return self._id_page(sweep, variables)
+        find_documents = {
+            "CuratorFindScene": ("findScene", "scene"),
+            "CuratorFindTag": ("findTag", "tag"),
+            "CuratorFindPerformer": ("findPerformer", "performer"),
+            "CuratorFindStudio": ("findStudio", "studio"),
+        }
+        find = next((value for name, value in find_documents.items() if name in document), None)
+        if find is not None:
+            root, entity_type = find
+            assert variables is not None
+            identifier = str(variables["id"])
+            item = next(
+                item for item in self.entities[entity_type] if str(item["id"]) == identifier
+            )
+            return {root: item}
         names = {
             "CuratorTags": ("tag", "findTags", "tags"),
             "CuratorStudios": ("studio", "findStudios", "studios"),
@@ -402,6 +417,79 @@ def test_plays_only_sync_after_incremental_sync_keeps_entity_cursors(
         connection.execute("SELECT state FROM sync_cursor WHERE entity_type='tag'").fetchone()[0]
         == "complete"
     )
+
+
+def test_targeted_upsert_fetches_and_persists_one_scene(connection: sqlite3.Connection) -> None:
+    client = SyntheticClient(_entities())
+    service = SyncService(client, SyncRepository(connection), page_size=10)
+
+    changed = service.upsert_entity("scene", "1")
+
+    assert changed is True
+    assert (
+        connection.execute("SELECT title FROM source_scene WHERE scene_id='1'").fetchone()[0]
+        == "Scene 1"
+    )
+    # Dependencies ride along: the scene's cast, tags, studio, and play history.
+    assert connection.execute("SELECT count(*) FROM source_tag").fetchone()[0] == 1
+    assert connection.execute("SELECT count(*) FROM source_performer").fetchone()[0] == 1
+    assert connection.execute("SELECT count(*) FROM source_studio").fetchone()[0] == 1
+    assert (
+        connection.execute("SELECT count(*) FROM source_play WHERE scene_id='1'").fetchone()[0] == 1
+    )
+    # The targeted upsert never starts a run or touches cursors.
+    assert connection.execute("SELECT count(*) FROM sync_run").fetchone()[0] == 0
+
+
+def test_targeted_upsert_is_idempotent_and_reports_change(
+    connection: sqlite3.Connection,
+) -> None:
+    client = SyntheticClient(_entities())
+    service = SyncService(client, SyncRepository(connection), page_size=10)
+
+    assert service.upsert_entity("performer", "p1") is True
+    assert service.upsert_entity("performer", "p1") is False
+
+    # An edited performer is a change again; the same value is not.
+    entities = _entities()
+    entities["performer"][0]["name"] = "Renamed"
+    client = SyntheticClient(entities)
+    renamed = SyncService(client, SyncRepository(connection), page_size=10)
+    assert renamed.upsert_entity("performer", "p1") is True
+    assert (
+        connection.execute("SELECT name FROM source_performer WHERE performer_id='p1'").fetchone()[
+            0
+        ]
+        == "Renamed"
+    )
+
+
+def test_targeted_delete_cascades_like_the_reconcile_pass(
+    connection: sqlite3.Connection,
+) -> None:
+    client = SyntheticClient(_entities())
+    service = SyncService(client, SyncRepository(connection), page_size=10)
+    service.upsert_entity("scene", "1")
+
+    service.delete_entity("scene", "1")
+
+    assert connection.execute("SELECT count(*) FROM source_scene").fetchone()[0] == 0
+    assert (
+        connection.execute("SELECT count(*) FROM source_play WHERE scene_id='1'").fetchone()[0] == 0
+    )
+    assert (
+        connection.execute("SELECT count(*) FROM scene_tag WHERE scene_id='1'").fetchone()[0] == 0
+    )
+
+
+def test_targeted_ops_reject_unknown_entity_types(connection: sqlite3.Connection) -> None:
+    client = SyntheticClient(_entities())
+    service = SyncService(client, SyncRepository(connection), page_size=10)
+
+    with pytest.raises(ValueError, match="unsupported entity type"):
+        service.upsert_entity("marker", "m1")
+    with pytest.raises(ValueError, match="unsupported entity type"):
+        service.delete_entity("marker", "m1")
 
 
 def test_full_sync_skips_the_play_pass(connection: sqlite3.Connection) -> None:

--- a/tests/integration/test_z_nomodel_ui.py
+++ b/tests/integration/test_z_nomodel_ui.py
@@ -1,0 +1,110 @@
+"""Fresh-install (no published model) UI coverage, run last.
+
+The seeded environment builds a model before the suite starts, so the no-model
+state cannot be observed during the normal run. This test runs after everything
+else (test_z_* ordering): it resets the plugin's sidecar database through the
+plugin's own reset operation, then asserts the fresh-install page renders the
+setup checklist and the no-model recommendation state without JS errors.
+
+The reset is safe here because no later test needs the sidecar.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import time
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from tests.integration.conftest import _gql
+
+if TYPE_CHECKING:
+    from playwright.sync_api import Page
+
+pytestmark = pytest.mark.integration
+
+CURATOR_PATH = "/plugins/stash-curator"
+
+
+def _stash_url() -> str:
+    return os.environ.get("STASH_URL", "http://localhost:9999").rstrip("/")
+
+
+def _dismiss_modals(page: Page) -> None:
+    """Dismiss Stash release notes and setup modals that block clicks."""
+    for _ in range(5):
+        for sel in (
+            "div.modal.show button.btn-close",
+            "div.modal.show .close",
+            "div.modal.show [aria-label='Close']",
+            "div.modal.show .btn-primary",
+        ):
+            btn = page.locator(sel)
+            if btn.count() > 0:
+                with contextlib.suppress(Exception):
+                    btn.first.click(force=True, timeout=2000)
+        page.keyboard.press("Escape")
+        page.wait_for_timeout(300)
+        if page.locator("div.modal.show").count() == 0:
+            break
+
+
+def _collect_errors(page: Page) -> list[str]:
+    tracked: list[Any] = getattr(page, "_errors", [])
+    return [str(e.message) for e in tracked]
+
+
+@pytest.fixture(autouse=True)
+def _track_errors(page: Page) -> None:
+    tracked: list[Any] = []
+    page.on("pageerror", lambda err: tracked.append(err))
+    page.__dict__["_errors"] = tracked
+
+
+def _wait_for_phrase(page: Page, phrase: str, timeout_s: float = 20) -> bool:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if phrase in page.content():
+            return True
+        page.wait_for_timeout(500)
+    return False
+
+
+def test_fresh_install_after_reset_renders_without_errors(page: Page, base_url: str) -> None:
+    """After a plugin reset the main route shows the no-model state cleanly."""
+    # The reset operation requires no running job; wait until Curator is idle.
+    deadline = time.monotonic() + 60
+    while time.monotonic() < deadline:
+        jobs = _gql(
+            _stash_url(),
+            (
+                "mutation JobStatus($args: Map!) { "
+                'runPluginOperation(plugin_id: "stash-curator", args: $args) }'
+            ),
+            {"args": {"operation": "get_job_status"}},
+        )["runPluginOperation"]["jobs"]
+        if not any(job["state"] == "running" for job in jobs):
+            break
+        time.sleep(2)
+
+    result = _gql(
+        _stash_url(),
+        (
+            "mutation Reset($args: Map!) { "
+            'runPluginOperation(plugin_id: "stash-curator", args: $args) }'
+        ),
+        {"args": {"operation": "reset", "confirmation": "RESET"}},
+    )["runPluginOperation"]
+    assert result.get("reset") is True
+
+    page.goto(base_url + CURATOR_PATH, wait_until="domcontentloaded")
+    _dismiss_modals(page)
+
+    # The fresh-install page shows the setup checklist and the no-model state.
+    for phrase in ("no published model", "Sync and build now", "Finish Curator setup"):
+        assert _wait_for_phrase(page, phrase), f"missing fresh-install phrase: {phrase!r}"
+
+    errors = _collect_errors(page)
+    assert not errors, f"JS errors on fresh-install page: {errors}"

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -998,8 +998,12 @@ def test_reused_model_keeps_existing_lane_classifications(
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    from curator.ranking import LanePolicy
+
+    # Existing lanes are reported as-is; classification is never re-run on the core
+    # connection, whose model tables are shadowed by the attached artifact's views.
     monkeypatch.setattr(
-        module.LanePolicy,
+        LanePolicy,
         "classify",
         lambda *_args: (_ for _ in ()).throw(AssertionError("reclassified")),
     )
@@ -1333,3 +1337,51 @@ def test_entity_hook_enqueues_and_drain_imports_or_removes(
     # A malformed payload never raises (hooks run inline inside Stash mutations).
     malformed = module._run_entity_hook({"args": {"hookContext": {"type": "Scene.Update.Post"}}})
     assert malformed["handled"] is False
+
+
+def test_classify_lanes_reports_zero_without_writing_the_shadowed_core_table(
+    tmp_path: Path,
+) -> None:
+    """A sparse library (no qualifying lanes) must not make the rebuild fail.
+
+    The model build classifies into the artifact and then attaches it to the task
+    connection as read-only views. Re-classifying on the core connection would try to
+    write through those views and fail; the count is authoritative instead.
+    """
+    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
+    spec = importlib.util.spec_from_file_location("curator_plugin_classify_lanes", backend)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    from curator.events import HistoricalEventStore
+    from curator.model import PreferenceModelBuilder
+    from curator.storage import MigrationRunner, connect_database
+    from curator.sync import SyncService
+    from curator.sync.repository import SyncRepository
+    from tests.integration.test_sync import SyntheticClient, _entities
+
+    database = tmp_path / "curator.sqlite3"
+    connection = connect_database(database)
+    MigrationRunner(connection).migrate(applied_at_ms=1)
+    entities = _entities()
+    # A fileless scene is ineligible for every lane, so the build publishes zero lanes
+    # (the same state a sparse fresh library reaches).
+    scene = entities["scene"][0]
+    scene["files"] = []
+    entities["scene"] = [scene]
+    SyncService(
+        SyntheticClient(entities),
+        SyncRepository(connection),
+        page_size=1,
+        clock_ms=lambda: 1_800_000_000_000,
+    ).sync(full=True)
+    HistoricalEventStore(connection).rebuild()
+    model = PreferenceModelBuilder(connection, clock_ms=lambda: 1_800_000_000_000).build()
+
+    # Regression: before the fix this raised "cannot modify model_scene_lane because
+    # it is a view" on the same connection the build just attached the artifact to.
+    assert model.scene_count == 1
+    assert connection.execute("SELECT count(*) FROM main.model_scene_lane").fetchone()[0] == 0
+    assert module._classify_lanes(connection, model.model_id) == 0
+    connection.close()

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -1220,10 +1220,10 @@ def test_every_user_visible_empty_and_error_message_is_defensive() -> None:
     assert '"Send to Whisparr"' in source
 
 
-def test_entity_hook_upserts_destroys_and_requests_model_update(
+def test_entity_hook_enqueues_and_drain_imports_or_removes(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Stash entity hooks import or remove one entity and mark the model dirty."""
+    """Stash entity hooks enqueue the change; the rebuild drain applies it."""
     backend = Path(__file__).parents[2] / "plugin" / "backend.py"
     spec = importlib.util.spec_from_file_location("curator_plugin_entity_hook", backend)
     assert spec and spec.loader
@@ -1272,15 +1272,17 @@ def test_entity_hook_upserts_destroys_and_requests_model_update(
         "hook_type": "Scene.Update.Post",
         "entity_type": "scene",
         "entity_id": "1",
-        "changed": True,
+        "enqueued": True,
     }
 
     connection = module._open(hook_payload("Scene.Update.Post"), {})
     try:
-        assert (
-            connection.execute("SELECT title FROM source_scene WHERE scene_id='1'").fetchone()[0]
-            == "Hooked Scene"
-        )
+        # The hook only records the change; the entity is not imported yet.
+        assert connection.execute("SELECT count(*) FROM source_scene").fetchone()[0] == 0
+        pending = connection.execute(
+            "SELECT entity_type, entity_id, operation FROM pending_entity_change"
+        ).fetchall()
+        assert [tuple(row) for row in pending] == [("scene", "1", "upsert")]
         state = connection.execute(
             "SELECT requested_generation, published_generation FROM model_update_state"
             " WHERE singleton=1"
@@ -1289,10 +1291,37 @@ def test_entity_hook_upserts_destroys_and_requests_model_update(
     finally:
         connection.close()
 
+    # The preference-rebuild drain applies the queued change.
+    connection = module._open(hook_payload("Scene.Update.Post"), {})
+    try:
+        drained = module._drain_pending_entity_changes(
+            hook_payload("Scene.Update.Post"), connection
+        )
+        assert drained == 1
+        assert connection.execute("SELECT count(*) FROM pending_entity_change").fetchone()[0] == 0
+        assert (
+            connection.execute("SELECT title FROM source_scene WHERE scene_id='1'").fetchone()[0]
+            == "Hooked Scene"
+        )
+    finally:
+        connection.close()
+
+    # A destroy after an update flips the queued operation to delete.
     destroyed = module._run_entity_hook(hook_payload("Scene.Destroy.Post"))
     assert destroyed["handled"] is True
     connection = module._open(hook_payload("Scene.Update.Post"), {})
     try:
+        assert (
+            connection.execute(
+                "SELECT operation FROM pending_entity_change WHERE entity_type='scene'"
+                " AND entity_id='1'"
+            ).fetchone()[0]
+            == "delete"
+        )
+        drained = module._drain_pending_entity_changes(
+            hook_payload("Scene.Update.Post"), connection
+        )
+        assert drained == 1
         assert connection.execute("SELECT count(*) FROM source_scene").fetchone()[0] == 0
     finally:
         connection.close()

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -1218,3 +1218,89 @@ def test_every_user_visible_empty_and_error_message_is_defensive() -> None:
     assert '"Configure Whisparr in plugin settings"' in source
     assert '"Retry sending to Whisparr"' in source
     assert '"Send to Whisparr"' in source
+
+
+def test_entity_hook_upserts_destroys_and_requests_model_update(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Stash entity hooks import or remove one entity and mark the model dirty."""
+    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
+    spec = importlib.util.spec_from_file_location("curator_plugin_entity_hook", backend)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    database = tmp_path / "curator.sqlite3"
+
+    def scene() -> dict[str, object]:
+        return {
+            "id": "1",
+            "title": "Hooked Scene",
+            "details": None,
+            "date": "2025-01-01",
+            "rating100": None,
+            "updated_at": "2026-01-01T00:00:00Z",
+            "play_count": 0,
+            "play_duration": 0.0,
+            "play_history": [],
+            "o_history": [],
+            "studio": None,
+            "tags": [],
+            "performers": [],
+            "files": [],
+            "scene_markers": [],
+        }
+
+    class FakeClient:
+        def execute(self, document: str, variables: object = None) -> dict[str, object]:
+            assert "CuratorFindScene" in document
+            return {"findScene": scene()}
+
+    monkeypatch.setattr(module, "_settings", lambda _payload: {})
+    monkeypatch.setattr(module, "_client", lambda _payload: FakeClient())
+
+    def hook_payload(hook_type: str) -> dict[str, object]:
+        return {
+            "args": {
+                "database_path": str(database),
+                "hookContext": {"id": 1, "type": hook_type, "input": {}, "inputFields": []},
+            }
+        }
+
+    updated = module._run_entity_hook(hook_payload("Scene.Update.Post"))
+    assert updated == {
+        "handled": True,
+        "hook_type": "Scene.Update.Post",
+        "entity_type": "scene",
+        "entity_id": "1",
+        "changed": True,
+    }
+
+    connection = module._open(hook_payload("Scene.Update.Post"), {})
+    try:
+        assert (
+            connection.execute("SELECT title FROM source_scene WHERE scene_id='1'").fetchone()[0]
+            == "Hooked Scene"
+        )
+        state = connection.execute(
+            "SELECT requested_generation, published_generation FROM model_update_state"
+            " WHERE singleton=1"
+        ).fetchone()
+        assert state["requested_generation"] > state["published_generation"]
+    finally:
+        connection.close()
+
+    destroyed = module._run_entity_hook(hook_payload("Scene.Destroy.Post"))
+    assert destroyed["handled"] is True
+    connection = module._open(hook_payload("Scene.Update.Post"), {})
+    try:
+        assert connection.execute("SELECT count(*) FROM source_scene").fetchone()[0] == 0
+    finally:
+        connection.close()
+
+    # A recognized-but-unhandled hook type (tag merges are deferred) is a no-op.
+    unknown = module._run_entity_hook(hook_payload("Tag.Merge.Post"))
+    assert unknown == {"handled": False, "hook_type": "Tag.Merge.Post"}
+
+    # A malformed payload never raises (hooks run inline inside Stash mutations).
+    malformed = module._run_entity_hook({"args": {"hookContext": {"type": "Scene.Update.Post"}}})
+    assert malformed["handled"] is False

--- a/tests/storage/test_artifacts.py
+++ b/tests/storage/test_artifacts.py
@@ -217,6 +217,6 @@ def test_attach_skips_tables_missing_from_older_artifact(tmp_path: Path) -> None
         assert "model_performer_edge" not in views
         # Migration 25 creates and indexes model_performer_edge; the shadowing view
         # used to make its CREATE INDEX fail with "views may not be indexed".
-        assert MigrationRunner(attached).migrate(applied_at_ms=2).current_version == 26
+        assert MigrationRunner(attached).migrate(applied_at_ms=2).current_version == 27
     finally:
         attached.close()

--- a/tests/storage/test_cli_db.py
+++ b/tests/storage/test_cli_db.py
@@ -15,7 +15,7 @@ def test_database_cli_migrate_status_and_backup(
 
     assert run(["--db", str(database), "db", "migrate", "--json"]) == 0
     migrated = json.loads(capsys.readouterr().out)
-    assert migrated["current_version"] == migrated["latest_version"] == 26
+    assert migrated["current_version"] == migrated["latest_version"] == 27
 
     assert run(["--db", str(database), "db", "status", "--json"]) == 0
     status = json.loads(capsys.readouterr().out)

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -38,10 +38,11 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
             24,
             25,
             26,
+            27,
         )
 
         after = runner.migrate(applied_at_ms=1234)
-        assert after.current_version == 26
+        assert after.current_version == 27
         assert after.pending_versions == ()
         assert runner.migrate(applied_at_ms=5678) == after
 
@@ -333,7 +334,7 @@ def test_status_stays_read_only_after_migrations(tmp_path: Path) -> None:
     reader.execute("PRAGMA busy_timeout=1")
     try:
         writer.execute("BEGIN IMMEDIATE")
-        assert MigrationRunner(reader).status().current_version == 26
+        assert MigrationRunner(reader).status().current_version == 27
     finally:
         writer.rollback()
         reader.close()
@@ -359,7 +360,7 @@ def test_stale_concurrent_migrator_rechecks_after_writer_lock(
 
     monkeypatch.setattr(second_runner, "status", status)
     try:
-        assert second_runner.migrate(applied_at_ms=2).current_version == 26
+        assert second_runner.migrate(applied_at_ms=2).current_version == 27
     finally:
         second.close()
         first.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_doctor_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
     assert result["status"] == "ok"
     assert result["stash"] == "not_configured"
     assert result["schema_current"] == 0
-    assert result["schema_latest"] == 26
+    assert result["schema_latest"] == 27
 
 
 def test_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Entity hooks: edits are enqueued, then applied before each rebuild

Create, edit, or delete a scene, performer, studio, or tag in Stash, and Curator records that change immediately via Stash's entity hooks. The hook **only enqueues** the change (one bounded write, no GraphQL fetch, no model build) — the preference-rebuild task **drains the queue** (fetching each entity by id, or removing it on destroy) before rebuilding, so the model always sees fresh source data while bulk edits pay only the process-spawn cost instead of a fetch + upsert per edit.

- New `pending_entity_change` queue (migration 27); a destroy after an update flips the queued operation, and any full sync supersedes the queue.
- Includes `fix: never re-classify lanes into the shadowed core table` — the rebuild's post-build lane step previously tried to write through the artifact's read-only views and failed ("cannot modify model_scene_lane because it is a view"), which the enqueue design exposes because every rebuild must now complete.
- Tag merges remain deferred to the next full sync.

## Verification

- `scripts/verify full` — 312 passed, ruff/mypy/node clean, plugin builds.
- `scripts/verify integration` — 14 passed (create/update/destroy enqueue → drain → land in the sidecar through the rebuild; smoke suite unaffected).

## Known trade-offs (review before merging)

- Each edit still pays the **Python process spawn** (~0.3–0.9 s) because Stash raw plugins spawn per hook; that's the target of the planned `interface: rpc` conversion (see the handover).
- Every changed edit marks the model dirty, so with default thresholds an active editing session triggers a full rebuild (~5 min on large libraries) hourly. Raise **Actions before model update** / **Minimum model update interval** in settings to tame this.
