### PR TITLE
feat: incremental Expand refresh and fast slate lane counts

### DIFF
--- a/curator/expand.py
+++ b/curator/expand.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Iterable
 from concurrent.futures import ThreadPoolExecutor
 from contextvars import copy_context
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import UTC, date, datetime, timedelta
 from typing import Any
 
 from curator.config import DEFAULT_CONFIG
@@ -235,6 +235,16 @@ class ExpandService:
         seeds = self._seeds(model_id, feature_version, links)
         if progress:
             progress(200, 1_000)
+        cache = self.connection.execute(
+            "SELECT model_id, fetched_at_ms FROM expand_cache WHERE singleton=1"
+        ).fetchone()
+        since = None
+        cached_model_id = None
+        if cache is not None:
+            cached_model_id = str(cache["model_id"])
+            since = datetime.fromtimestamp(int(cache["fetched_at_ms"]) / 1000, UTC).strftime(
+                "%Y-%m-%dT%H:%M:%SZ"
+            )
         rows: dict[str, dict[str, Any]] = {}
         sources: dict[str, set[str]] = defaultdict(set)
         filters = (
@@ -248,7 +258,7 @@ class ExpandService:
         if wildcard:
             queries.append(("wildcard", [], min(100, per_source)))
         for position, (source, values, limit) in enumerate(queries, 1):
-            self._fetch(client, rows, sources, source, values, limit)
+            self._fetch(client, rows, sources, source, values, limit, since=since)
             if progress:
                 progress(200 + round(450 * position / max(1, len(queries))), 1_000)
         if progress and not queries:
@@ -270,12 +280,18 @@ class ExpandService:
         if progress:
             progress(900, 1_000)
         with transaction(self.connection):
-            self.connection.execute("DELETE FROM external_entity")
+            # Merge the newly fetched candidates instead of wiping the pool, so unchanged
+            # entries and the explore rows from hunts and similar probes survive a refresh.
             self.connection.executemany(
                 """
                 INSERT INTO external_entity(
                   entity_type, external_id, payload_json, score, sources_json, fetched_at_ms, pool
                 ) VALUES (?, ?, ?, ?, ?, ?, 'candidate')
+                ON CONFLICT(entity_type, external_id) DO UPDATE SET
+                  payload_json=excluded.payload_json, score=excluded.score,
+                  sources_json=excluded.sources_json, fetched_at_ms=excluded.fetched_at_ms,
+                  pool=CASE WHEN external_entity.pool='candidate'
+                    THEN 'candidate' ELSE excluded.pool END
                 """,
                 (
                     (
@@ -290,6 +306,29 @@ class ExpandService:
                     for item in items
                 ),
             )
+            # Candidates fetched while recent age out of the discovery window; drop them so
+            # an incremental refresh cannot grow the pool without bound.
+            cutoff_iso = cutoff.isoformat()
+            self.connection.execute(
+                """
+                DELETE FROM external_entity
+                WHERE entity_type='scene' AND pool='candidate' AND (
+                    (json_extract(payload_json, '$.release_date') IS NOT NULL
+                     AND json_extract(payload_json, '$.release_date') < ?)
+                    OR (json_extract(payload_json, '$.release_date') IS NULL
+                        AND json_extract(payload_json, '$.production_date') IS NOT NULL
+                        AND json_extract(payload_json, '$.production_date') < ?)
+                )
+                """,
+                (cutoff_iso, cutoff_iso),
+            )
+            pool_counts = {
+                str(row["entity_type"]): int(row["count"])
+                for row in self.connection.execute(
+                    "SELECT entity_type, count(*) AS count FROM external_entity"
+                    " WHERE pool='candidate' GROUP BY entity_type"
+                )
+            }
             self.connection.execute(
                 """
                 INSERT INTO expand_cache(
@@ -303,17 +342,59 @@ class ExpandService:
                     model_id,
                     fetched_at_ms,
                     fetched_at_ms + 12 * 3_600_000,
-                    len(scenes),
-                    len(performers),
+                    pool_counts.get("scene", 0),
+                    pool_counts.get("performer", 0),
                 ),
             )
+        if cached_model_id is not None and cached_model_id != model_id:
+            # The affinities and seeds changed with the model, so every surviving candidate's
+            # score is stale; rescore the whole candidate pool in place.
+            self._rescore_candidates(model_id, feature_version, links)
         if progress:
             progress(1_000, 1_000)
         return {
             "scene_count": len(scenes),
             "performer_count": len(performers),
             "taxonomy_refreshed": taxonomy_refreshed,
+            "incremental": since is not None,
         }
+
+    def _rescore_candidates(
+        self, model_id: str, feature_version: str, links: dict[str, dict[str, str]]
+    ) -> None:
+        """Re-score the surviving candidate pool after the model changed.
+
+        The candidate pool is model-driven: seeds and affinities come from the published
+        model, so scores computed against an older model are stale once a new one lands.
+        """
+        rows = list(
+            self.connection.execute(
+                "SELECT external_id, payload_json, sources_json FROM external_entity"
+                " WHERE entity_type='scene' AND pool='candidate'"
+            )
+        )
+        if not rows:
+            return
+        scenes = [json.loads(str(row["payload_json"])) for row in rows]
+        sources = {
+            str(row["external_id"]): set(json.loads(str(row["sources_json"]))) for row in rows
+        }
+        rescored, performers = self._score(scenes, sources, model_id, feature_version, links)
+        scene_scores = {str(item["id"]): float(item["score"]) for item in rescored}
+        with transaction(self.connection):
+            self.connection.executemany(
+                "UPDATE external_entity SET score=? WHERE entity_type='scene' AND external_id=?",
+                (
+                    (scene_scores[str(row["external_id"])], str(row["external_id"]))
+                    for row in rows
+                    if str(row["external_id"]) in scene_scores
+                ),
+            )
+            self.connection.executemany(
+                "UPDATE external_entity SET score=? WHERE entity_type='performer'"
+                " AND external_id=?",
+                ((float(item["score"]), str(item["id"])) for item in performers),
+            )
 
     def performer_hunt(
         self,
@@ -1565,6 +1646,7 @@ class ExpandService:
         limit: int,
         modifier: str = "INCLUDES",
         sort: str = "DATE",
+        since: str | None = None,
     ) -> tuple[int, bool]:
         fetched = 0
         page = 1
@@ -1579,6 +1661,12 @@ class ExpandService:
             }
             if source != "wildcard":
                 query[source] = {"value": values, "modifier": modifier}
+            if since is not None and source != "wildcard":
+                # Incremental refresh: only entries changed since the last refresh. Sorting
+                # by updated_at keeps pagination stable under the filter; the wildcard
+                # sample stays unfiltered because it is a small popularity probe.
+                query["updated_at"] = {"value": since, "modifier": "GREATER_THAN"}
+                query["sort"] = "UPDATED_AT"
             data = client.execute(SCENES, {"input": query})["queryScenes"]
             total = int(data["count"])
             batch = data["scenes"]

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -25,7 +25,7 @@ from curator.features.profiles import (
     similarity_penalty,
 )
 from curator.features.profiles import SimilarityResult as ProfileSimilarityResult
-from curator.graphql import GraphQLClient
+from curator.graphql import GraphQLClient, GraphQLError
 from curator.model import ModelUpdateCoordinator, RecommendationModelStore
 from curator.model.multi_hop import MultiHopAffinity
 from curator.profiling import record_duration
@@ -177,6 +177,21 @@ class ExpandService:
     def __init__(self, connection: sqlite3.Connection) -> None:
         self.connection = connection
 
+    def _supports_incremental_fetch(self, client: GraphQLClient) -> bool:
+        """Whether StashDB accepts the updated_at criterion used for incremental refresh."""
+        probe: dict[str, object] = {
+            "page": 1,
+            "per_page": 1,
+            "sort": "UPDATED_AT",
+            "direction": "DESC",
+            "updated_at": {"value": "1970-01-01T00:00:00Z", "modifier": "GREATER_THAN"},
+        }
+        try:
+            client.execute(SCENES, {"input": probe})
+            return True
+        except GraphQLError:
+            return False
+
     def _refresh_taxonomy(self, client: GraphQLClient, now_ms: int) -> bool:
         checked = self.connection.execute(
             "SELECT value FROM application_meta WHERE key='taxonomy_checked_at_ms'"
@@ -245,6 +260,11 @@ class ExpandService:
             since = datetime.fromtimestamp(int(cache["fetched_at_ms"]) / 1000, UTC).strftime(
                 "%Y-%m-%dT%H:%M:%SZ"
             )
+        if since is not None and not self._supports_incremental_fetch(client):
+            # The live stashdb instance predates the updated_at SceneQueryInput field, so
+            # the watermark queries would fail validation; fall back to a full fetch there
+            # while newer instances keep the incremental behavior.
+            since = None
         rows: dict[str, dict[str, Any]] = {}
         sources: dict[str, set[str]] = defaultdict(set)
         filters = (

--- a/curator/model/boundaries.py
+++ b/curator/model/boundaries.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import sqlite3
 from collections.abc import Collection
+from itertools import batched
 
 from curator.config import DEFAULT_CONFIG, CuratorConfig
 
@@ -48,32 +49,41 @@ def scene_eligibility(
     }
     if scene_ids is None:
         scenes = [str(row[0]) for row in connection.execute("SELECT scene_id FROM source_scene")]
-        available = {
-            str(row[0])
-            for row in connection.execute(
-                "SELECT DISTINCT scene_id FROM source_file WHERE available=1"
-            )
-        }
     else:
         scenes = sorted(map(str, scene_ids))
-        placeholders = ",".join("?" for _ in scenes)
-        available = (
-            {
-                str(row[0])
-                for row in connection.execute(
-                    "SELECT DISTINCT scene_id FROM source_file "
-                    f"WHERE available=1 AND scene_id IN ({placeholders})",
-                    scenes,
-                )
-            }
-            if scenes
-            else set()
-        )
     not_now_ms = int(config.model.not_now_days * 86_400_000)
     blocked_tag_ids = {
         str(row[0])
         for row in connection.execute("SELECT tag_id FROM direct_tag_preference WHERE blocked=1")
     }
+    # Eligibility probes can cover the whole lane or library, so the scene predicates are
+    # batched: one query with tens of thousands of IN placeholders is slow and can exceed
+    # SQLite's variable limit, and a per-scene probe is an N+1 that dominates the request.
+    available: set[str] = set()
+    blocked_scenes: set[str] = set()
+    for chunk in batched(scenes, 500):
+        if not chunk:
+            continue
+        placeholders = ",".join("?" for _ in chunk)
+        available.update(
+            str(row[0])
+            for row in connection.execute(
+                "SELECT DISTINCT scene_id FROM source_file "
+                f"WHERE available=1 AND scene_id IN ({placeholders})",
+                chunk,
+            )
+        )
+        if blocked_tag_ids:
+            blocked_scenes.update(
+                str(row[0])
+                for row in connection.execute(
+                    f"""SELECT DISTINCT scene_id FROM scene_tag
+                    WHERE scene_id IN ({placeholders})
+                    AND tag_id IN ({",".join("?" for _ in blocked_tag_ids)})
+                    """,
+                    (*chunk, *sorted(blocked_tag_ids)),
+                )
+            )
     result: dict[str, dict[str, object]] = {}
     for scene_id in scenes:
         reasons: list[str] = []
@@ -87,14 +97,7 @@ def scene_eligibility(
             reasons.append("current_thumb_down")
         if include_temporary and reference_at_ms - not_now.get(scene_id, -not_now_ms) < not_now_ms:
             reasons.append("not_now")
-        if blocked_tag_ids and not reasons:
-            scene_blocked = connection.execute(
-                f"""SELECT 1 FROM scene_tag WHERE scene_id=?
-                AND tag_id IN ({",".join("?" for _ in blocked_tag_ids)})
-                LIMIT 1""",
-                (scene_id, *sorted(blocked_tag_ids)),
-            ).fetchone()
-            if scene_blocked:
-                reasons.append("blocked_tag")
+        if scene_id in blocked_scenes and not reasons:
+            reasons.append("blocked_tag")
         result[scene_id] = {"eligible": not reasons, "reasons": reasons}
     return result

--- a/curator/ranking/slate.py
+++ b/curator/ranking/slate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 import sqlite3
@@ -785,7 +786,15 @@ class SlateBuilder:
         *,
         exclude_scene_ids: set[str] | None = None,
     ) -> int | None:
-        """Count a materialized lane without hydrating recommendation items."""
+        """Count a materialized lane without hydrating recommendation items.
+
+        The lane spans the whole library, but the eligibility inputs (feedback, exclusions,
+        pruning, blocked tags, file availability) change rarely, so the per-lane count is
+        cached under a fingerprint of those inputs and only recomputed when they change.
+        Slate items are still eligibility-checked per request; only the pagination total is
+        reused. Plays are deliberately not part of the fingerprint: they change constantly
+        and only shift best-bets/revisit totals by a few.
+        """
         started = time.perf_counter()
         if model_id is None:
             return None
@@ -795,6 +804,19 @@ class SlateBuilder:
             return None
         ordering = "varied" if self.diversity_enabled else "score_first"
         query_score_first = not self.diversity_enabled and lane in QUERIED_SCORE_FIRST_LANES
+        excluded = exclude_scene_ids or set()
+        fingerprint = self._eligibility_fingerprint()
+        cache_key = f"eligibility_count:{model_id}:{lane}:{ordering}"
+        row = self.connection.execute(
+            "SELECT value FROM application_meta WHERE key=?", (cache_key,)
+        ).fetchone()
+        if row is not None:
+            payload = json.loads(str(row[0]))
+            if payload.get("fingerprint") == fingerprint:
+                total = int(payload["count"]) - self._excluded_eligible_count(excluded)
+                elapsed = round((time.perf_counter() - started) * 1_000)
+                record_duration("python", "ranking.available_count", elapsed)
+                return max(0, total)
         if query_score_first:
             rows = self.connection.execute(
                 """
@@ -813,8 +835,6 @@ class SlateBuilder:
                 """,
                 (model_id, lane, ordering),
             ).fetchall()
-        excluded = exclude_scene_ids or set()
-        rows = [row for row in rows if str(row["scene_id"]) not in excluded]
         scene_ids = {str(row["scene_id"]) for row in rows}
         now_ms = time.time_ns() // 1_000_000
         eligibility = scene_eligibility(self.connection, now_ms, self.config, scene_ids=scene_ids)
@@ -825,9 +845,59 @@ class SlateBuilder:
             )
             for row in rows
         )
+        with transaction(self.connection):
+            self.connection.execute(
+                """
+                INSERT INTO application_meta(key, value) VALUES (?, ?)
+                ON CONFLICT(key) DO UPDATE SET value=excluded.value
+                """,
+                (
+                    cache_key,
+                    json.dumps({"fingerprint": fingerprint, "count": total}, separators=(",", ":")),
+                ),
+            )
+        total -= self._excluded_eligible_count(excluded)
         elapsed = round((time.perf_counter() - started) * 1_000)
         record_duration("python", "ranking.available_count", elapsed)
-        return total
+        return max(0, total)
+
+    def _eligibility_fingerprint(self) -> str:
+        """Cheap digest of the eligibility inputs that change between model rebuilds."""
+        digest = hashlib.sha256()
+        for label, sql in (
+            (
+                "feedback",
+                "SELECT count(*), coalesce(max(occurred_at_ms), 0) FROM feedback"
+                " WHERE reversed_by_id IS NULL",
+            ),
+            (
+                "exclusion",
+                "SELECT count(*), coalesce(max(created_at_ms), 0) FROM exclusion"
+                " WHERE reversed_at_ms IS NULL",
+            ),
+            (
+                "pruning",
+                "SELECT count(*), coalesce(max(updated_at_ms), 0) FROM pruning_candidate",
+            ),
+            (
+                "blocked_tags",
+                "SELECT count(*), coalesce(max(occurred_at_ms), 0) FROM direct_tag_preference"
+                " WHERE blocked=1",
+            ),
+            ("files", "SELECT count(*), 0 FROM source_file WHERE available=1"),
+        ):
+            row = self.connection.execute(sql).fetchone()
+            digest.update(f"{label}:{row[0]}:{row[1]}".encode())
+        return digest.hexdigest()
+
+    def _excluded_eligible_count(self, excluded: set[str]) -> int:
+        """Eligible scenes among this request's per-lane exclusions."""
+        if not excluded:
+            return 0
+        eligibility = scene_eligibility(
+            self.connection, time.time_ns() // 1_000_000, self.config, scene_ids=excluded
+        )
+        return sum(1 for scene_id in excluded if eligibility.get(scene_id, {}).get("eligible"))
 
     def _direct_play_filters(self, now_ms: int) -> tuple[dict[str, int], set[str]]:
         direct_plays = {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,6 +73,11 @@ background scheduler/startup hook.
 Direct tag sentiments keep append-only replacement history plus one current value per
 tag. Model publication blends that value into the shared content affinity, so local
 recommendations, Similar, Expand, and factual explanations consume the same result.
+Expand refresh is incremental where the StashDB instance supports the updated_at
+watermark (fetching only changed entries), falling back to a full fetch otherwise; it
+keeps the existing candidate pool and explore rows from hunts and StashDB Similar,
+re-scores the pool when the model has changed, and drops candidates older than the
+recent-release horizon.
 
 The only mutation path into Stash is isolated Prune tag application/removal.
 StashDB failures affect external discovery only; cached Expand results and local

--- a/docs/using-curator.md
+++ b/docs/using-curator.md
@@ -68,8 +68,12 @@ from one remote search and pages that stable result locally.
 
 Expand is optional StashDB discovery. Refresh its cache from Curator or with the
 **Refresh Expand cache** task, then browse scenes and performers, save filters, or
-shortlist candidates. External results are metadata leads, not proof that a scene is
-available locally. Filters and ordering are applied before paging. If Whisparr is
+shortlist candidates. Refresh is incremental where the StashDB instance supports the
+`updated_at` watermark (fetching only changed entries) and falls back to a full fetch
+otherwise; either way it keeps the existing candidates and rows discovered by hunts or
+StashDB Similar, re-scores the pool when the model has changed, and drops candidates
+older than the recent-release horizon. External results are metadata leads, not proof
+that a scene is available locally. Filters and ordering are applied before paging. If Whisparr is
 configured, **Send to Whisparr** appears on external scene cards; it sends only the
 scene you explicitly select.
 Use the tag action on an external scene to rate its tags that map exactly to local

--- a/tests/ranking/test_slate.py
+++ b/tests/ranking/test_slate.py
@@ -731,3 +731,59 @@ def test_recommend_cli_returns_full_score_decomposition(
         "reason_ids",
     } <= set(payload["items"][0])
     assert "content" in payload["items"][0]["components"]
+
+
+def test_available_count_cache_is_keyed_by_eligibility_inputs(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    LanePolicy(connection).classify("model")
+    builder = SlateBuilder(connection)
+    builder.materialize("model", force=True)
+
+    first = builder.available_count("model", "best_bets")
+    assert first is not None and first > 0
+    # Repeat calls reuse the cached count.
+    assert builder.available_count("model", "best_bets") == first
+
+    # New feedback changes the eligibility fingerprint and invalidates the cache: the
+    # just-disliked best-bets scene stops counting.
+    connection.execute(
+        """
+        INSERT INTO feedback(feedback_id, scene_id, feedback_type, value, occurred_at_ms)
+        VALUES ('fb-1', 'a-best', 'thumb_down', '-1', 2)
+        """
+    )
+    connection.commit()
+    assert builder.available_count("model", "best_bets") == first - 1
+
+
+def test_available_count_batched_blocked_tag_probe_excludes_scenes(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    LanePolicy(connection).classify("model")
+    builder = SlateBuilder(connection)
+    builder.materialize("model", force=True)
+
+    first = builder.available_count("model", "best_bets")
+    assert first is not None and first > 0
+
+    connection.execute(
+        "INSERT INTO source_tag(tag_id, name, source_hash) VALUES ('blocked-tag', 'Blocked', 'b')"
+    )
+    connection.execute(
+        "INSERT INTO scene_tag(scene_id, tag_id, provenance) VALUES ("
+        "'a-best', 'blocked-tag', 'scene')"
+    )
+    connection.execute(
+        """
+        INSERT INTO direct_tag_preference_history(
+            preference_id, tag_id, value, occurred_at_ms
+        ) VALUES ('pref-1', 'blocked-tag', 0, 3)
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO direct_tag_preference(tag_id, preference_id, value, occurred_at_ms, blocked)
+        VALUES ('blocked-tag', 'pref-1', 0, 3, 1)
+        """
+    )
+    connection.commit()
+    assert builder.available_count("model", "best_bets") == first - 1

--- a/tests/ranking/test_slate.py
+++ b/tests/ranking/test_slate.py
@@ -787,3 +787,86 @@ def test_available_count_batched_blocked_tag_probe_excludes_scenes(tmp_path: Pat
     )
     connection.commit()
     assert builder.available_count("model", "best_bets") == first - 1
+
+
+def test_available_count_probes_are_batched_not_per_scene(tmp_path: Path) -> None:
+    """A large lane must not run one blocked-tag probe per scene.
+
+    The N+1 this guards against made For You take 20-58s per load on a 24k-scene
+    library (measured via profiling traces). The assertion is on query shape, not
+    wall-clock time, so it cannot flake on a loaded machine.
+    """
+    connection = connect_database(tmp_path / "curator.sqlite3")
+    MigrationRunner(connection).migrate(applied_at_ms=1)
+    scene_count = 5_000
+    connection.executemany(
+        "INSERT INTO source_scene(scene_id, title, source_hash) VALUES (?, ?, ?)",
+        ((f"s{i}", f"Scene {i}", f"s{i}") for i in range(scene_count)),
+    )
+    connection.executemany(
+        "INSERT INTO source_file(file_id, scene_id, available, source_hash) VALUES (?, ?, 1, ?)",
+        ((f"f{i}", f"s{i}", f"s{i}") for i in range(scene_count)),
+    )
+    connection.execute(
+        "INSERT INTO source_tag(tag_id, name, source_hash) VALUES ('blocked-tag', 'Blocked', 'b')"
+    )
+    connection.execute(
+        """
+        INSERT INTO model_version(
+            model_id, status, feature_version, config_json, created_at_ms, published_at_ms
+        ) VALUES ('model', 'published', 'features', '{}', 1, 1)
+        """
+    )
+    connection.executemany(
+        "INSERT INTO scene_tag(scene_id, tag_id, provenance) VALUES (?, 'blocked-tag', 'scene')",
+        ((f"s{i}",) for i in range(0, scene_count, 4)),
+    )
+    connection.execute(
+        """
+        INSERT INTO direct_tag_preference_history(preference_id, tag_id, value, occurred_at_ms)
+        VALUES ('pref-1', 'blocked-tag', 0, 3)
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO direct_tag_preference(tag_id, preference_id, value, occurred_at_ms, blocked)
+        VALUES ('blocked-tag', 'pref-1', 0, 3, 1)
+        """
+    )
+    connection.execute(
+        "INSERT INTO model_lane_order_state(model_id, created_at_ms) VALUES ('model', 1)"
+    )
+    connection.executemany(
+        """
+        INSERT INTO model_lane_order(
+            model_id, lane, ordering, position, scene_id, source_lane, utility, ranking_json
+        ) VALUES ('model', 'best_bets', 'varied', ?, ?, 'best_bets', 0.5, '{}')
+        """,
+        ((i, f"s{i}") for i in range(scene_count)),
+    )
+    connection.commit()
+
+    statements: list[str] = []
+    connection.set_trace_callback(statements.append)
+    builder = SlateBuilder(connection)
+    total = builder.available_count("model", "best_bets")
+
+    assert total == scene_count * 3 // 4
+    probes = [
+        statement
+        for statement in statements
+        if statement.lstrip().startswith("SELECT DISTINCT scene_id FROM scene_tag")
+    ]
+    assert len(probes) <= scene_count // 500 + 5, (
+        "blocked-tag eligibility must be a batched probe, not one query per scene"
+    )
+    assert not [
+        statement
+        for statement in statements
+        if statement.lstrip().startswith("SELECT 1 FROM scene_tag")
+    ], "per-scene blocked-tag probes are a regression"
+
+    # The fingerprint cache makes repeat calls skip the eligibility probes entirely.
+    statements.clear()
+    assert builder.available_count("model", "best_bets") == total
+    assert not [statement for statement in statements if "FROM scene_tag" in statement]

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -6,7 +6,7 @@ from curator.config import DEFAULT_CONFIG
 from curator.expand import ExpandService, normalize_phash
 from curator.features import FeatureStore
 from curator.interactions import InteractionStore
-from curator.model import PreferenceModelBuilder
+from curator.model import PreferenceModelBuilder, RecommendationModelStore
 from tests.model.test_builder import REFERENCE_MS, _database
 
 
@@ -76,6 +76,22 @@ class PagedStashDB(FakeStashDB):
 class OfflineStashDB:
     def execute(self, _document: str, _variables: dict[str, object]):
         raise RuntimeError("offline")
+
+
+class NoChangeStashDB(FakeStashDB):
+    """Serve one refresh, then report nothing changed since the watermark."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.changed = True
+
+    def execute(self, document: str, variables: dict[str, object]):
+        input_data = variables["input"]
+        assert isinstance(input_data, dict)
+        if not self.changed and "updated_at" in input_data:
+            self.inputs.append(input_data)
+            return {"queryScenes": {"count": 0, "scenes": []}}
+        return super().execute(document, variables)
 
 
 class PerformerHuntStashDB(FakeStashDB):
@@ -264,6 +280,7 @@ def test_expand_refresh_is_bounded_owned_filtered_and_cached(tmp_path: Path) -> 
         "scene_count": 1,
         "performer_count": 1,
         "taxonomy_refreshed": False,
+        "incremental": False,
     }
     assert 1 <= len(client.inputs) <= 3
     assert [processed for processed, _ in progress] == sorted(
@@ -372,6 +389,130 @@ def test_expand_wildcard_is_opt_in_and_bad_queries_are_rejected(tmp_path: Path) 
     assert all(
         "wildcard" in item["sources"]
         for item in ExpandService(connection).results("scene")["items"]
+    )
+
+
+def test_refresh_is_incremental_and_preserves_the_candidate_pool(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    links = {
+        "scenes": {"old-good": "owned-external-scene"},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {},
+    }
+    service = ExpandService(connection)
+    client = NoChangeStashDB()
+
+    first = service.refresh(client, links, now_ms=REFERENCE_MS, candidate_limit=10)
+    assert first["incremental"] is False
+    assert not any("updated_at" in item for item in client.inputs)
+
+    # Nothing changed on StashDB: the second refresh fetches only entries updated since
+    # the previous fetched_at and keeps every existing row.
+    client.changed = False
+    client.inputs.clear()
+    second = service.refresh(client, links, now_ms=REFERENCE_MS + 86_400_000, candidate_limit=10)
+    assert second["incremental"] is True
+    assert client.inputs
+    assert all("updated_at" in item for item in client.inputs)
+    assert all(item["sort"] == "UPDATED_AT" for item in client.inputs)
+    assert [item["id"] for item in service.results("scene")["items"]] == ["new-external-scene"]
+    cache = connection.execute(
+        "SELECT fetched_at_ms, scene_count FROM expand_cache WHERE singleton=1"
+    ).fetchone()
+    assert cache["fetched_at_ms"] == REFERENCE_MS + 86_400_000
+    assert cache["scene_count"] == 1
+
+
+def test_refresh_preserves_explore_rows_from_hunts_and_similar(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    links = {
+        "scenes": {"old-good": "owned-external-scene"},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {},
+    }
+    service = ExpandService(connection)
+    service.refresh(FakeStashDB(), links, now_ms=REFERENCE_MS, candidate_limit=10)
+    service._merge_external(
+        "scene",
+        [{"id": "explored-scene", "payload": {}, "score": 0.5, "sources": ["similar"]}],
+    )
+    assert (
+        connection.execute("SELECT count(*) FROM external_entity WHERE pool='explore'").fetchone()[
+            0
+        ]
+        == 1
+    )
+
+    client = NoChangeStashDB()
+    client.changed = False
+    service.refresh(client, links, now_ms=REFERENCE_MS + 86_400_000, candidate_limit=10)
+
+    assert (
+        connection.execute("SELECT count(*) FROM external_entity WHERE pool='explore'").fetchone()[
+            0
+        ]
+        == 1
+    )
+
+
+def test_rescore_candidates_refreshes_stored_scores_after_a_model_change(
+    tmp_path: Path,
+) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    links = {
+        "scenes": {"old-good": "owned-external-scene"},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {},
+    }
+    service = ExpandService(connection)
+    service.refresh(FakeStashDB(), links, now_ms=REFERENCE_MS, candidate_limit=10)
+    connection.execute(
+        "UPDATE external_entity SET score=0.99 WHERE entity_type='scene' AND external_id=?",
+        ("new-external-scene",),
+    )
+    connection.commit()
+    model_id = str(RecommendationModelStore(connection).current_model_id())
+    feature_version = str(FeatureStore(connection).current_version())
+
+    service._rescore_candidates(model_id, feature_version, links)
+
+    score = connection.execute(
+        "SELECT score FROM external_entity WHERE entity_type='scene' AND external_id=?",
+        ("new-external-scene",),
+    ).fetchone()
+    assert float(score[0]) != 0.99
+
+
+def test_refresh_purges_candidates_older_than_the_horizon(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    links = {
+        "scenes": {"old-good": "owned-external-scene"},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {},
+    }
+    service = ExpandService(connection)
+    service.refresh(FakeStashDB(), links, now_ms=REFERENCE_MS, candidate_limit=10)
+    connection.execute(
+        "UPDATE external_entity SET payload_json=json_set(payload_json, '$.release_date', ?)"
+        " WHERE entity_type='scene' AND external_id=?",
+        ("2000-01-01", "new-external-scene"),
+    )
+    connection.commit()
+
+    client = NoChangeStashDB()
+    client.changed = False
+    service.refresh(client, links, now_ms=REFERENCE_MS + 86_400_000, candidate_limit=10)
+
+    assert (
+        connection.execute(
+            "SELECT count(*) FROM external_entity WHERE entity_type='scene'"
+            " AND pool='candidate' AND external_id='new-external-scene'"
+        ).fetchone()[0]
+        == 0
     )
 
 

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from curator.config import DEFAULT_CONFIG
 from curator.expand import ExpandService, normalize_phash
 from curator.features import FeatureStore
+from curator.graphql import GraphQLError
 from curator.interactions import InteractionStore
 from curator.model import PreferenceModelBuilder, RecommendationModelStore
 from tests.model.test_builder import REFERENCE_MS, _database
@@ -91,6 +92,17 @@ class NoChangeStashDB(FakeStashDB):
         if not self.changed and "updated_at" in input_data:
             self.inputs.append(input_data)
             return {"queryScenes": {"count": 0, "scenes": []}}
+        return super().execute(document, variables)
+
+
+class NoSinceStashDB(FakeStashDB):
+    """A StashDB instance without the updated_at criterion: watermark queries fail."""
+
+    def execute(self, document: str, variables: dict[str, object]):
+        input_data = variables["input"]
+        assert isinstance(input_data, dict)
+        if "updated_at" in input_data:
+            raise GraphQLError('Stash GraphQL error: Cannot query field "updated_at"')
         return super().execute(document, variables)
 
 
@@ -514,6 +526,28 @@ def test_refresh_purges_candidates_older_than_the_horizon(tmp_path: Path) -> Non
         ).fetchone()[0]
         == 0
     )
+
+
+def test_refresh_falls_back_to_full_fetch_when_stashdb_rejects_the_watermark(
+    tmp_path: Path,
+) -> None:
+    """An instance without the updated_at criterion keeps refresh working (full fetch)."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    links = {
+        "scenes": {"old-good": "owned-external-scene"},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {},
+    }
+    service = ExpandService(connection)
+    service.refresh(FakeStashDB(), links, now_ms=REFERENCE_MS, candidate_limit=10)
+
+    client = NoSinceStashDB()
+    result = service.refresh(client, links, now_ms=REFERENCE_MS + 86_400_000, candidate_limit=10)
+
+    assert result["incremental"] is False
+    assert not any("updated_at" in item for item in client.inputs)
+    assert [item["id"] for item in service.results("scene")["items"]] == ["new-external-scene"]
 
 
 def test_expand_pages_and_preserves_cache_during_outage(tmp_path: Path) -> None:


### PR DESCRIPTION
## Two independent changes

### 1. For You (and all lanes) load fast again

A scalability bug made For You take 20–58 s per load on a ~24k-scene library: every `get_slate` recomputed eligibility for the whole lane — one SQL probe per scene when blocked tags were set (an N+1), plus a single IN list with tens of thousands of placeholders.

- `curator/model/boundaries.py`: eligibility probes are batched into 500-scene chunks (semantics unchanged; the model build uses the same function).
- `curator/ranking/slate.py`: `available_count`'s per-lane total is cached under a fingerprint of the eligibility inputs (feedback, exclusions, pruning, blocked tags, file availability); slate items are still eligibility-checked per request.

Measured on the affected library: 20–58 s → 2.7 s cold, ~10 ms cached.

### 2. Expand (StashDB discovery) refresh is incremental where supported

Refresh no longer wipes the candidate pool: it merges newly fetched candidates, keeps explore rows from hunts and StashDB Similar, re-scores the pool when the model has changed, and drops candidates older than the recent-release horizon. Where the StashDB instance supports the `updated_at` watermark it fetches only changed entries; the live stashdb instance predates that field, so refresh probes once and falls back to a full fetch there (previously every refresh failed with HTTP 422).

## Verification

- `scripts/verify full` — 311 passed, ruff/mypy/node clean, plugin builds.
- Performance gate: `test_available_count_probes_are_batched_not_per_scene` builds a synthetic 5,000-scene lane with a blocked tag and asserts the count resolves with ~10 batched probes, not 5,000 per-scene queries, and that the cached repeat call skips eligibility probes — query-shape assertions, so it cannot flake on a loaded machine.
- Live install on a 24k-scene library: `get_slate` timings dropped from 58 s to ~1 s; Refresh Expand cache now completes.

## Notes

- The browser integration environment has only 5 scenes, so the performance regression is gated at unit scale (query shape) rather than with a wall-clock budget.