### PR TITLE
feat: profile the compiled core stages inside the plugin trace

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -32,6 +32,14 @@ Each stage reads one JSON payload from stdin and writes newline-delimited JSON
 to stdout: optional `{"progress": fraction}` lines followed by a final
 `{"result": ...}` line. Errors go to stderr with a non-zero exit status.
 
+When the payload requests `"profile": true` (the Python side sets it when the
+plugin's profiling is active), the binary additionally emits
+`{"span": {"name", "cat": "core", "offset_us", "dur_us"}}` lines before the
+result — offsets relative to the binary's process start. `curator/core.py`
+folds them into the plugin's profile_trace with category `core`, so builds
+show an inside-the-binary breakdown (read_features, preference_vectors,
+build_columns, kernel, encode_result).
+
 ```
 curator-core version
 curator-core content-neighbors

--- a/core/content.go
+++ b/core/content.go
@@ -52,6 +52,7 @@ type contentPayload struct {
 	Config         contentConfig            `json:"config"`
 	ProgressTotal  int                      `json:"progress_total"`
 	Threads        int                      `json:"threads,omitempty"`
+	Profile        bool                     `json:"profile,omitempty"`
 }
 
 // contentNeighbor mirrors the production evidence tuple (scene id, similarity,
@@ -204,23 +205,29 @@ func runContentNeighbors() {
 	if err := json.NewDecoder(os.Stdin).Decode(&payload); err != nil {
 		fail("content-neighbors: invalid payload: %v", err)
 	}
+	profile := newProfileRecorder(payload.Profile)
 	db, err := openReadonly(payload.DB)
 	if err != nil {
 		fail("content-neighbors: open %s: %v", payload.DB, err)
 	}
 	defer db.Close()
+	end := profile.begin("core.read_features")
 	rows, err := readContentRows(db, payload.FeatureVersion)
+	end()
 	if err != nil {
 		fail("content-neighbors: read features: %v", err)
 	}
+	end = profile.begin("core.preference_vectors")
 	preference, sceneOrder, err := preferenceVectors(rows, payload.Affinities, payload.Config.GenericWeight)
+	end()
 	if err != nil {
 		fail("content-neighbors: derive preference vectors: %v", err)
 	}
-	result, err := contentNeighborEvidence(payload, preference, sceneOrder)
+	result, err := contentNeighborEvidence(payload, preference, sceneOrder, profile)
 	if err != nil {
 		fail("content-neighbors: %v", err)
 	}
+	profile.emit()
 	if err := writeJSONLine(map[string]any{"result": result}); err != nil {
 		fail("content-neighbors: write result: %v", err)
 	}
@@ -230,7 +237,9 @@ func contentNeighborEvidence(
 	payload contentPayload,
 	preference map[string]map[string]float64,
 	sceneOrder []string,
+	profile *profileRecorder,
 ) (map[string]any, error) {
+	end := profile.begin("core.build_columns")
 	// Column mapping: every feature name across all preference vectors, sorted.
 	seenNames := make(map[string]bool)
 	for _, vector := range preference {
@@ -288,9 +297,14 @@ func contentNeighborEvidence(
 		}
 		ownPos[i] = own
 	}
+	end()
+
+	end = profile.begin("core.kernel")
 	neighbors := contentKernel(targetRows, ownPos, colLists, labeledConf, labeledIDs,
 		payload.Config, payload.ProgressTotal, nthreads(payload.Threads))
+	end()
 
+	end = profile.begin("core.encode_result")
 	result := make(map[string]any, n)
 	for i, sceneID := range sceneOrder {
 		entries := make([][]any, 0, len(neighbors[i]))
@@ -304,6 +318,7 @@ func contentNeighborEvidence(
 		}
 		result[sceneID] = map[string]any{"neighbors": entries}
 	}
+	end()
 	return result, nil
 }
 

--- a/core/content_test.go
+++ b/core/content_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 )
 
 func genSparseRows(t *testing.T, n, nnz, d int, seed int64) ([]sparseRow, []string) {
@@ -224,7 +225,7 @@ func TestPerformerKernelDeterministicAcrossThreads(t *testing.T) {
 	}
 	profiles := make(map[string]*performerProfile)
 	for i := 0; i < 200; i++ {
-		id := string(rune('p' + i%26)) + string(rune('a'+i/26))
+		id := string(rune('p'+i%26)) + string(rune('a'+i/26))
 		blocks := map[string]map[string]profileValue{
 			"content":      {"tag:a": {value: 0.8, confidence: 0.9}, "tag:b": {value: 0.4, confidence: 0.7}},
 			"hair":         {"brown": {value: 1.0, confidence: 0.8}},
@@ -278,5 +279,26 @@ func TestPerformerPairHandComputed(t *testing.T) {
 	}
 	if !reflect.DeepEqual(blocks, map[string]float64{"content": 0.5}) {
 		t.Fatalf("unexpected blocks: %v", blocks)
+	}
+}
+
+func TestProfileRecorderSpans(t *testing.T) {
+	disabled := newProfileRecorder(false)
+	end := disabled.begin("core.nothing")
+	end()
+	disabled.emit()
+	if len(disabled.spans) != 0 {
+		t.Fatalf("disabled recorder must not collect spans")
+	}
+	enabled := newProfileRecorder(true)
+	end = enabled.begin("core.work")
+	time.Sleep(2 * time.Millisecond)
+	end()
+	if len(enabled.spans) != 1 {
+		t.Fatalf("expected one span, got %d", len(enabled.spans))
+	}
+	span := enabled.spans[0]
+	if span.name != "core.work" || span.durUs < 1000 || span.offsetUs < 0 {
+		t.Fatalf("unexpected span: %+v", span)
 	}
 }

--- a/core/performer.go
+++ b/core/performer.go
@@ -25,14 +25,15 @@ import (
 )
 
 type performerPayload struct {
-	DB               string             `json:"db"`
-	FeatureVersion   string             `json:"feature_version"`
+	DB               string               `json:"db"`
+	FeatureVersion   string               `json:"feature_version"`
 	IdentityAffinity map[string][]float64 `json:"identity_affinity"`
-	BlockWeights     map[string]float64 `json:"block_weights"`
-	Cutoff           float64            `json:"cutoff"`
-	NumericBlocks    []string           `json:"numeric_blocks"`
-	NumericScales    map[string]float64 `json:"numeric_scales"`
-	Threads          int                `json:"threads,omitempty"`
+	BlockWeights     map[string]float64   `json:"block_weights"`
+	Cutoff           float64              `json:"cutoff"`
+	NumericBlocks    []string             `json:"numeric_blocks"`
+	NumericScales    map[string]float64   `json:"numeric_scales"`
+	Threads          int                  `json:"threads,omitempty"`
+	Profile          bool                 `json:"profile,omitempty"`
 }
 
 type profileValue struct {
@@ -132,6 +133,7 @@ func runPerformerSimilarity() {
 	if err := json.NewDecoder(os.Stdin).Decode(&payload); err != nil {
 		fail("performer-similarity: invalid payload: %v", err)
 	}
+	profile := newProfileRecorder(payload.Profile)
 	db, err := openReadonly(payload.DB)
 	if err != nil {
 		fail("performer-similarity: open %s: %v", payload.DB, err)
@@ -141,14 +143,21 @@ func runPerformerSimilarity() {
 	for _, block := range payload.NumericBlocks {
 		numeric[block] = true
 	}
+	end := profile.begin("core.read_profiles")
 	profiles, err := readProfiles(db, payload.FeatureVersion, numeric)
+	end()
 	if err != nil {
 		fail("performer-similarity: read profiles: %v", err)
 	}
+	end = profile.begin("core.kernel")
 	result := performerSimilarityScores(payload, profiles, numeric)
+	end()
+	end = profile.begin("core.encode_result")
+	profile.emit()
 	if err := writeJSONLine(map[string]any{"result": result}); err != nil {
 		fail("performer-similarity: write result: %v", err)
 	}
+	end()
 }
 
 func performerSimilarityScores(

--- a/core/profile.go
+++ b/core/profile.go
@@ -1,0 +1,71 @@
+package main
+
+// Lightweight span profiling for the compiled core. When the payload requests
+// it (`profile: true`), stages record (name, offset from process start,
+// duration) and emit them as NDJSON `{"span": ...}` lines before the result;
+// the Python side (curator/core.py run_core) folds them into the plugin's
+// profile_trace with category "core". Chrome-trace microsecond units, same as
+// the Python Trace.record payloads.
+
+import (
+	"sync"
+	"time"
+)
+
+var processStarted = time.Now()
+
+type spanRecord struct {
+	name     string
+	offsetUs int64
+	durUs    int64
+}
+
+type profileRecorder struct {
+	mu      sync.Mutex
+	started time.Time
+	enabled bool
+	spans   []spanRecord
+}
+
+func newProfileRecorder(enabled bool) *profileRecorder {
+	return &profileRecorder{started: processStarted, enabled: enabled}
+}
+
+// begin opens a span; call the returned function to close it.
+func (p *profileRecorder) begin(name string) func() {
+	if p == nil || !p.enabled {
+		return func() {}
+	}
+	started := time.Now()
+	return func() {
+		ended := time.Now()
+		p.mu.Lock()
+		p.spans = append(p.spans, spanRecord{
+			name:     name,
+			offsetUs: started.Sub(p.started).Microseconds(),
+			durUs:    ended.Sub(started).Microseconds(),
+		})
+		p.mu.Unlock()
+	}
+}
+
+// emit writes the recorded spans as NDJSON lines before the final result.
+func (p *profileRecorder) emit() {
+	if p == nil || !p.enabled {
+		return
+	}
+	p.mu.Lock()
+	spans := make([]spanRecord, len(p.spans))
+	copy(spans, p.spans)
+	p.mu.Unlock()
+	for _, s := range spans {
+		_ = writeJSONLine(map[string]any{
+			"span": map[string]any{
+				"name":     s.name,
+				"cat":      "core",
+				"offset_us": s.offsetUs,
+				"dur_us":    s.durUs,
+			},
+		})
+	}
+}

--- a/curator/core.py
+++ b/curator/core.py
@@ -23,6 +23,7 @@ import json
 import os
 import platform
 import subprocess
+import time
 from collections.abc import Callable
 from pathlib import Path
 
@@ -128,15 +129,21 @@ def run_core(
     payload: dict[str, object],
     *,
     progress: Callable[[float], None] | None = None,
+    profile: bool = False,
 ) -> dict[str, object]:
     """Run one core stage: JSON payload on stdin, NDJSON on stdout.
 
     ``progress`` receives raw stage fractions (0..1) as the binary streams
-    them; the caller maps them onto the build's own progress scale.
+    them; the caller maps them onto the build's own progress scale. When
+    ``profile`` is set the binary emits ``core.*`` spans, which are folded
+    into the active profiling trace (``curator.profiling``), if any.
     """
     binary = core_binary()
     if binary is None:
         raise CoreError("compiled core is not available")
+    if profile:
+        payload = {**payload, "profile": True}
+    spawn_started_ns = time.perf_counter_ns()
     proc = subprocess.Popen(
         [str(binary), mode],
         stdin=subprocess.PIPE,
@@ -148,6 +155,7 @@ def run_core(
     proc.stdin.write(json.dumps(payload, separators=(",", ":")))
     proc.stdin.close()
     result: dict[str, object] | None = None
+    spans: list[tuple[str, int, int]] = []
     assert proc.stdout is not None
     for line in proc.stdout:
         if not line.strip():
@@ -163,6 +171,16 @@ def run_core(
             if not isinstance(candidate, dict):
                 raise CoreError("compiled core result is not an object")
             result = candidate
+        elif "span" in message:
+            span = message["span"]
+            if isinstance(span, dict) and isinstance(span.get("name"), str):
+                spans.append(
+                    (
+                        span["name"],
+                        int(span.get("offset_us", 0)),
+                        int(span.get("dur_us", 0)),
+                    )
+                )
         elif "progress" in message and progress is not None:
             progress(float(message["progress"]))
     stderr = proc.stderr.read() if proc.stderr is not None else ""
@@ -171,6 +189,21 @@ def run_core(
         raise CoreError(
             f"compiled core failed ({mode}, exit {returncode}): {stderr.strip()[-500:]}"
         )
+    if spans:
+        from curator.profiling import current_trace
+
+        trace = current_trace()
+        if trace is not None:
+            # The binary's offsets are from its process start, which is
+            # (spawn + a few ms of Go runtime init); record expects absolute
+            # perf-counter readings, so convert back from the spawn point.
+            for name, offset_us, duration_us in spans:
+                trace.record(
+                    "core",
+                    name,
+                    spawn_started_ns + offset_us * 1_000,
+                    duration_us * 1_000,
+                )
     return result
 
 

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -24,7 +24,7 @@ from curator.features.profiles import NUMERIC_BLOCKS, NUMERIC_SCALES, performer_
 from curator.features.store import StoredFeature
 from curator.model.boundaries import scene_eligibility
 from curator.model.curves import blend_appeal, direct_confidence, scene_recovery
-from curator.profiling import record_duration, span
+from curator.profiling import current_trace, record_duration, span
 from curator.storage import ModelStore, transaction
 from curator.storage.artifacts import (
     ARTIFACT_SCHEMA_VERSION,
@@ -1270,6 +1270,7 @@ class PreferenceModelBuilder:
             progress=(
                 (lambda fraction: self._report(0.35 + 0.40 * fraction)) if self.progress else None
             ),
+            profile=current_trace() is not None,
         )
         entries = cast(dict[str, dict[str, object]], response)
         default = _NeighborEvidence(0.0, 0.0, 0.0, 0.0, 0.0, ())
@@ -1349,7 +1350,9 @@ class PreferenceModelBuilder:
             "numeric_blocks": sorted(NUMERIC_BLOCKS),
             "numeric_scales": dict(NUMERIC_SCALES),
         }
-        response = core.run_core("performer-similarity", payload)
+        response = core.run_core(
+            "performer-similarity", payload, profile=current_trace() is not None
+        )
         return cast(dict[str, dict[str, object]], response)
 
     def _performer_similarity_scores_python(

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -396,6 +396,46 @@ def test_run_core_streams_progress(tmp_path: Path, binary: Path) -> None:
     assert set(result) == set(corpus["scenes"])
 
 
+def test_run_core_records_core_spans_into_trace(tmp_path: Path, binary: Path) -> None:
+    from curator.profiling import begin_trace, end_trace
+
+    corpus = synthetic_corpus(41, 400, 150, 10, n_performers=0)
+    trace, token = begin_trace("unit", "test")
+    try:
+        run_core(
+            "content-neighbors",
+            _content_payload(tmp_path, corpus),
+            profile=True,
+        )
+    finally:
+        end_trace(trace, token)
+    names = [event["name"] for event in trace.events if event["cat"] == "core"]
+    expected = {
+        "core.read_features",
+        "core.preference_vectors",
+        "core.build_columns",
+        "core.kernel",
+        "core.encode_result",
+    }
+    assert expected <= set(names)
+    for event in trace.events:
+        if event["cat"] == "core":
+            assert int(event["dur"]) > 0
+            assert event["ts"] >= trace.started_at_ns // 1_000
+
+
+def test_run_core_profiling_off_emits_no_spans(tmp_path: Path, binary: Path) -> None:
+    from curator.profiling import begin_trace, end_trace
+
+    corpus = synthetic_corpus(43, 200, 100, 8, n_performers=0)
+    trace, token = begin_trace("unit", "test")
+    try:
+        run_core("content-neighbors", _content_payload(tmp_path, corpus), profile=False)
+    finally:
+        end_trace(trace, token)
+    assert not [event for event in trace.events if event["cat"] == "core"]
+
+
 def _fake_binary(tmp_path: Path, *, stage_exit: int = 0) -> Path:
     script = tmp_path / "fake-curator-core"
     script.write_text(


### PR DESCRIPTION
## Summary

Follow-up to #97 (compiled core, merged and released as 0.6.0): profile the Go binary's stages inside the plugin's profiling trace.

The binary previously showed as a single `model.score_neighbors` / `model.score_performer_similarity` span with no internal breakdown. Now, when profiling is active, the binary emits `core.*` spans — `read_features`, `preference_vectors`, `build_columns`, `kernel`, `encode_result` — as NDJSON; the Python transport folds them into the active `profile_trace` with category `core`, positioned relative to the subprocess spawn. The builder enables it automatically when the plugin's profiling is on, so a build trace shows exactly where the binary's time went (and `scripts/benchmark.py` reports surface the spans too, since its aggregation has no category filter).

Zero overhead when profiling is off — the binary skips timing entirely.

## Commits

- `feat:` profile the compiled core stages inside the plugin trace

## Verification

- `scripts/verify full` green (332 tests with the binary active).
- New tests: span emission end-to-end (all five spans before the result line) and trace-folding (spans recorded with category `core`, correct timestamps; no spans when profiling is off).
- The installed local instance already carries this binary via the manual install.
