### PR TITLE
feat: multi-hop pagerank in the compiled core

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -82,6 +82,17 @@ production result dict:
 `{"result": {performer_id: {value, confidence, matches: [{performer_id,
 similarity, affinity, confidence, blocks: {block: value}}]}}}`.
 
+### multi-hop
+
+Input: `adjacency` (row-stochastic `{node: {target: weight}}`), `seed`,
+`damping`, `max_iterations`, `tolerance`, optional `threads`/`profile`.
+
+Mirrors `MultiHopAffinity._pagerank_python` / `_pagerank_networkx`: personalized
+PageRank with damping 0.85, personalization concentrated on the seed, dangling
+mass returned to the seed, converging when `sum(|x - xlast|) < N * tolerance`
+(max 100 iterations). Nodes and per-node targets iterate in sorted order,
+matching the pure-Python recurrence. Output: `{"result": {node: score}}`.
+
 ## Determinism
 
 Both kernels are deterministic: fixed chunking across goroutines, no

--- a/core/content_test.go
+++ b/core/content_test.go
@@ -302,3 +302,26 @@ func TestProfileRecorderSpans(t *testing.T) {
 		t.Fatalf("unexpected span: %+v", span)
 	}
 }
+
+func TestPagerankConvergesAndIsDeterministic(t *testing.T) {
+	adjacency := map[string]map[string]float64{
+		"a": {"b": 0.6, "c": 0.4},
+		"b": {"a": 1.0},
+		"c": {}, // dangling
+	}
+	first := pagerank(adjacency, "a", 0.85, 100, 1e-6)
+	second := pagerank(adjacency, "a", 0.85, 100, 1e-6)
+	if !reflect.DeepEqual(first, second) {
+		t.Fatal("pagerank must be deterministic")
+	}
+	total := 0.0
+	for _, score := range first {
+		total += score
+	}
+	if math.Abs(total-1.0) > 1e-3 {
+		t.Fatalf("scores must conserve mass, got %v", total)
+	}
+	if first["a"] <= 0 || first["b"] <= 0 || first["c"] <= 0 {
+		t.Fatalf("all nodes must have positive mass: %v", first)
+	}
+}

--- a/core/main.go
+++ b/core/main.go
@@ -59,6 +59,8 @@ func main() {
 		runContentNeighbors()
 	case "performer-similarity":
 		runPerformerSimilarity()
+	case "multi-hop":
+		runMultiHop()
 	default:
 		fail("unknown command: %s", args[0])
 	}

--- a/core/multi_hop.go
+++ b/core/multi_hop.go
@@ -1,0 +1,148 @@
+package main
+
+// Multi-hop stage: personalized PageRank over the walkable performer graph.
+//
+// Mirrors MultiHopAffinity._pagerank_python / _pagerank_networkx
+// (curator/model/multi_hop.py) exactly: the adjacency is already row-stochastic,
+// damping alpha, personalization concentrated on the seed, dangling mass
+// returned to the seed, converging when sum(|x - xlast|) < N * tolerance.
+// Nodes and per-node targets iterate in sorted order, matching the pure-Python
+// recurrence bit-for-bit; the result is deterministic regardless of input map
+// ordering (keys are sorted before use).
+
+import (
+	"encoding/json"
+	"os"
+	"sort"
+)
+
+const (
+	defaultDamping       = 0.85
+	defaultMaxIterations = 100
+	defaultTolerance     = 1e-6
+)
+
+type multiHopPayload struct {
+	Adjacency     map[string]map[string]float64 `json:"adjacency"`
+	Seed          string                        `json:"seed"`
+	Damping       float64                       `json:"damping"`
+	MaxIterations int                           `json:"max_iterations"`
+	Tolerance     float64                       `json:"tolerance"`
+	Profile       bool                          `json:"profile,omitempty"`
+}
+
+func runMultiHop() {
+	var payload multiHopPayload
+	if err := json.NewDecoder(os.Stdin).Decode(&payload); err != nil {
+		fail("multi-hop: invalid payload: %v", err)
+	}
+	damping := payload.Damping
+	if damping <= 0 {
+		damping = defaultDamping
+	}
+	maxIterations := payload.MaxIterations
+	if maxIterations <= 0 {
+		maxIterations = defaultMaxIterations
+	}
+	tolerance := payload.Tolerance
+	if tolerance <= 0 {
+		tolerance = defaultTolerance
+	}
+	profile := newProfileRecorder(payload.Profile)
+	end := profile.begin("core.pagerank")
+	scores := pagerank(payload.Adjacency, payload.Seed, damping, maxIterations, tolerance)
+	end()
+	profile.emit()
+	if err := writeJSONLine(map[string]any{"result": scores}); err != nil {
+		fail("multi-hop: write result: %v", err)
+	}
+}
+
+// pagerank runs the power iteration with networkx/pure-Python semantics.
+func pagerank(
+	adjacency map[string]map[string]float64,
+	seed string,
+	damping float64,
+	maxIterations int,
+	tolerance float64,
+) map[string]float64 {
+	nodes := make([]string, 0, len(adjacency))
+	for node := range adjacency {
+		nodes = append(nodes, node)
+	}
+	sort.Strings(nodes)
+	n := len(nodes)
+	if n == 0 {
+		return map[string]float64{}
+	}
+	dangling := make([]string, 0)
+	for _, node := range nodes {
+		if len(adjacency[node]) == 0 {
+			dangling = append(dangling, node)
+		}
+	}
+	// Sorted per-node targets for deterministic accumulation order.
+	targets := make([][]string, n)
+	weights := make([][]float64, n)
+	for i, node := range nodes {
+		edges := adjacency[node]
+		keys := make([]string, 0, len(edges))
+		for target := range edges {
+			keys = append(keys, target)
+		}
+		sort.Strings(keys)
+		targets[i] = keys
+		weights[i] = make([]float64, len(keys))
+		for k, target := range keys {
+			weights[i][k] = edges[target]
+		}
+	}
+	x := make([]float64, n)
+	for i := range x {
+		x[i] = 1.0 / float64(n)
+	}
+	position := make(map[string]int, n)
+	for i, node := range nodes {
+		position[node] = i
+	}
+	for iteration := 0; iteration < maxIterations; iteration++ {
+		xlast := x
+		x = make([]float64, n)
+		dangleSum := 0.0
+		for _, d := range dangling {
+			dangleSum += xlast[position[d]]
+		}
+		dangleSum *= damping
+		for i, node := range nodes {
+			value := xlast[i]
+			for k, target := range targets[i] {
+				x[position[target]] += damping * value * weights[i][k]
+			}
+			if node == seed {
+				// Two separate additions match the pure-Python recurrence
+				// bit-for-bit (dangling redistribution, then teleport).
+				x[i] += dangleSum
+				x[i] += 1 - damping
+			}
+		}
+		error := 0.0
+		for i := range nodes {
+			error += absFloat(x[i] - xlast[i])
+		}
+		if error < float64(n)*tolerance {
+			break
+		}
+	}
+	result := make(map[string]float64, n)
+	for i, node := range nodes {
+		result[node] = x[i]
+	}
+	return result
+}
+
+func absFloat(value float64) float64 {
+	if value < 0 {
+		return -value
+	}
+	return value
+}

--- a/curator/model/multi_hop.py
+++ b/curator/model/multi_hop.py
@@ -24,8 +24,10 @@ from __future__ import annotations
 import sqlite3
 from collections import defaultdict
 from dataclasses import dataclass
+from typing import Any, cast
 
-from curator import optional_deps
+from curator import core, optional_deps
+from curator.profiling import current_trace
 
 DAMPING = 0.85
 MAX_ITERATIONS = 100
@@ -232,10 +234,32 @@ class MultiHopAffinity:
         graph = self._graph_for(seed_id)
         if len(graph.adjacency) < 2:
             return {}
+        if core.core_binary() is not None:
+            return self._walk_core(graph)
         nx = optional_deps.nx
         if nx is not None and _scipy_available():
             return _pagerank_networkx(graph)
         return _pagerank_python(graph)
+
+    def _walk_core(self, graph: _Graph) -> dict[str, float]:
+        """PageRank via the compiled core (networkx's role).
+
+        The walkable graph is built here (sidecar reads + seed resolution); the
+        binary only runs the power iteration over the row-stochastic adjacency,
+        mirroring the pure-Python recurrence bit-for-bit.
+        """
+        response = core.run_core(
+            "multi-hop",
+            {
+                "adjacency": {node: dict(edges) for node, edges in graph.adjacency.items()},
+                "seed": graph.seed,
+                "damping": DAMPING,
+                "max_iterations": MAX_ITERATIONS,
+                "tolerance": TOLERANCE,
+            },
+            profile=current_trace() is not None,
+        )
+        return {str(node): float(score) for node, score in cast(dict[str, Any], response).items()}
 
     def _graph_for(self, seed_id: str) -> _Graph:
         """Walkable graph seeded at a scene or performer node."""

--- a/docs/decisions/002-runtime-swap-planning.md
+++ b/docs/decisions/002-runtime-swap-planning.md
@@ -408,4 +408,9 @@ yet** — distribution (5.2/5.3) is the next work package.
   target — native per-arch runners were not needed. The `raw` interface
   stays; switching the exec line to the binary is a later, separate step.
 - **Phase 4 (optional):** full backend in Go on `raw` (no RPC), if the hybrid
-  proves out and the port budget is available.
+  proves out and the port budget is available. **Progress:** the multi-hop
+  pagerank kernel is ported (`core/multi-hop`), keeping networkx/scipy as a
+  dev-only oracle; percentiles stay Python (pure-Python fallback is
+  negligible). The remaining runtime dependencies (the numpy/networkx venv)
+  are the next removal target — the plan is binary-required-at-runtime with
+  numpy as the differential oracle and the pure-Python kernels deleted.

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -515,3 +515,25 @@ def test_run_core_raises_on_broken_binary(tmp_path: Path) -> None:
     finally:
         monkeypatch.undo()
         core_module._clear_cache()
+
+
+def test_run_core_records_multihop_span_into_trace(tmp_path: Path, binary: Path) -> None:
+    from curator.profiling import begin_trace, end_trace
+
+    trace, token = begin_trace("unit", "test")
+    try:
+        run_core(
+            "multi-hop",
+            {
+                "adjacency": {
+                    "a": {"b": 1.0},
+                    "b": {"a": 1.0},
+                    "c": {},
+                },
+                "seed": "a",
+            },
+            profile=True,
+        )
+    finally:
+        end_trace(trace, token)
+    assert [event["name"] for event in trace.events if event["cat"] == "core"] == ["core.pagerank"]

--- a/tests/model/test_multi_hop.py
+++ b/tests/model/test_multi_hop.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import random
 import sqlite3
 from pathlib import Path
 
@@ -15,6 +16,7 @@ from curator.model import builder as builder_module
 from curator.model.multi_hop import (
     REACH_FLOOR,
     MultiHopAffinity,
+    _Graph,
     _pagerank_networkx,
     _pagerank_python,
 )
@@ -153,6 +155,7 @@ def test_reach_matches_pure_python_when_networkx_unavailable(
 ) -> None:
     connection = _graph_database(tmp_path / "curator.sqlite3")
     monkeypatch.setattr(optional_deps, "nx", None)
+    monkeypatch.setattr(builder_module.core, "core_binary", lambda: None)
     service = MultiHopAffinity(connection, "m")
     scores = _pagerank_python(service._graph("s"))
     expected = {
@@ -261,3 +264,59 @@ def test_similarity_annotates_multi_hop_when_reachable(
         assert reach is None or 0.0 < reach <= 1.0
         if "multi_hop" in item.relationships:
             assert item.details["multi_hop_reach"] >= REACH_FLOOR
+
+
+def test_core_pagerank_matches_networkx_and_python(tmp_path: Path) -> None:
+    if builder_module.core.core_binary() is None:
+        pytest.skip("curator-core binary is not built")
+    connection = _graph_database(tmp_path / "curator.sqlite3")
+    service = MultiHopAffinity(connection, "m")
+    graph = service._graph_for("s")
+    core_scores = service._walk_core(graph)
+    assert core_scores == pytest.approx(_pagerank_python(graph), rel=1e-12)
+    if optional_deps.nx is not None and _scipy_importable():
+        assert core_scores == pytest.approx(_pagerank_networkx(graph), rel=1e-9)
+
+
+@pytest.mark.parametrize(
+    ("n_nodes", "density", "seed_index"),
+    [(10, 0.3, 0), (50, 0.15, 1), (200, 0.05, 2), (25, 0.4, 3)],
+)
+def test_core_pagerank_matches_on_seeded_corpora(
+    n_nodes: int, density: float, seed_index: int
+) -> None:
+    if builder_module.core.core_binary() is None:
+        pytest.skip("curator-core binary is not built")
+    rng = random.Random(1000 + seed_index)
+    nodes = [f"n{index:03d}" for index in range(n_nodes)]
+    adjacency: dict[str, dict[str, float]] = {}
+    for node in nodes:
+        edges = {
+            target: rng.random() for target in nodes if target != node and rng.random() < density
+        }
+        if edges:
+            total = sum(edges.values())
+            adjacency[node] = {target: weight / total for target, weight in edges.items()}
+        else:
+            adjacency[node] = {}
+    graph = _Graph(adjacency, nodes[seed_index % n_nodes], frozenset())
+    service = MultiHopAffinity(None, "m")
+    core_scores = service._walk_core(graph)
+    assert core_scores == pytest.approx(_pagerank_python(graph), rel=1e-12)
+    if optional_deps.nx is not None and _scipy_importable():
+        assert core_scores == pytest.approx(_pagerank_networkx(graph), rel=1e-9)
+
+
+def test_core_reach_matches_python(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    if builder_module.core.core_binary() is None:
+        pytest.skip("curator-core binary is not built")
+    connection = _graph_database(tmp_path / "curator.sqlite3")
+    service = MultiHopAffinity(connection, "m")
+    real_binary = builder_module.core.core_binary
+    monkeypatch.setattr(builder_module.core, "core_binary", lambda: None)
+    expected = service.reach("s")
+    monkeypatch.setattr(builder_module.core, "core_binary", real_binary)
+    core_reach = service.reach("s")
+    assert set(core_reach) == set(expected)
+    for scene, score in expected.items():
+        assert core_reach[scene] == pytest.approx(score, rel=1e-12)


### PR DESCRIPTION
## Summary

Port the multi-hop PageRank kernel into the compiled core (`curator-core multi-hop`), so networkx/scipy stop being a runtime dependency for the reach walk.

The walkable graph is still assembled in Python (sidecar reads, seed resolution, studio/tag bridges — unchanged); the binary runs only the power iteration over the row-stochastic adjacency, mirroring `MultiHopAffinity._pagerank_python` / `_pagerank_networkx` exactly: damping 0.85, personalization concentrated on the seed, dangling mass returned to the seed, convergence at `sum(|x - xlast|) < N * tolerance` (max 100 iterations). Nodes and per-node targets iterate in sorted order to match the pure-Python recurrence bit-for-bit.

`reach()` / `performer_reach()` dispatch compiled core > networkx > pure Python.

## Commits

- `feat:` multi-hop pagerank in the compiled core

## Verification

- Differential tests pin the Go kernel against both Python engines on the fixture graph and on seeded random corpora (10-200 nodes, varying density/dangling), plus `reach()` through the core vs the Python path at rel=1e-12.
- `scripts/verify full` green (336 tests with the binary active).
- The stage ships in the per-arch binaries; the local instance is updated via the install script.

## Follow-ups

- This PR intentionally doesn't wire the `profile` span flag for the new stage — that lands with #98 (profiling), which introduced the `profile` kwarg; a 4-line addition once #98 merges.
- Next after this: remove the numpy/networkx venv task and make the compiled core a runtime requirement (numpy stays as the differential oracle only), per the discussion on #97.
