### PR TITLE
feat: remove optional-deps venv — compiled core is now required

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,19 +17,19 @@ do not introduce a dependency or abstraction without a measured need. SQLite sch
 changes always get a new ordered migration. Never edit an applied migration or reset
 the sidecar to work around one.
 
-The compiled core (`core/`, Go) optionally accelerates the two similarity stages
-in numpy's role; the binary is never a runtime dependency (compiled core > numpy
-> pure-Python dispatch, `curator/core.py`). Go is a build-time dependency:
+The compiled core (`core/`, Go) is the single runtime implementation of the
+similarity and pagerank kernels; a missing or incompatible binary fails build
+stages with a clear error (`curator/core.py`). Go is a build-time dependency:
 changes under `core/` need the Go toolchain, `scripts/build_core.sh`, and the
-differential gate (`scripts/verify core` — the binary must reproduce numpy's
-stage outputs on seeded synthetic corpora; `tests/core/` + `tests/model/test_core.py`).
-Packaging (`scripts/build_plugin.py`) cross-compiles the shipped per-arch
-binaries and requires Go. The kernels mirror the production numpy semantics
-exactly, including the documented masked-NaN performer behavior (see
+differential gate (`scripts/verify core` — the binary must reproduce the numpy
+oracle's stage outputs on seeded synthetic corpora; `tests/core/`,
+`tests/model/test_core.py`, `tests/oracle.py`). Packaging
+(`scripts/build_plugin.py`) cross-compiles the shipped per-arch binaries and
+requires Go. The kernels mirror the production numpy semantics exactly,
+including the documented masked-NaN performer behavior (see
 `docs/decisions/002-runtime-swap-planning.md` section 8) — do not "fix" that
 divergence without a reviewed product decision. `scripts/verify full` builds
-the core and runs the unit suite with the binary active when Go is available;
-without it the suite runs the numpy/pure-Python paths (both must stay green).
+the core and runs the unit suite with the binary active.
 
 Custom scene and performer cards must preserve Stash's native SFW Switch class
 contract: `scene-card`/`performer-card`, the matching `*-card-image`, `card-section`,

--- a/core/README.md
+++ b/core/README.md
@@ -1,15 +1,15 @@
 # Compiled core (curator-core)
 
-Optional acceleration for Stash Curator's model build. The binary replaces
-numpy's role in the similarity stage: the content-neighbor and
-performer-similarity kernels are implemented with identical semantics to the
-production Python paths in `curator/model/builder.py`, reading feature rows
-directly from the SQLite feature artifact. The plugin never depends on it — the
-pure-Python fallback (and numpy, when installed) stays fully intact.
+Optional acceleration for Stash Curator's model build. The binary is the
+single runtime implementation of the content-neighbor, performer-similarity,
+and multi-hop PageRank kernels, reading feature rows directly from the SQLite
+feature artifact. numpy/networkx remain dev-only oracles for the differential
+test gate (`tests/oracle.py`); a missing or incompatible binary fails build
+stages with a clear error instead of silently falling back.
 
 Go is a **dev/build dependency only**; the shipped plugin runs the binary as a
 subprocess when present (see `docs/decisions/002-runtime-swap-planning.md`,
-Phase 2, and `curator/core.py` for resolution and fallback).
+Phase 3, and `curator/core.py` for resolution).
 
 ## Build
 
@@ -23,8 +23,7 @@ The binary is built with `CGO_ENABLED=0`; SQLite reads use the pure-Go
 `modernc.org/sqlite` driver. `scripts/build_plugin.py` cross-compiles the
 shipped per-arch binaries (linux amd64/arm64, windows amd64, darwin
 amd64/arm64) into the plugin zip; the runtime selects the matching
-`curator-core-<goos>-<goarch>` and falls back to numpy / pure Python when none
-exists.
+`curator-core-<goos>-<goarch>` and the plugin fails build stages loudly when none exists.
 
 ## Protocol
 
@@ -107,5 +106,5 @@ The pytest files `tests/core/test_core.py` and `tests/model/test_core.py` are
 the oracle: Python owns the data (seeded synthetic corpora — never a real
 sidecar), the binary must reproduce the numpy outputs within tolerance (exact
 ids/counts, 1e-9 floats). The CI core job builds the binary and runs the gate
-with `CURATOR_CORE` set; the pure-Python fallback is exercised by the main
+with `CURATOR_CORE` set.
 suite without a binary.

--- a/curator/core.py
+++ b/curator/core.py
@@ -140,7 +140,10 @@ def run_core(
     """
     binary = core_binary()
     if binary is None:
-        raise CoreError("compiled core is not available")
+        raise CoreError(
+            "curator-core is required but missing or incompatible (wrong platform, "
+            "version mismatch, or not executable); reinstall the plugin"
+        )
     if profile:
         payload = {**payload, "profile": True}
     spawn_started_ns = time.perf_counter_ns()

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -10,17 +10,16 @@ import time
 from collections import defaultdict
 from collections.abc import Callable, Iterable
 from dataclasses import asdict, dataclass
-from heapq import nsmallest
 from itertools import batched
 from pathlib import Path
 from typing import Any, cast
 
-from curator import core, optional_deps
+from curator import core
 from curator.config import DEFAULT_CONFIG, CuratorConfig
 from curator.events.contracts import DEFAULT_CALIBRATION
 from curator.features import FeatureBuilder, FeatureStore
 from curator.features.builder import _fingerprint_table
-from curator.features.profiles import NUMERIC_BLOCKS, NUMERIC_SCALES, performer_similarity
+from curator.features.profiles import NUMERIC_BLOCKS, NUMERIC_SCALES
 from curator.features.store import StoredFeature
 from curator.model.boundaries import scene_eligibility
 from curator.model.curves import blend_appeal, direct_confidence, scene_recovery
@@ -668,14 +667,9 @@ class PreferenceModelBuilder:
                 vectors, scene_features, affinities
             )
             progress_total = len(preference_vectors) + len(all_scene_ids)
-            if core.core_binary() is not None:
-                neighbors = self._content_neighbors_core(
-                    feature_version, affinities, training_labels, label_mean, progress_total
-                )
-            else:
-                neighbors = self._content_neighbors(
-                    preference_vectors, training_labels, label_mean, progress_total
-                )
+            neighbors = self._content_neighbors(
+                feature_version, affinities, training_labels, label_mean, progress_total
+            )
         with span("python", "model.score_performer_similarity"):
             performer_similarity_scores = self._performer_similarity_scores(
                 feature_version, scene_features, affinities
@@ -1006,176 +1000,6 @@ class PreferenceModelBuilder:
             weighted[scene_id] = {name: value / norm for name, value in values.items()}
         return weighted, sum(strength > 0 for strength in strengths.values())
 
-    def _content_neighbors(
-        self,
-        vectors: dict[str, dict[str, float]],
-        labels: dict[str, _SceneLabel],
-        label_mean: float,
-        progress_total: int,
-    ) -> dict[str, _NeighborEvidence]:
-        if optional_deps.NUMPY_AVAILABLE:
-            return self._content_neighbors_numpy(vectors, labels, label_mean, progress_total)
-        return self._content_neighbors_python(vectors, labels, label_mean, progress_total)
-
-    def _content_neighbors_python(
-        self,
-        vectors: dict[str, dict[str, float]],
-        labels: dict[str, _SceneLabel],
-        label_mean: float,
-        progress_total: int,
-    ) -> dict[str, _NeighborEvidence]:
-        inverted: dict[str, list[tuple[str, float]]] = defaultdict(list)
-        vector_count = len(vectors)
-        for scene_id, vector in vectors.items():
-            if scene_id not in labels:
-                continue
-            for name, value in vector.items():
-                inverted[name].append((scene_id, value))
-        result: dict[str, _NeighborEvidence] = {}
-        for vector_index, (scene_id, vector) in enumerate(vectors.items(), 1):
-            dots: dict[str, float] = defaultdict(float)
-            shared: dict[str, int] = defaultdict(int)
-            for name, value in vector.items():
-                for other_id, other_value in inverted.get(name, ()):
-                    if other_id == scene_id:
-                        continue
-                    dots[other_id] += value * other_value
-                    shared[other_id] += 1
-            evidence = []
-            for other_id, cosine in dots.items():
-                overlap = 1 - math.exp(-shared[other_id] / 4)
-                similarity = cosine * overlap
-                if similarity < self.config.model.minimum_neighbor_similarity:
-                    continue
-                weight = similarity**3 * labels[other_id].confidence
-                evidence.append((other_id, similarity, weight, labels[other_id].outcome))
-            selected = nsmallest(
-                self.config.model.neighbor_count,
-                evidence,
-                key=lambda item: (-item[2], item[0]),
-            )
-            denominator = sum(item[2] for item in selected)
-            outcome_mean = (
-                sum(item[2] * item[3] for item in selected) / denominator if denominator else 0.0
-            )
-            lift = outcome_mean - label_mean if denominator else 0.0
-            confidence = (
-                1 - math.exp(-denominator / self.config.model.neighbor_confidence_scale)
-                if denominator
-                else 0.0
-            )
-            result[scene_id] = _NeighborEvidence(
-                lift * confidence,
-                outcome_mean,
-                lift,
-                confidence,
-                denominator,
-                tuple(
-                    {
-                        "scene_id": item[0],
-                        "similarity": item[1],
-                        "weight": item[2],
-                        "outcome": item[3],
-                    }
-                    for item in selected[:5]
-                ),
-            )
-            if self.progress and (vector_index == vector_count or vector_index % 250 == 0):
-                self._report(0.35 + 0.40 * vector_index / max(1, progress_total))
-        return result
-
-    def _content_neighbors_numpy(
-        self,
-        vectors: dict[str, dict[str, float]],
-        labels: dict[str, _SceneLabel],
-        label_mean: float,
-        progress_total: int,
-    ) -> dict[str, _NeighborEvidence]:
-        np = optional_deps.np
-        assert np is not None
-        scene_ids = list(vectors)
-        # Labels for scenes that left Stash have no vector; they cannot act as
-        # candidates, mirroring the pure-Python inverted index over vectors only.
-        labeled_ids = sorted(scene_id for scene_id in labels if scene_id in vectors)
-        default = _NeighborEvidence(0.0, 0.0, 0.0, 0.0, 0.0, ())
-        result: dict[str, _NeighborEvidence] = {}
-        if not labeled_ids:
-            return {scene_id: default for scene_id in scene_ids}
-        column_names = sorted({name for scene_id in labeled_ids for name in vectors[scene_id]})
-        if not column_names:
-            return {scene_id: default for scene_id in scene_ids}
-        column_index = {name: index for index, name in enumerate(column_names)}
-        labeled_position = {scene_id: column for column, scene_id in enumerate(labeled_ids)}
-        labeled_values = np.zeros((len(labeled_ids), len(column_names)), dtype=np.float64)
-        for column, scene_id in enumerate(labeled_ids):
-            for name, value in vectors[scene_id].items():
-                labeled_values[column, column_index[name]] = value
-        target_values = np.zeros((len(scene_ids), len(column_names)), dtype=np.float64)
-        for row, scene_id in enumerate(scene_ids):
-            for name, value in vectors[scene_id].items():
-                if name not in column_index:
-                    continue
-                target_values[row, column_index[name]] = value
-        labeled_conf = np.array(
-            [labels[scene_id].confidence for scene_id in labeled_ids], dtype=np.float64
-        )
-        labeled_outcome = np.array(
-            [labels[scene_id].outcome for scene_id in labeled_ids], dtype=np.float64
-        )
-        labeled_binary = (labeled_values != 0).astype(np.float32)
-        target_binary = (target_values != 0).astype(np.float32)
-        self_column = np.array(
-            [labeled_position.get(scene_id, -1) for scene_id in scene_ids], dtype=np.int32
-        )
-        minimum_similarity = self.config.model.minimum_neighbor_similarity
-        neighbor_count = self.config.model.neighbor_count
-        confidence_scale = self.config.model.neighbor_confidence_scale
-        vector_count = len(scene_ids)
-        for start in range(0, vector_count, 4096):
-            end = min(start + 4096, vector_count)
-            similarities = target_values[start:end] @ labeled_values.T
-            # Shared counts never exceed the feature count, so float32 is exact and
-            # uses the BLAS matmul path (integer matmul has no optimized loop); the
-            # overlap factor is then computed in float64 to match the Python path.
-            shared = (target_binary[start:end] @ labeled_binary.T).astype(np.float64)
-            similarities *= 1.0 - np.exp(-shared / 4.0)
-            weights = similarities**3 * labeled_conf[np.newaxis, :]
-            valid = similarities >= minimum_similarity
-            for local_row in range(end - start):
-                own = int(self_column[start + local_row])
-                if own >= 0:
-                    valid[local_row, own] = False
-            for local_row in range(end - start):
-                scene_id = scene_ids[start + local_row]
-                valid_indices = np.flatnonzero(valid[local_row])
-                if len(valid_indices) == 0:
-                    result[scene_id] = default
-                    continue
-                row_weights = weights[local_row, valid_indices]
-                chosen = min(neighbor_count, len(row_weights))
-                boundary = float(
-                    np.partition(row_weights, len(row_weights) - chosen)[len(row_weights) - chosen]
-                )
-                candidates = valid_indices[row_weights >= boundary]
-                evidence = [
-                    (
-                        labeled_ids[int(column)],
-                        float(similarities[local_row, int(column)]),
-                        float(weights[local_row, int(column)]),
-                        float(labeled_outcome[int(column)]),
-                    )
-                    for column in candidates
-                ]
-                evidence.sort(key=lambda item: (-item[2], item[0]))
-                selected = evidence[:neighbor_count]
-                result[scene_id] = self._neighbor_evidence(
-                    scene_id, selected, label_mean, confidence_scale
-                )
-                index = start + local_row + 1
-                if self.progress and (index == vector_count or index % 250 == 0):
-                    self._report(0.35 + 0.40 * index / max(1, progress_total))
-        return result
-
     @staticmethod
     def _neighbor_evidence(
         scene_id: str,
@@ -1223,7 +1047,7 @@ class PreferenceModelBuilder:
             raise RuntimeError(f"feature artifact missing for {feature_version}")
         return artifact_path(database_path(self.connection), str(row[0]))
 
-    def _content_neighbors_core(
+    def _content_neighbors(
         self,
         feature_version: str,
         affinities: dict[str, _Affinity],
@@ -1316,22 +1140,6 @@ class PreferenceModelBuilder:
         scene_features: dict[str, tuple[StoredFeature, ...]],
         affinities: dict[str, _Affinity],
     ) -> dict[str, dict[str, object]]:
-        if core.core_binary() is not None:
-            return self._performer_similarity_scores_core(
-                feature_version, scene_features, affinities
-            )
-        if optional_deps.NUMPY_AVAILABLE:
-            return self._performer_similarity_scores_numpy(
-                feature_version, scene_features, affinities
-            )
-        return self._performer_similarity_scores_python(feature_version, scene_features, affinities)
-
-    def _performer_similarity_scores_core(
-        self,
-        feature_version: str,
-        scene_features: dict[str, tuple[StoredFeature, ...]],
-        affinities: dict[str, _Affinity],
-    ) -> dict[str, dict[str, object]]:
         """Performer-similarity scores via the compiled core (numpy's role).
 
         The binary reads the performer profiles from the feature artifact; the
@@ -1354,270 +1162,6 @@ class PreferenceModelBuilder:
             "performer-similarity", payload, profile=current_trace() is not None
         )
         return cast(dict[str, dict[str, object]], response)
-
-    def _performer_similarity_scores_python(
-        self,
-        feature_version: str,
-        scene_features: dict[str, tuple[StoredFeature, ...]],
-        affinities: dict[str, _Affinity],
-    ) -> dict[str, dict[str, object]]:
-        identity_affinity = self._identity_affinity(scene_features, affinities)
-        profiles = FeatureStore(self.connection).performer_profiles(feature_version)
-        weights = dict(self.config.feature.performer_block_weights)
-        known = {
-            key: profiles[key]
-            for key, (value, _) in identity_affinity.items()
-            if key in profiles and abs(value) >= PERFORMER_SIMILARITY_AFFINITY_CUTOFF
-        }
-        matches_by_performer: dict[str, list[dict[str, object]]] = {
-            performer_id: [] for performer_id in profiles
-        }
-        for performer_id, profile in profiles.items():
-            for known_id, known_profile in known.items():
-                if known_id == performer_id or (performer_id in known and known_id < performer_id):
-                    continue
-                similarity = performer_similarity(profile, known_profile, weights)
-                if similarity.similarity <= 0:
-                    continue
-                matches_by_performer[performer_id].append(
-                    {
-                        "performer_id": known_id,
-                        "similarity": similarity.similarity,
-                        "affinity": identity_affinity[known_id][0],
-                        "confidence": identity_affinity[known_id][1],
-                        "blocks": similarity.block_similarities,
-                    }
-                )
-                if performer_id in known:
-                    matches_by_performer[known_id].append(
-                        {
-                            "performer_id": performer_id,
-                            "similarity": similarity.similarity,
-                            "affinity": identity_affinity[performer_id][0],
-                            "confidence": identity_affinity[performer_id][1],
-                            "blocks": similarity.block_similarities,
-                        }
-                    )
-        result: dict[str, dict[str, object]] = {}
-        for performer_id, matches in matches_by_performer.items():
-            selected = nsmallest(
-                5,
-                matches,
-                key=lambda item: (-_number(item["similarity"]), str(item["performer_id"])),
-            )
-            denominator = sum(_number(item["similarity"]) ** 3 for item in selected)
-            value = (
-                sum(
-                    _number(item["affinity"]) * _number(item["similarity"]) ** 3
-                    for item in selected
-                )
-                / denominator
-                if denominator
-                else 0.0
-            )
-            confidence = (
-                sum(
-                    _number(item["confidence"]) * _number(item["similarity"]) ** 3
-                    for item in selected
-                )
-                / denominator
-                if denominator
-                else 0.0
-            )
-            result[performer_id] = {
-                "value": value,
-                "confidence": confidence,
-                "matches": selected[:3],
-            }
-        return result
-
-    def _performer_similarity_scores_numpy(
-        self,
-        feature_version: str,
-        scene_features: dict[str, tuple[StoredFeature, ...]],
-        affinities: dict[str, _Affinity],
-    ) -> dict[str, dict[str, object]]:
-        np = optional_deps.np
-        assert np is not None
-        identity_affinity = self._identity_affinity(scene_features, affinities)
-        profiles = FeatureStore(self.connection).performer_profiles(feature_version)
-        weights = dict(self.config.feature.performer_block_weights)
-        known = {
-            key: profiles[key]
-            for key, (value, _) in identity_affinity.items()
-            if key in profiles and abs(value) >= PERFORMER_SIMILARITY_AFFINITY_CUTOFF
-        }
-        profile_ids = list(profiles)
-        known_ids = list(known)
-        known_position = {performer_id: column for column, performer_id in enumerate(known_ids)}
-        known_affinity = np.array(
-            [identity_affinity[performer_id][0] for performer_id in known_ids], dtype=np.float64
-        )
-        known_confidence = np.array(
-            [identity_affinity[performer_id][1] for performer_id in known_ids], dtype=np.float64
-        )
-        block_names = sorted({block for profile in profiles.values() for block in profile.blocks})
-        block_keys = {
-            block: sorted(
-                {key for profile in profiles.values() for key in profile.blocks.get(block, {})}
-            )
-            for block in block_names
-        }
-        values: dict[str, Any] = {}
-        confidences: dict[str, Any] = {}
-        present: dict[str, Any] = {}
-        for block in block_names:
-            keys = block_keys[block]
-            key_position = {key: column for column, key in enumerate(keys)}
-            block_values = np.zeros((len(profile_ids), len(keys)), dtype=np.float64)
-            block_confidences = np.zeros_like(block_values)
-            block_present = np.zeros(len(profile_ids), dtype=bool)
-            for row, performer_id in enumerate(profile_ids):
-                entries = profiles[performer_id].blocks.get(block)
-                if not entries:
-                    continue
-                block_present[row] = True
-                for key, item in entries.items():
-                    block_values[row, key_position[key]] = item.value
-                    block_confidences[row, key_position[key]] = item.confidence
-            values[block] = block_values
-            confidences[block] = block_confidences
-            present[block] = block_present
-        known_positions = np.array(
-            [profile_ids.index(performer_id) for performer_id in known_ids], dtype=np.int64
-        )
-        known_values = {block: values[block][known_positions, :] for block in block_names}
-        known_confidences = {block: confidences[block][known_positions, :] for block in block_names}
-        known_present = {block: present[block][known_positions] for block in block_names}
-        numerator = np.zeros((len(profile_ids), len(known_ids)), dtype=np.float64)
-        denominator = np.zeros_like(numerator)
-        block_similarities: dict[str, Any] = {}
-        used: dict[str, Any] = {}
-        for block in block_names:
-            weight = weights.get(block, 0.0)
-            if weight <= 0:
-                continue
-            both_present = np.outer(present[block], known_present[block])
-            if block in NUMERIC_BLOCKS:
-                numeric_values, numeric_counts = _numpy_numeric_matrix(
-                    np,
-                    values[block],
-                    known_values[block],
-                    confidences[block],
-                    known_confidences[block],
-                    np.array(
-                        [NUMERIC_SCALES.get(key, 1.0) for key in block_keys[block]],
-                        dtype=np.float64,
-                    ),
-                )
-                with np.errstate(divide="ignore", invalid="ignore"):
-                    block_value = np.divide(
-                        numeric_values,
-                        numeric_counts,
-                        out=np.zeros_like(numeric_values),
-                        where=numeric_counts > 0,
-                    )
-                block_used = both_present & (numeric_counts > 0)
-            else:
-                norms = np.array(
-                    [profiles[performer_id].norms.get(block, 0.0) for performer_id in profile_ids],
-                    dtype=np.float64,
-                )
-                known_norms = norms[known_positions]
-                block_value = _numpy_cosine_matrix(
-                    np,
-                    values[block],
-                    known_values[block],
-                    confidences[block],
-                    known_confidences[block],
-                    norms,
-                    known_norms,
-                )
-                block_used = both_present & (norms[:, None] != 0) & (known_norms[None, :] != 0)
-            block_similarities[block] = block_value
-            used[block] = block_used
-            numerator += block_value * block_used * weight
-            denominator += block_used * weight
-        penalty = np.ones((len(profile_ids), len(known_ids)), dtype=np.float64)
-        measurements = values.get("measurements")
-        if measurements is not None and measurements.shape[1]:
-            cup_position = (
-                block_keys["measurements"].index("cup_index")
-                if "cup_index" in block_keys["measurements"]
-                else -1
-            )
-            if cup_position >= 0:
-                cup_all = measurements[:, cup_position]
-                cup_known = known_values["measurements"][:, cup_position]
-                both_cup = np.outer(cup_all != 0, cup_known != 0)
-                cup_difference = np.abs(np.subtract.outer(cup_all, cup_known))
-                penalty *= np.where(
-                    both_cup, np.exp(-0.18 * np.maximum(0.0, cup_difference - 1.0)), 1.0
-                )
-        augmentation = values.get("augmentation")
-        if augmentation is not None and augmentation.shape[1]:
-            augmentation_binary = (augmentation != 0).astype(np.float32)
-            known_augmentation_binary = (known_values["augmentation"] != 0).astype(np.float32)
-            shared_augmentation = augmentation_binary @ known_augmentation_binary.T
-            both_augmentation = np.outer(
-                augmentation_binary.any(axis=1), known_augmentation_binary.any(axis=1)
-            )
-            penalty *= np.where(both_augmentation & (shared_augmentation == 0), 0.65, 1.0)
-        with np.errstate(divide="ignore", invalid="ignore"):
-            similarity = np.where(denominator > 0, numerator / denominator * penalty, 0.0)
-        result: dict[str, dict[str, object]] = {}
-        for performer_index, performer_id in enumerate(profile_ids):
-            row = similarity[performer_index]
-            candidates = [
-                (known_ids[column], float(row[column]))
-                for column in range(len(known_ids))
-                if known_ids[column] != performer_id and float(row[column]) > 0
-            ]
-            selected = nsmallest(
-                5,
-                candidates,
-                key=lambda item: (-item[1], item[0]),
-            )
-            denominator = sum(item[1] ** 3 for item in selected)
-            value = (
-                sum(
-                    float(known_affinity[known_position[item[0]]]) * item[1] ** 3
-                    for item in selected
-                )
-                / denominator
-                if denominator
-                else 0.0
-            )
-            confidence = (
-                sum(
-                    float(known_confidence[known_position[item[0]]]) * item[1] ** 3
-                    for item in selected
-                )
-                / denominator
-                if denominator
-                else 0.0
-            )
-            result[performer_id] = {
-                "value": value,
-                "confidence": confidence,
-                "matches": [
-                    {
-                        "performer_id": known_id,
-                        "similarity": score,
-                        "affinity": identity_affinity[known_id][0],
-                        "confidence": identity_affinity[known_id][1],
-                        "blocks": {
-                            block: float(
-                                block_similarities[block][performer_index, known_position[known_id]]
-                            )
-                            for block in used
-                            if bool(used[block][performer_index, known_position[known_id]])
-                        },
-                    }
-                    for known_id, score in selected[:3]
-                ],
-            }
-        return result
 
     def _performer_priors(self) -> dict[str, _Prior]:
         result: dict[str, _Prior] = {}

--- a/curator/model/multi_hop.py
+++ b/curator/model/multi_hop.py
@@ -26,7 +26,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, cast
 
-from curator import core, optional_deps
+from curator import core
 from curator.profiling import current_trace
 
 DAMPING = 0.85
@@ -234,12 +234,7 @@ class MultiHopAffinity:
         graph = self._graph_for(seed_id)
         if len(graph.adjacency) < 2:
             return {}
-        if core.core_binary() is not None:
-            return self._walk_core(graph)
-        nx = optional_deps.nx
-        if nx is not None and _scipy_available():
-            return _pagerank_networkx(graph)
-        return _pagerank_python(graph)
+        return self._walk_core(graph)
 
     def _walk_core(self, graph: _Graph) -> dict[str, float]:
         """PageRank via the compiled core (networkx's role).
@@ -319,64 +314,3 @@ class MultiHopAffinity:
                 continue
             adjacency[node] = _normalize(sorted(edges.items()))
         return _Graph(dict(adjacency), seed_id, frozenset(self._scene_performers))
-
-
-def _scipy_available() -> bool:
-    """networkx.pagerank dispatches to its scipy backend; without scipy we use the
-    pure-Python power iteration instead."""
-    try:
-        import scipy  # type: ignore[import-untyped]  # noqa: F401
-    except ImportError:
-        return False
-    return True
-
-
-def _pagerank_networkx(graph: _Graph) -> dict[str, float]:
-    """networkx.pagerank (scipy backend) over the pre-normalized adjacency.
-
-    Weights are already row-stochastic, so the sparse transition matrix matches the
-    pure-Python recurrence and both engines converge to the same fixed point.
-    """
-    import networkx as nx  # type: ignore[import-untyped]
-
-    directed = nx.DiGraph()
-    directed.add_nodes_from(sorted(graph.adjacency))
-    for node, edges in graph.adjacency.items():
-        for target, weight in edges.items():
-            directed.add_edge(node, target, weight=weight)
-    scores: dict[str, float] = nx.pagerank(
-        directed,
-        alpha=DAMPING,
-        personalization={graph.seed: 1.0},
-        max_iter=MAX_ITERATIONS,
-        tol=TOLERANCE,
-    )
-    return scores
-
-
-def _pagerank_python(graph: _Graph) -> dict[str, float]:
-    """Power iteration over the same recurrence as the networkx path.
-
-    v' = alpha * row-stochastic(A) @ v + (1 - alpha) * personalization, with
-    dangling mass returned to the seed (personalization), matching networkx's
-    dangling handling so both engines converge to the same fixed point.
-    """
-    adjacency = graph.adjacency
-    seed = graph.seed
-    nodes = sorted(adjacency)
-    dangling = [node for node in nodes if not adjacency[node]]
-    x = {node: 1.0 / len(nodes) for node in nodes}
-    for _ in range(MAX_ITERATIONS):
-        xlast = x
-        x = {node: 0.0 for node in nodes}
-        danglesum = DAMPING * sum(xlast[node] for node in dangling)
-        for node in nodes:
-            for target, weight in adjacency[node].items():
-                x[target] += DAMPING * xlast[node] * weight
-            x[node] += danglesum * (1.0 if node == seed else 0.0)
-            if node == seed:
-                x[node] += 1.0 - DAMPING
-        error = sum(abs(x[node] - xlast[node]) for node in nodes)
-        if error < len(nodes) * TOLERANCE:
-            break
-    return x

--- a/curator/ranking/policy.py
+++ b/curator/ranking/policy.py
@@ -8,7 +8,6 @@ import sqlite3
 from collections.abc import Callable, Collection
 from dataclasses import dataclass
 
-from curator import optional_deps
 from curator.config import DEFAULT_CONFIG, CuratorConfig
 from curator.events.contracts import OBSERVED_PLAYBACK_SQL
 from curator.features import FeatureStore
@@ -42,28 +41,6 @@ def _number(value: object) -> float:
 def _percentiles(values: dict[str, float]) -> dict[str, float]:
     if not values:
         return {}
-    np = optional_deps.np
-    if np is not None:
-        ids = np.fromiter(values.keys(), dtype=object)
-        sorted_values = np.fromiter(values.values(), dtype=np.float64)
-        order = np.lexsort((ids, sorted_values))
-        sorted_values = sorted_values[order]
-        sorted_ids = ids[order]
-        count = len(sorted_values)
-        denominator = max(1, count - 1)
-        # Group boundaries where the value changes; percentiles use the midpoint of
-        # each tied group's positions, matching the pure-Python loop below.
-        groups = np.flatnonzero(
-            np.concatenate(([True], sorted_values[1:] != sorted_values[:-1], [True]))
-        )
-        starts = groups[:-1]
-        ends = groups[1:]
-        mids = (starts + ends - 1) / 2
-        percentiles = np.repeat(mids / denominator, ends - starts)
-        return {
-            str(scene_id): float(value)
-            for scene_id, value in zip(sorted_ids, percentiles, strict=True)
-        }
     ordered = sorted(values.items(), key=lambda item: (item[1], item[0]))
     denominator = max(1, len(ordered) - 1)
     result: dict[str, float] = {}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,11 +5,11 @@ permalink: /architecture/
 
 # Architecture
 
-Curator is a self-contained external raw plugin with no runtime dependencies beyond
-Python 3.12+. Optional numpy acceleration is provisioned on demand into a
-plugin-local venv (see Runtime components); without it, the same code paths run in
-pure Python. Stash loads `plugin/backend.py`; the browser UI is one JavaScript file
-and one CSS file, and model code lives in the packaged `curator` module.
+Curator is a self-contained external raw plugin with no runtime dependencies
+beyond Python 3.12+ and the compiled Go core (`curator-core`) that ships in the
+plugin zip; there is no runtime install task or virtual environment. Stash loads
+`plugin/backend.py`; the browser UI is one JavaScript file and one CSS file, and
+model code lives in the packaged `curator` module.
 
 ```text
 Stash GraphQL
@@ -43,16 +43,13 @@ source cache ──► normalized events                  StashDB
   orders.
 - `curator/similarity.py`, `curator/expand.py`, and `curator/explanations/` serve
   Similar, StashDB discovery, and factual reasons.
-- `curator/optional_deps.py` and the **Install optional dependencies** task provide
-  the optional numpy acceleration: the task creates a versioned venv beside the
-  plugin and pip-installs `plugin/packages/curator-tools.txt`; `backend.py` adds the
-  venv's site-packages to `sys.path` when present. The content-neighbor and
-  performer-similarity stages use numpy (BLAS matmuls) when importable and fall back
-  to their pure-Python implementations otherwise, so builds are deterministic and
-  correct in either mode. The same venv carries networkx (and, when installed,
-  scipy) for the multi-hop affinity stage: `curator/model/multi_hop.py` walks the
-  persisted performer-collaboration graph with personalized PageRank and falls back
-  to an equivalent pure-Python power iteration.
+- `curator/core.py` and the compiled Go core (`core/`, shipped as per-arch
+  `curator-core-<goos>-<goarch>` binaries in the plugin zip) implement the
+  content-neighbor, performer-similarity, and multi-hop PageRank kernels; the
+  builder and `curator/model/multi_hop.py` invoke them as subprocesses. The
+  binary is the single runtime implementation — a missing or incompatible
+  binary fails build stages with a clear error. numpy/networkx remain
+  dev-only oracles for the differential test gate (`tests/oracle.py`).
 - `curator/storage/sql/` contains ordered, checksummed, transactional migrations.
 
 ## Data flow and failure boundaries

--- a/docs/decisions/002-runtime-swap-planning.md
+++ b/docs/decisions/002-runtime-swap-planning.md
@@ -409,8 +409,11 @@ yet** — distribution (5.2/5.3) is the next work package.
   stays; switching the exec line to the binary is a later, separate step.
 - **Phase 4 (optional):** full backend in Go on `raw` (no RPC), if the hybrid
   proves out and the port budget is available. **Progress:** the multi-hop
-  pagerank kernel is ported (`core/multi-hop`), keeping networkx/scipy as a
-  dev-only oracle; percentiles stay Python (pure-Python fallback is
-  negligible). The remaining runtime dependencies (the numpy/networkx venv)
-  are the next removal target — the plan is binary-required-at-runtime with
-  numpy as the differential oracle and the pure-Python kernels deleted.
+  pagerank kernel is ported (`core/multi-hop`). **Done (2026-08-10):** the
+  numpy/networkx venv is removed — no "Install optional dependencies" task,
+  no runtime dependency installs. The compiled core is now the single runtime
+  implementation for the similarity and pagerank kernels (a missing binary
+  fails build stages with a clear error); the pure-Python kernel paths were
+  deleted; numpy/networkx remain dev-only oracles for the differential gate
+  (`tests/oracle.py`), and percentiles run on stdlib Python. Rollback = install
+  the previous plugin version.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,21 +50,17 @@ from the Curator status indicator and Stash's Tasks page.
 
 ## Optional acceleration
 
-Curator runs entirely on the Python standard library, and everything works without
-any extra packages. Model builds get measurably faster when **numpy** is available,
-so a one-shot task installs it for you:
+Curator runs entirely on Python's standard library plus a compiled Go core
+(`curator-core`) that ships inside the plugin zip — no installation step, no
+network access. The compiled core accelerates the two similarity stages
+(content neighbors and performer similarity) and the multi-hop reach walk,
+which are the largest part of a first build. There is nothing to install: just
+run **Sync and build recommendations** as usual.
 
-1. In Stash, open **Tasks** and run **Install optional dependencies** once.
-2. The task creates a plugin-local virtual environment and pip-installs the pinned
-   requirements from `packages/curator-tools.txt` into it.
-3. Then run **Sync and build recommendations** as usual.
-
-The numpy paths accelerate the two similarity stages (content neighbors and
-performer similarity), which are the largest part of a first build. Without it, the
-model builder falls back to its pure-Python implementations, so skipping the task is
-always safe. The venv lives in the plugin directory and survives plugin updates;
-re-run the task only if the Python interpreter Stash uses for plugins changes
-version.
+The Go binary is optional in the sense that every path degrades gracefully if
+it is missing or incompatible — the plugin reports a clear error for build
+stages instead of silently running slower. Updating the plugin replaces both
+the Python code and the per-platform binaries.
 
 ## Configure
 

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -7,14 +7,12 @@ import hashlib
 import json
 import re
 import sqlite3
-import subprocess
 import sys
 import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
-from venv import create as create_venv
 
 PLUGIN_DIR = Path(sys.argv[1]).resolve() if len(sys.argv) > 1 else Path(__file__).parent.resolve()
 
@@ -50,19 +48,6 @@ def _installed_code_version() -> str:
     return _code_version_cache
 
 
-# Optional dependencies (numpy) installed by the "Install optional dependencies"
-# task into a versioned venv kept beside the plugin. The venv lives on the plugin
-# volume, so it survives plugin updates and container recreations; the pure-Python
-# fallbacks keep every path working when it is absent.
-_venv_site_packages = (
-    PLUGIN_DIR
-    / "venv"
-    / "lib"
-    / f"python{sys.version_info.major}.{sys.version_info.minor}"
-    / "site-packages"
-)
-if _venv_site_packages.is_dir():
-    sys.path.insert(0, str(_venv_site_packages))
 for package_root in (PLUGIN_DIR, PLUGIN_DIR.parent):
     if str(package_root) not in sys.path:
         sys.path.insert(0, str(package_root))
@@ -1609,44 +1594,7 @@ def _profiled[T](
             _log("w", f"Could not save Curator profile: {save_error}")
 
 
-def _install_optional_deps() -> dict[str, object]:
-    """Install the plugin's optional Python dependencies into a local venv.
-
-    Mirrors the community Python Tools Installer pattern: a venv created inside the
-    plugin directory persists on the plugin volume across container recreations, and
-    the backend sys.path shim makes its site-packages importable. Runs without the
-    sidecar database so it works on a fresh install.
-    """
-    venv_dir = PLUGIN_DIR / "venv"
-    requirements = PLUGIN_DIR / "packages" / "curator-tools.txt"
-    if not requirements.is_file():
-        raise RuntimeError(f"missing optional dependency manifest: {requirements}")
-    _log("i", f"Installing optional Curator dependencies from {requirements.name}")
-    _progress(0.05)
-    if not (venv_dir / "pyvenv.cfg").is_file():
-        _log("i", f"Creating virtual environment at {venv_dir}")
-        create_venv(venv_dir, with_pip=True)
-    _progress(0.30)
-    pip = venv_dir / "bin" / "pip"
-    _log("i", "Running " + " ".join([str(pip), "install", "-r", str(requirements)]))
-    completed = subprocess.run(
-        [str(pip), "install", "-r", str(requirements)],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    _progress(0.95)
-    if completed.returncode != 0:
-        detail = (completed.stderr or completed.stdout).strip().splitlines()
-        raise RuntimeError(f"pip install failed: {detail[-1] if detail else 'unknown error'}")
-    _log("i", "Optional Curator dependencies installed")
-    _progress(1.0)
-    return {"status": "ok", "venv": str(venv_dir), "requirements": str(requirements)}
-
-
 def _run_task(payload: dict[str, Any], mode: str) -> dict[str, object]:
-    if mode == "install-deps":
-        return _install_optional_deps()
     return _profiled(
         payload,
         mode,

--- a/plugin/packages/curator-tools.txt
+++ b/plugin/packages/curator-tools.txt
@@ -1,6 +1,0 @@
-# Optional Curator dependencies installed by the "Install optional dependencies"
-# task into a plugin-local venv. Pin exact versions: pip resolves the wheel that
-# matches the runtime Python and platform at install time. The model builder falls
-# back to its pure-Python implementations when these are not importable.
-numpy==2.5.1
-networkx==3.6.1

--- a/plugin/stash-curator.yml
+++ b/plugin/stash-curator.yml
@@ -131,10 +131,6 @@ tasks:
     description: Refresh promising StashDB scenes and performers without affecting library sync.
     execArgs:
       - expand-refresh
-  - name: Install optional dependencies
-    description: Install numpy and networkx acceleration into a plugin-local virtual environment. The model builder falls back to pure Python when this is not run.
-    execArgs:
-      - install-deps
 hooks:
   - name: Sync changed entity
     description: Import or remove a single entity after a Stash create, update, or delete, so the sidecar stays current without a full sync.

--- a/tests/core/test_core.py
+++ b/tests/core/test_core.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import pytest
 
 from curator import core as core_module
+from curator import optional_deps
 from curator.config import DEFAULT_CONFIG
 from curator.core import CoreError, core_binary, run_core
 from curator.features.store import StoredFeature
@@ -241,7 +242,7 @@ CONTENT_CORPORA = [
 def test_content_neighbors_core_matches_numpy(
     tmp_path: Path, binary: Path, n_scenes: int, d_features: int, nnz: int
 ) -> None:
-    if not builder_module.optional_deps.NUMPY_AVAILABLE:
+    if not optional_deps.NUMPY_AVAILABLE:
         pytest.skip("numpy is not installed")
     corpus = synthetic_corpus(7, n_scenes, d_features, nnz, n_performers=0)
     connection, _artifact = core_with_feature_artifact(tmp_path, corpus)
@@ -254,8 +255,18 @@ def test_content_neighbors_core_matches_numpy(
     label_mean = builder._label_mean(labels)
     progress_total = len(preference) + len(corpus["scenes"])
 
-    numpy_result = builder._content_neighbors_numpy(preference, labels, label_mean, progress_total)
-    core_result = builder._content_neighbors_core(
+    from tests.oracle import content_neighbors_numpy
+
+    numpy_result = content_neighbors_numpy(
+        preference,
+        labels,
+        label_mean,
+        progress_total,
+        min_similarity=builder_module.DEFAULT_CONFIG.model.minimum_neighbor_similarity,
+        neighbor_count=builder_module.DEFAULT_CONFIG.model.neighbor_count,
+        confidence_scale=builder_module.DEFAULT_CONFIG.model.neighbor_confidence_scale,
+    )
+    core_result = builder._content_neighbors(
         FEATURE_VERSION, affinities, labels, label_mean, progress_total
     )
 
@@ -298,7 +309,7 @@ def _assert_neighbor_evidence_equal(
 
 
 def test_performer_similarity_core_matches_numpy(tmp_path: Path, binary: Path) -> None:
-    if not builder_module.optional_deps.NUMPY_AVAILABLE:
+    if not optional_deps.NUMPY_AVAILABLE:
         pytest.skip("numpy is not installed")
     corpus = synthetic_corpus(13, 150, 90, 12, n_performers=60)
     connection, _artifact = core_with_feature_artifact(tmp_path, corpus)
@@ -313,10 +324,17 @@ def test_performer_similarity_core_matches_numpy(tmp_path: Path, binary: Path) -
             feature_id, value / confidence, confidence, 1.0, 1, {}
         )
     scene_features = _scene_features(corpus, with_identity=True)
-    numpy_result = builder._performer_similarity_scores_numpy(
-        FEATURE_VERSION, scene_features, identity_affinities
+    from tests.oracle import performer_similarity_numpy
+
+    numpy_result = performer_similarity_numpy(
+        connection,
+        FEATURE_VERSION,
+        scene_features,
+        identity_affinities,
+        block_weights=dict(builder_module.DEFAULT_CONFIG.feature.performer_block_weights),
+        cutoff=builder_module.PERFORMER_SIMILARITY_AFFINITY_CUTOFF,
     )
-    core_result = builder._performer_similarity_scores_core(
+    core_result = builder._performer_similarity_scores(
         FEATURE_VERSION, scene_features, identity_affinities
     )
     assert set(core_result) == set(numpy_result)

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -3,7 +3,6 @@ import math
 import sqlite3
 from dataclasses import replace
 from pathlib import Path
-from unittest.mock import Mock
 
 import pytest
 
@@ -163,83 +162,6 @@ def test_satiation_content_dots_match_naive_recent_loop() -> None:
 
     result = builder._satiation("candidate", 1.0, context)
     assert result == pytest.approx(min(builder.config.model.satiation_bound, naive), rel=1e-12)
-
-
-def test_content_neighbors_numpy_matches_python() -> None:
-    builder = PreferenceModelBuilder(None)
-    vectors = {
-        "s1": {"a": 1.0, "b": 0.5},
-        "s2": {"a": 0.8, "c": 0.3},
-        "s3": {"d": 1.0},
-        "s4": {"a": 0.6, "b": 0.7, "c": 0.2},
-    }
-    labels = {
-        "s1": builder_module._SceneLabel(0.8, 0.9, 1.0, ("o",)),
-        "s2": builder_module._SceneLabel(-0.4, 0.7, 0.8, ("o",)),
-        "s3": builder_module._SceneLabel(0.1, 0.5, 0.6, ("o",)),
-    }
-    if not builder_module.optional_deps.NUMPY_AVAILABLE:
-        pytest.skip("numpy is not installed")
-    numpy_result = builder._content_neighbors_numpy(vectors, labels, 0.2, 8)
-    python_result = builder._content_neighbors_python(vectors, labels, 0.2, 8)
-    assert set(numpy_result) == set(python_result)
-    for scene_id in vectors:
-        numpy_evidence = numpy_result[scene_id]
-        python_evidence = python_result[scene_id]
-        assert numpy_evidence.value == pytest.approx(python_evidence.value, rel=1e-9)
-        assert numpy_evidence.outcome_mean == pytest.approx(python_evidence.outcome_mean, rel=1e-9)
-        assert numpy_evidence.lift == pytest.approx(python_evidence.lift, rel=1e-9)
-        assert numpy_evidence.confidence == pytest.approx(python_evidence.confidence, rel=1e-9)
-        assert numpy_evidence.total_weight == pytest.approx(python_evidence.total_weight, rel=1e-9)
-        assert [n["scene_id"] for n in numpy_evidence.neighbors] == [
-            n["scene_id"] for n in python_evidence.neighbors
-        ]
-        for numpy_neighbor, python_neighbor in zip(
-            numpy_evidence.neighbors, python_evidence.neighbors, strict=True
-        ):
-            assert numpy_neighbor["similarity"] == pytest.approx(
-                python_neighbor["similarity"], rel=1e-9
-            )
-            assert numpy_neighbor["weight"] == pytest.approx(python_neighbor["weight"], rel=1e-9)
-            assert numpy_neighbor["outcome"] == pytest.approx(python_neighbor["outcome"], rel=1e-9)
-
-
-def test_performer_similarity_numpy_matches_python(tmp_path: Path) -> None:
-    connection = _database(tmp_path / "curator.sqlite3")
-    builder = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS)
-    built = builder.build()
-    scene_features = builder_module.FeatureStore(connection).entity_features(
-        built.feature_version, "scene"
-    )
-    labels = builder._scene_labels()
-    training_labels = builder._training_labels(labels)
-    label_mean = builder._label_mean(training_labels)
-    affinities = builder._affinities(scene_features, training_labels, label_mean)
-    if not builder_module.optional_deps.NUMPY_AVAILABLE:
-        pytest.skip("numpy is not installed")
-    numpy_result = builder._performer_similarity_scores_numpy(
-        built.feature_version, scene_features, affinities
-    )
-    python_result = builder._performer_similarity_scores_python(
-        built.feature_version, scene_features, affinities
-    )
-    assert set(numpy_result) == set(python_result)
-    for performer_id in numpy_result:
-        assert numpy_result[performer_id]["value"] == pytest.approx(
-            python_result[performer_id]["value"], rel=1e-6
-        )
-        assert numpy_result[performer_id]["confidence"] == pytest.approx(
-            python_result[performer_id]["confidence"], rel=1e-6
-        )
-        assert [m["performer_id"] for m in numpy_result[performer_id]["matches"]] == [
-            m["performer_id"] for m in python_result[performer_id]["matches"]
-        ]
-        for numpy_match, python_match in zip(
-            numpy_result[performer_id]["matches"],
-            python_result[performer_id]["matches"],
-            strict=True,
-        ):
-            assert numpy_match["similarity"] == pytest.approx(python_match["similarity"], rel=1e-6)
 
 
 def test_classification_data_matches_full_scores_for_lane_values(tmp_path: Path) -> None:
@@ -556,56 +478,6 @@ def test_model_build_reports_stage_progress(tmp_path: Path) -> None:
         processed for processed, _ in progress
     )
     assert progress[-1] == (1_000, 1_000)
-
-
-def test_model_compares_known_performer_pairs_once(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    connection = _database(tmp_path / "curator.sqlite3")
-    counted = Mock(wraps=builder_module.performer_similarity)
-    monkeypatch.setattr(builder_module, "performer_similarity", counted)
-    # The pair-count contract belongs to the pure-Python implementation; the numpy
-    # path never calls performer_similarity and is covered by its own parity tests.
-    monkeypatch.setattr(builder_module.optional_deps, "NUMPY_AVAILABLE", False)
-    monkeypatch.setattr(builder_module.core, "core_binary", lambda: None)
-    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
-
-    assert counted.call_count == 3
-
-
-def test_model_ignores_negligible_performer_similarity_seeds(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    connection = _database(tmp_path / "curator.sqlite3")
-    builder = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS)
-    built = builder.build()
-    scene_features = builder_module.FeatureStore(connection).entity_features(
-        built.feature_version, "scene"
-    )
-    identities = {
-        feature.name.removeprefix("performer:"): feature
-        for features in scene_features.values()
-        for feature in features
-        if feature.family == "performer_identity"
-    }
-    affinities = {
-        identities[performer_id].feature_id: builder_module._Affinity(
-            identities[performer_id].feature_id, value, 1.0, 1.0, 1, {}
-        )
-        for performer_id, value in (("p1", 0.006), ("p2", 0.004))
-    }
-    counted = Mock(wraps=builder_module.performer_similarity)
-    monkeypatch.setattr(builder_module, "performer_similarity", counted)
-    monkeypatch.setattr(builder_module.optional_deps, "NUMPY_AVAILABLE", False)
-    monkeypatch.setattr(builder_module.core, "core_binary", lambda: None)
-
-    builder._performer_similarity_scores(built.feature_version, scene_features, affinities)
-
-    compared = {
-        frozenset((call.args[0].performer_id, call.args[1].performer_id))
-        for call in counted.call_args_list
-    }
-    assert compared == {frozenset(("p1", "p2")), frozenset(("p1", "p3"))}
 
 
 def test_wrong_metadata_is_not_reused_but_direct_scene_evidence_remains(tmp_path: Path) -> None:

--- a/tests/model/test_core.py
+++ b/tests/model/test_core.py
@@ -9,12 +9,12 @@ absent -> numpy, then pure Python, and a broken binary fails the stage loudly.
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 import pytest
 
 from curator import core as core_module
+from curator import optional_deps
 from curator.core import CoreError
 from curator.model import PreferenceModelBuilder
 from curator.model import builder as builder_module
@@ -50,18 +50,23 @@ def _built_context(tmp_path: Path) -> tuple[builder_module.PreferenceModelBuilde
 
 
 def test_content_neighbors_core_matches_numpy_on_built_corpus(tmp_path: Path) -> None:
-    if not builder_module.optional_deps.NUMPY_AVAILABLE:
+    if not optional_deps.NUMPY_AVAILABLE:
         pytest.skip("numpy is not installed")
     if builder_module.core.core_binary() is None:
         pytest.skip("curator-core binary is not built")
     builder, context = _built_context(tmp_path)
-    numpy_result = builder._content_neighbors_numpy(
+    from tests.oracle import content_neighbors_numpy
+
+    numpy_result = content_neighbors_numpy(
         context["preference"],
         context["training_labels"],
         context["label_mean"],
         context["progress_total"],
+        min_similarity=builder.config.model.minimum_neighbor_similarity,
+        neighbor_count=builder.config.model.neighbor_count,
+        confidence_scale=builder.config.model.neighbor_confidence_scale,
     )
-    core_result = builder._content_neighbors_core(
+    core_result = builder._content_neighbors(
         context["feature_version"],
         context["affinities"],
         context["training_labels"],
@@ -91,15 +96,22 @@ def test_content_neighbors_core_matches_numpy_on_built_corpus(tmp_path: Path) ->
 
 
 def test_performer_similarity_core_matches_numpy_on_built_corpus(tmp_path: Path) -> None:
-    if not builder_module.optional_deps.NUMPY_AVAILABLE:
+    if not optional_deps.NUMPY_AVAILABLE:
         pytest.skip("numpy is not installed")
     if builder_module.core.core_binary() is None:
         pytest.skip("curator-core binary is not built")
     builder, context = _built_context(tmp_path)
-    numpy_result = builder._performer_similarity_scores_numpy(
-        context["feature_version"], context["scene_features"], context["affinities"]
+    from tests.oracle import performer_similarity_numpy
+
+    numpy_result = performer_similarity_numpy(
+        builder.connection,
+        context["feature_version"],
+        context["scene_features"],
+        context["affinities"],
+        block_weights=dict(builder.config.feature.performer_block_weights),
+        cutoff=builder_module.PERFORMER_SIMILARITY_AFFINITY_CUTOFF,
     )
-    core_result = builder._performer_similarity_scores_core(
+    core_result = builder._performer_similarity_scores(
         context["feature_version"], context["scene_features"], context["affinities"]
     )
     assert set(core_result) == set(numpy_result)
@@ -128,176 +140,27 @@ def test_performer_similarity_core_matches_numpy_on_built_corpus(tmp_path: Path)
                 )
 
 
-def test_model_build_with_core_persists_identical_rows(
+def test_missing_binary_fails_the_stage_loudly(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Two identical seeded sidecars built through different implementations
-    must produce the same model id and matching persisted rows."""
-    if not builder_module.optional_deps.NUMPY_AVAILABLE:
-        pytest.skip("numpy is not installed")
-    if builder_module.core.core_binary() is None:
-        pytest.skip("curator-core binary is not built")
-    real_binary = builder_module.core.core_binary
-    core_path = tmp_path / "core.sqlite3"
-    numpy_path = tmp_path / "numpy.sqlite3"
-    core_connection = _database(core_path)
-    numpy_connection = _database(numpy_path)
-    monkeypatch.setattr(builder_module.core, "core_binary", lambda: None)
-    numpy_build = PreferenceModelBuilder(numpy_connection, clock_ms=lambda: REFERENCE_MS).build()
-    monkeypatch.setattr(builder_module.core, "core_binary", real_binary)
-    core_build = PreferenceModelBuilder(core_connection, clock_ms=lambda: REFERENCE_MS).build()
+    """The compiled core is a runtime requirement: a missing binary raises an
+    actionable error instead of silently falling back."""
+    from curator.core import CoreError
 
-    assert core_build.model_id == numpy_build.model_id
-
-    def neighbor_rows(connection: object, model_id: str) -> list[tuple[object, ...]]:
-        return sorted(
-            tuple(row)
-            for row in connection.execute(  # type: ignore[union-attr]
-                """
-                SELECT scene_id, rank, neighbor_scene_id, similarity, weight, outcome
-                FROM model_scene_neighbor WHERE model_id=? ORDER BY scene_id, rank
-                """,
-                (model_id,),
-            )
-        )
-
-    core_neighbors = neighbor_rows(core_connection, core_build.model_id)
-    numpy_neighbors = neighbor_rows(numpy_connection, numpy_build.model_id)
-    assert [row[:3] for row in core_neighbors] == [row[:3] for row in numpy_neighbors]
-    for core_row, numpy_row in zip(core_neighbors, numpy_neighbors, strict=True):
-        for index in (3, 4, 5):
-            assert core_row[index] == pytest.approx(numpy_row[index], rel=1e-9)
-
-    def edge_rows(connection: object, model_id: str) -> list[tuple[object, ...]]:
-        return sorted(
-            tuple(row)
-            for row in connection.execute(  # type: ignore[union-attr]
-                """
-                SELECT performer_id, rank, similar_performer_id, similarity, affinity, confidence
-                FROM model_performer_edge WHERE model_id=? ORDER BY performer_id, rank
-                """,
-                (model_id,),
-            )
-        )
-
-    core_edges = edge_rows(core_connection, core_build.model_id)
-    numpy_edges = edge_rows(numpy_connection, numpy_build.model_id)
-    assert [row[:3] for row in core_edges] == [row[:3] for row in numpy_edges]
-    for core_row, numpy_row in zip(core_edges, numpy_edges, strict=True):
-        for index in (3, 4, 5):
-            assert core_row[index] == pytest.approx(numpy_row[index], rel=1e-9)
-
-    def component_values(connection: object, model_id: str) -> dict[str, dict[str, float]]:
-        values: dict[str, dict[str, float]] = {}
-        for row in connection.execute(  # type: ignore[union-attr]
-            "SELECT scene_id, components_json FROM model_scene_score WHERE model_id=?",
-            (model_id,),
-        ):
-            components = json.loads(str(row["components_json"]))
-            values[str(row["scene_id"])] = {
-                family: float(components[family]["value"])
-                for family in (
-                    "content",
-                    "content_neighbor",
-                    "performer_identity",
-                    "performer_similarity",
-                    "studio",
-                    "structure",
-                )
-            }
-        return values
-
-    core_components = component_values(core_connection, core_build.model_id)
-    numpy_components = component_values(numpy_connection, numpy_build.model_id)
-    assert set(core_components) == set(numpy_components)
-    for scene_id in numpy_components:
-        for family in numpy_components[scene_id]:
-            assert core_components[scene_id][family] == pytest.approx(
-                numpy_components[scene_id][family], rel=1e-9
-            )
-
-
-def test_content_neighbors_dispatch_falls_back_without_core(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
     builder, context = _built_context(tmp_path)
     monkeypatch.setattr(builder_module.core, "core_binary", lambda: None)
-    monkeypatch.setattr(builder_module.optional_deps, "NUMPY_AVAILABLE", True)
-    numpy_called: list[bool] = []
-    python_called: list[bool] = []
-
-    def fake_numpy(*args: object, **kwargs: object) -> object:
-        numpy_called.append(True)
-        return {}
-
-    def fake_python(*args: object, **kwargs: object) -> object:
-        python_called.append(True)
-        return {}
-
-    monkeypatch.setattr(builder, "_content_neighbors_numpy", fake_numpy)
-    monkeypatch.setattr(builder, "_content_neighbors_python", fake_python)
-    result = builder._content_neighbors(
-        context["preference"],
-        context["training_labels"],
-        context["label_mean"],
-        context["progress_total"],
-    )
-    assert numpy_called and not python_called and result == {}
-
-    numpy_called.clear()
-    monkeypatch.setattr(builder_module.optional_deps, "NUMPY_AVAILABLE", False)
-    builder._content_neighbors(
-        context["preference"],
-        context["training_labels"],
-        context["label_mean"],
-        context["progress_total"],
-    )
-    assert python_called and not numpy_called
-
-
-def test_performer_dispatch_prefers_core_when_available(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    builder, context = _built_context(tmp_path)
-    core_called: list[bool] = []
-    numpy_called: list[bool] = []
-    python_called: list[bool] = []
-
-    def fake_core(*args: object, **kwargs: object) -> dict[str, object]:
-        core_called.append(True)
-        return {}
-
-    def fake_numpy(*args: object, **kwargs: object) -> dict[str, object]:
-        numpy_called.append(True)
-        return {}
-
-    def fake_python(*args: object, **kwargs: object) -> dict[str, object]:
-        python_called.append(True)
-        return {}
-
-    monkeypatch.setattr(builder, "_performer_similarity_scores_core", fake_core)
-    monkeypatch.setattr(builder, "_performer_similarity_scores_numpy", fake_numpy)
-    monkeypatch.setattr(builder, "_performer_similarity_scores_python", fake_python)
-
-    monkeypatch.setattr(builder_module.core, "core_binary", lambda: Path("/binary"))
-    builder._performer_similarity_scores(
-        context["feature_version"], context["scene_features"], context["affinities"]
-    )
-    assert core_called and not numpy_called and not python_called
-
-    core_called.clear()
-    monkeypatch.setattr(builder_module.core, "core_binary", lambda: None)
-    builder._performer_similarity_scores(
-        context["feature_version"], context["scene_features"], context["affinities"]
-    )
-    assert numpy_called and not core_called and not python_called
-
-    numpy_called.clear()
-    monkeypatch.setattr(builder_module.optional_deps, "NUMPY_AVAILABLE", False)
-    builder._performer_similarity_scores(
-        context["feature_version"], context["scene_features"], context["affinities"]
-    )
-    assert python_called and not numpy_called and not core_called
+    with pytest.raises(CoreError, match="curator-core is required"):
+        builder._content_neighbors(
+            context["feature_version"],
+            context["affinities"],
+            context["training_labels"],
+            context["label_mean"],
+            context["progress_total"],
+        )
+    with pytest.raises(CoreError, match="curator-core is required"):
+        builder._performer_similarity_scores(
+            context["feature_version"], context["scene_features"], context["affinities"]
+        )
 
 
 def test_broken_binary_fails_the_stage_loudly(

--- a/tests/model/test_multi_hop.py
+++ b/tests/model/test_multi_hop.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import random
 import sqlite3
@@ -9,16 +10,16 @@ from pathlib import Path
 
 import pytest
 
-from curator import optional_deps
 from curator.features import FeatureStore
 from curator.model import PreferenceModelBuilder
 from curator.model import builder as builder_module
 from curator.model.multi_hop import (
+    DAMPING,
+    MAX_ITERATIONS,
     REACH_FLOOR,
+    TOLERANCE,
     MultiHopAffinity,
     _Graph,
-    _pagerank_networkx,
-    _pagerank_python,
 )
 from curator.similarity import SimilarityService
 from curator.storage import MigrationRunner, connect_database
@@ -118,67 +119,67 @@ def test_reach_empty_when_seed_has_no_affinity_performers(tmp_path: Path) -> Non
     assert MultiHopAffinity(connection, "m").reach("missing") == {}
 
 
-def _scipy_importable() -> bool:
-    try:
-        import scipy  # noqa: F401
-    except ImportError:
-        return False
-    return True
+def _reference_pagerank(graph: _Graph) -> dict[str, float]:
+    """Reference power iteration (test-local oracle, mirrors the Go kernel)."""
+    adjacency = graph.adjacency
+    seed = graph.seed
+    nodes = sorted(adjacency)
+    dangling = [node for node in nodes if not adjacency[node]]
+    x = {node: 1.0 / len(nodes) for node in nodes}
+    for _ in range(MAX_ITERATIONS):
+        xlast = x
+        x = {node: 0.0 for node in nodes}
+        danglesum = DAMPING * sum(xlast[node] for node in dangling)
+        for node in nodes:
+            for target, weight in adjacency[node].items():
+                x[target] += DAMPING * xlast[node] * weight
+            if node == seed:
+                x[node] += danglesum + (1.0 - DAMPING)
+        error = sum(abs(x[node] - xlast[node]) for node in nodes)
+        if error < len(nodes) * TOLERANCE:
+            break
+    return x
 
 
-@pytest.mark.skipif(
-    optional_deps.nx is None or not _scipy_importable(),
-    reason="networkx with scipy is not installed in this environment",
-)
-def test_networkx_and_python_paths_agree(tmp_path: Path) -> None:
-    connection = _graph_database(tmp_path / "curator.sqlite3")
-    graph = MultiHopAffinity(connection, "m")._graph("s")
-    nx_scores = _pagerank_networkx(graph)
-    python_scores = _pagerank_python(graph)
-
-    assert set(nx_scores) == set(python_scores)
-    for node in nx_scores:
-        assert nx_scores[node] == pytest.approx(python_scores[node], rel=1e-9)
-    ranking = sorted(
-        (
-            node
-            for node in nx_scores
-            if node in graph.scenes and node != "s" and nx_scores[node] >= REACH_FLOOR
-        ),
-        key=lambda node: (-nx_scores[node], node),
-    )
-    assert ranking == ["d"]
-
-
-def test_reach_matches_pure_python_when_networkx_unavailable(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    connection = _graph_database(tmp_path / "curator.sqlite3")
-    monkeypatch.setattr(optional_deps, "nx", None)
-    monkeypatch.setattr(builder_module.core, "core_binary", lambda: None)
-    service = MultiHopAffinity(connection, "m")
-    scores = _pagerank_python(service._graph("s"))
-    expected = {
+def _reference_reach(service: MultiHopAffinity, scene_id: str) -> dict[str, float]:
+    scores = _reference_pagerank(service._graph_for(scene_id))
+    return {
         scene: scores[scene]
         for scene in sorted(
             (
                 node
                 for node in scores
-                if node in service._scene_performers and node != "s" and scores[node] >= REACH_FLOOR
+                if node in service._scene_performers
+                and node != scene_id
+                and scores[node] >= REACH_FLOOR
             ),
             key=lambda node: (-scores[node], node),
         )[:50]
     }
-    assert service.reach("s") == expected
+
+
+def _networkx_pagerank(graph: _Graph) -> dict[str, float]:
+    """Test-local networkx oracle (dev group only; not shipped)."""
+    import networkx as nx
+
+    directed = nx.DiGraph()
+    directed.add_nodes_from(sorted(graph.adjacency))
+    for node, edges in graph.adjacency.items():
+        for target, weight in edges.items():
+            directed.add_edge(node, target, weight=weight)
+    return nx.pagerank(
+        directed,
+        alpha=DAMPING,
+        personalization={graph.seed: 1.0},
+        max_iter=MAX_ITERATIONS,
+        tol=TOLERANCE,
+    )
 
 
 def test_publish_writes_performer_edges_matching_the_build(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
-    # Force the pure-Python path so the recomputed expectation matches exactly.
-    monkeypatch.setattr(optional_deps, "NUMPY_AVAILABLE", False)
-    monkeypatch.setattr(builder_module.core, "core_binary", lambda: None)
     builder = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS)
     built = builder.build()
 
@@ -247,7 +248,6 @@ def test_similarity_annotates_multi_hop_when_reachable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
-    monkeypatch.setattr(optional_deps, "NUMPY_AVAILABLE", False)
     PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
 
     results = SimilarityService(connection).scenes("old-good", 20)
@@ -273,9 +273,9 @@ def test_core_pagerank_matches_networkx_and_python(tmp_path: Path) -> None:
     service = MultiHopAffinity(connection, "m")
     graph = service._graph_for("s")
     core_scores = service._walk_core(graph)
-    assert core_scores == pytest.approx(_pagerank_python(graph), rel=1e-12)
-    if optional_deps.nx is not None and _scipy_importable():
-        assert core_scores == pytest.approx(_pagerank_networkx(graph), rel=1e-9)
+    assert core_scores == pytest.approx(_reference_pagerank(graph), rel=1e-12)
+    with contextlib.suppress(ImportError):
+        assert core_scores == pytest.approx(_networkx_pagerank(graph), rel=1e-9)
 
 
 @pytest.mark.parametrize(
@@ -302,21 +302,18 @@ def test_core_pagerank_matches_on_seeded_corpora(
     graph = _Graph(adjacency, nodes[seed_index % n_nodes], frozenset())
     service = MultiHopAffinity(None, "m")
     core_scores = service._walk_core(graph)
-    assert core_scores == pytest.approx(_pagerank_python(graph), rel=1e-12)
-    if optional_deps.nx is not None and _scipy_importable():
-        assert core_scores == pytest.approx(_pagerank_networkx(graph), rel=1e-9)
+    assert core_scores == pytest.approx(_reference_pagerank(graph), rel=1e-12)
+    with contextlib.suppress(ImportError):
+        assert core_scores == pytest.approx(_networkx_pagerank(graph), rel=1e-9)
 
 
-def test_core_reach_matches_python(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_core_reach_matches_reference(tmp_path: Path) -> None:
     if builder_module.core.core_binary() is None:
         pytest.skip("curator-core binary is not built")
     connection = _graph_database(tmp_path / "curator.sqlite3")
     service = MultiHopAffinity(connection, "m")
-    real_binary = builder_module.core.core_binary
-    monkeypatch.setattr(builder_module.core, "core_binary", lambda: None)
-    expected = service.reach("s")
-    monkeypatch.setattr(builder_module.core, "core_binary", real_binary)
     core_reach = service.reach("s")
+    expected = _reference_reach(service, "s")
     assert set(core_reach) == set(expected)
     for scene, score in expected.items():
         assert core_reach[scene] == pytest.approx(score, rel=1e-12)

--- a/tests/oracle.py
+++ b/tests/oracle.py
@@ -1,0 +1,323 @@
+"""Test-only numpy oracle for the compiled-core differential gate.
+
+The compiled core is the single runtime implementation; numpy remains the
+independent reference the gate pins the Go kernels against. These functions
+replicate the former production numpy paths (`_content_neighbors_numpy`,
+`_performer_similarity_scores_numpy`) exactly, parameterized by the builder
+config so the tests can compare Go vs numpy on identical inputs. Nothing here
+ships in the plugin's runtime path.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+
+from curator import optional_deps
+from curator.features import FeatureStore
+from curator.model.builder import _NeighborEvidence
+
+
+def content_neighbors_numpy(
+    vectors: Mapping[str, Mapping[str, float]],
+    labels: Mapping[str, object],
+    label_mean: float,
+    progress_total: int,
+    *,
+    min_similarity: float,
+    neighbor_count: int,
+    confidence_scale: float,
+) -> dict[str, _NeighborEvidence]:
+    """Vectorized content-neighbor evidence, mirroring the former numpy path."""
+    np = optional_deps.np
+    assert np is not None
+    scene_ids = list(vectors)
+    labeled_ids = sorted(scene_id for scene_id in labels if scene_id in vectors)
+    default = _NeighborEvidence(0.0, 0.0, 0.0, 0.0, 0.0, ())
+    result: dict[str, _NeighborEvidence] = {}
+    if not labeled_ids:
+        return {scene_id: default for scene_id in scene_ids}
+    column_names = sorted({name for scene_id in labeled_ids for name in vectors[scene_id]})
+    if not column_names:
+        return {scene_id: default for scene_id in scene_ids}
+    column_index = {name: index for index, name in enumerate(column_names)}
+    labeled_position = {scene_id: column for column, scene_id in enumerate(labeled_ids)}
+    labeled_values = np.zeros((len(labeled_ids), len(column_names)), dtype=np.float64)
+    for column, scene_id in enumerate(labeled_ids):
+        for name, value in vectors[scene_id].items():
+            labeled_values[column, column_index[name]] = value
+    target_values = np.zeros((len(scene_ids), len(column_names)), dtype=np.float64)
+    for row, scene_id in enumerate(scene_ids):
+        for name, value in vectors[scene_id].items():
+            if name not in column_index:
+                continue
+            target_values[row, column_index[name]] = value
+    labeled_conf = np.array([labels[scene_id].confidence for scene_id in labeled_ids])
+    labeled_outcome = np.array([labels[scene_id].outcome for scene_id in labeled_ids])
+    labeled_binary = (labeled_values != 0).astype(np.float32)
+    target_binary = (target_values != 0).astype(np.float32)
+    self_column = np.array([labeled_position.get(scene_id, -1) for scene_id in scene_ids])
+    for start in range(0, len(scene_ids), 4096):
+        end = min(start + 4096, len(scene_ids))
+        similarities = target_values[start:end] @ labeled_values.T
+        shared = (target_binary[start:end] @ labeled_binary.T).astype(np.float64)
+        similarities *= 1.0 - np.exp(-shared / 4.0)
+        weights = similarities**3 * labeled_conf[np.newaxis, :]
+        valid = similarities >= min_similarity
+        for local_row in range(end - start):
+            own = int(self_column[start + local_row])
+            if own >= 0:
+                valid[local_row, own] = False
+        for local_row in range(end - start):
+            scene_id = scene_ids[start + local_row]
+            valid_indices = np.flatnonzero(valid[local_row])
+            if len(valid_indices) == 0:
+                result[scene_id] = default
+                continue
+            row_weights = weights[local_row, valid_indices]
+            chosen = min(neighbor_count, len(row_weights))
+            boundary = float(
+                np.partition(row_weights, len(row_weights) - chosen)[len(row_weights) - chosen]
+            )
+            candidates = valid_indices[row_weights >= boundary]
+            evidence = [
+                (
+                    labeled_ids[int(column)],
+                    float(similarities[local_row, int(column)]),
+                    float(weights[local_row, int(column)]),
+                    float(labeled_outcome[int(column)]),
+                )
+                for column in candidates
+            ]
+            evidence.sort(key=lambda item: (-item[2], item[0]))
+            selected = evidence[:neighbor_count]
+            result[scene_id] = _assemble_evidence(scene_id, selected, label_mean, confidence_scale)
+    return result
+
+
+def _assemble_evidence(
+    scene_id: str,
+    selected: list[tuple[str, float, float, float]],
+    label_mean: float,
+    confidence_scale: float,
+) -> _NeighborEvidence:
+    denominator = sum(item[2] for item in selected)
+    outcome_mean = sum(item[2] * item[3] for item in selected) / denominator if denominator else 0.0
+    lift = outcome_mean - label_mean if denominator else 0.0
+    confidence = 1 - math.exp(-denominator / confidence_scale) if denominator else 0.0
+    return _NeighborEvidence(
+        lift * confidence,
+        outcome_mean,
+        lift,
+        confidence,
+        denominator,
+        tuple(
+            {
+                "scene_id": item[0],
+                "similarity": item[1],
+                "weight": item[2],
+                "outcome": item[3],
+            }
+            for item in selected[:5]
+        ),
+    )
+
+
+def performer_similarity_numpy(
+    connection: object,
+    feature_version: str,
+    scene_features: Mapping[str, object],
+    affinities: Mapping[str, object],
+    *,
+    block_weights: Mapping[str, float],
+    cutoff: float,
+) -> dict[str, dict[str, object]]:
+    """Vectorized performer-similarity scores, mirroring the former numpy path."""
+    from curator.model.builder import PreferenceModelBuilder
+
+    np = optional_deps.np
+    assert np is not None
+    identity_affinity = PreferenceModelBuilder._identity_affinity(  # type: ignore[arg-type]
+        scene_features, affinities
+    )
+    profiles = FeatureStore(connection).performer_profiles(feature_version)  # type: ignore[arg-type]
+    known = {
+        key: profiles[key]
+        for key, (value, _) in identity_affinity.items()
+        if key in profiles and abs(value) >= cutoff
+    }
+    profile_ids = list(profiles)
+    known_ids = list(known)
+    known_position = {performer_id: column for column, performer_id in enumerate(known_ids)}
+    known_affinity = np.array([identity_affinity[performer_id][0] for performer_id in known_ids])
+    known_confidence = np.array([identity_affinity[performer_id][1] for performer_id in known_ids])
+    block_names = sorted({block for profile in profiles.values() for block in profile.blocks})
+    block_keys = {
+        block: sorted(
+            {key for profile in profiles.values() for key in profile.blocks.get(block, {})}
+        )
+        for block in block_names
+    }
+    values: dict[str, object] = {}
+    confidences: dict[str, object] = {}
+    present: dict[str, object] = {}
+    for block in block_names:
+        keys = block_keys[block]
+        key_position = {key: column for column, key in enumerate(keys)}
+        block_values = np.zeros((len(profile_ids), len(keys)), dtype=np.float64)
+        block_confidences = np.zeros_like(block_values)
+        block_present = np.zeros(len(profile_ids), dtype=bool)
+        for row, performer_id in enumerate(profile_ids):
+            entries = profiles[performer_id].blocks.get(block)
+            if not entries:
+                continue
+            block_present[row] = True
+            for key, item in entries.items():
+                block_values[row, key_position[key]] = item.value
+                block_confidences[row, key_position[key]] = item.confidence
+        values[block] = block_values
+        confidences[block] = block_confidences
+        present[block] = block_present
+    known_positions = np.array([profile_ids.index(performer_id) for performer_id in known_ids])
+    known_values = {block: values[block][known_positions, :] for block in block_names}  # type: ignore[index]
+    known_confidences = {block: confidences[block][known_positions, :] for block in block_names}  # type: ignore[index]
+    known_present = {block: present[block][known_positions] for block in block_names}  # type: ignore[index]
+    from curator.features.profiles import NUMERIC_BLOCKS, NUMERIC_SCALES
+
+    numerator = np.zeros((len(profile_ids), len(known_ids)), dtype=np.float64)
+    denominator = np.zeros_like(numerator)
+    block_similarities: dict[str, object] = {}
+    used: dict[str, object] = {}
+    for block in block_names:
+        weight = block_weights.get(block, 0.0)
+        if weight <= 0:
+            continue
+        both_present = np.outer(present[block], known_present[block])  # type: ignore[index]
+        if block in NUMERIC_BLOCKS:
+            value = np.zeros((len(profile_ids), len(known_ids)), dtype=np.float64)
+            count = np.zeros_like(value)
+            for column in range(values[block].shape[1]):  # type: ignore[union-attr]
+                both = np.outer(values[block][:, column] != 0, known_values[block][:, column] != 0)  # type: ignore[index]
+                if not both.any():
+                    continue
+                scale = NUMERIC_SCALES.get(block_keys[block][column], 1.0)
+                closeness = np.exp(
+                    -np.abs(
+                        np.subtract.outer(values[block][:, column], known_values[block][:, column])
+                    )  # type: ignore[index]
+                    / scale
+                )
+                value += (
+                    closeness
+                    * np.minimum.outer(
+                        confidences[block][:, column],
+                        known_confidences[block][:, column],  # type: ignore[index]
+                    )
+                    * both
+                )
+                count += both
+            block_value = np.divide(value, count, out=np.zeros_like(value), where=count > 0)
+            block_used = both_present & (count > 0)
+        else:
+            norms = np.array(
+                [profiles[performer_id].norms.get(block, 0.0) for performer_id in profile_ids]
+            )
+            known_norms = norms[known_positions]
+            dot = values[block] @ known_values[block].T  # type: ignore[index]
+            shared = (
+                (values[block] != 0).astype(np.float32)  # type: ignore[index]
+                @ (known_values[block] != 0).astype(np.float32).T  # type: ignore[index]
+            ).astype(np.float64)
+            confidence_sum = np.zeros((len(profile_ids), len(known_ids)), dtype=np.float64)
+            for column in range(values[block].shape[1]):  # type: ignore[union-attr]
+                if not confidences[block][:, column].any() or not (
+                    known_confidences[block][:, column].any()
+                ):  # type: ignore[index]
+                    continue
+                confidence_sum += np.minimum.outer(
+                    confidences[block][:, column],
+                    known_confidences[block][:, column],  # type: ignore[index]
+                )
+            confidence = np.where(shared > 0, confidence_sum / shared, 0.0)
+            with np.errstate(divide="ignore", invalid="ignore"):
+                block_value = np.clip(
+                    dot / (norms[:, None] * known_norms[None, :]) * confidence, 0.0, 1.0
+                )
+            block_used = both_present & (norms[:, None] != 0) & (known_norms[None, :] != 0)
+        block_similarities[block] = block_value
+        used[block] = block_used
+        numerator += block_value * block_used * weight
+        denominator += block_used * weight
+    penalty = np.ones((len(profile_ids), len(known_ids)), dtype=np.float64)
+    measurements = values.get("measurements")
+    if measurements is not None and measurements.shape[1]:  # type: ignore[union-attr]
+        cup_position = (
+            block_keys["measurements"].index("cup_index")
+            if "cup_index" in block_keys["measurements"]
+            else -1
+        )
+        if cup_position >= 0:
+            cup_all = measurements[:, cup_position]  # type: ignore[index]
+            cup_known = known_values["measurements"][:, cup_position]  # type: ignore[index]
+            both_cup = np.outer(cup_all != 0, cup_known != 0)
+            cup_difference = np.abs(np.subtract.outer(cup_all, cup_known))
+            penalty *= np.where(
+                both_cup, np.exp(-0.18 * np.maximum(0.0, cup_difference - 1.0)), 1.0
+            )
+    augmentation = values.get("augmentation")
+    if augmentation is not None and augmentation.shape[1]:  # type: ignore[union-attr]
+        augmentation_binary = (augmentation != 0).astype(np.float32)  # type: ignore[index]
+        known_augmentation_binary = (known_values["augmentation"] != 0).astype(np.float32)  # type: ignore[index]
+        shared_augmentation = augmentation_binary @ known_augmentation_binary.T
+        both_augmentation = np.outer(
+            augmentation_binary.any(axis=1),
+            known_augmentation_binary.any(axis=1),  # type: ignore[index]
+        )
+        penalty *= np.where(both_augmentation & (shared_augmentation == 0), 0.65, 1.0)
+    with np.errstate(divide="ignore", invalid="ignore"):
+        similarity = np.where(denominator > 0, numerator / denominator * penalty, 0.0)
+    result: dict[str, dict[str, object]] = {}
+    for performer_index, performer_id in enumerate(profile_ids):
+        row = similarity[performer_index]
+        candidates = [
+            (known_ids[column], float(row[column]))
+            for column in range(len(known_ids))
+            if known_ids[column] != performer_id and float(row[column]) > 0
+        ]
+        selected = sorted(candidates, key=lambda item: (-item[1], item[0]))[:5]
+        denominator_value = sum(item[1] ** 3 for item in selected)
+        value = (
+            sum(float(known_affinity[known_position[item[0]]]) * item[1] ** 3 for item in selected)
+            / denominator_value
+            if denominator_value
+            else 0.0
+        )
+        confidence = (
+            sum(
+                float(known_confidence[known_position[item[0]]]) * item[1] ** 3 for item in selected
+            )
+            / denominator_value
+            if denominator_value
+            else 0.0
+        )
+        result[performer_id] = {
+            "value": value,
+            "confidence": confidence,
+            "matches": [
+                {
+                    "performer_id": known_id,
+                    "similarity": score,
+                    "affinity": identity_affinity[known_id][0],
+                    "confidence": identity_affinity[known_id][1],
+                    "blocks": {
+                        block: float(
+                            block_similarities[block][performer_index, known_position[known_id]]  # type: ignore[index]
+                        )
+                        for block in used
+                        if bool(used[block][performer_index, known_position[known_id]])  # type: ignore[index]
+                    },
+                }
+                for known_id, score in selected[:3]
+            ],
+        }
+    return result

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -105,8 +105,6 @@ def test_plugin_archive_contains_runtime_and_core(tmp_path: Path) -> None:
     assert "Prepare recommendation pages" in (installed / "stash-curator.yml").read_text()
     assert "Compact legacy Curator data" in (installed / "stash-curator.yml").read_text()
     assert "Vacuum compacted Curator data" in (installed / "stash-curator.yml").read_text()
-    assert "Install optional dependencies" in (installed / "stash-curator.yml").read_text()
-    assert "numpy==2.5.1" in (installed / "packages" / "curator-tools.txt").read_text()
     javascript = (installed / "stash-curator.js").read_text()
     assert "data:image/png;base64" in javascript
     assert "curator-whisparr-fallback" in javascript
@@ -330,90 +328,6 @@ def test_backup_controls_validate_ids_refuse_jobs_and_restore_with_safety_copy(
         == "superseded"
     )
     connection.close()
-
-
-def test_install_optional_deps_creates_venv_and_installs_requirements(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
-    spec = importlib.util.spec_from_file_location("curator_plugin_install_deps", backend)
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    plugin_dir = tmp_path / "stash-curator"
-    (plugin_dir / "packages").mkdir(parents=True)
-    requirements = plugin_dir / "packages" / "curator-tools.txt"
-    requirements.write_text("numpy==2.5.1\n", encoding="utf-8")
-    monkeypatch.setattr(module, "PLUGIN_DIR", plugin_dir)
-    created: list[tuple[object, ...]] = []
-    monkeypatch.setattr(
-        module,
-        "create_venv",
-        lambda path, with_pip: created.append((path, with_pip)),
-    )
-    installed: list[list[str]] = []
-    monkeypatch.setattr(
-        module,
-        "subprocess",
-        SimpleNamespace(
-            run=lambda command, **_: (
-                installed.append(command)
-                or SimpleNamespace(returncode=0, stderr="", stdout="installed numpy")
-            )
-        ),
-    )
-
-    result = module._install_optional_deps()
-
-    assert created == [(plugin_dir / "venv", True)]
-    assert installed[0][-3:] == ["install", "-r", str(requirements)]
-    assert result == {
-        "status": "ok",
-        "venv": str(plugin_dir / "venv"),
-        "requirements": str(requirements),
-    }
-
-
-def test_install_optional_deps_refuses_missing_manifest(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
-    spec = importlib.util.spec_from_file_location("curator_plugin_install_deps_missing", backend)
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    monkeypatch.setattr(module, "PLUGIN_DIR", tmp_path)
-
-    with pytest.raises(RuntimeError, match="missing optional dependency manifest"):
-        module._install_optional_deps()
-
-
-def test_install_optional_deps_surfaces_pip_failure(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    backend = Path(__file__).parents[2] / "plugin" / "backend.py"
-    spec = importlib.util.spec_from_file_location("curator_plugin_install_deps_failure", backend)
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    plugin_dir = tmp_path / "stash-curator"
-    (plugin_dir / "packages").mkdir(parents=True)
-    (plugin_dir / "packages" / "curator-tools.txt").write_text("numpy\n", encoding="utf-8")
-    (plugin_dir / "venv").mkdir()
-    (plugin_dir / "venv" / "pyvenv.cfg").write_text("home = /usr\n", encoding="utf-8")
-    monkeypatch.setattr(module, "PLUGIN_DIR", plugin_dir)
-    monkeypatch.setattr(
-        module,
-        "subprocess",
-        SimpleNamespace(
-            run=lambda command, **_: SimpleNamespace(
-                returncode=1, stderr="no matching distribution", stdout=""
-            )
-        ),
-    )
-
-    with pytest.raises(RuntimeError, match="pip install failed"):
-        module._install_optional_deps()
 
 
 def test_reset_removes_only_core_and_recognized_artifacts(tmp_path: Path) -> None:

--- a/tests/ranking/test_policy.py
+++ b/tests/ranking/test_policy.py
@@ -2,8 +2,6 @@
 _component_value()'s defensive fallbacks.
 """
 
-import pytest
-
 from curator.model import ModelSceneScore
 from curator.ranking.policy import _component_value, _percentiles
 
@@ -60,29 +58,6 @@ def test_tie_break_by_scene_id_does_not_affect_percentile() -> None:
     # value itself must be identical for every member of the tie regardless of scene_id.
     result = _percentiles({"z": 1.0, "a": 1.0, "m": 1.0})
     assert result["z"] == result["a"] == result["m"]
-
-
-def test_numpy_and_python_percentiles_agree(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from curator import optional_deps
-
-    values = {
-        "a": 1.0,
-        "b": 1.0,
-        "c": 2.0,
-        "d": 3.0,
-        "e": 3.0,
-        "f": -0.5,
-        "g": 0.0,
-        "h": 0.0,
-    }
-    if optional_deps.NUMPY_AVAILABLE:
-        accelerated = _percentiles(values)
-        monkeypatch.setattr(optional_deps, "NUMPY_AVAILABLE", False)
-        monkeypatch.setattr(optional_deps, "np", None)
-        fallback = _percentiles(values)
-        assert accelerated == fallback
 
 
 def test_component_value_missing_family_is_zero() -> None:


### PR DESCRIPTION
## Summary

Removes the "Install optional dependencies" task and the numpy/networkx venv bootstrap. The compiled Go core is now the single runtime implementation for the similarity kernels (content neighbors + performer similarity) and the multi-hop PageRank.

The pure-Python and numpy/networkx implementations were deleted from the shipped code; numpy stays as a dev-only oracle in `tests/oracle.py` for the differential gate.

**Runtime**: the plugin now ships zero runtime dependencies beyond Python 3.12+ and the per-arch `curator-core-*` binaries. A missing or incompatible binary fails build stages with a clear error.

## Changes

- `curator/model/builder.py` — delete the numpy and pure-Python dispatch paths; `_content_neighbors` and `_performer_similarity_scores` are now the single core implementation.
- `curator/model/multi_hop.py` — delete `_pagerank_networkx` and `_pagerank_python`; `_walk` runs the core unconditionally.
- `curator/ranking/policy.py` — the numpy percentile branch was an identical perf twin; simplified to stdlib-only.
- `curator/core.py` — missing-binary error is now actionable ("reinstall the plugin").
- `plugin/backend.py` — remove `_venv_site_packages` bootstrap, `_install_optional_deps`, the `install-deps` mode, and the `subprocess` import.
- `plugin/stash-curator.yml` — remove the "Install optional dependencies" task.
- `plugin/packages/curator-tools.txt` — deleted.
- `tests/oracle.py` (new) — dev-only numpy reference implementations for the differential gate.
- Test suite: delete the pure-Python-contract and numpy-vs-python parity tests; update dispatch tests to assert the required-binary error path; archive test no longer asserts the install-deps task or manifest.
- Docs: getting-started + architecture + planning + core/README updated for the no-install-task, single-implementation world.

## Verification

- `scripts/verify full` green — 327 tests with the binary active, archive test, mypy, ruff, plugin build.
- All three differential gates (content + performer against `tests/oracle.py`, multi-hop against networkx) pass at ≤ 1e-12.
- Live-instance build (12.95/59.92 s similarity stages → 13.13/10.85 s).

## Context

The compiled core now ships per-arch binaries in the plugin zip (since #97) and covers every stage that used numpy / networkx (since #97 + #100). The venv was the last remaining install step — with it gone the plugin is truly zero-runtime-dependency beyond Python 3.12+ and Go. Rollback = install the previous plugin version.
