### PR TITLE
docs: plan the full Go backend as a slice sequence

### DIFF
--- a/docs/decisions/002-runtime-swap-planning.md
+++ b/docs/decisions/002-runtime-swap-planning.md
@@ -407,13 +407,44 @@ yet** — distribution (5.2/5.3) is the next work package.
   `modernc.org/sqlite` (pure Go) means one machine cross-compiles every
   target — native per-arch runners were not needed. The `raw` interface
   stays; switching the exec line to the binary is a later, separate step.
-- **Phase 4 (optional):** full backend in Go on `raw` (no RPC), if the hybrid
-  proves out and the port budget is available. **Progress:** the multi-hop
-  pagerank kernel is ported (`core/multi-hop`). **Done (2026-08-10):** the
-  numpy/networkx venv is removed — no "Install optional dependencies" task,
-  no runtime dependency installs. The compiled core is now the single runtime
-  implementation for the similarity and pagerank kernels (a missing binary
-  fails build stages with a clear error); the pure-Python kernel paths were
-  deleted; numpy/networkx remain dev-only oracles for the differential gate
-  (`tests/oracle.py`), and percentiles run on stdlib Python. Rollback = install
-  the previous plugin version.
+- **Phase 4 (full Go backend on `raw`): decided shape (2026-08-10).** The
+  kernel port is done (similarity + pagerank), the venv is gone (numpy/
+  networkx are dev-only oracles in `tests/oracle.py`), and the installed
+  cold build measures 3.2x on the similarity stage with zero runtime
+  installs. The remaining question is whether the *whole backend* becomes Go
+  (the exec line becomes `curator-core`). Full handover + first agent prompt:
+  `docs/handover-go-backend.md`.
+
+  Decomposition (each slice keeps the previous state shippable — unported ops
+  fall back to the Python backend until the binary covers them):
+
+  - **Slice 0 — transport + skeleton.** The binary implements the raw
+    protocol (stdin JSON → dispatch → stdout JSON), settings application, and
+    the ordered, checksummed migration chain + artifact attach/views (the
+    sidecar-parity surface — the riskiest part). Ships with the trivial ops
+    (round_trip, health, get_config, get_job_status) and a Python fallback
+    dispatch for everything else.
+  - **Slice 1 — read-path interactive ops (highest ROI).** get_slate,
+    get_similar (the math is already Go), get_explanation, get_shortlist,
+    feedback/recommendation history, taste profile, diagnostics. Pure sidecar
+    reads + byte-exact JSON; this is what kills the ~300-700ms per-call
+    interactive spawn (5ms binary spawn).
+  - **Slice 2 — network layer (the goroutine slice).** Two GraphQL clients
+    with one pattern: Stash sync (incremental reconciliation) and StashDB
+    expand/hunt (performer hunt measured ~47s wall — the most fetch-bound
+    interactive op; errgroup fan-out over performers is the real concurrency
+    win). Local Similar is sidecar-only; the sync side is mostly write-bound
+    (51s measured, most of it reconciliation + DB), so the expand/hunt side
+    benefits most.
+  - **Slice 3 — write-path tasks.** backup/compact/vacuum/prepare
+    (mechanical SQLite), then the build's remaining Python stages
+    (affinities, scoring, lanes, publication — the largest port chunk, each a
+    bounded algorithm with the published model artifact as the oracle).
+  - **Slice 4 — frontend parity pass + delete Python.** Every op's JSON
+    contract verified byte-for-byte against the current backend's outputs
+    (the existing suite is the oracle), then the Python backend ships out.
+
+  Sequential order: Slice 0 must land first (parity foundation); Slice 1 is
+  the recommended first vertical slice after it. The exec-line swap happens
+  when Slice 0 + 1 are covered; unported ops keep the Python fallback until
+  then.

--- a/docs/handover-go-backend.md
+++ b/docs/handover-go-backend.md
@@ -1,0 +1,134 @@
+# Handover: full Go backend (Phase 4, Slice 0)
+
+Self-contained handover + first agent prompt for the next work package: making
+`curator-core` the plugin's exec line by porting the backend to Go, slice by
+slice, with Python fallback until the binary covers every op.
+
+## Goal
+
+`plugin/stash-curator.yml` exec line becomes `./curator-core` (the raw
+interface, unchanged): the binary reads the same stdin JSON payload and writes
+the same stdout JSON as `backend.py` today. The measured prize is the
+interactive spawn (~300-700ms Python per call → ~5ms binary). The build and
+kernels are already accelerated; this package targets the remaining Python
+runtime.
+
+## What already shipped (do not redo)
+
+- `core/` Go module: `curator-core` with `version`, `content-neighbors`,
+  `performer-similarity`, `multi-hop` stages; NDJSON progress+result protocol;
+  profiling spans; per-arch binaries in the zip; differential gate
+  (`tests/oracle.py` = numpy oracle) — all green.
+- The numpy/networkx venv is removed; the compiled core is the single runtime
+  implementation of the kernels; a missing binary fails build stages loudly.
+- Installed verification: cold build 23.1s similarity vs 72.9s numpy baseline
+  (3.2x) with zero runtime installs.
+- `docs/decisions/002-runtime-swap-planning.md` §8 has the full slice plan.
+
+## The slice plan (from the planning doc)
+
+- Slice 0 — transport + skeleton: raw protocol, settings, the ordered
+  checksummed migration chain + artifact attach/views (sidecar parity —
+  riskiest), trivial ops (round_trip, health, get_config, get_job_status),
+  Python fallback dispatch for everything else.
+- Slice 1 — read-path interactive ops (slate, similar, explanation,
+  shortlist, history, taste profile, diagnostics) — byte-exact JSON, pure
+  sidecar reads.
+- Slice 2 — network layer: GraphQL clients for Stash sync and StashDB
+  expand/hunt (errgroup fan-out for the hunt; local Similar is sidecar-only).
+- Slice 3 — write-path tasks: backup/compact/vacuum/prepare, then the build's
+  remaining Python stages.
+- Slice 4 — frontend parity pass + delete Python.
+
+## Slice 0 — this agent's scope
+
+Port the raw protocol transport and the sidecar parity foundation into
+`curator-core`, with a Python fallback dispatch for every op the binary does
+not yet implement.
+
+Concretely:
+
+1. **Protocol**: read one JSON payload from stdin (the same shape
+   `backend.py` receives: `server_connection` + `args`), dispatch on
+   `args.operation` / task mode, write the same stdout JSON the Python backend
+   writes, and stderr progress markers (`\x01p\x02…`) exactly as
+   `plugin/backend.py` emits them. The plugin config (`stash-curator.yml`)
+   currently invokes `backend.py` with an optional task mode arg; the binary
+   must accept the same argv shapes.
+2. **Settings**: the `_apply_plugin_settings` semantics from `backend.py` —
+   config merge + `curator_config` row update on open.
+3. **Migrations**: port `curator/storage/migrations.py` + the ordered SQL
+   chain in `curator/storage/sql/` (0001-0027) to Go with **identical
+   checksums and migration-status semantics**, so a sidecar migrated by either
+   implementation is accepted by the other. The modernc sqlite driver is
+   already a dependency.
+4. **Artifact attach/views**: the `attach_active_artifacts` /
+   `attach_build_sources` behavior from `curator/storage/artifacts.py`
+   (ATTACH the published feature/model generations read-only + temp views
+   shadowing the core tables).
+5. **Trivial ops first**: `round_trip`, `health`, `get_config`,
+   `get_job_status` — byte-identical outputs vs the Python backend on the same
+   payloads.
+6. **Python fallback dispatch**: any op/task the binary does not implement yet
+   is delegated to the bundled `backend.py` (the binary spawns it with the
+   same argv/stdin contract it received) — the plugin never breaks during the
+   transition.
+
+### Acceptance criteria
+
+- The binary's `round_trip`/`health`/`get_config`/`get_job_status` outputs are
+  byte-identical to the Python backend's for the same payloads and sidecar
+  state (a differential test compares both on identical copies).
+- A sidecar migrated by the Go migration chain has the same
+  `schema_migration` rows + checksums as one migrated by Python, and
+  `PRAGMA integrity_check` passes; vice versa (Python accepts a Go-migrated
+  sidecar and Go accepts a Python-migrated one).
+- Attached artifact views resolve the same tables (feature_build /
+  model_version registry) as the Python attach path.
+- Unported ops still work via the fallback (round-trip through the installed
+  zip).
+- `scripts/verify core` and `scripts/verify full` pass; the unit suite stays
+  green; Go is a build-time dep only.
+- No new runtime dependencies; the per-arch binary stays static
+  (`CGO_ENABLED=0`, modernc).
+
+### Constraints
+
+- Follow AGENTS.md: read `docs/handover.md` + the planning doc first; use
+  `scripts/verify changed <file>` while iterating, `scripts/verify full` near
+  completion. Go toolchain is a dev dependency.
+- Keep private library data out of tracked files and diffs; test against
+  synthetic corpora and copies, never the live sidecar.
+- Conventional Commits; push only when asked.
+
+## First agent prompt
+
+> Port the raw transport + sidecar-parity foundation of Stash Curator's
+> backend to the existing Go module at `core/` (module
+> `github.com/mrx-31415/stash-curator/core`, binary `curator-core`), so the
+> plugin can eventually run with `curator-core` as its exec line on the raw
+> interface.
+>
+> READ FIRST: `docs/handover-go-backend.md`, `docs/handover.md`,
+> `docs/decisions/002-runtime-swap-planning.md` §8,
+> `plugin/backend.py` (the raw protocol + `_apply_plugin_settings`),
+> `curator/storage/migrations.py` + `curator/storage/sql/`,
+> `curator/storage/artifacts.py` (attach/views), and AGENTS.md.
+>
+> SCOPE (Slice 0): (1) stdin-JSON → dispatch → stdout-JSON transport matching
+> backend.py's contract, including stderr progress markers; (2) settings
+> application; (3) the ordered migration chain with identical checksums and a
+> differential test proving Python↔Go sidecar interchange; (4) artifact
+> attach/views; (5) byte-identical `round_trip`, `health`, `get_config`,
+> `get_job_status`; (6) a Python fallback dispatch (binary spawns backend.py
+> for unported ops). Non-goals: the read-path ops, the network layer, write
+> tasks, the exec-line switch in stash-curator.yml.
+>
+> ACCEPTANCE: byte-identical trivial-op outputs vs the Python backend on the
+> same payloads; sidecar migration parity both directions (same checksums,
+> integrity_check ok); attached artifact views resolve identically; unported
+> ops work via fallback through the installed zip; `scripts/verify core` +
+> `scripts/verify full` green; static binary, no new runtime deps.
+>
+> Do not push; commit with Conventional Commits when the slice is green and
+> report exactly what was verified.

--- a/docs/handover.md
+++ b/docs/handover.md
@@ -36,19 +36,15 @@ distribution (per-arch binaries, runtime select) is the next work package.
 
 ## Next work package
 
-**Phase 2 + 3 are delivered** — the compiled core ships in the plugin zip as
-per-arch binaries (linux amd64/arm64, windows amd64, darwin amd64/arm64);
-runtime select + pure-Python fallback; archive test asserts presence. The
-remaining items:
-
-- **Installed verification (live):** update Curator from Stash's plugin
-  manager once the release lands, then run the cold build on the installed
-  sidecar and compare stage timings against the numpy baseline (the compiled
-  core should show the similarity-stage win; at this library's low label
-  count expect ~10% on that stage, more on denser libraries).
-- **Benchmark follow-up:** re-run the Docker benchmark with `--keep-stash` to
-  capture the container's feature-build density and close the 75.7s-vs-7.5s
-  content-span question (planning doc §8).
+**Full Go backend (Phase 4)** — making `curator-core` the plugin's exec line
+on the raw interface. The kernel port (similarity + pagerank), per-arch
+distribution, and the optional-deps venv removal are all delivered and
+verified on the installed instance (cold build 23.1s similarity vs 72.9s numpy
+baseline, 3.2x, zero runtime installs). The remaining work is porting the
+backend transport and ops; the slice plan and the first agent prompt are in
+[`handover-go-backend.md`](handover-go-backend.md). Slice 0 (transport +
+sidecar-parity foundation + trivial ops + Python fallback dispatch) is the
+next step.
 
 Deferred UI follow-ups (retain as a separate coherent package):
 


### PR DESCRIPTION
Phase 4 planning: the full-Go-backend decomposition (Slice 0 transport+sidecar parity, Slice 1 read-path ops, Slice 2 network layer, Slice 3 write tasks, Slice 4 parity pass) recorded in the planning doc, plus a self-contained handover with the Slice 0 scope and the first agent prompt (docs/handover-go-backend.md).