### PR TITLE
feat: description-term ratings, remote term ranking, busy-lock retry, and task progress fixes

### DIFF
--- a/core/backend.go
+++ b/core/backend.go
@@ -199,6 +199,12 @@ func dispatch(pluginDir string, payload jVal) (jVal, error) {
 		return opClearProfiles(pluginDir, payload)
 	case "get_external_tag_choices":
 		return opGetExternalTagChoices(pluginDir, payload)
+	case "get_scene_tag_choices":
+		return opGetSceneTagChoices(pluginDir, payload)
+	case "get_scene_description_tokens":
+		return opGetSceneDescriptionTokens(pluginDir, payload)
+	case "submit_term_preferences":
+		return opSubmitTermPreferences(pluginDir, payload)
 	case "get_inspector_entity":
 		return opGetInspectorEntity(pluginDir, payload)
 	case "get_tag_sentiment_follow_up":

--- a/core/backups.go
+++ b/core/backups.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	sqlite "modernc.org/sqlite"
 )
@@ -328,23 +329,46 @@ WHERE status='published'`); err != nil {
 
 // withTxn runs fn inside one BEGIN IMMEDIATE transaction on the pool's
 // single connection, committing on success and rolling back on error —
-// mirroring curator.storage.transaction (no nested transactions).
+// mirroring curator.storage.transaction (no nested transactions). Busy
+// failures before COMMIT are retried with backoff (the #109 mitigation for
+// extended SQLITE_BUSY codes the busy_timeout handler does not cover); a
+// COMMIT failure is never retried — its outcome is ambiguous and re-running
+// fn could double-apply writes.
 func withTxn(db dbx, fn func(conn *sql.Conn) error) error {
-	conn, err := db.Conn(context.Background())
-	if err != nil {
-		return err
+	var lastErr error
+	for attempt := range busyRetryAttempts {
+		conn, err := db.Conn(context.Background())
+		if err != nil {
+			return err
+		}
+		ctx := context.Background()
+		if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+			conn.Close()
+			if isBusyError(err) && attempt < busyRetryAttempts-1 {
+				lastErr = err
+				time.Sleep(busyRetryBackoff(attempt))
+				continue
+			}
+			return err
+		}
+		if err := fn(conn); err != nil {
+			conn.ExecContext(ctx, "ROLLBACK")
+			conn.Close()
+			if isBusyError(err) && attempt < busyRetryAttempts-1 {
+				lastErr = err
+				time.Sleep(busyRetryBackoff(attempt))
+				continue
+			}
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+			conn.Close()
+			return err
+		}
+		conn.Close()
+		return nil
 	}
-	defer conn.Close()
-	ctx := context.Background()
-	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
-		return err
-	}
-	if err := fn(conn); err != nil {
-		conn.ExecContext(ctx, "ROLLBACK")
-		return err
-	}
-	_, err = conn.ExecContext(ctx, "COMMIT")
-	return err
+	return lastErr
 }
 
 // isRegularFile reports whether path names a regular, non-symlink file

--- a/core/db.go
+++ b/core/db.go
@@ -139,6 +139,11 @@ func fileURI(path string, readonly bool) string {
 }
 
 // openSidecar mirrors backend.py's _open: connect, migrate, apply settings.
+// A SQLite busy failure can surface during the open/setup phase itself —
+// concurrent first opens of a WAL sidecar race on the -shm recovery lock,
+// which does not always invoke the busy handler. Migrations and plugin
+// settings are transactional/idempotent, so the whole open is retried with
+// backoff (the #109 mitigation), matching withTxn/execImmediate.
 func openSidecar(pluginDir string, payload, settings jVal, attachArtifacts bool) (dbx, error) {
 	path := realpath(databasePath(pluginDir, payload, settings))
 	parent := filepath.Dir(path)
@@ -147,25 +152,49 @@ func openSidecar(pluginDir string, payload, settings jVal, attachArtifacts bool)
 			return nil, fmt.Errorf("could not create database directory: %v", err)
 		}
 	}
-	db, err := openDatabase(path, false, currentTrace())
-	if err != nil {
-		return nil, err
-	}
-	if err := migrate(db, nowMs()); err != nil {
-		db.Close()
-		return nil, err
-	}
-	if err := applyPluginSettings(db, settings, nowMs()); err != nil {
-		db.Close()
-		return nil, err
-	}
-	if attachArtifacts {
-		if err := attachActiveArtifacts(db); err != nil {
-			db.Close()
+	var lastErr error
+	for attempt := range busyRetryAttempts {
+		db, err := openDatabase(path, false, currentTrace())
+		if err != nil {
+			if isBusyError(err) && attempt < busyRetryAttempts-1 {
+				lastErr = err
+				time.Sleep(busyRetryBackoff(attempt))
+				continue
+			}
 			return nil, err
 		}
+		if err := migrate(db, nowMs()); err != nil {
+			db.Close()
+			if isBusyError(err) && attempt < busyRetryAttempts-1 {
+				lastErr = err
+				time.Sleep(busyRetryBackoff(attempt))
+				continue
+			}
+			return nil, err
+		}
+		if err := applyPluginSettings(db, settings, nowMs()); err != nil {
+			db.Close()
+			if isBusyError(err) && attempt < busyRetryAttempts-1 {
+				lastErr = err
+				time.Sleep(busyRetryBackoff(attempt))
+				continue
+			}
+			return nil, err
+		}
+		if attachArtifacts {
+			if err := attachActiveArtifacts(db); err != nil {
+				db.Close()
+				if isBusyError(err) && attempt < busyRetryAttempts-1 {
+					lastErr = err
+					time.Sleep(busyRetryBackoff(attempt))
+					continue
+				}
+				return nil, err
+			}
+		}
+		return db, nil
 	}
-	return db, nil
+	return nil, lastErr
 }
 
 func nowMs() int64 {

--- a/core/eligibility.go
+++ b/core/eligibility.go
@@ -4,6 +4,7 @@
 package main
 
 import (
+	"database/sql"
 	"math"
 	"sort"
 	"strings"
@@ -143,6 +144,36 @@ AND reversed_at_ms IS NULL AND (expires_at_ms IS NULL OR expires_at_ms > ?)`, re
 		return nil, err
 	}
 	sort.Strings(blockedTagIDs)
+	blockedTerms := make([]string, 0)
+	rows, err = db.Query(`SELECT term FROM direct_term_preference WHERE blocked=1`)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var term string
+		if err := rows.Scan(&term); err != nil {
+			return nil, err
+		}
+		blockedTerms = append(blockedTerms, term)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Strings(blockedTerms)
+	// Blocked-term exclusion maps terms to scenes through the built model's
+	// entity_feature desc rows (no scene_tag join: a scene "carries" a term
+	// only when the model built a desc:<term> feature for it).
+	termFeatureVersion := ""
+	if modelID, err := currentModelID(db); err == nil && modelID != "" {
+		err := db.QueryRow(`SELECT feature_version FROM model_version WHERE model_id=?`,
+			modelID).Scan(&termFeatureVersion)
+		if err != nil && err != sql.ErrNoRows {
+			return nil, err
+		}
+	} else if err != nil {
+		return nil, err
+	}
 
 	notNowMs := int64(notNowDays * 86_400_000)
 	available := make(map[string]bool)
@@ -180,6 +211,36 @@ WHERE available=1 AND scene_id IN (`+placeholders+`)`, args...)
 			}
 			rows, err = db.Query(`SELECT DISTINCT scene_id FROM scene_tag
 WHERE scene_id IN (`+placeholders+`) AND tag_id IN (`+inClause(len(blockedTagIDs))+`)`, tagArgs...)
+			if err != nil {
+				return nil, err
+			}
+			for rows.Next() {
+				var sceneID string
+				if err := rows.Scan(&sceneID); err != nil {
+					return nil, err
+				}
+				blockedScenes[sceneID] = true
+			}
+			rows.Close()
+			if err := rows.Err(); err != nil {
+				return nil, err
+			}
+		}
+		if len(blockedTerms) > 0 && termFeatureVersion != "" {
+			termArgs := make([]any, 0, len(chunk)+len(blockedTerms)+1)
+			termArgs = append(termArgs, termFeatureVersion)
+			for _, sceneID := range chunk {
+				termArgs = append(termArgs, sceneID)
+			}
+			for _, term := range blockedTerms {
+				termArgs = append(termArgs, "desc:"+term)
+			}
+			rows, err = db.Query(`SELECT DISTINCT ef.entity_id FROM entity_feature ef
+JOIN feature_definition fd ON fd.feature_id=ef.feature_id
+WHERE ef.feature_version=? AND ef.entity_type='scene'
+  AND ef.entity_id IN (`+placeholders+`)
+  AND fd.family='content'
+  AND fd.name IN (`+inClause(len(blockedTerms))+`)`, termArgs...)
 			if err != nil {
 				return nil, err
 			}

--- a/core/expand.go
+++ b/core/expand.go
@@ -236,6 +236,22 @@ func finalizeProfileNorms(p *performerProfile) {
 	}
 }
 
+// descriptionTokenSet mirrors ExpandService._description_tokens: tokenize a
+// description with the model's tokenizer pipeline ([a-zA-Z]{3,}, lowercased,
+// stopword-filtered, deduped) — featurebuild.go's desc-term extraction
+// without the library-wide TF-IDF selection. Unmodeled tokens have no
+// affinity and simply contribute nothing.
+func descriptionTokenSet(details string) map[string]bool {
+	tokens := map[string]bool{}
+	for _, match := range descTokenRegex.FindAllString(details, -1) {
+		token := strings.ToLower(match)
+		if !descStopwords[token] {
+			tokens[token] = true
+		}
+	}
+	return tokens
+}
+
 // expandTagValue mirrors ExpandService._tag_value.
 func expandTagValue(tag jVal, affinities map[string]float64) float64 {
 	if value, ok := affinities["id:"+tag.get("id").asString()]; ok {
@@ -250,7 +266,7 @@ func expandCastWeight(count int) float64 {
 }
 
 // expandWhy mirrors ExpandService._why.
-func expandWhy(scene jVal, tagAffinity map[string]float64, identity, similarity float64, castCount int) jVal {
+func expandWhy(scene jVal, tagAffinity, termAffinity map[string]float64, identity, similarity float64, castCount int) jVal {
 	type tagPair struct {
 		value float64
 		name  string
@@ -266,9 +282,26 @@ func expandWhy(scene jVal, tagAffinity map[string]float64, identity, similarity 
 	if len(pairs) > 3 {
 		pairs = pairs[:3]
 	}
+	type termPair struct {
+		value float64
+		term  string
+	}
+	termPairs := make([]termPair, 0)
+	for token := range descriptionTokenSet(scene.get("details").asString()) {
+		if value := termAffinity[token]; value > 0 {
+			termPairs = append(termPairs, termPair{value: value, term: token})
+		}
+	}
+	sort.SliceStable(termPairs, func(i, j int) bool { return termPairs[i].value > termPairs[j].value })
+	if len(termPairs) > 2 {
+		termPairs = termPairs[:2]
+	}
 	reasons := jvArr()
 	for _, pair := range pairs {
 		reasons.arr = append(reasons.arr, jvStr(pair.name))
+	}
+	for _, pair := range termPairs {
+		reasons.arr = append(reasons.arr, jvStr(pair.term))
 	}
 	if identity > 0 {
 		reasons.arr = append(reasons.arr, jvStr("a performer you already enjoy"))
@@ -517,7 +550,8 @@ func (m *anchorMatcher) best(performer jVal, recorded jVal) (anchorMatch, bool) 
 
 // expandSceneMatches mirrors ExpandService._scene_matches.
 func expandSceneMatches(payload jVal, includeTags, excludeTags, performerNames, studioNames []string,
-	performerQuery, studioQuery string, includeGroups, excludeGroups, blockedGroups []map[string]bool) bool {
+	performerQuery, studioQuery string, includeGroups, excludeGroups, blockedGroups []map[string]bool,
+	blockedTerms map[string]bool) bool {
 	tags := map[string]bool{}
 	for _, item := range payload.get("tags").arr {
 		tags[strings.ToLower(pythonStrOrEmpty(item.get("name")))] = true
@@ -529,6 +563,13 @@ func expandSceneMatches(payload jVal, includeTags, excludeTags, performerNames, 
 	studio := strings.ToLower(pythonStrOrEmpty(payload.get("studio").get("name")))
 	if anyGroupIntersects(blockedGroups, tags) {
 		return false
+	}
+	if len(blockedTerms) > 0 {
+		for token := range descriptionTokenSet(payload.get("details").asString()) {
+			if blockedTerms[token] {
+				return false
+			}
+		}
 	}
 	if len(includeTags) > 0 && !allGroupsIntersect(includeGroups, tags) {
 		return false
@@ -624,6 +665,30 @@ func expandDiverseScenes(rows []jVal) []jVal {
 		remaining = append(remaining[:index], remaining[index+1:]...)
 	}
 	return selected
+}
+
+// blockedTermSet mirrors ExpandService._blocked_terms: every blocked
+// description term. Remote scenes whose description tokens include one are
+// excluded (tokenized with the model's pipeline; the term->scene mapping has
+// no SQL join for remote candidates).
+func (s *expandService) blockedTermSet() (map[string]bool, error) {
+	terms := map[string]bool{}
+	rows, err := s.db.Query(`SELECT term FROM direct_term_preference WHERE blocked=1`)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var term string
+		if err := rows.Scan(&term); err != nil {
+			return nil, err
+		}
+		terms[term] = true
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return terms, nil
 }
 
 // blockedTagNameGroups mirrors ExpandService._blocked_tag_name_groups.
@@ -1673,6 +1738,45 @@ LEFT JOIN source_tag_stash_id ids ON ids.tag_id=t.tag_id
 	if err := prefRows.Err(); err != nil {
 		return nil, nil, err
 	}
+	termAffinity := map[string]float64{}
+	termRows, err := s.db.Query(`
+SELECT d.name, a.affinity * a.confidence AS value
+FROM feature_affinity a JOIN feature_definition d USING(feature_id)
+WHERE a.model_id=? AND d.feature_version=? AND d.family='content'
+  AND d.name LIKE 'desc:%'`, modelID, featureVersion)
+	if err != nil {
+		return nil, nil, err
+	}
+	for termRows.Next() {
+		var name string
+		var value float64
+		if err := termRows.Scan(&name, &value); err != nil {
+			return nil, nil, err
+		}
+		termAffinity[strings.TrimPrefix(name, "desc:")] = value
+	}
+	termRows.Close()
+	if err := termRows.Err(); err != nil {
+		return nil, nil, err
+	}
+	directTermRows, err := s.db.Query(`SELECT term, value FROM direct_term_preference`)
+	if err != nil {
+		return nil, nil, err
+	}
+	for directTermRows.Next() {
+		var term string
+		var value float64
+		if err := directTermRows.Scan(&term, &value); err != nil {
+			return nil, nil, err
+		}
+		if _, ok := termAffinity[term]; !ok {
+			termAffinity[term] = value
+		}
+	}
+	directTermRows.Close()
+	if err := directTermRows.Err(); err != nil {
+		return nil, nil, err
+	}
 	externalStudioAppeal := map[string]float64{}
 	appealRows, err := s.db.Query(`
 WITH appeal AS (
@@ -1801,6 +1905,17 @@ WHERE s.studio_id IS NOT NULL GROUP BY s.studio_id`, modelID)
 					signals = signals[:5]
 				}
 				tagValue := math.Tanh(sumFloats(signals))
+				termSignals := make([]float64, 0, 8)
+				for token := range descriptionTokenSet(scene.get("details").asString()) {
+					if value, ok := termAffinity[token]; ok {
+						termSignals = append(termSignals, value)
+					}
+				}
+				sort.SliceStable(termSignals, func(i, j int) bool { return math.Abs(termSignals[i]) > math.Abs(termSignals[j]) })
+				if len(termSignals) > 5 {
+					termSignals = termSignals[:5]
+				}
+				termValue := math.Tanh(sumFloats(termSignals))
 				cast := make([]jVal, 0, len(scene.get("performers").arr))
 				for _, item := range scene.get("performers").arr {
 					cast = append(cast, item.get("performer"))
@@ -1898,10 +2013,10 @@ WHERE s.studio_id IS NOT NULL GROUP BY s.studio_id`, modelID)
 						score:      performerScore,
 					})
 				}
-				score := 0.45*tagValue + 0.25*identity + 0.10*studioValue + 0.20*similarityValue
+				score := 0.40*tagValue + 0.10*termValue + 0.25*identity + 0.10*studioValue + 0.15*similarityValue
 				payload := cloneObj(scene)
 				payload.set("studio", studioPayload)
-				payload.set("why", expandWhy(scene, tagAffinity, identity, similarityValue, len(cast)))
+				payload.set("why", expandWhy(scene, tagAffinity, termAffinity, identity, similarityValue, len(cast)))
 				work[index] = sceneWork{
 					row: scoredScene{
 						id:      scene.get("id").asString(),

--- a/core/expand_ops.go
+++ b/core/expand_ops.go
@@ -132,6 +132,10 @@ func expandResults(db dbx, entityType string, page int64, sortBy string, perform
 	if err != nil {
 		return jvNull(), err
 	}
+	blockedTerms, err := service.blockedTermSet()
+	if err != nil {
+		return jvNull(), err
+	}
 	rows := make([]jVal, 0)
 	entityRows, err := db.Query(`SELECT * FROM external_entity WHERE entity_type=? AND pool='candidate'`, entityType)
 	if err != nil {
@@ -195,7 +199,7 @@ func expandResults(db dbx, entityType string, page int64, sortBy string, perform
 		}
 		if entityType == "scene" && !expandSceneMatches(payload, includeTags, excludeTags,
 			performerNames, studioNames, performerQuery, studioQuery,
-			includeGroups, excludeGroups, blockedGroups) {
+			includeGroups, excludeGroups, blockedGroups, blockedTerms) {
 			continue
 		}
 		sources, err := parseJSON([]byte(asDBString(row["sources_json"])))
@@ -385,6 +389,10 @@ func expandPerformerHunt(db dbx, clientURL, apiKey string, links jVal, performer
 	if err != nil {
 		return jvNull(), err
 	}
+	blockedTerms, err := service.blockedTermSet()
+	if err != nil {
+		return jvNull(), err
+	}
 	shortlisted := map[string]bool{}
 	shortRows, err := db.Query(`SELECT external_id FROM external_shortlist WHERE entity_type='scene'`)
 	if err != nil {
@@ -404,7 +412,7 @@ func expandPerformerHunt(db dbx, clientURL, apiKey string, links jVal, performer
 	items := make([]jVal, 0, len(scenes))
 	for _, scene := range scenes {
 		if !expandSceneMatches(scene.payload, includeTags, excludeTags, nil, nil, "", "",
-			includeGroups, excludeGroups, blockedGroups) {
+			includeGroups, excludeGroups, blockedGroups, blockedTerms) {
 			continue
 		}
 		item := jvObj(

--- a/core/expand_refresh.go
+++ b/core/expand_refresh.go
@@ -507,6 +507,12 @@ ORDER BY a.affinity * a.confidence DESC LIMIT 50`, modelID, featureVersion)
 func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int,
 	gender string, wildcard bool, nowMs int64, progress func(processed, total int)) (jVal, error) {
 	fetchedAtMs := nowMs
+	// The taxonomy check and seed load used to be markerless: on a large
+	// library the bar sat at 5% for the whole stretch. The 50/150 ticks
+	// bracket both phases (issue #110).
+	if progress != nil {
+		progress(50, 1000)
+	}
 	taxonomyRefreshed, err := refreshTaxonomy(db, clientURL, apiKey, fetchedAtMs)
 	if err != nil {
 		return jvNull(), err
@@ -526,6 +532,9 @@ func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int
 		return jvNull(), err
 	}
 	s := newExpandService(db)
+	if progress != nil {
+		progress(150, 1000)
+	}
 	seeds, err := refreshSeeds(s, modelID, featureVersion, links)
 	if err != nil {
 		return jvNull(), err

--- a/core/expand_similar.go
+++ b/core/expand_similar.go
@@ -215,7 +215,7 @@ WHERE st.scene_id=? AND lower(t.name)='compilation' LIMIT 1`, entityID).Scan(&pr
 				}
 			}
 			if !expandSceneMatches(payload, includeTags, excludeTags, performerNames, studioNames,
-				"", "", includeGroups, excludeGroups, nil) {
+				"", "", includeGroups, excludeGroups, nil, nil) {
 				continue
 			}
 			if favoriteOnly {
@@ -724,6 +724,10 @@ func expandTargetedSimilar(db dbx, clientURL, apiKey string, links jVal, entityT
 	if err != nil {
 		return jvNull(), err
 	}
+	blockedTerms, err := service.blockedTermSet()
+	if err != nil {
+		return jvNull(), err
+	}
 	filtered := make([]jVal, 0, len(rawItems))
 	for _, item := range rawItems {
 		if gender != "" && !payloadMatchesGender(item.get("payload"), entityType, gender) {
@@ -735,7 +739,7 @@ func expandTargetedSimilar(db dbx, clientURL, apiKey string, links jVal, entityT
 		sceneFiltered := make([]jVal, 0, len(filtered))
 		for _, item := range filtered {
 			if expandSceneMatches(item.get("payload"), nil, nil, nil, nil, "", "",
-				nil, nil, blockedGroups) {
+				nil, nil, blockedGroups, blockedTerms) {
 				sceneFiltered = append(sceneFiltered, item)
 			}
 		}

--- a/core/frontend.go
+++ b/core/frontend.go
@@ -171,6 +171,171 @@ WHERE tta.snapshot_id=? AND lower(tta.alias)=?`,
 	), nil
 }
 
+// ── get_scene_tag_choices ──────────────────────────────────────────────────
+
+// opGetSceneTagChoices mirrors backend.py's get_scene_tag_choices branch:
+// the scene's own classified tags (tag_role for the current config version)
+// with their direct preferences, sorted by name — the local-card counterpart
+// of get_external_tag_choices. A tag can appear once per provenance, so rows
+// are grouped by tag_id.
+func opGetSceneTagChoices(pluginDir string, payload jVal) (jVal, error) {
+	return profiledOperation(pluginDir, payload, "get_scene_tag_choices",
+		func(settings jVal) (jVal, error) { return sceneTagChoicesBody(pluginDir, payload, settings) })
+}
+
+func sceneTagChoicesBody(pluginDir string, payload, settings jVal) (jVal, error) {
+	sceneID := pythonStrOrEmpty(payload.get("args").get("scene_id"))
+	if sceneID == "" {
+		return jvNull(), fmt.Errorf("scene_id is required")
+	}
+	db, err := openAPISidecar(pluginDir, payload, settings)
+	if err != nil {
+		return jvNull(), err
+	}
+	defer db.Close()
+	configVersion := "cfg-" + featureFingerprint()[:20]
+	rows, err := db.Query(`SELECT t.tag_id, t.name, p.value AS direct_value,
+       p.blocked AS direct_blocked
+FROM scene_tag st
+JOIN source_tag t ON t.tag_id=st.tag_id
+JOIN tag_role r ON r.tag_id=t.tag_id AND r.config_version=?
+LEFT JOIN direct_tag_preference p ON p.tag_id=t.tag_id
+WHERE st.scene_id=?
+GROUP BY t.tag_id
+ORDER BY t.name COLLATE NOCASE, t.tag_id`, configVersion, sceneID)
+	if err != nil {
+		return jvNull(), err
+	}
+	out := jvArr()
+	for rows.Next() {
+		var tagID string
+		var name string
+		var directValue sql.NullFloat64
+		var directBlocked sql.NullInt64
+		if err := rows.Scan(&tagID, &name, &directValue, &directBlocked); err != nil {
+			rows.Close()
+			return jvNull(), err
+		}
+		if name == "" {
+			name = tagID
+		}
+		value := jvNull()
+		if directValue.Valid {
+			value = jvFloat(directValue.Float64)
+		}
+		out.arr = append(out.arr, jvObj(
+			jvKey("tag_id", jvStr(tagID)),
+			jvKey("name", jvStr(name)),
+			jvKey("direct_value", value),
+			jvKey("direct_blocked", jvBool(directBlocked.Valid && directBlocked.Int64 != 0)),
+		))
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return jvNull(), err
+	}
+	return jvObj(
+		jvKey("schema_version", jvInt(apiSchemaVersion)),
+		jvKey("items", out),
+	), nil
+}
+
+// ── get_scene_description_tokens ───────────────────────────────────────────
+
+// opGetSceneDescriptionTokens mirrors backend.py's get_scene_description_tokens
+// branch: the scene's desc:<term> content features from the current feature
+// build, with direct term preferences — the data source for the term-rating
+// view. Terms are truthful to the built model (library-relative TF-IDF), never
+// re-tokenized from the scene text.
+func opGetSceneDescriptionTokens(pluginDir string, payload jVal) (jVal, error) {
+	return profiledOperation(pluginDir, payload, "get_scene_description_tokens",
+		func(settings jVal) (jVal, error) { return sceneDescriptionTokensBody(pluginDir, payload, settings) })
+}
+
+func sceneDescriptionTokensBody(pluginDir string, payload, settings jVal) (jVal, error) {
+	sceneID := pythonStrOrEmpty(payload.get("args").get("scene_id"))
+	if sceneID == "" {
+		return jvNull(), fmt.Errorf("scene_id is required")
+	}
+	db, err := openAPISidecar(pluginDir, payload, settings)
+	if err != nil {
+		return jvNull(), err
+	}
+	defer db.Close()
+	direct := make(map[string]termPref)
+	rows, err := db.Query(`SELECT term, value, blocked FROM direct_term_preference`)
+	if err != nil {
+		return jvNull(), err
+	}
+	for rows.Next() {
+		var term string
+		var value float64
+		var blocked int64
+		if err := rows.Scan(&term, &value, &blocked); err != nil {
+			rows.Close()
+			return jvNull(), err
+		}
+		direct[term] = termPref{value: value, blocked: blocked != 0}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return jvNull(), err
+	}
+	featureVersion, err := currentFeatureVersion(db)
+	if err != nil {
+		return jvNull(), err
+	}
+	out := jvArr()
+	if featureVersion != "" {
+		rows, err := db.Query(`SELECT fd.name, fd.metadata_json
+FROM entity_feature ef
+JOIN feature_definition fd ON fd.feature_id=ef.feature_id
+WHERE ef.feature_version=? AND ef.entity_type='scene' AND ef.entity_id=?
+  AND fd.family='content' AND fd.name LIKE 'desc:%'
+ORDER BY fd.name`, featureVersion, sceneID)
+		if err != nil {
+			return jvNull(), err
+		}
+		for rows.Next() {
+			var name string
+			var metadataJSON string
+			if err := rows.Scan(&name, &metadataJSON); err != nil {
+				rows.Close()
+				return jvNull(), err
+			}
+			term := strings.TrimPrefix(name, "desc:")
+			metadata := parseJSONOr(metadataJSON)
+			documentFrequency := int64(pythonFloatOr(metadata.get("document_frequency"), 0))
+			value := jvNull()
+			blocked := false
+			if pref, ok := direct[term]; ok {
+				value = jvFloat(pref.value)
+				blocked = pref.blocked
+			}
+			out.arr = append(out.arr, jvObj(
+				jvKey("term", jvStr(term)),
+				jvKey("document_frequency", jvInt(documentFrequency)),
+				jvKey("direct_value", value),
+				jvKey("direct_blocked", jvBool(blocked)),
+			))
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return jvNull(), err
+		}
+	}
+	return jvObj(
+		jvKey("schema_version", jvInt(apiSchemaVersion)),
+		jvKey("items", out),
+	), nil
+}
+
+// termPref is a direct_term_preference row (value + blocked flag).
+type termPref struct {
+	value   float64
+	blocked bool
+}
+
 // ── get_inspector_entity ───────────────────────────────────────────────────
 
 // inspectorSceneScore carries every ModelSceneScore field asdict() exposes,

--- a/core/links.go
+++ b/core/links.go
@@ -82,16 +82,18 @@ func cachedExternalLinks(db dbx, state string) (jVal, bool, error) {
 // and each map's keys are inserted in scan order — the byte-identical cache
 // row depends on that.
 func externalLinks(payload jVal, db dbx) (jVal, error) {
-	return externalLinksImpl(payload, db, false)
+	return externalLinksImpl(payload, db, false, nil)
 }
 
 // externalLinksRefresh mirrors _external_links with refresh=True: skip the
-// cache read but still write the cache row.
-func externalLinksRefresh(payload jVal, db dbx) (jVal, error) {
-	return externalLinksImpl(payload, db, true)
+// cache read but still write the cache row. progress, when non-nil, receives
+// (processed, total) page ticks over the paginated walk (issue #110: the
+// expand-refresh bar used to sit at 5% for the whole library walk).
+func externalLinksRefresh(payload jVal, db dbx, progress func(processed, total int)) (jVal, error) {
+	return externalLinksImpl(payload, db, true, progress)
 }
 
-func externalLinksImpl(payload jVal, db dbx, refresh bool) (jVal, error) {
+func externalLinksImpl(payload jVal, db dbx, refresh bool, progress func(processed, total int)) (jVal, error) {
 	state := ""
 	var err error
 	if db != nil && !refresh {
@@ -165,6 +167,19 @@ func externalLinksImpl(payload jVal, db dbx, refresh bool) (jVal, error) {
 			if page*500 < pythonInt(collection.get("count")) {
 				more = true
 			}
+		}
+		if progress != nil {
+			total := int64(0)
+			for _, kind := range []string{"scenes", "performers", "studios"} {
+				if count := pythonInt(data.get(kind).get("count")); count > total {
+					total = count
+				}
+			}
+			processed := page * 500
+			if processed > total {
+				processed = total
+			}
+			progress(int(processed), int(total))
 		}
 		if !more {
 			break

--- a/core/migrations/0028_direct_term_preferences.sql
+++ b/core/migrations/0028_direct_term_preferences.sql
@@ -1,0 +1,30 @@
+-- Direct description-term preferences: a five-point rating plus an optional
+-- hard block for the description tokens the model already builds as
+-- `desc:<term>` content features. Terms are library-relative tokens from the
+-- same tokenizer (lowercase [a-zA-Z]{3,}, stopword-filtered, TF-IDF-capped);
+-- unlike tags they have no source table, so `term` is stored as plain text.
+-- The shape mirrors 0016/0026 (append-only history + current row, fixed
+-- five-point scale, blocked flag) so the preference queue, staleness
+-- replacement, and model-rebuild trigger behave identically to tags. A
+-- blocked entry stores value -1 and the blocked flag drives hard exclusion.
+
+CREATE TABLE direct_term_preference_history (
+    preference_id TEXT PRIMARY KEY,
+    term TEXT NOT NULL,
+    value REAL CHECK (value IS NULL OR value IN (-1, -0.5, 0, 0.5, 1)),
+    blocked INTEGER NOT NULL DEFAULT 0 CHECK (blocked IN (0, 1)),
+    occurred_at_ms INTEGER NOT NULL CHECK (occurred_at_ms >= 0),
+    replaced_by_id TEXT REFERENCES direct_term_preference_history(preference_id)
+) STRICT;
+
+CREATE INDEX direct_term_preference_history_term_idx
+ON direct_term_preference_history(term, occurred_at_ms);
+
+CREATE TABLE direct_term_preference (
+    term TEXT PRIMARY KEY,
+    preference_id TEXT NOT NULL UNIQUE
+        REFERENCES direct_term_preference_history(preference_id) ON DELETE CASCADE,
+    value REAL NOT NULL CHECK (value IN (-1, -0.5, 0, 0.5, 1)),
+    blocked INTEGER NOT NULL DEFAULT 0 CHECK (blocked IN (0, 1)),
+    occurred_at_ms INTEGER NOT NULL CHECK (occurred_at_ms >= 0)
+) STRICT, WITHOUT ROWID;

--- a/core/migrations_test.go
+++ b/core/migrations_test.go
@@ -19,7 +19,7 @@ func openTempDB(t *testing.T) (dbx, string) {
 }
 
 // The full chain applies on a fresh database, producing the same status a
-// Python-migrated sidecar has (current/latest 27, nothing pending), and a
+// Python-migrated sidecar has (current/latest 28, nothing pending), and a
 // second migrate is a no-op.
 func TestMigrateFullChain(t *testing.T) {
 	db, _ := openTempDB(t)
@@ -34,18 +34,18 @@ func TestMigrateFullChain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status.currentVersion != 27 || status.latestVersion != 27 || len(status.pending) != 0 {
+	if status.currentVersion != 28 || status.latestVersion != 28 || len(status.pending) != 0 {
 		t.Fatalf("unexpected status: %+v", status)
 	}
-	if len(migrations) != 27 {
-		t.Fatalf("expected 27 migrations, got %d", len(migrations))
+	if len(migrations) != 28 {
+		t.Fatalf("expected 28 migrations, got %d", len(migrations))
 	}
 	var rows int
 	if err := db.QueryRow(`SELECT count(*) FROM schema_migration`).Scan(&rows); err != nil {
 		t.Fatal(err)
 	}
-	if rows != 27 {
-		t.Fatalf("schema_migration has %d rows, want 27", rows)
+	if rows != 28 {
+		t.Fatalf("schema_migration has %d rows, want 28", rows)
 	}
 	// Idempotent second migrate.
 	if err := migrate(db, 1_700_000_000_001); err != nil {
@@ -54,7 +54,7 @@ func TestMigrateFullChain(t *testing.T) {
 	if err := db.QueryRow(`SELECT count(*) FROM schema_migration`).Scan(&rows); err != nil {
 		t.Fatal(err)
 	}
-	if rows != 27 {
+	if rows != 28 {
 		t.Fatalf("second migrate added rows: %d", rows)
 	}
 	var integrity string

--- a/core/modelbuild.go
+++ b/core/modelbuild.go
@@ -16,6 +16,7 @@ import (
 	"math"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 const (
@@ -577,6 +578,56 @@ func modelAffinities(db dbx, sceneFeatures map[string][]storedFeature,
 	}
 	rows.Close()
 	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	termFeatures := map[string]string{}
+	for _, features := range sceneFeatures {
+		for _, feature := range features {
+			if feature.family == "content" && strings.HasPrefix(feature.name, "desc:") {
+				termFeatures[strings.TrimPrefix(feature.name, "desc:")] = feature.featureID
+			}
+		}
+	}
+	termRows, err := db.Query(`SELECT term, value FROM direct_term_preference ORDER BY term`)
+	if err != nil {
+		return nil, err
+	}
+	for termRows.Next() {
+		var term string
+		var directValue float64
+		if err := termRows.Scan(&term, &directValue); err != nil {
+			termRows.Close()
+			return nil, err
+		}
+		featureID, ok := termFeatures[term]
+		if !ok {
+			continue
+		}
+		learned, exists := result[featureID]
+		if !exists {
+			learned = modelAffinity{featureID: featureID}
+		}
+		directSupport := 8.0
+		blended := clamp((learned.affinity*learned.support + directValue*directSupport) /
+			(learned.support + directSupport))
+		contextJSON := jvObj()
+		for _, pair := range learned.contexts.obj {
+			contextJSON.set(pair.key, pair.val)
+		}
+		contextJSON.set("declared_preference", jvFloat(directValue))
+		contextJSON.set("learned_affinity", jvFloat(learned.affinity))
+		contextJSON.set("learned_confidence", jvFloat(learned.confidence))
+		result[featureID] = modelAffinity{
+			featureID:  featureID,
+			affinity:   blended,
+			confidence: math.Max(learned.confidence, 0.9),
+			support:    learned.support + directSupport,
+			sceneCount: learned.sceneCount,
+			contexts:   contextJSON,
+		}
+	}
+	termRows.Close()
+	if err := termRows.Err(); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/core/ops.go
+++ b/core/ops.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const apiSchemaVersion = 1
@@ -66,24 +67,68 @@ ON CONFLICT(key) DO UPDATE SET value=CAST(value AS INTEGER)+1`); err != nil {
 	), nil
 }
 
+// isBusyError reports whether err is a SQLite busy failure: SQLITE_BUSY (5)
+// and the extended SQLITE_BUSY_RECOVERY (261), SQLITE_BUSY_SNAPSHOT (517),
+// and SQLITE_BUSY_TIMEOUT (773) codes. The busy_timeout handler retries only
+// the plain code in some SQLite versions (modernc ships 3.41.2), so the
+// extended codes get a bounded retry here — the #109 mitigation for
+// lock contention between concurrent plugin processes. The matcher follows
+// similar.go's casefold "locked" convention.
+func isBusyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	message := strings.ToLower(err.Error())
+	return strings.Contains(message, "locked") || strings.Contains(message, "busy")
+}
+
+// busyRetryBackoff is the sleep between busy-retry attempts (150 ms, 300 ms).
+func busyRetryBackoff(attempt int) time.Duration {
+	return time.Duration(150*(attempt+1)) * time.Millisecond
+}
+
+const busyRetryAttempts = 3
+
 // execImmediate runs one statement in an explicit BEGIN IMMEDIATE transaction,
-// mirroring curator.storage.transaction (no nested transactions).
+// mirroring curator.storage.transaction (no nested transactions). Busy
+// failures before COMMIT are retried with backoff; a COMMIT failure is never
+// retried (its outcome is ambiguous and re-running the statement could
+// double-apply non-idempotent writes).
 func execImmediate(db dbx, statement string, args ...any) error {
-	conn, err := db.Conn(context.Background())
-	if err != nil {
-		return err
+	var lastErr error
+	for attempt := range busyRetryAttempts {
+		conn, err := db.Conn(context.Background())
+		if err != nil {
+			return err
+		}
+		ctx := context.Background()
+		if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
+			conn.Close()
+			if isBusyError(err) && attempt < busyRetryAttempts-1 {
+				lastErr = err
+				time.Sleep(busyRetryBackoff(attempt))
+				continue
+			}
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, statement, args...); err != nil {
+			conn.ExecContext(ctx, "ROLLBACK")
+			conn.Close()
+			if isBusyError(err) && attempt < busyRetryAttempts-1 {
+				lastErr = err
+				time.Sleep(busyRetryBackoff(attempt))
+				continue
+			}
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
+			conn.Close()
+			return err
+		}
+		conn.Close()
+		return nil
 	}
-	defer conn.Close()
-	ctx := context.Background()
-	if _, err := conn.ExecContext(ctx, "BEGIN IMMEDIATE"); err != nil {
-		return err
-	}
-	if _, err := conn.ExecContext(ctx, statement, args...); err != nil {
-		conn.ExecContext(ctx, "ROLLBACK")
-		return err
-	}
-	_, err = conn.ExecContext(ctx, "COMMIT")
-	return err
+	return lastErr
 }
 
 func opGetJobStatus(pluginDir string, payload jVal) (jVal, error) {

--- a/core/similar.go
+++ b/core/similar.go
@@ -536,6 +536,50 @@ WHERE model_id=? AND performer_id=? ORDER BY rank`, s.modelID, targetID)
 			return nil, err
 		}
 	}
+	blockedTerms := make([]string, 0)
+	rows, err = s.db.Query(`SELECT term FROM direct_term_preference WHERE blocked=1`)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var term string
+		if err := rows.Scan(&term); err != nil {
+			return nil, err
+		}
+		blockedTerms = append(blockedTerms, term)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	sort.Strings(blockedTerms)
+	if len(blockedTerms) > 0 {
+		placeholders := inClause(len(blockedTerms))
+		args := make([]any, 0, len(blockedTerms)+1)
+		args = append(args, s.featureVersion)
+		for _, term := range blockedTerms {
+			args = append(args, "desc:"+term)
+		}
+		rows, err := s.db.Query(`SELECT DISTINCT ef.entity_id FROM entity_feature ef
+JOIN feature_definition fd ON fd.feature_id=ef.feature_id
+WHERE ef.feature_version=? AND ef.entity_type='scene'
+  AND fd.family='content'
+  AND fd.name IN (`+placeholders+`)`, args...)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var sceneID string
+			if err := rows.Scan(&sceneID); err != nil {
+				return nil, err
+			}
+			blockedScenes[sceneID] = true
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+	}
 	performerIDSet := make(map[string]bool, len(performerIDs))
 	for _, id := range performerIDs {
 		performerIDSet[id] = true

--- a/core/slate.go
+++ b/core/slate.go
@@ -843,6 +843,7 @@ func eligibilityFingerprint(db dbx) (string, error) {
 		{"exclusion", `SELECT count(*), coalesce(max(created_at_ms), 0) FROM exclusion WHERE reversed_at_ms IS NULL`},
 		{"pruning", `SELECT count(*), coalesce(max(updated_at_ms), 0) FROM pruning_candidate`},
 		{"blocked_tags", `SELECT count(*), coalesce(max(occurred_at_ms), 0) FROM direct_tag_preference WHERE blocked=1`},
+		{"blocked_terms", `SELECT count(*), coalesce(max(occurred_at_ms), 0) FROM direct_term_preference WHERE blocked=1`},
 		{"files", `SELECT count(*), 0 FROM source_file WHERE available=1`},
 	}
 	for _, q := range queries {

--- a/core/tasks.go
+++ b/core/tasks.go
@@ -252,7 +252,7 @@ func taskExpandRefresh(db dbx, pluginDir string, payload jVal, settings jVal) (j
 	if err != nil {
 		return jvNull(), err
 	}
-	links, err := externalLinksRefresh(payload, db)
+	links, err := externalLinksRefresh(payload, db, mappedProgress(0.05, 0.08))
 	if err != nil {
 		return jvNull(), err
 	}
@@ -263,7 +263,7 @@ func taskExpandRefresh(db dbx, pluginDir string, payload jVal, settings jVal) (j
 			int(pythonInt(cfg.get("expand_horizon_days"))),
 			cfg.get("expand_gender").asString(),
 			cfg.get("expand_wildcard").truthy(),
-			nowMs(), mappedProgress(0.05, 0.98))
+			nowMs(), mappedProgress(0.08, 0.98))
 		return err
 	})
 	if err != nil {

--- a/core/writes.go
+++ b/core/writes.go
@@ -11,6 +11,7 @@ import (
 	"database/sql"
 	"fmt"
 	"math"
+	"regexp"
 	"sort"
 	"strings"
 )
@@ -535,6 +536,164 @@ ON CONFLICT(tag_id) DO UPDATE SET
 		}
 		if inserted > 0 {
 			return coordinatorRequest(conn, "direct_tag_preference", nowMs())
+		}
+		return nil
+	})
+	if err != nil {
+		return jvNull(), err
+	}
+	return jvObj(
+		jvKey("schema_version", jvInt(apiSchemaVersion)),
+		jvKey("accepted", jvInt(inserted)),
+	), nil
+}
+
+// ── submit_term_preferences ─────────────────────────────────────────────────
+
+// termPreferenceEntry mirrors InteractionStore._term_preference_entry's output.
+type termPreferenceEntry struct {
+	preferenceID string
+	term         string
+	value        jVal // jvNull = None
+	blocked      bool
+	occurredAtMs int64
+}
+
+var termTokenRE = regexp.MustCompile(`^[a-zA-Z]{3,}$`)
+
+// normalizeTermPreferenceEntry mirrors InteractionStore._term_preference_entry:
+// the five-point scale and blocked semantics of tags, keyed by a lowercase
+// description token (the tokenizer's [a-zA-Z]{3,} shape). Terms have no source
+// table, so unlike tags there is no membership check — a preference for a term
+// the current model has not qualified simply has no feature to blend into.
+func normalizeTermPreferenceEntry(entry jVal) (termPreferenceEntry, error) {
+	preferenceID := pythonStrOrEmpty(entry.get("preference_id"))
+	term := strings.ToLower(strings.TrimSpace(pythonStrOrEmpty(entry.get("term"))))
+	occurredAtMs := pythonIntErrOr(entry.get("occurred_at_ms"), -1)
+	blocked := entry.get("blocked").truthy()
+	value := entry.get("value")
+	if value.kind != jNull {
+		if value.kind == jBool || !isJSONNumber(value) {
+			return termPreferenceEntry{}, fmt.Errorf("term sentiment must be numeric or null")
+		}
+		f, err := pythonFloat(value)
+		if err != nil || !tagSentimentValues[f] {
+			return termPreferenceEntry{}, fmt.Errorf("term sentiment must use the fixed five-point scale")
+		}
+		value = jvFloat(f)
+	}
+	if blocked {
+		value = jvFloat(blockedTagValue)
+	}
+	if preferenceID == "" || term == "" || occurredAtMs < 0 {
+		return termPreferenceEntry{}, fmt.Errorf("preference_id, term, and occurred_at_ms are required")
+	}
+	if !termTokenRE.MatchString(term) {
+		return termPreferenceEntry{}, fmt.Errorf("term must be a description token ([a-zA-Z]{3,})")
+	}
+	return termPreferenceEntry{
+		preferenceID: preferenceID,
+		term:         term,
+		value:        value,
+		blocked:      blocked,
+		occurredAtMs: occurredAtMs,
+	}, nil
+}
+
+func opSubmitTermPreferences(pluginDir string, payload jVal) (jVal, error) {
+	return profiledOperation(pluginDir, payload, "submit_term_preferences",
+		func(settings jVal) (jVal, error) { return submitTermPreferencesBody(pluginDir, payload, settings) })
+}
+
+func submitTermPreferencesBody(pluginDir string, payload, settings jVal) (jVal, error) {
+	entries := payload.get("args").get("entries")
+	if !isList(entries) {
+		return jvNull(), fmt.Errorf("entries must be a list")
+	}
+	db, err := openAPISidecar(pluginDir, payload, settings)
+	if err != nil {
+		return jvNull(), err
+	}
+	defer db.Close()
+	normalized := make([]termPreferenceEntry, len(entries.arr))
+	for i, entry := range entries.arr {
+		item, err := normalizeTermPreferenceEntry(entry)
+		if err != nil {
+			return jvNull(), err
+		}
+		normalized[i] = item
+	}
+	inserted := int64(0)
+	err = withTxn(db, func(conn *sql.Conn) error {
+		ctx := context.Background()
+		for _, entry := range normalized {
+			var currentID string
+			var currentAtMs int64
+			currentErr := conn.QueryRowContext(ctx,
+				`SELECT preference_id, occurred_at_ms FROM direct_term_preference WHERE term=?`,
+				entry.term).Scan(&currentID, &currentAtMs)
+			hasCurrent := currentErr == nil
+			if currentErr != nil && currentErr != sql.ErrNoRows {
+				return currentErr
+			}
+			valueArg := any(nil)
+			if entry.value.kind != jNull {
+				valueArg = pythonFloatOr(entry.value, 0)
+			}
+			res, err := conn.ExecContext(ctx, `
+INSERT OR IGNORE INTO direct_term_preference_history(
+    preference_id, term, value, blocked, occurred_at_ms
+) VALUES (?, ?, ?, ?, ?)`,
+				entry.preferenceID, entry.term, valueArg, boolToInt(entry.blocked), entry.occurredAtMs)
+			if err != nil {
+				return err
+			}
+			rows, err := res.RowsAffected()
+			if err != nil {
+				return err
+			}
+			if rows == 0 {
+				continue
+			}
+			inserted++
+			if hasCurrent && (currentAtMs > entry.occurredAtMs ||
+				(currentAtMs == entry.occurredAtMs && currentID >= entry.preferenceID)) {
+				if _, err := conn.ExecContext(ctx,
+					`UPDATE direct_term_preference_history SET replaced_by_id=? WHERE preference_id=?`,
+					currentID, entry.preferenceID); err != nil {
+					return err
+				}
+				continue
+			}
+			if hasCurrent {
+				if _, err := conn.ExecContext(ctx,
+					`UPDATE direct_term_preference_history SET replaced_by_id=? WHERE preference_id=?`,
+					entry.preferenceID, currentID); err != nil {
+					return err
+				}
+			}
+			if entry.value.kind == jNull {
+				if _, err := conn.ExecContext(ctx,
+					`DELETE FROM direct_term_preference WHERE term=?`, entry.term); err != nil {
+					return err
+				}
+				continue
+			}
+			if _, err := conn.ExecContext(ctx, `
+INSERT INTO direct_term_preference(
+    term, preference_id, value, blocked, occurred_at_ms
+) VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(term) DO UPDATE SET
+    preference_id=excluded.preference_id,
+    value=excluded.value,
+    blocked=excluded.blocked,
+    occurred_at_ms=excluded.occurred_at_ms`,
+				entry.term, entry.preferenceID, valueArg, boolToInt(entry.blocked), entry.occurredAtMs); err != nil {
+				return err
+			}
+		}
+		if inserted > 0 {
+			return coordinatorRequest(conn, "direct_term_preference", nowMs())
 		}
 		return nil
 	})

--- a/curator/api.py
+++ b/curator/api.py
@@ -462,6 +462,75 @@ class CuratorAPI:
         inserted = InteractionStore(self.connection).submit_tag_preferences(entries)
         return {"schema_version": API_SCHEMA_VERSION, "accepted": inserted}
 
+    def submit_term_preferences(self, entries: list[dict[str, Any]]) -> dict[str, object]:
+        inserted = InteractionStore(self.connection).submit_term_preferences(entries)
+        return {"schema_version": API_SCHEMA_VERSION, "accepted": inserted}
+
+    def get_scene_tag_choices(self, scene_id: str) -> dict[str, object]:
+        if not scene_id:
+            raise ValueError("scene_id is required")
+        config_version = f"cfg-{DEFAULT_CONFIG.feature_fingerprint()[:20]}"
+        items: list[dict[str, object]] = []
+        for row in self.connection.execute(
+            """
+            SELECT t.tag_id, t.name, p.value AS direct_value, p.blocked AS direct_blocked
+            FROM scene_tag st
+            JOIN source_tag t ON t.tag_id=st.tag_id
+            JOIN tag_role r ON r.tag_id=t.tag_id AND r.config_version=?
+            LEFT JOIN direct_tag_preference p ON p.tag_id=t.tag_id
+            WHERE st.scene_id=?
+            GROUP BY t.tag_id
+            ORDER BY t.name COLLATE NOCASE, t.tag_id
+            """,
+            (config_version, scene_id),
+        ):
+            items.append(
+                {
+                    "tag_id": str(row["tag_id"]),
+                    "name": str(row["name"] or row["tag_id"]),
+                    "direct_value": (
+                        float(row["direct_value"]) if row["direct_value"] is not None else None
+                    ),
+                    "direct_blocked": bool(row["direct_blocked"]),
+                }
+            )
+        return {"schema_version": API_SCHEMA_VERSION, "items": items}
+
+    def get_scene_description_tokens(self, scene_id: str) -> dict[str, object]:
+        if not scene_id:
+            raise ValueError("scene_id is required")
+        feature_version = FeatureStore(self.connection).current_version()
+        direct: dict[str, tuple[float | None, bool]] = {}
+        for row in self.connection.execute(
+            "SELECT term, value, blocked FROM direct_term_preference"
+        ):
+            direct[str(row["term"])] = (float(row["value"]), bool(row["blocked"]))
+        items: list[dict[str, object]] = []
+        if feature_version is not None:
+            for row in self.connection.execute(
+                """
+                SELECT fd.name, fd.metadata_json
+                FROM entity_feature ef
+                JOIN feature_definition fd ON fd.feature_id=ef.feature_id
+                WHERE ef.feature_version=? AND ef.entity_type='scene' AND ef.entity_id=?
+                  AND fd.family='content' AND fd.name LIKE 'desc:%'
+                ORDER BY fd.name
+                """,
+                (feature_version, scene_id),
+            ):
+                term = str(row["name"])[len("desc:") :]
+                metadata = json.loads(str(row["metadata_json"] or "{}"))
+                direct_value, direct_blocked = direct.get(term, (None, False))
+                items.append(
+                    {
+                        "term": term,
+                        "document_frequency": int(metadata.get("document_frequency", 0)),
+                        "direct_value": direct_value,
+                        "direct_blocked": direct_blocked,
+                    }
+                )
+        return {"schema_version": API_SCHEMA_VERSION, "items": items}
+
     def taste_profile(self) -> dict[str, object]:
         model_id = RecommendationModelStore(self.connection).current_model_id()
         if model_id is None:

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -16,6 +16,10 @@ from typing import Any
 
 from curator.config import DEFAULT_CONFIG
 from curator.features import FeatureStore, PerformerProfile, performer_similarity
+from curator.features.builder import (
+    _DESCRIPTION_STOPWORDS,
+    _DESCRIPTION_TOKEN_RE,
+)
 from curator.features.measurements import CUP_ALIASES, augmentation_category
 from curator.features.profiles import (
     ProfileValue,
@@ -39,6 +43,21 @@ from curator.taxonomy import (
 
 STASHDB = "https://stashdb.org/graphql"
 PERFORMER_HUNT_LIMIT = 1_000
+
+
+def _description_tokens(details: str | None) -> frozenset[str]:
+    """Tokenize a description with the model's tokenizer pipeline: [a-zA-Z]{3,}
+    matches, lowercased, stopword-filtered, per-scene deduped (features/builder.py
+    desc-term extraction, without the library-wide TF-IDF selection). Tokens the
+    model never qualified have no affinity and simply contribute nothing."""
+    tokens: set[str] = set()
+    for token in _DESCRIPTION_TOKEN_RE.findall(str(details or "")):
+        token = token.lower()
+        if token not in _DESCRIPTION_STOPWORDS:
+            tokens.add(token)
+    return frozenset(tokens)
+
+
 SCENES = """
 query CuratorExpandScenes($input: SceneQueryInput!) {
   queryScenes(input: $input) {
@@ -236,6 +255,11 @@ class ExpandService:
         progress: Callable[[int, int], None] | None = None,
     ) -> dict[str, object]:
         fetched_at_ms = now_ms if now_ms is not None else time.time_ns() // 1_000_000
+        # The taxonomy check and seed load used to be markerless: on a large
+        # library the bar sat at 5% for the whole stretch. The 50/150 ticks
+        # bracket both phases (issue #110).
+        if progress:
+            progress(50, 1_000)
         taxonomy_refreshed = self._refresh_taxonomy(client, fetched_at_ms)
         if progress:
             progress(100, 1_000)
@@ -247,6 +271,8 @@ class ExpandService:
             "SELECT feature_version FROM model_version WHERE model_id=?", (model_id,)
         ).fetchone()
         feature_version = str(model[0])
+        if progress:
+            progress(150, 1_000)
         seeds = self._seeds(model_id, feature_version, links)
         if progress:
             progress(200, 1_000)
@@ -480,6 +506,7 @@ class ExpandService:
         include_groups = equivalent_tag_names(self.connection, include_tags)
         exclude_groups = equivalent_tag_names(self.connection, exclude_tags)
         blocked_groups = self._blocked_tag_name_groups()
+        blocked_terms = self._blocked_terms()
         shortlisted = {
             str(row[0])
             for row in self.connection.execute(
@@ -504,6 +531,7 @@ class ExpandService:
                 include_groups=include_groups,
                 exclude_groups=exclude_groups,
                 blocked_groups=blocked_groups,
+                blocked_terms=blocked_terms,
             )
         ]
         items.sort(
@@ -579,6 +607,7 @@ class ExpandService:
         include_groups = equivalent_tag_names(self.connection, include_tags)
         exclude_groups = equivalent_tag_names(self.connection, exclude_tags)
         blocked_groups = self._blocked_tag_name_groups()
+        blocked_terms = self._blocked_terms()
         for row in self.connection.execute(
             "SELECT * FROM external_entity WHERE entity_type=? AND pool='candidate'",
             (entity_type,),
@@ -620,6 +649,7 @@ class ExpandService:
                 include_groups,
                 exclude_groups,
                 blocked_groups=blocked_groups,
+                blocked_terms=blocked_terms,
             ):
                 continue
             rows.append(
@@ -665,6 +695,7 @@ class ExpandService:
         include_groups: tuple[frozenset[str], ...] = (),
         exclude_groups: tuple[frozenset[str], ...] = (),
         blocked_groups: tuple[frozenset[str], ...] = (),
+        blocked_terms: frozenset[str] = frozenset(),
     ) -> bool:
         tags = {str(item.get("name") or "").casefold() for item in payload.get("tags", [])}
         cast = {
@@ -674,6 +705,7 @@ class ExpandService:
         studio = str((payload.get("studio") or {}).get("name") or "").casefold()
         return (
             not any(group & tags for group in blocked_groups)
+            and not (_description_tokens(payload.get("details")) & blocked_terms)
             and (not include_tags or all(group & tags for group in include_groups))
             and not any(group & tags for group in exclude_groups)
             and (not performer_names or all(value.casefold() in cast for value in performer_names))
@@ -702,6 +734,17 @@ class ExpandService:
                     sorted(blocked_ids),
                 )
             ),
+        )
+
+    def _blocked_terms(self) -> frozenset[str]:
+        """Every blocked description term. Remote scenes whose description
+        tokens include one are excluded (tokenized with the model's pipeline;
+        the term->scene mapping has no SQL join for remote candidates)."""
+        return frozenset(
+            str(row[0])
+            for row in self.connection.execute(
+                "SELECT term FROM direct_term_preference WHERE blocked=1"
+            )
         )
 
     @staticmethod
@@ -1214,6 +1257,7 @@ class ExpandService:
         raw_items = result["items"]
         assert isinstance(raw_items, list)
         blocked_groups = self._blocked_tag_name_groups()
+        blocked_terms = self._blocked_terms()
         filtered_items = [
             item
             for item in raw_items
@@ -1223,7 +1267,9 @@ class ExpandService:
             filtered_items = [
                 item
                 for item in filtered_items
-                if self._scene_matches(item["payload"], blocked_groups=blocked_groups)
+                if self._scene_matches(
+                    item["payload"], blocked_groups=blocked_groups, blocked_terms=blocked_terms
+                )
             ]
         filtered_items = filtered_items[:count]
         if entity_type == "performer":
@@ -1767,6 +1813,19 @@ class ExpandService:
             tag_affinity.setdefault(f"name:{str(row['name']).casefold()}", value)
             if row["stash_id"]:
                 tag_affinity.setdefault(f"id:{row['stash_id']}", value)
+        term_affinity: dict[str, float] = {}
+        for row in self.connection.execute(
+            """
+            SELECT d.name, a.affinity * a.confidence AS value
+            FROM feature_affinity a JOIN feature_definition d USING(feature_id)
+            WHERE a.model_id=? AND d.feature_version=? AND d.family='content'
+              AND d.name LIKE 'desc:%'
+            """,
+            (model_id, feature_version),
+        ):
+            term_affinity[str(row["name"])[len("desc:") :]] = float(row["value"])
+        for row in self.connection.execute("SELECT term, value FROM direct_term_preference"):
+            term_affinity.setdefault(str(row["term"]), float(row["value"]))
         external_studio_appeal = {
             links["studios"][str(row["studio_id"])]: float(row["appeal"])
             for row in self.connection.execute(
@@ -1802,6 +1861,15 @@ class ExpandService:
                 reverse=True,
             )[:5]
             tag_value = math.tanh(sum(tag_signals))
+            term_signals = sorted(
+                (
+                    term_affinity.get(token, 0.0)
+                    for token in _description_tokens(scene.get("details"))
+                ),
+                key=abs,
+                reverse=True,
+            )[:5]
+            term_value = math.tanh(sum(term_signals))
             cast = [item["performer"] for item in scene.get("performers", [])]
             cast_weight = self._cast_weight(len(cast))
             identity_evidence = max(
@@ -1867,7 +1935,11 @@ class ExpandService:
                 )
                 performer_rows[external_id]["sources"].update(sources[str(scene["id"])])
             score = (
-                0.45 * tag_value + 0.25 * identity + 0.10 * studio_value + 0.20 * similarity_value
+                0.40 * tag_value
+                + 0.10 * term_value
+                + 0.25 * identity
+                + 0.10 * studio_value
+                + 0.15 * similarity_value
             )
             payload = {
                 **scene,
@@ -1875,7 +1947,9 @@ class ExpandService:
                 "performers": [
                     {"performer": performer_rows[str(item["id"])]["payload"]} for item in cast
                 ],
-                "why": self._why(scene, tag_affinity, identity, similarity_value, len(cast)),
+                "why": self._why(
+                    scene, tag_affinity, term_affinity, identity, similarity_value, len(cast)
+                ),
             }
             scene_rows.append(
                 {
@@ -2070,6 +2144,7 @@ class ExpandService:
     def _why(
         scene: dict[str, Any],
         tag_affinity: dict[str, float],
+        term_affinity: dict[str, float],
         identity: float,
         similarity: float,
         cast_count: int = 1,
@@ -2083,6 +2158,15 @@ class ExpandService:
             reverse=True,
         )[:3]
         reasons = [name for _, name in tags]
+        terms = sorted(
+            (
+                (term_affinity.get(token, 0.0), token)
+                for token in _description_tokens(scene.get("details"))
+                if term_affinity.get(token, 0.0) > 0
+            ),
+            reverse=True,
+        )[:2]
+        reasons.extend(term for _, term in terms)
         if identity > 0:
             reasons.append("a performer you already enjoy")
         elif similarity > 0:

--- a/curator/interactions.py
+++ b/curator/interactions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import sqlite3
 from collections.abc import Iterable
 from dataclasses import asdict
@@ -31,6 +32,10 @@ FEEDBACK_TYPES = {
 }
 TAG_SENTIMENT_VALUES = {-1.0, -0.5, 0.0, 0.5, 1.0}
 BLOCKED_TAG_VALUE = -1.0  # Stored value when blocked=1; the blocked flag drives exclusion.
+
+# Description-term preferences use the same five-point scale and blocked
+# convention as tags; only the key (a lowercase description token) differs.
+TERM_TOKEN_RE = re.compile(r"[a-zA-Z]{3,}")
 
 
 class InteractionStore:
@@ -333,6 +338,83 @@ class InteractionStore:
                 ModelUpdateCoordinator(self.connection).request("direct_tag_preference")
         return inserted
 
+    def submit_term_preferences(self, entries: list[dict[str, Any]]) -> int:
+        normalized = [self._term_preference_entry(entry) for entry in entries]
+        inserted = 0
+        with transaction(self.connection):
+            for entry in normalized:
+                current = self.connection.execute(
+                    """
+                    SELECT preference_id, occurred_at_ms FROM direct_term_preference
+                    WHERE term=?
+                    """,
+                    (entry["term"],),
+                ).fetchone()
+                cursor = self.connection.execute(
+                    """
+                    INSERT OR IGNORE INTO direct_term_preference_history(
+                        preference_id, term, value, blocked, occurred_at_ms
+                    ) VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (
+                        entry["preference_id"],
+                        entry["term"],
+                        entry["value"],
+                        int(entry["blocked"]),
+                        entry["occurred_at_ms"],
+                    ),
+                )
+                if not cursor.rowcount:
+                    continue
+                inserted += 1
+                if current and (
+                    int(current["occurred_at_ms"]),
+                    str(current["preference_id"]),
+                ) >= (entry["occurred_at_ms"], entry["preference_id"]):
+                    self.connection.execute(
+                        """
+                        UPDATE direct_term_preference_history SET replaced_by_id=?
+                        WHERE preference_id=?
+                        """,
+                        (current["preference_id"], entry["preference_id"]),
+                    )
+                    continue
+                if current:
+                    self.connection.execute(
+                        """
+                        UPDATE direct_term_preference_history SET replaced_by_id=?
+                        WHERE preference_id=?
+                        """,
+                        (entry["preference_id"], current["preference_id"]),
+                    )
+                if entry["value"] is None:
+                    self.connection.execute(
+                        "DELETE FROM direct_term_preference WHERE term=?", (entry["term"],)
+                    )
+                else:
+                    self.connection.execute(
+                        """
+                        INSERT INTO direct_term_preference(
+                            term, preference_id, value, blocked, occurred_at_ms
+                        ) VALUES (?, ?, ?, ?, ?)
+                        ON CONFLICT(term) DO UPDATE SET
+                            preference_id=excluded.preference_id,
+                            value=excluded.value,
+                            blocked=excluded.blocked,
+                            occurred_at_ms=excluded.occurred_at_ms
+                        """,
+                        (
+                            entry["term"],
+                            entry["preference_id"],
+                            entry["value"],
+                            int(entry["blocked"]),
+                            entry["occurred_at_ms"],
+                        ),
+                    )
+            if inserted:
+                ModelUpdateCoordinator(self.connection).request("direct_term_preference")
+        return inserted
+
     def submit_sessions(self, entries: list[dict[str, Any]]) -> int:
         sessions = [self._session(entry) for entry in entries]
         inserted = 0
@@ -552,6 +634,32 @@ class InteractionStore:
         return {
             "preference_id": preference_id,
             "tag_id": tag_id,
+            "value": value,
+            "blocked": blocked,
+            "occurred_at_ms": occurred_at_ms,
+        }
+
+    def _term_preference_entry(self, entry: dict[str, Any]) -> dict[str, Any]:
+        preference_id = str(entry.get("preference_id") or "")
+        term = str(entry.get("term") or "").strip().lower()
+        occurred_at_ms = int(entry.get("occurred_at_ms", -1))
+        value = entry.get("value")
+        blocked = bool(entry.get("blocked", False))
+        if value is not None:
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise ValueError("term sentiment must be numeric or null")
+            value = float(value)
+            if value not in TAG_SENTIMENT_VALUES:
+                raise ValueError("term sentiment must use the fixed five-point scale")
+        if blocked:
+            value = BLOCKED_TAG_VALUE
+        if not preference_id or not term or occurred_at_ms < 0:
+            raise ValueError("preference_id, term, and occurred_at_ms are required")
+        if not TERM_TOKEN_RE.fullmatch(term):
+            raise ValueError("term must be a description token ([a-zA-Z]{3,})")
+        return {
+            "preference_id": preference_id,
+            "term": term,
             "value": value,
             "blocked": blocked,
             "occurred_at_ms": occurred_at_ms,

--- a/curator/model/boundaries.py
+++ b/curator/model/boundaries.py
@@ -7,6 +7,7 @@ from collections.abc import Collection
 from itertools import batched
 
 from curator.config import DEFAULT_CONFIG, CuratorConfig
+from curator.model.store import RecommendationModelStore
 
 
 def scene_eligibility(
@@ -56,6 +57,21 @@ def scene_eligibility(
         str(row[0])
         for row in connection.execute("SELECT tag_id FROM direct_tag_preference WHERE blocked=1")
     }
+    blocked_terms = sorted(
+        str(row[0])
+        for row in connection.execute("SELECT term FROM direct_term_preference WHERE blocked=1")
+    )
+    # Blocked-term exclusion maps terms to scenes through the built model's
+    # entity_feature desc rows (the term->scene mapping has no scene_tag join:
+    # a scene "carries" a term only when the model built a desc:<term> feature
+    # for it). Terms the model never qualified simply have no scenes.
+    model_id = RecommendationModelStore(connection).current_model_id()
+    term_feature_version: str | None = None
+    if model_id is not None:
+        row = connection.execute(
+            "SELECT feature_version FROM model_version WHERE model_id=?", (model_id,)
+        ).fetchone()
+        term_feature_version = str(row[0]) if row else None
     # Eligibility probes can cover the whole lane or library, so the scene predicates are
     # batched: one query with tens of thousands of IN placeholders is slow and can exceed
     # SQLite's variable limit, and a per-scene probe is an N+1 that dominates the request.
@@ -82,6 +98,24 @@ def scene_eligibility(
                     AND tag_id IN ({",".join("?" for _ in blocked_tag_ids)})
                     """,
                     (*chunk, *sorted(blocked_tag_ids)),
+                )
+            )
+        if blocked_terms and term_feature_version is not None:
+            blocked_scenes.update(
+                str(row[0])
+                for row in connection.execute(
+                    f"""SELECT DISTINCT ef.entity_id FROM entity_feature ef
+                    JOIN feature_definition fd ON fd.feature_id=ef.feature_id
+                    WHERE ef.feature_version=? AND ef.entity_type='scene'
+                    AND ef.entity_id IN ({placeholders})
+                    AND fd.family='content'
+                    AND fd.name IN ({",".join("?" for _ in blocked_terms)})
+                    """,
+                    (
+                        term_feature_version,
+                        *chunk,
+                        *[f"desc:{term}" for term in blocked_terms],
+                    ),
                 )
             )
     result: dict[str, dict[str, object]] = {}

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -617,6 +617,40 @@ class PreferenceModelBuilder:
                     "learned_confidence": learned.confidence,
                 },
             )
+        term_features = {
+            feature.name.removeprefix("desc:"): feature.feature_id
+            for features in scene_features.values()
+            for feature in features
+            if feature.family == "content" and feature.name.startswith("desc:")
+        }
+        for row in self.connection.execute(
+            "SELECT term, value FROM direct_term_preference ORDER BY term"
+        ):
+            direct_feature_id = term_features.get(str(row["term"]))
+            if direct_feature_id is None:
+                continue
+            learned = result.get(
+                direct_feature_id,
+                _Affinity(direct_feature_id, 0.0, 0.0, 0.0, 0, {}),
+            )
+            direct_support = 8.0
+            direct_value = float(row["value"])
+            result[direct_feature_id] = _Affinity(
+                direct_feature_id,
+                _clamp(
+                    (learned.affinity * learned.support + direct_value * direct_support)
+                    / (learned.support + direct_support)
+                ),
+                max(learned.confidence, 0.9),
+                learned.support + direct_support,
+                learned.scene_count,
+                {
+                    **learned.contexts,
+                    "declared_preference": direct_value,
+                    "learned_affinity": learned.affinity,
+                    "learned_confidence": learned.confidence,
+                },
+            )
         return result
 
     @staticmethod

--- a/curator/ranking/slate.py
+++ b/curator/ranking/slate.py
@@ -884,6 +884,11 @@ class SlateBuilder:
                 "SELECT count(*), coalesce(max(occurred_at_ms), 0) FROM direct_tag_preference"
                 " WHERE blocked=1",
             ),
+            (
+                "blocked_terms",
+                "SELECT count(*), coalesce(max(occurred_at_ms), 0) FROM direct_term_preference"
+                " WHERE blocked=1",
+            ),
             ("files", "SELECT count(*), 0 FROM source_file WHERE available=1"),
         ):
             row = self.connection.execute(sql).fetchone()

--- a/curator/similarity.py
+++ b/curator/similarity.py
@@ -179,6 +179,12 @@ class SimilarityService:
                 "SELECT tag_id FROM direct_tag_preference WHERE blocked=1"
             )
         }
+        blocked_terms = sorted(
+            str(row[0])
+            for row in self.connection.execute(
+                "SELECT term FROM direct_term_preference WHERE blocked=1"
+            )
+        )
         blocked_scenes: set[str] = set()
         if blocked_tag_ids:
             for row in self.connection.execute(
@@ -187,6 +193,16 @@ class SimilarityService:
                 sorted(blocked_tag_ids),
             ):
                 blocked_scenes.add(str(row["scene_id"]))
+        if blocked_terms:
+            for row in self.connection.execute(
+                f"""SELECT DISTINCT ef.entity_id FROM entity_feature ef
+                JOIN feature_definition fd ON fd.feature_id=ef.feature_id
+                WHERE ef.feature_version=? AND ef.entity_type='scene'
+                AND fd.family='content'
+                AND fd.name IN ({",".join("?" for _ in blocked_terms)})""",
+                (self.feature_version, *[f"desc:{term}" for term in blocked_terms]),
+            ):
+                blocked_scenes.add(str(row["entity_id"]))
         results: list[SimilarityResult] = []
         for candidate_id in candidate_ids:
             candidate_appeal = self.appeals[candidate_id]

--- a/curator/storage/sql/0028_direct_term_preferences.sql
+++ b/curator/storage/sql/0028_direct_term_preferences.sql
@@ -1,0 +1,30 @@
+-- Direct description-term preferences: a five-point rating plus an optional
+-- hard block for the description tokens the model already builds as
+-- `desc:<term>` content features. Terms are library-relative tokens from the
+-- same tokenizer (lowercase [a-zA-Z]{3,}, stopword-filtered, TF-IDF-capped);
+-- unlike tags they have no source table, so `term` is stored as plain text.
+-- The shape mirrors 0016/0026 (append-only history + current row, fixed
+-- five-point scale, blocked flag) so the preference queue, staleness
+-- replacement, and model-rebuild trigger behave identically to tags. A
+-- blocked entry stores value -1 and the blocked flag drives hard exclusion.
+
+CREATE TABLE direct_term_preference_history (
+    preference_id TEXT PRIMARY KEY,
+    term TEXT NOT NULL,
+    value REAL CHECK (value IS NULL OR value IN (-1, -0.5, 0, 0.5, 1)),
+    blocked INTEGER NOT NULL DEFAULT 0 CHECK (blocked IN (0, 1)),
+    occurred_at_ms INTEGER NOT NULL CHECK (occurred_at_ms >= 0),
+    replaced_by_id TEXT REFERENCES direct_term_preference_history(preference_id)
+) STRICT;
+
+CREATE INDEX direct_term_preference_history_term_idx
+ON direct_term_preference_history(term, occurred_at_ms);
+
+CREATE TABLE direct_term_preference (
+    term TEXT PRIMARY KEY,
+    preference_id TEXT NOT NULL UNIQUE
+        REFERENCES direct_term_preference_history(preference_id) ON DELETE CASCADE,
+    value REAL NOT NULL CHECK (value IN (-1, -0.5, 0, 0.5, 1)),
+    blocked INTEGER NOT NULL DEFAULT 0 CHECK (blocked IN (0, 1)),
+    occurred_at_ms INTEGER NOT NULL CHECK (occurred_at_ms >= 0)
+) STRICT, WITHOUT ROWID;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -67,7 +67,13 @@ the Python code and the per-platform binaries.
 Curator's settings live with Stash's plugin settings. Useful early choices are:
 
 - **Sidecar database path:** set this before first use if plugin updates or removal
-  may replace the plugin data directory.
+  may replace the plugin data directory. SQLite does not work reliably on network
+  filesystems (NFS/SMB shares): the working sidecar must live on **local** storage.
+  If your plugin data directory is on a share, point this at a local directory and
+  use the **Backup directory** setting for durable copies (below).
+- **Backup directory:** where **Backup Curator data** writes timestamped snapshots.
+  Leave empty to write beside the sidecar. A network share is a fine place for
+  backups — it is the *working* database that must stay local.
 - **Results per page:** defaults to 20 for recommendations, Similar, and Expand.
 - **Disable recommendation variety:** leave unchecked to avoid repeating performers,
   studios, and similar content; check it for score-first ordering.
@@ -101,8 +107,17 @@ database migrations to finish, then load Curator and confirm the model is ready.
 ## Back up and uninstall safely
 
 Run **Backup Curator data** from Stash's Tasks page. The timestamped SQLite backup is
-written beside the sidecar. Keep a copy outside the plugin directory before an
-update or uninstall if that directory may be replaced.
+written beside the sidecar, or into the configured **Backup directory**. The backup
+uses SQLite's backup API, so it is a consistent snapshot even while the sidecar is
+in WAL mode — safe to keep on a network share. Keep a copy outside the plugin
+directory before an update or uninstall if that directory may be replaced.
+
+If your plugin data directory lives on a network share, the recommended layout is
+two paths: **Sidecar database path** on local storage (the hot, lock-contended
+files) and **Backup directory** on the share (durable, crash-consistent snapshots).
+A live WAL database must never be file-copied while Stash is running; restore only
+through the Curator **Backups** view, which uses the backup API and validates the
+snapshot first.
 
 The Curator **Backups** view can also create, restore, and delete recognized backups.
 Restoring first creates a safety copy of the current sidecar, then invalidates the

--- a/docs/handover.md
+++ b/docs/handover.md
@@ -52,6 +52,60 @@ plugin zip with runtime select and a pure-Python fallback.
 
 ## Next work package
 
+**Open-issues follow-up (issues #92, #93, #94, #95, #103, #109, #110) —
+delivered (2026-08-11) on `fix/slice4-open-issues` (stacked on
+`feat/slice4-frontend-parity`).** A single package closing the seven open
+issues:
+
+- **#92** — the compact tag-rating rows reserve the Clear slot (`visibility:
+  hidden` placeholder) so rated and unrated rows align, and the card action
+  row renders above the expanded list.
+- **#93** — `get_scene_tag_choices` op (scene's classified tags, alphabetical,
+  with direct preferences) plus the "Rate tags & terms" panel on
+  recommendation lanes and library Similar cards (outside `card-section`, so
+  the SFW Switch contract holds).
+- **#94** — migration 0028 (`direct_term_preference` + history, mirroring
+  0016/0026), `get_scene_description_tokens` + `submit_term_preferences` ops
+  (Go + Python oracle), the direct-term affinity blend in the model build,
+  blocked-term enforcement (lanes via `entity_feature` mapping, Similar,
+  remote Expand via description tokenization; the slate eligibility
+  fingerprint gained a `blocked_terms` digest), and the merged
+  tags-and-terms expander on external, recommendation, and Similar cards.
+  Terms are truthful to the built model (never re-tokenized for display).
+- **#95** — remote scenes are ranked by description term affinity: a new
+  `0.10 * term_value` component (weights renormalized to
+  `0.40/0.10/0.25/0.10/0.15`), blocked terms exclude remote candidates whose
+  description tokens carry them, and `_why`/`expandWhy` name positive term
+  contributions. Local Similar's content dot-product is intentionally
+  unchanged (affinities are not blended into vectors).
+- **#109** — root-caused: concurrent first opens of a WAL sidecar race on the
+  `-shm` recovery lock and fail *instantly* with `database is locked (5)`
+  (the busy handler does not cover it; reproduced by a new contention test).
+  The whole `openSidecar` phase plus `withTxn`/`execImmediate` now retry busy
+  failures (bounded, 150/300 ms backoff; COMMIT failures are never retried),
+  and the frontend maps surviving lock errors to an actionable
+  `databasePath`-on-local-storage message. `busy_timeout` itself is honored
+  for ordinary contention (verified 30 s waits).
+- **#110** — the expand-refresh marker stream gained dense ticks for the
+  previously markerless pre-work (external-links walk 0.05→0.08, taxonomy
+  and seed phases bracketed at 50/150 ticks inside 0.08→0.98), matched
+  Go/Python, and the task indicator shows a completed job at 100% ("Done")
+  for 15 s instead of reverting to idle at the last sub-100% value.
+- **#103** — the two-path layout is documented in `getting-started.md` and
+  `privacy.md`: the working sidecar on local storage, backups (SQLite backup
+  API, WAL-consistent) on the network share via `backupPath`. No sync task
+  (deferred); #109's retry + message is the mitigation until the layout is
+  applied.
+
+Delivery details: migration 0028 is byte-identical in
+`core/migrations/` and `curator/storage/sql/` (checksum-guarded); all new
+ops have Go/Python byte-identical differential tests
+(`tests/core/test_backend_slice4.py`, `test_backend_slice3_modelbuild.py`,
+`test_backend_slice3_writes.py`); blocked-term and ranking behavior has
+synthetic tests (`tests/ranking/test_slate.py`,
+`tests/model/test_multi_hop.py`, `tests/test_expand.py`,
+`tests/test_interactions.py`); `scripts/verify full` passes (490 tests).
+
 **Full Go backend (Phase 4), Slice 4 — frontend parity + cleanup — delivered
 (2026-08-11).** Slices 0–4 are complete: the binary serves every operation,
 task mode, and the `entity-sync` hook mode the frontend or Stash can invoke

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -38,9 +38,14 @@ entity IDs, and personal evaluation notes out of shared repositories.
 ## Backups, reset, and uninstall
 
 The default sidecar is `{pluginDir}/data/curator.sqlite3`. Configure another path
-before first use if plugin lifecycle operations may replace that directory. The
-**Backup Curator data** task creates a timestamped SQLite backup. Copy it somewhere
-safe before updates or uninstalling.
+before first use if plugin lifecycle operations may replace that directory. SQLite
+needs POSIX locking that network filesystems do not provide, so the working sidecar
+must stay on **local** storage; point the **Sidecar database path** at a local
+directory when the plugin data directory is on a share. The **Backup Curator data**
+task creates a timestamped SQLite backup via SQLite's backup API (a consistent
+snapshot even in WAL mode) — that copy is the right thing to keep on a network share,
+configured with the **Backup directory** setting. Copy it somewhere safe before
+updates or uninstalling.
 
 The Curator **Backups** view can restore a recognized backup. It first creates a
 safety copy of the current sidecar, then invalidates the current recommendation

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -260,11 +260,15 @@ def _external_links(
     connection: sqlite3.Connection | None = None,
     *,
     refresh: bool = False,
+    progress: Callable[[int, int], None] | None = None,
 ) -> dict[str, dict[str, str]]:
     """Map local entities to their StashDB ids, reusing the last scan while Stash is unchanged.
 
     Rebuilding this walks every linked scene for its fingerprints, which dominates the cost of
     the operations that need it, so it is kept until Stash reports a different library.
+    progress, when non-nil, receives (processed, total) page ticks over the
+    walk (issue #110: the expand-refresh bar used to sit at 5% for the whole
+    library walk).
     """
     state = _external_links_state(payload) if connection is not None else ""
     if connection is not None and not refresh:
@@ -306,6 +310,9 @@ def _external_links(
                                 if value:
                                     result["scene_phashes"].setdefault(value, str(row["id"]))
             more |= page * 500 < int(collection["count"])
+        if progress:
+            total = max(int(data[kind]["count"]) for kind in ("scenes", "performers", "studios"))
+            progress(min(page * 500, total), total)
         if not more:
             break
         page += 1
@@ -856,6 +863,15 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
             if not isinstance(tags, list):
                 raise ValueError("tags must be a list")
             return api.external_tag_choices(tags)
+        if operation == "get_scene_tag_choices":
+            return api.get_scene_tag_choices(str(args.get("scene_id") or ""))
+        if operation == "get_scene_description_tokens":
+            return api.get_scene_description_tokens(str(args.get("scene_id") or ""))
+        if operation == "submit_term_preferences":
+            entries = args.get("entries")
+            if not isinstance(entries, list):
+                raise ValueError("entries must be a list")
+            return api.submit_term_preferences(entries)
         if operation == "submit_events":
             entries = args.get("entries")
             if not isinstance(entries, list):
@@ -1527,11 +1543,16 @@ def _run_task_body(
                 summary = ExpandService(connection).refresh(
                     _stashdb(payload),
                     # The refresh task is the escape hatch when Stash under-reports a change.
-                    _external_links(payload, connection, refresh=True),
+                    _external_links(
+                        payload,
+                        connection,
+                        refresh=True,
+                        progress=_mapped_progress(0.05, 0.08),
+                    ),
                     horizon_days=int(config["expand_horizon_days"]),
                     gender=str(config["expand_gender"]),
                     wildcard=bool(config["expand_wildcard"]),
-                    progress=_mapped_progress(0.05, 0.98),
+                    progress=_mapped_progress(0.08, 0.98),
                 )
             _progress(0.98)
         else:

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -271,6 +271,10 @@
   white-space: nowrap;
 }
 
+.curator-sentiment-clear-placeholder {
+  visibility: hidden;
+}
+
 .curator-sentiment .btn-sm {
   font-size: 0.75rem;
   padding: 0.15rem 0.4rem;
@@ -375,6 +379,17 @@
   font-size: 0.7rem;
   min-width: 1.45rem;
   padding: 0.12rem 0.25rem;
+}
+
+.curator-rating-section {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.curator-rating-section-title {
+  color: var(--text-muted, #adb5bd);
+  font-size: 0.75rem;
+  font-weight: 600;
 }
 
 .curator-profiling-toolbar {
@@ -600,6 +615,15 @@
 .curator-task-indicator-failed .curator-task-progress-fill {
   background: #dc3545;
   width: 100%;
+}
+
+.curator-task-indicator-done .curator-task-progress-fill {
+  background: var(--success, #198754);
+  width: 100%;
+}
+
+.curator-task-indicator-done .curator-task-progress-meta strong {
+  color: var(--success, #198754);
 }
 
 .curator-task-indicator-idle .curator-task-progress-fill {

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -117,6 +117,7 @@
   const laneByValue = new Map(LANES.map((lane) => [lane.value, lane]));
   const EVENT_QUEUE_KEY = "stash-curator:event-queue:v1";
   const TAG_PREFERENCE_QUEUE_KEY = "stash-curator:tag-preference-queue:v1";
+  const TERM_PREFERENCE_QUEUE_KEY = "stash-curator:term-preference-queue:v1";
   const ORIGIN_KEY = "stash-curator:origin:v1";
   const SLATE_CACHE_KEY = "stash-curator:slates:v1";
   const FILTER_PRESETS_KEY = "stash-curator:filter-presets:v1";
@@ -169,6 +170,16 @@
     return crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`;
   }
 
+  // actionError adds an actionable hint to SQLite busy/lock failures (#109):
+  // the working sidecar must live on local storage, not a network share.
+  function actionError(message) {
+    const text = String(message || "");
+    if (/database is locked|database is busy|SQLITE_BUSY/i.test(text)) {
+      return `${text} — Curator could not access its database. If this repeats, move the Sidecar database path to local storage and keep backups on the network share (plugin settings).`;
+    }
+    return text;
+  }
+
   async function operation(args, timeoutMs = 30000) {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -192,6 +203,7 @@
       return payload.data.runPluginOperation;
     } catch (error) {
       if (error.name === "AbortError") throw new Error("Curator operation timed out");
+      error.message = actionError(error.message);
       throw error;
     } finally {
       clearTimeout(timeout);
@@ -465,6 +477,7 @@
   ];
 
   function TagSentimentControl({ tag, value, blocked, onChange, compact = false }) {
+    const rated = value !== null && value !== undefined || blocked;
     return React.createElement(
       "div",
       { className: `curator-sentiment${compact ? " curator-sentiment-compact" : ""}`, role: "group", "aria-label": `Sentiment for ${tag.name}` },
@@ -474,7 +487,7 @@
         const shortLabel = score === -1 ? "--" : score === -0.5 ? "-" : score === 0 ? "0" : score === 0.5 ? "+" : "++";
         return React.createElement(Button, { key: score, size: "sm", className: `${cls}${selected ? " curator-sentiment-active" : ""}`, "aria-pressed": selected, "aria-label": label, title: label, onClick: () => onChange({ value: score, blocked: false }) }, compact ? shortLabel : label);
       }),
-      (value !== null && value !== undefined || blocked) && React.createElement(Button, { size: "sm", variant: "link", "aria-label": "Clear answer", title: "Clear answer", onClick: () => onChange({ value: null, blocked: false }) }, compact ? "Clear" : "Clear answer")
+      (rated || compact) && React.createElement(Button, { size: "sm", variant: "link", className: compact && !rated ? "curator-sentiment-clear-placeholder" : undefined, "aria-label": "Clear answer", title: "Clear answer", onClick: () => onChange({ value: null, blocked: false }) }, compact ? "Clear" : "Clear answer")
     );
   }
 
@@ -511,6 +524,145 @@
     queue.push({ preference_id: uuid(), tag_id: tagId, value, blocked: !!blocked, occurred_at_ms: Date.now() });
     localStorage.setItem(TAG_PREFERENCE_QUEUE_KEY, JSON.stringify(queue));
     flushTagPreferenceQueue();
+  }
+
+  function readTermPreferenceQueue() {
+    try {
+      const value = JSON.parse(localStorage.getItem(TERM_PREFERENCE_QUEUE_KEY) || "[]");
+      return Array.isArray(value) ? value : [];
+    } catch (_) {
+      return [];
+    }
+  }
+
+  let flushingTermPreferences = false;
+  async function flushTermPreferenceQueue() {
+    if (flushingTermPreferences) return;
+    const entries = readTermPreferenceQueue();
+    if (!entries.length) return;
+    flushingTermPreferences = true;
+    try {
+      await operation({ operation: "submit_term_preferences", entries });
+      const sent = new Set(entries.map((entry) => entry.preference_id));
+      localStorage.setItem(TERM_PREFERENCE_QUEUE_KEY, JSON.stringify(readTermPreferenceQueue().filter((entry) => !sent.has(entry.preference_id))));
+      clearSlateCache();
+      scheduleModelUpdate();
+    } catch (_) {
+      // Retry on the next route, online event, or plugin page load.
+    } finally {
+      flushingTermPreferences = false;
+    }
+  }
+
+  function submitTermPreference(term, {value, blocked}) {
+    const queue = readTermPreferenceQueue();
+    queue.push({ preference_id: uuid(), term, value, blocked: !!blocked, occurred_at_ms: Date.now() });
+    localStorage.setItem(TERM_PREFERENCE_QUEUE_KEY, JSON.stringify(queue));
+    flushTermPreferenceQueue();
+  }
+
+  // RatingRows renders one sentiment row (name + compact TagSentimentControl).
+  // Shared by the external, recommendation, and Similar cards' rating panels.
+  function RatingRows({ rows, onAnswer, emptyLabel }) {
+    if (!rows.length) {
+      return React.createElement("small", null, emptyLabel);
+    }
+    return rows.map((row) =>
+      React.createElement(
+        "div",
+        { key: row.key, className: "curator-external-tag-row" },
+        React.createElement("strong", { className: "curator-external-tag-name" }, row.name),
+        React.createElement(TagSentimentControl, {
+          tag: { name: row.name },
+          value: row.direct_value,
+          blocked: row.direct_blocked,
+          compact: true,
+          onChange: (value) => onAnswer(row, value),
+        })
+      )
+    );
+  }
+
+  // RatingSection is one titled block of sentiment rows inside a rating panel.
+  function RatingSection({ title, rows, onAnswer, emptyLabel }) {
+    return React.createElement(
+      "div",
+      { className: "curator-rating-section" },
+      React.createElement("strong", { className: "curator-rating-section-title" }, `${title} (${rows.length})`),
+      React.createElement(RatingRows, { rows, onAnswer, emptyLabel })
+    );
+  }
+
+  // LocalRatingPanel is the "Rate tags & terms" expander for local cards
+  // (recommendation lanes and library Similar): the scene's classified tags
+  // (get_scene_tag_choices) plus its built description terms. The toggle
+  // renders above the expanded list, and the panel sits outside card-section
+  // so the SFW Switch contract holds.
+  function LocalRatingPanel({ sceneId }) {
+    const [open, setOpen] = React.useState(false);
+    const [tagChoices, setTagChoices] = React.useState(null);
+    const [termChoices, setTermChoices] = React.useState(null);
+    const [loading, setLoading] = React.useState(false);
+    const [error, setError] = React.useState("");
+    useCuratorActivity(`local-tags-${sceneId}`, loading, "Matching local tags…");
+    async function toggle() {
+      if (open) {
+        setOpen(false);
+        return;
+      }
+      setOpen(true);
+      setLoading(true);
+      setError("");
+      try {
+        const [tagsResult, termsResult] = await Promise.all([
+          operation({ operation: "get_scene_tag_choices", scene_id: sceneId }),
+          operation({ operation: "get_scene_description_tokens", scene_id: sceneId }),
+        ]);
+        setTagChoices(tagsResult.items);
+        setTermChoices(termsResult.items);
+      } catch (failure) {
+        setError(failure.message);
+        setTagChoices([]);
+        setTermChoices([]);
+      } finally {
+        setLoading(false);
+      }
+    }
+    function answerTag(row, {value, blocked}) {
+      submitTagPreference(row.tag_id, {value, blocked});
+      setTagChoices((current) => current.map((item) => item.tag_id === row.tag_id ? { ...item, direct_value: value, direct_blocked: !!blocked } : item));
+    }
+    function answerTerm(row, {value, blocked}) {
+      submitTermPreference(row.term, {value, blocked});
+      setTermChoices((current) => current.map((item) => item.term === row.term ? { ...item, direct_value: value, direct_blocked: !!blocked } : item));
+    }
+    return React.createElement(
+      React.Fragment,
+      null,
+      React.createElement(
+        Button,
+        { className: "curator-icon-action", size: "sm", variant: open ? "primary" : "secondary", title: "Rate tags & terms", "aria-label": "Rate tags & terms", "aria-pressed": open, onClick: toggle },
+        React.createElement(FontAwesomeIcon, { icon: faTag })
+      ),
+      open && React.createElement(
+        "div",
+        { className: "curator-external-tag-rating" },
+        React.createElement(
+          "div",
+          { className: "curator-external-tag-rating-header" },
+          React.createElement("strong", null, "Rate tags & terms"),
+          React.createElement(Button, { size: "sm", variant: "link", className: "curator-external-tag-rating-close", "aria-label": "Collapse matching local tag ratings", title: "Collapse matching local tag ratings", onClick: toggle }, "Collapse")
+        ),
+        loading && React.createElement("small", { role: "status" }, "Matching local tags…"),
+        error && React.createElement("small", { className: "text-danger", role: "status" }, error),
+        !loading && !error && React.createElement(
+          React.Fragment,
+          null,
+          React.createElement(RatingSection, { title: "Matching local tags", rows: tagChoices.map((tag) => ({ key: tag.tag_id, tag_id: tag.tag_id, name: tag.name, direct_value: tag.direct_value, direct_blocked: tag.direct_blocked })), onAnswer: answerTag, emptyLabel: "No matching local tags." }),
+          React.createElement(RatingSection, { title: "Description terms", rows: termChoices.map((term) => ({ key: term.term, term: term.term, name: term.term, direct_value: term.direct_value, direct_blocked: term.direct_blocked })), onAnswer: answerTerm, emptyLabel: "No description terms in the model." })
+        )
+      )
+    );
   }
 
   function TasteProfilePanel() {
@@ -671,6 +823,7 @@
     const [copied, setCopied] = React.useState(false);
     const [whisparr, setWhisparr] = React.useState(null);
     const [tagChoices, setTagChoices] = React.useState(null);
+    const [termChoices, setTermChoices] = React.useState(null);
     const [tagLoading, setTagLoading] = React.useState(false);
     const [tagError, setTagError] = React.useState("");
     useCuratorActivity(`external-tags-${kind}-${item.id}`, tagLoading, "Matching local tags…");
@@ -713,25 +866,38 @@
       }
     }
     async function rateTags() {
-      if (tagChoices !== null) return setTagChoices(null);
+      if (tagChoices !== null) {
+        setTagChoices(null);
+        setTermChoices(null);
+        return;
+      }
       setTagLoading(true);
       setTagError("");
       try {
-        const result = await operation({
-          operation: "get_external_tag_choices",
-          tags: tags.map((tag) => ({ id: tag.id, name: tag.name })),
-        });
-        setTagChoices(result.items);
+        const [tagsResult, termsResult] = await Promise.all([
+          operation({
+            operation: "get_external_tag_choices",
+            tags: tags.map((tag) => ({ id: tag.id, name: tag.name })),
+          }),
+          operation({ operation: "get_scene_description_tokens", scene_id: item.id }),
+        ]);
+        setTagChoices(tagsResult.items);
+        setTermChoices(termsResult.items);
       } catch (failure) {
         setTagError(failure.message);
         setTagChoices([]);
+        setTermChoices([]);
       } finally {
         setTagLoading(false);
       }
     }
-    function answerTag(tag, {value, blocked}) {
-      submitTagPreference(tag.tag_id, {value, blocked});
-      setTagChoices((current) => current.map((item) => item.tag_id === tag.tag_id ? { ...item, direct_value: value, direct_blocked: !!blocked } : item));
+    function answerTag(row, {value, blocked}) {
+      submitTagPreference(row.tag_id, {value, blocked});
+      setTagChoices((current) => current.map((item) => item.tag_id === row.tag_id ? { ...item, direct_value: value, direct_blocked: !!blocked } : item));
+    }
+    function answerTerm(row, {value, blocked}) {
+      submitTermPreference(row.term, {value, blocked});
+      setTermChoices((current) => current.map((item) => item.term === row.term ? { ...item, direct_value: value, direct_blocked: !!blocked } : item));
     }
     return React.createElement(
       "article",
@@ -742,8 +908,8 @@
       React.createElement("div", { className: `curator-external-thumbnail thumbnail-section ${kind === "scene" ? "video-section" : ""}` }, React.createElement("a", { className: `${kind}-card-link`, href, target: "_blank", rel: "noreferrer" }, image && React.createElement("img", { className: `${kind}-card-image`, src: image, loading: "lazy", alt: "" })), kind === "scene" && payload.studio?.name && React.createElement("span", { className: "curator-external-studio-overlay" }, payload.studio.name)),
       React.createElement("div", { className: "card-section" }, React.createElement(TitleLink, localProfile, React.createElement("h5", { className: "card-section-title flex-aligned" }, title)), React.createElement("div", { className: kind === "scene" ? "scene-card__details" : "curator-external-details" }, React.createElement("span", null, payload.release_date || payload.birth_date || ""), metadataControls), kind === "scene" && payload.details && React.createElement("p", { className: "curator-card-description" }, payload.details)),
       React.createElement("div", { className: "curator-card-body" }, (() => { let scoreDetail; if (item.similarity === undefined) { scoreDetail = `Match ${item.score.toFixed(2)} · found via ${item.sources.join(", ")}`; } else { scoreDetail = `Similarity ${item.similarity.toFixed(2)}` + (item.appeal !== undefined ? ` · appeal ${item.appeal.toFixed(2)}` : ""); const mh = item.details && item.details.score_breakdown && item.details.score_breakdown.multi_hop; if (mh > 0) scoreDetail += " + multi-hop " + mh.toFixed(4); } return React.createElement("div", { className: "curator-card-details" }, payload.why?.length && React.createElement("details", { className: "curator-evidence" }, React.createElement("summary", null, "Why this?"), React.createElement("p", { className: "curator-explanation" }, payload.why.join(" · "))), React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, `Score · ${item.score.toFixed(2)}`), scoreBar(item), React.createElement("p", null, scoreDetail))); })()),
-      kind === "scene" && tagChoices !== null && React.createElement("div", { className: "curator-external-tag-rating" }, React.createElement("div", { className: "curator-external-tag-rating-header" }, React.createElement("strong", null, `Matching local tags (${tagChoices.length})`), React.createElement(Button, { size: "sm", variant: "link", className: "curator-external-tag-rating-close", "aria-label": "Collapse matching local tag ratings", title: "Collapse matching local tag ratings", onClick: rateTags }, "Collapse")), tagLoading && React.createElement("small", { role: "status" }, "Matching local tags…"), tagError && React.createElement("small", { className: "text-danger", role: "status" }, tagError), !tagLoading && !tagError && tagChoices.length === 0 && React.createElement("small", null, "No matching local tags."), tagChoices.map((tag) => React.createElement("div", { key: tag.tag_id, className: "curator-external-tag-row" }, React.createElement("strong", { className: "curator-external-tag-name" }, tag.name), React.createElement(TagSentimentControl, { tag, value: tag.direct_value, blocked: tag.direct_blocked, compact: true, onChange: (value) => answerTag(tag, value) })))),
-      React.createElement("div", { className: "curator-prune-actions" }, React.createElement("a", { className: "btn btn-secondary btn-sm curator-icon-action", href, target: "_blank", rel: "noreferrer", title: "Open on StashDB", "aria-label": "Open on StashDB" }, React.createElement(FontAwesomeIcon, { icon: faExternalLinkAlt })), React.createElement(Button, { className: "curator-icon-action", size: "sm", title: copied ? "Copied" : "Copy StashDB ID", "aria-label": copied ? "Copied" : "Copy StashDB ID", onClick: async () => { try { await copyText(item.id); setCopied(true); setTimeout(() => setCopied(false), 1500); } catch (_) { setCopied(false); } } }, React.createElement(FontAwesomeIcon, { icon: copied ? faCheckCircle : faCopy })), onShortlist && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: item.shortlisted ? "primary" : "secondary", title: item.shortlisted ? "Remove from shortlist" : "Add to shortlist", "aria-label": item.shortlisted ? "Remove from shortlist" : "Add to shortlist", onClick: () => onShortlist(item, kind) }, React.createElement(FontAwesomeIcon, { icon: faList })), kind === "scene" && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: tagChoices !== null ? "primary" : "secondary", disabled: tags.length === 0 || tagLoading, title: "Rate matching local tags", "aria-label": "Rate matching local tags", onClick: rateTags }, React.createElement(FontAwesomeIcon, { icon: faTag })), kind === "performer" && onShowScenes && React.createElement(Button, { className: "curator-icon-action", size: "sm", title: "Show this performer's scenes", "aria-label": "Show this performer's scenes", onClick: () => onShowScenes(item) }, React.createElement(FontAwesomeIcon, { icon: faFilm })), kind === "scene" && onWhisparr && React.createElement(Button, { className: "curator-icon-action curator-whisparr-action", size: "sm", variant: "primary", disabled: !whisparrEnabled || whisparr?.status === "adding" || whisparr?.status === "sent" || whisparr?.status === "already_exists", title: !whisparrEnabled ? "Configure Whisparr in plugin settings" : whisparr?.status === "error" ? "Retry sending to Whisparr" : "Send to Whisparr", "aria-label": !whisparrEnabled ? "Whisparr is not configured" : whisparr?.status === "error" ? "Retry sending to Whisparr" : "Send to Whisparr", onClick: addToWhisparr }, React.createElement("span", { className: "curator-whisparr-logo", "aria-hidden": "true" }, React.createElement("span", { className: "curator-whisparr-fallback" }, "W"), React.createElement("img", { src: WHISPARR_LOGO, alt: "", onError: (event) => event.currentTarget.remove() }))), whisparr && React.createElement("small", { className: `curator-whisparr-status ${whisparr.status === "error" ? "text-danger" : ""}`, role: "status" }, whisparr.message))
+      React.createElement("div", { className: "curator-prune-actions" }, React.createElement("a", { className: "btn btn-secondary btn-sm curator-icon-action", href, target: "_blank", rel: "noreferrer", title: "Open on StashDB", "aria-label": "Open on StashDB" }, React.createElement(FontAwesomeIcon, { icon: faExternalLinkAlt })), React.createElement(Button, { className: "curator-icon-action", size: "sm", title: copied ? "Copied" : "Copy StashDB ID", "aria-label": copied ? "Copied" : "Copy StashDB ID", onClick: async () => { try { await copyText(item.id); setCopied(true); setTimeout(() => setCopied(false), 1500); } catch (_) { setCopied(false); } } }, React.createElement(FontAwesomeIcon, { icon: copied ? faCheckCircle : faCopy })), onShortlist && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: item.shortlisted ? "primary" : "secondary", title: item.shortlisted ? "Remove from shortlist" : "Add to shortlist", "aria-label": item.shortlisted ? "Remove from shortlist" : "Add to shortlist", onClick: () => onShortlist(item, kind) }, React.createElement(FontAwesomeIcon, { icon: faList })), kind === "scene" && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: tagChoices !== null ? "primary" : "secondary", disabled: tags.length === 0 || tagLoading, title: "Rate tags & terms", "aria-label": "Rate tags & terms", onClick: rateTags }, React.createElement(FontAwesomeIcon, { icon: faTag })), kind === "performer" && onShowScenes && React.createElement(Button, { className: "curator-icon-action", size: "sm", title: "Show this performer's scenes", "aria-label": "Show this performer's scenes", onClick: () => onShowScenes(item) }, React.createElement(FontAwesomeIcon, { icon: faFilm })), kind === "scene" && onWhisparr && React.createElement(Button, { className: "curator-icon-action curator-whisparr-action", size: "sm", variant: "primary", disabled: !whisparrEnabled || whisparr?.status === "adding" || whisparr?.status === "sent" || whisparr?.status === "already_exists", title: !whisparrEnabled ? "Configure Whisparr in plugin settings" : whisparr?.status === "error" ? "Retry sending to Whisparr" : "Send to Whisparr", "aria-label": !whisparrEnabled ? "Whisparr is not configured" : whisparr?.status === "error" ? "Retry sending to Whisparr" : "Send to Whisparr", onClick: addToWhisparr }, React.createElement("span", { className: "curator-whisparr-logo", "aria-hidden": "true" }, React.createElement("span", { className: "curator-whisparr-fallback" }, "W"), React.createElement("img", { src: WHISPARR_LOGO, alt: "", onError: (event) => event.currentTarget.remove() }))), whisparr && React.createElement("small", { className: `curator-whisparr-status ${whisparr.status === "error" ? "text-danger" : ""}`, role: "status" }, whisparr.message)),
+      kind === "scene" && tagChoices !== null && React.createElement("div", { className: "curator-external-tag-rating" }, React.createElement("div", { className: "curator-external-tag-rating-header" }, React.createElement("strong", null, "Rate tags & terms"), React.createElement(Button, { size: "sm", variant: "link", className: "curator-external-tag-rating-close", "aria-label": "Collapse matching local tag ratings", title: "Collapse matching local tag ratings", onClick: rateTags }, "Collapse")), tagLoading && React.createElement("small", { role: "status" }, "Matching local tags…"), tagError && React.createElement("small", { className: "text-danger", role: "status" }, tagError), !tagLoading && !tagError && React.createElement(React.Fragment, null, React.createElement(RatingSection, { title: "Matching local tags", rows: tagChoices.map((tag) => ({ key: tag.tag_id, tag_id: tag.tag_id, name: tag.name, direct_value: tag.direct_value, direct_blocked: tag.direct_blocked })), onAnswer: answerTag, emptyLabel: "No matching local tags." }), React.createElement(RatingSection, { title: "Description terms", rows: termChoices.map((term) => ({ key: term.term, term: term.term, name: term.term, direct_value: term.direct_value, direct_blocked: term.direct_blocked })), onAnswer: answerTerm, emptyLabel: "No description terms in the model." })))
     );
   });
 
@@ -1020,6 +1186,7 @@
       React.createElement(
         "div",
         { className: "curator-card-body" },
+        scene && React.createElement(LocalRatingPanel, { sceneId: item.scene_id }),
         React.createElement(
           "div",
           { className: "curator-card-details" },
@@ -1423,7 +1590,7 @@
         items.map((item) => {
           const entity = entities.get(String(item.entity_id));
           if (!entity) return null;
-          const body = React.createElement("div", { className: "curator-card-body" }, React.createElement("div", { className: "curator-card-details" }, React.createElement("details", { className: "curator-evidence" }, React.createElement("summary", null, "Why this?"), React.createElement("p", { className: "curator-explanation" }, relationshipChips(item))), React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, `Score · ${item.rank_score.toFixed(2)}`), scoreBar(item), React.createElement("p", null, `Similarity ${item.similarity.toFixed(2)} · predicted appeal ${item.appeal.toFixed(2)}`))));
+          const body = React.createElement("div", { className: "curator-card-body" }, entityType === "scene" && React.createElement(LocalRatingPanel, { sceneId: item.entity_id }), React.createElement("div", { className: "curator-card-details" }, React.createElement("details", { className: "curator-evidence" }, React.createElement("summary", null, "Why this?"), React.createElement("p", { className: "curator-explanation" }, relationshipChips(item))), React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, `Score · ${item.rank_score.toFixed(2)}`), scoreBar(item), React.createElement("p", null, `Similarity ${item.similarity.toFixed(2)} · predicted appeal ${item.appeal.toFixed(2)}`))));
           if (entityType === "performer") return React.createElement("article", { key: item.entity_id, className: "curator-card" }, React.createElement(PerformerCard, { performer: entity }), body);
           const feedbackItem = { ...item, scene_id: item.entity_id, impression_id: result.impression_id };
           function rememberOrigin(event) {
@@ -1976,7 +2143,32 @@
     return stage;
   }
 
-  function CuratorTaskIndicator({ activeJobs, activities, failure }) {
+  const TASK_MODE_LABELS = {
+    "sync-build": "Sync and build recommendations",
+    "full-sync-build": "Full sync and build recommendations",
+    build: "Rebuild recommendation model",
+    "update-model": "Apply recent Curator feedback",
+    prepare: "Prepare recommendation pages",
+    "sync-plays": "Sync recent plays",
+    backup: "Backup Curator data",
+    compact: "Compact legacy Curator data",
+    vacuum: "Vacuum compacted Curator data",
+    "expand-refresh": "Refresh Expand cache",
+  };
+
+  function taskModeLabel(job) {
+    return TASK_MODE_LABELS[job?.job_type] || "Curator task";
+  }
+
+  // doneJob is a curator_job row that just completed; the indicator shows it
+  // at 100% ("Done") until it ages out (issue #110: the final 1.0 marker
+  // leaves Stash's queue before the 5 s poll can catch it, so the bar used
+  // to freeze at the last sub-100% value and then revert to idle).
+  function CuratorTaskIndicator({ activeJobs, activities, failure, doneJob }) {
+    const running = activeJobs.length > 0 || activities.length > 0;
+    const doneTask = !running && doneJob
+      ? { key: `done-${doneJob.job_id}`, label: taskModeLabel(doneJob), progress: 1, stage: "Done" }
+      : null;
     const tasks = [
       ...activeJobs.map((job) => ({
         key: `job-${job.id}`,
@@ -1985,18 +2177,20 @@
         stage: curatorTaskStage(job),
       })),
       ...activities.map((activity) => ({ ...activity, stage: activity.label })),
+      ...(doneTask ? [doneTask] : []),
     ];
-    const running = tasks.length > 0;
     const primary = tasks[0];
-    const state = running ? "running" : failure ? "failed" : "idle";
+    const state = running ? "running" : failure ? "failed" : doneTask ? "done" : "idle";
     const progress = primary?.progress ?? null;
-    const showTaskDetails = activeJobs.length > 0 || state === "failed";
+    const showTaskDetails = running || state === "failed" || state === "done";
     const detail = tasks.map((task) => `${task.label}: ${task.stage}`).join("; ");
     const label = running
       ? `${tasks.length} Curator task${tasks.length === 1 ? "" : "s"} running: ${detail}`
       : failure
-        ? `Last Curator task failed: ${failure.error || "Open Tasks for details"}`
-        : "Curator is idle";
+        ? `Last Curator task failed: ${actionError(failure.error || "Open Tasks for details")}`
+        : doneTask
+          ? `Curator task complete: ${doneTask.label}`
+          : "Curator is idle";
     return React.createElement(
       NavLink,
       { className: `curator-task-indicator curator-task-indicator-${state}`, to: "/settings?tab=tasks", title: `${label}. Open Tasks`, "aria-label": `${label}. Open Tasks` },
@@ -2006,15 +2200,15 @@
         showTaskDetails && React.createElement(
           "span",
           { className: "curator-task-progress-meta" },
-          React.createElement("strong", null, running ? progress === null ? "Working" : `${Math.round(progress * 100)}%` : "Failed"),
+          React.createElement("strong", null, running ? progress === null ? "Working" : `${Math.round(progress * 100)}%` : doneTask ? "Done" : "Failed"),
           running && tasks.length > 1 && React.createElement("span", null, `${tasks.length} tasks`)
         ),
         React.createElement(
           "span",
           { className: `curator-task-progress-track${running && progress === null ? " curator-task-progress-indeterminate" : ""}` },
-          React.createElement("span", { className: "curator-task-progress-fill", style: running && progress !== null ? { width: `${Math.round(progress * 100)}%` } : undefined })
+          React.createElement("span", { className: "curator-task-progress-fill", style: (running || doneTask) && progress !== null ? { width: `${Math.round(progress * 100)}%` } : undefined })
         ),
-        showTaskDetails && React.createElement("span", { className: "curator-task-progress-detail" }, running ? primary?.stage : failure.error || "Open Tasks for details")
+        showTaskDetails && React.createElement("span", { className: "curator-task-progress-detail" }, running ? primary?.stage : doneTask ? "Done" : failure.error || "Open Tasks for details")
       )
     );
   }
@@ -2045,7 +2239,12 @@
       refreshStatus();
     }, []);
     React.useEffect(() => {
-      if (!health?.active_jobs?.length && !health?.active_job) return undefined;
+      // One extra poll shortly after the last active job leaves Stash's queue
+      // so the completed curator_job row (and its summary) is picked up.
+      if (!health?.active_jobs?.length && !health?.active_job) {
+        const timer = setTimeout(refreshStatus, 5000);
+        return () => clearTimeout(timer);
+      }
       const timer = setInterval(refreshStatus, 5000);
       return () => clearInterval(timer);
     }, [Boolean(health?.active_jobs?.length || health?.active_job)]);
@@ -2082,6 +2281,21 @@
     const activeJobs = health?.active_jobs || (health?.active_job ? [health.active_job] : []);
     const activeJob = activeJobs[0];
     const latestFailure = !activeJobs.length && jobs[0]?.state === "failed" ? jobs[0] : null;
+    const recentlyDone =
+      !activeJobs.length && jobs[0]?.state === "complete"
+        ? jobs[0]
+        : null;
+    const [doneExpiredAt, setDoneExpiredAt] = React.useState(0);
+    React.useEffect(() => {
+      if (!recentlyDone) return undefined;
+      const timer = setTimeout(
+        () => setDoneExpiredAt(Date.now()),
+        Math.max(0, recentlyDone.finished_at_ms + 15_000 - Date.now())
+      );
+      return () => clearTimeout(timer);
+    }, [recentlyDone?.job_id]);
+    const doneJob =
+      recentlyDone && recentlyDone.finished_at_ms > doneExpiredAt ? recentlyDone : null;
     const setupChecklist = health && !health.ready && React.createElement(
       "section",
       { className: "curator-setup-checklist", "aria-labelledby": "curator-setup-heading" },
@@ -2113,7 +2327,7 @@
           "div",
           { className: "curator-status", role: "status" },
           React.createElement("span", { title: running ? `Running ${running.job_type}` : hasSynced ? "Library synchronized" : "Library has not been synchronized" }, React.createElement(FontAwesomeIcon, { icon: faDatabase }), running ? "Running" : hasSynced ? "Synced" : "Not synced"),
-          React.createElement(CuratorTaskIndicator, { activeJobs, activities, failure: latestFailure }),
+          React.createElement(CuratorTaskIndicator, { activeJobs, activities, failure: latestFailure, doneJob }),
           React.createElement("span", { title: health?.model_pending ? "Playback and feedback are batched before rebuilding the preference model." : modelStatus }, React.createElement(FontAwesomeIcon, { icon: health?.model_pending ? faClock : health?.ready ? faCheckCircle : faWrench }), modelStatus),
           React.createElement("span", { title: "Playback sessions captured by Curator" }, React.createElement(FontAwesomeIcon, { icon: faPlay }), health?.capture?.direct_playback_sessions || 0),
           health?.last_sync_at_ms && React.createElement("span", { title: `Last sync ${new Date(health.last_sync_at_ms).toLocaleString()}` }, React.createElement(FontAwesomeIcon, { icon: faClock }), new Date(health.last_sync_at_ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }))

--- a/tests/core/test_backend.py
+++ b/tests/core/test_backend.py
@@ -389,7 +389,7 @@ def test_migration_parity_python_accepts_go(tmp_path: Path, binary: Path) -> Non
         integrity = connection.execute("PRAGMA integrity_check").fetchone()[0]
     finally:
         connection.close()
-    assert status.current_version == status.latest_version == 27
+    assert status.current_version == status.latest_version == 28
     assert not status.pending_versions
     assert integrity == "ok"
 

--- a/tests/core/test_backend_slice3_featurebuild.py
+++ b/tests/core/test_backend_slice3_featurebuild.py
@@ -81,6 +81,34 @@ def make_feature_sidecar(path: Path) -> None:
             "INSERT INTO application_meta(key, value)"
             " VALUES ('taxonomy_snapshot_id', 'tax-feature')"
         )
+        # Direct term preferences exercise the affinity blend in the model
+        # build: terms the feature builder emits (romantic/intense/adventure
+        # qualify from the seeded descriptions) get declared evidence blended
+        # with learned affinity, byte-identically in both implementations.
+        connection.executemany(
+            """
+            INSERT INTO direct_term_preference_history(
+                preference_id, term, value, occurred_at_ms, blocked
+            ) VALUES (?, ?, ?, ?, 0)
+            """,
+            [
+                ("term-pref-1", "romantic", 1.0, REFERENCE_MS - 1_000),
+                ("term-pref-2", "intense", -1.0, REFERENCE_MS - 2_000),
+                ("term-pref-3", "adventure", 0.5, REFERENCE_MS - 3_000),
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO direct_term_preference(
+                term, preference_id, value, occurred_at_ms, blocked
+            ) VALUES (?, ?, ?, ?, 0)
+            """,
+            [
+                ("romantic", "term-pref-1", 1.0, REFERENCE_MS - 1_000),
+                ("intense", "term-pref-2", -1.0, REFERENCE_MS - 2_000),
+                ("adventure", "term-pref-3", 0.5, REFERENCE_MS - 3_000),
+            ],
+        )
         connection.commit()
     finally:
         connection.close()

--- a/tests/core/test_backend_slice3_writes.py
+++ b/tests/core/test_backend_slice3_writes.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import ClassVar
@@ -509,6 +510,50 @@ def test_submit_tag_preferences_unknown_tag_byte_identical(
         ],
     )
     assert_slice3_identical(binary, raw, writes_sidecar)
+
+
+# ── concurrency ──────────────────────────────────────────────────────────────
+
+
+def test_concurrent_write_ops_never_surface_database_locked(tmp_path: Path, binary: Path) -> None:
+    """Concurrent plugin processes opening the sidecar at once — the #109
+    multi-tab burst (health polls, hooks, and tasks each spawn a process) —
+    must never surface a SQLite busy error: the 30 s busy_timeout plus the
+    Go-side retry on the extended busy codes absorbs the contention. Every
+    write must land."""
+    sidecar = tmp_path / "curator.sqlite3"
+    make_writes_sidecar(sidecar)
+    raws = [
+        _writes_payload(
+            "submit_tag_preferences",
+            sidecar,
+            "http://127.0.0.1:1",
+            entries=[
+                {
+                    "preference_id": f"concurrent-{index}",
+                    "tag_id": "t1",
+                    "value": 0.5,
+                    "occurred_at_ms": index,
+                }
+            ],
+        )
+        for index in range(12)
+    ]
+    with ThreadPoolExecutor(max_workers=6) as pool:
+        futures = [pool.submit(run_backend, binary, PLUGIN_DIR, raw) for raw in raws]
+        results = [future.result() for future in futures]
+    for result in results:
+        assert result.returncode == 0, result.stdout + result.stderr
+        assert b"locked" not in (result.stdout + result.stderr).lower()
+    connection = sqlite3.connect(sidecar)
+    try:
+        count = connection.execute(
+            "SELECT count(*) FROM direct_tag_preference_history"
+            " WHERE preference_id LIKE 'concurrent-%'"
+        ).fetchone()[0]
+    finally:
+        connection.close()
+    assert count == 12
 
 
 # ── events ───────────────────────────────────────────────────────────────────

--- a/tests/core/test_backend_slice4.py
+++ b/tests/core/test_backend_slice4.py
@@ -235,6 +235,54 @@ def make_slice4_sidecar(path: Path) -> None:
         )
         connection.execute(
             """
+            INSERT INTO feature_definition(
+                feature_id, feature_version, family, name, provenance, metadata_json
+            ) VALUES
+                ('fd-d1', ?, 'content', 'desc:anal', 'seed', '{"document_frequency": 7}'),
+                ('fd-d2', ?, 'content', 'desc:blonde', 'seed', '{"document_frequency": 3}'),
+                ('fd-d3', ?, 'content', 'desc:solo', 'seed', '{"document_frequency": 9}')
+            """,
+            (FEATURE_VERSION, FEATURE_VERSION, FEATURE_VERSION),
+        )
+        connection.execute(
+            """
+            INSERT INTO feature_affinity(
+                feature_id, model_id, affinity, confidence, effective_support,
+                distinct_scene_count
+            ) VALUES
+                ('fd-d1', ?, 0.8, 0.9, 0.6, 2),
+                ('fd-d2', ?, -0.2, 0.4, 0.2, 1),
+                ('fd-d3', ?, 0.5, 0.7, 0.4, 3)
+            """,
+            (MODEL_ID, MODEL_ID, MODEL_ID),
+        )
+        connection.execute(
+            """
+            INSERT INTO entity_feature(
+                feature_version, entity_type, entity_id, feature_id, value, confidence
+            ) VALUES
+                (?, 'scene', 's1', 'fd-d1', 0.9, 1.0),
+                (?, 'scene', 's1', 'fd-d3', 0.5, 1.0),
+                (?, 'scene', 's2', 'fd-d2', 0.4, 1.0)
+            """,
+            (FEATURE_VERSION, FEATURE_VERSION, FEATURE_VERSION),
+        )
+        connection.execute(
+            """
+            INSERT INTO direct_term_preference_history(
+                preference_id, term, value, occurred_at_ms, blocked
+            ) VALUES ('pref-d1', 'anal', 0.5, 1, 0), ('pref-d2', 'solo', 0.0, 1, 1)
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO direct_term_preference(
+                term, preference_id, value, occurred_at_ms, blocked
+            ) VALUES ('anal', 'pref-d1', 0.5, 1, 0), ('solo', 'pref-d2', 0.0, 1, 1)
+            """
+        )
+        connection.execute(
+            """
             INSERT INTO entity_feature(
                 feature_version, entity_type, entity_id, feature_id, value, confidence
             ) VALUES
@@ -364,6 +412,144 @@ def test_external_tag_choices_validation_errors(
                 {"id": "", "name": "   "},
             ],
         ),
+        slice4_sidecar,
+    )
+
+
+# ── get_scene_tag_choices ───────────────────────────────────────────────────
+
+
+def test_scene_tag_choices_byte_identical(
+    tmp_path: Path, binary: Path, stub_stash: str, slice4_sidecar: Path
+) -> None:
+    # s1 carries t1 (blonde, direct 0.5), t2 (anal), t4 (ponytail): the
+    # classified scene tags sorted by name with their direct preferences.
+    raw = payload("get_scene_tag_choices", slice4_sidecar, stub_stash, scene_id="s1")
+    assert_slice4_identical(binary, raw, slice4_sidecar)
+
+
+def test_scene_tag_choices_unclassified_and_unknown(
+    tmp_path: Path, binary: Path, stub_stash: str, slice4_sidecar: Path
+) -> None:
+    # s3 carries only t3 (solo, blocked) — classified, with its preference.
+    raw = payload("get_scene_tag_choices", slice4_sidecar, stub_stash, scene_id="s3")
+    assert_slice4_identical(binary, raw, slice4_sidecar)
+    # Unknown scene and missing scene_id both error identically.
+    raw = payload("get_scene_tag_choices", slice4_sidecar, stub_stash, scene_id="ghost")
+    assert_slice4_identical(binary, raw, slice4_sidecar)
+    raw = payload("get_scene_tag_choices", slice4_sidecar, stub_stash, scene_id="")
+    assert_slice4_identical(binary, raw, slice4_sidecar)
+
+
+# ── get_scene_description_tokens ────────────────────────────────────────────
+
+
+def test_scene_description_tokens_byte_identical(
+    tmp_path: Path, binary: Path, stub_stash: str, slice4_sidecar: Path
+) -> None:
+    # s1 has desc:anal (df 7, direct 0.5) and desc:solo (df 9, blocked).
+    raw = payload("get_scene_description_tokens", slice4_sidecar, stub_stash, scene_id="s1")
+    assert_slice4_identical(binary, raw, slice4_sidecar)
+
+
+def test_scene_description_tokens_empty_and_unknown(
+    tmp_path: Path, binary: Path, stub_stash: str, slice4_sidecar: Path
+) -> None:
+    # s3 has no desc features -> empty items.
+    raw = payload("get_scene_description_tokens", slice4_sidecar, stub_stash, scene_id="s3")
+    assert_slice4_identical(binary, raw, slice4_sidecar)
+    raw = payload("get_scene_description_tokens", slice4_sidecar, stub_stash, scene_id="ghost")
+    assert_slice4_identical(binary, raw, slice4_sidecar)
+    raw = payload("get_scene_description_tokens", slice4_sidecar, stub_stash, scene_id="")
+    assert_slice4_identical(binary, raw, slice4_sidecar)
+
+
+# ── submit_term_preferences ─────────────────────────────────────────────────
+
+
+def test_submit_term_preferences_byte_identical(
+    tmp_path: Path, binary: Path, stub_stash: str, slice4_sidecar: Path
+) -> None:
+    raw = payload(
+        "submit_term_preferences",
+        slice4_sidecar,
+        stub_stash,
+        entries=[
+            # overwrite the seeded anal preference
+            {"preference_id": "pref-n1", "term": "anal", "value": -0.5, "occurred_at_ms": 200},
+            # clear a term with no current preference (no-op upsert path)
+            {"preference_id": "pref-n2", "term": "blonde", "value": None, "occurred_at_ms": 300},
+            # term normalization: "HARDcore" -> "hardcore", a valid token
+            {"preference_id": "pref-n3", "term": "HARDcore", "value": 1.0, "occurred_at_ms": 400},
+        ],
+    )
+    assert_slice4_identical(binary, raw, slice4_sidecar)
+
+
+def test_submit_term_preferences_blocked_byte_identical(
+    tmp_path: Path, binary: Path, stub_stash: str, slice4_sidecar: Path
+) -> None:
+    raw = payload(
+        "submit_term_preferences",
+        slice4_sidecar,
+        stub_stash,
+        entries=[
+            {
+                "preference_id": "pref-n4",
+                "term": "anal",
+                "value": 1.0,
+                "blocked": True,
+                "occurred_at_ms": 250,
+            }
+        ],
+    )
+    assert_slice4_identical(binary, raw, slice4_sidecar)
+
+
+def test_submit_term_preferences_validation_errors(
+    tmp_path: Path, binary: Path, stub_stash: str, slice4_sidecar: Path
+) -> None:
+    # Off-scale value.
+    assert_slice4_identical(
+        binary,
+        payload(
+            "submit_term_preferences",
+            slice4_sidecar,
+            stub_stash,
+            entries=[
+                {"preference_id": "pref-n5", "term": "anal", "value": 0.3, "occurred_at_ms": 100}
+            ],
+        ),
+        slice4_sidecar,
+    )
+    # Non-token term (too short / punctuation).
+    assert_slice4_identical(
+        binary,
+        payload(
+            "submit_term_preferences",
+            slice4_sidecar,
+            stub_stash,
+            entries=[
+                {"preference_id": "pref-n6", "term": "a!", "value": 0.5, "occurred_at_ms": 100}
+            ],
+        ),
+        slice4_sidecar,
+    )
+    # Missing preference_id and negative occurred_at_ms.
+    assert_slice4_identical(
+        binary,
+        payload(
+            "submit_term_preferences",
+            slice4_sidecar,
+            stub_stash,
+            entries=[{"preference_id": "", "term": "anal", "value": 0.5, "occurred_at_ms": -1}],
+        ),
+        slice4_sidecar,
+    )
+    # Non-list entries.
+    assert_slice4_identical(
+        binary,
+        payload("submit_term_preferences", slice4_sidecar, stub_stash, entries="nope"),
         slice4_sidecar,
     )
 
@@ -578,7 +764,7 @@ def test_reset_removes_core_and_artifacts_identically(
     assert py[0] == go[0], f"stdout differs:\npython: {py[0]!r}\ngo:     {go[0]!r}"
     assert py[2] == go[2] == ["curator-derived", "curator.sqlite3"]
     assert py[3] == go[3] == ["junk.txt"]
-    assert py[4] == go[4] == 27
+    assert py[4] == go[4] == 28
     assert py[5] == go[5] == "ok"
 
 

--- a/tests/model/test_multi_hop.py
+++ b/tests/model/test_multi_hop.py
@@ -266,6 +266,76 @@ def test_similarity_annotates_multi_hop_when_reachable(
             assert item.details["multi_hop_reach"] >= REACH_FLOOR
 
 
+def test_similarity_excludes_scenes_carrying_a_blocked_term(tmp_path: Path) -> None:
+    """Blocking a description term removes every local scene whose built
+    entity_feature rows carry it from Similar results (term->scene mapping
+    via the published model's desc features, mirroring the blocked-tag path).
+
+    The model build publishes feature tables into the derived artifact and
+    attaches them as views, so the desc feature is written into the artifact
+    database — the same place the runtime reads it from."""
+    sidecar = tmp_path / "curator.sqlite3"
+    connection = _database(sidecar)
+    model = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    basename = connection.execute(
+        "SELECT artifact_basename FROM feature_build WHERE feature_version=?",
+        (model.feature_version,),
+    ).fetchone()[0]
+    connection.close()
+
+    # The published artifact is attached read-only (immutable=1), so a fresh
+    # sidecar connection is opened both before and after the artifact write.
+    service = SimilarityService(connect_database(sidecar))
+    before = {item.entity_id for item in service.scenes("old-good", 20)}
+    assert before
+    target = sorted(before)[0]
+
+    artifact = sqlite3.connect(tmp_path / "curator-derived" / basename)
+    try:
+        artifact.execute(
+            """
+            INSERT INTO feature_definition(
+                feature_id, feature_version, family, name, provenance, metadata_json
+            ) VALUES ('fd-term', ?, 'content', 'desc:anal', 'seed',
+                      '{"document_frequency": 3}')
+            """,
+            (model.feature_version,),
+        )
+        artifact.execute(
+            """
+            INSERT INTO entity_feature(
+                feature_version, entity_type, entity_id, feature_id, value, confidence
+            ) VALUES (?, 'scene', ?, 'fd-term', 0.8, 1.0)
+            """,
+            (model.feature_version, target),
+        )
+        artifact.commit()
+    finally:
+        artifact.close()
+    fresh = connect_database(sidecar)
+    try:
+        fresh.execute(
+            """
+            INSERT INTO direct_term_preference_history(
+                preference_id, term, value, occurred_at_ms, blocked
+            ) VALUES ('pref-term', 'anal', 0, 3, 1)
+            """
+        )
+        fresh.execute(
+            """
+            INSERT INTO direct_term_preference(
+                term, preference_id, value, occurred_at_ms, blocked
+            ) VALUES ('anal', 'pref-term', 0, 3, 1)
+            """
+        )
+        fresh.commit()
+        after = {item.entity_id for item in SimilarityService(fresh).scenes("old-good", 20)}
+    finally:
+        fresh.close()
+    assert target not in after
+    assert len(after) == len(before) - 1
+
+
 def test_core_pagerank_matches_networkx_and_python(tmp_path: Path) -> None:
     if builder_module.core.core_binary() is None:
         pytest.skip("curator-core binary is not built")

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -497,9 +497,22 @@ def test_external_scene_cards_can_rate_matching_local_tags() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
 
     assert 'operation: "get_external_tag_choices"' in source
-    assert '"Rate matching local tags"' in source
+    assert '"Rate tags & terms"' in source
     assert '"No matching local tags."' in source
     assert "submitTagPreference(tag.tag_id, {value, blocked});" in source
+
+
+def test_recommendation_and_similar_cards_can_rate_local_tags_and_terms() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
+
+    assert "function LocalRatingPanel" in source
+    assert 'operation: "get_scene_tag_choices"' in source
+    assert "React.createElement(LocalRatingPanel, { sceneId: item.scene_id })" in source
+    assert "React.createElement(LocalRatingPanel, { sceneId: item.entity_id })" in source
+    assert "submitTagPreference(row.tag_id, {value, blocked});" in source
+    assert "submitTermPreference(row.term, {value, blocked});" in source
+    assert "TERM_PREFERENCE_QUEUE_KEY" in source
+    assert "localStorage.setItem(TERM_PREFERENCE_QUEUE_KEY" in source
 
 
 def test_curator_external_components_are_public_and_patchable() -> None:
@@ -930,7 +943,8 @@ def test_task_indicator_and_compact_external_tag_rating_are_shared_ui_contracts(
     source = (root / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
     css = (root / "plugin" / "stash-curator.css").read_text(encoding="utf-8")
 
-    assert "function CuratorTaskIndicator({ activeJobs, activities, failure })" in source
+    assert "function CuratorTaskIndicator({ activeJobs, activities, failure, doneJob })" in source
+    assert "curator-task-indicator-done" in css
     assert "health?.active_jobs" in source
     assert 'to: "/settings?tab=tasks"' in source
     assert "curatorTaskStage(job)" in source
@@ -939,12 +953,13 @@ def test_task_indicator_and_compact_external_tag_rating_are_shared_ui_contracts(
     assert '"Installing optional dependencies"' in source
     assert "curator-task-progress-indeterminate" in source
     assert "showTaskDetails" in source
-    assert 'activeJobs.length > 0 || state === "failed"' in source
+    assert 'running || state === "failed" || state === "done"' in source
     assert '"No active tasks"' not in source
     assert "Querying StashDB" not in source
     assert 'className: "curator-loading", role: "status"' in source
     assert 'className: "curator-progress"' not in source
-    assert "Matching local tags (${tagChoices.length})" in source
+    assert '"Rate tags & terms"' in source
+    assert "RatingSection" in source
     assert "Collapse matching local tag ratings" in source
     assert "compact: true" in source
     assert 'const shortLabel = score === -1 ? "--"' in source
@@ -1185,7 +1200,12 @@ def test_every_user_visible_empty_and_error_message_is_defensive() -> None:
 
     # ── external card tag rating states ──
     assert '"Matching local tags…"' in source
-    assert '"Rate matching local tags"' in source
+    assert '"Rate tags & terms"' in source
+    assert '"Description terms"' in source
+    assert '"No description terms in the model."' in source
+    assert "TERM_PREFERENCE_QUEUE_KEY" in source
+    assert 'operation: "get_scene_description_tokens"' in source
+    assert 'operation: "submit_term_preferences"' in source
     assert '"Configure Whisparr in plugin settings"' in source
     assert '"Retry sending to Whisparr"' in source
     assert '"Send to Whisparr"' in source

--- a/tests/ranking/test_slate.py
+++ b/tests/ranking/test_slate.py
@@ -789,6 +789,51 @@ def test_available_count_batched_blocked_tag_probe_excludes_scenes(tmp_path: Pat
     assert builder.available_count("model", "best_bets") == first - 1
 
 
+def test_available_count_blocked_term_probe_excludes_scenes(tmp_path: Path) -> None:
+    """Blocking a description term hard-excludes every scene whose built
+    entity_feature rows carry it — the term->scene mapping comes from the
+    published model's desc features, not a scene_tag join."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    LanePolicy(connection).classify("model")
+    builder = SlateBuilder(connection)
+    builder.materialize("model", force=True)
+
+    first = builder.available_count("model", "best_bets")
+    assert first is not None and first > 0
+
+    connection.execute(
+        """
+        INSERT INTO feature_definition(
+            feature_id, feature_version, family, name, provenance, metadata_json
+        ) VALUES ('fd-term', 'features', 'content', 'desc:anal', 'seed',
+                  '{"document_frequency": 3}')
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO entity_feature(
+            feature_version, entity_type, entity_id, feature_id, value, confidence
+        ) VALUES ('features', 'scene', 'a-best', 'fd-term', 0.8, 1.0)
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO direct_term_preference_history(
+            preference_id, term, value, occurred_at_ms, blocked
+        ) VALUES ('pref-term', 'anal', 0, 3, 1)
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO direct_term_preference(
+            term, preference_id, value, occurred_at_ms, blocked
+        ) VALUES ('anal', 'pref-term', 0, 3, 1)
+        """
+    )
+    connection.commit()
+    assert builder.available_count("model", "best_bets") == first - 1
+
+
 def test_available_count_probes_are_batched_not_per_scene(tmp_path: Path) -> None:
     """A large lane must not run one blocked-tag probe per scene.
 

--- a/tests/storage/test_artifacts.py
+++ b/tests/storage/test_artifacts.py
@@ -217,6 +217,6 @@ def test_attach_skips_tables_missing_from_older_artifact(tmp_path: Path) -> None
         assert "model_performer_edge" not in views
         # Migration 25 creates and indexes model_performer_edge; the shadowing view
         # used to make its CREATE INDEX fail with "views may not be indexed".
-        assert MigrationRunner(attached).migrate(applied_at_ms=2).current_version == 27
+        assert MigrationRunner(attached).migrate(applied_at_ms=2).current_version == 28
     finally:
         attached.close()

--- a/tests/storage/test_cli_db.py
+++ b/tests/storage/test_cli_db.py
@@ -15,7 +15,7 @@ def test_database_cli_migrate_status_and_backup(
 
     assert run(["--db", str(database), "db", "migrate", "--json"]) == 0
     migrated = json.loads(capsys.readouterr().out)
-    assert migrated["current_version"] == migrated["latest_version"] == 27
+    assert migrated["current_version"] == migrated["latest_version"] == 28
 
     assert run(["--db", str(database), "db", "status", "--json"]) == 0
     status = json.loads(capsys.readouterr().out)

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -39,10 +39,11 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
             25,
             26,
             27,
+            28,
         )
 
         after = runner.migrate(applied_at_ms=1234)
-        assert after.current_version == 27
+        assert after.current_version == 28
         assert after.pending_versions == ()
         assert runner.migrate(applied_at_ms=5678) == after
 
@@ -334,7 +335,7 @@ def test_status_stays_read_only_after_migrations(tmp_path: Path) -> None:
     reader.execute("PRAGMA busy_timeout=1")
     try:
         writer.execute("BEGIN IMMEDIATE")
-        assert MigrationRunner(reader).status().current_version == 27
+        assert MigrationRunner(reader).status().current_version == 28
     finally:
         writer.rollback()
         reader.close()
@@ -360,7 +361,7 @@ def test_stale_concurrent_migrator_rechecks_after_writer_lock(
 
     monkeypatch.setattr(second_runner, "status", status)
     try:
-        assert second_runner.migrate(applied_at_ms=2).current_version == 27
+        assert second_runner.migrate(applied_at_ms=2).current_version == 28
     finally:
         second.close()
         first.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_doctor_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
     assert result["status"] == "ok"
     assert result["stash"] == "not_configured"
     assert result["schema_current"] == 0
-    assert result["schema_latest"] == 27
+    assert result["schema_latest"] == 28
 
 
 def test_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -1604,3 +1604,88 @@ def test_unused_local_tag_preference_scores_matching_external_scenes(tmp_path: P
 
     scores = {item["id"]: item["score"] for item in scenes}
     assert scores["tagged"] < scores["plain"]
+
+
+def test_description_term_preference_ranks_matching_external_scenes(
+    tmp_path: Path,
+) -> None:
+    """Remote scenes are ranked by description term affinity: with identical
+    tags/performers/studio, the scene whose description carries a positively
+    declared term scores higher, and the explanation names the term."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    model = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    InteractionStore(connection).submit_term_preferences(
+        [{"preference_id": "term-good", "term": "romantic", "value": 1, "occurred_at_ms": 10}]
+    )
+    scenes, _ = ExpandService(connection)._score(
+        [
+            {
+                "id": "described",
+                "details": "A romantic candlelight encounter with intense chemistry.",
+                "tags": [],
+                "performers": [],
+            },
+            {
+                "id": "plain",
+                "details": "An athletic outdoor adventure near the mountains.",
+                "tags": [],
+                "performers": [],
+            },
+        ],
+        {"described": {"wildcard"}, "plain": {"wildcard"}},
+        model.model_id,
+        model.feature_version,
+        {"scenes": {}, "performers": {}, "studios": {}},
+    )
+
+    scores = {item["id"]: item["score"] for item in scenes}
+    assert scores["described"] > scores["plain"]
+    why = {item["id"]: item["payload"]["why"] for item in scenes}
+    assert "romantic" in why["described"]
+    assert "romantic" not in why["plain"]
+
+
+class DescribedStashDB(FakeStashDB):
+    """FakeStashDB whose candidates carry a description mentioning 'romantic'."""
+
+    def execute(self, document: str, variables: dict[str, object]):
+        result = super().execute(document, variables)
+        for scene in result["queryScenes"]["scenes"]:
+            scene["details"] = "A romantic candlelight encounter with intense chemistry."
+        return result
+
+
+def test_blocked_term_excludes_remote_pool_scenes(tmp_path: Path) -> None:
+    """Blocking a description term removes every remote candidate whose
+    description tokens include it from the Expand results, even when the term
+    is not part of the built model (the remote mapping tokenizes the
+    description; it has no entity_feature join)."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    client = DescribedStashDB()
+    links = {
+        "scenes": {"old-good": "owned-external-scene"},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {"studio-1": "external-studio"},
+    }
+    ExpandService(connection).refresh(client, links, now_ms=REFERENCE_MS, candidate_limit=10)
+    assert [item["id"] for item in ExpandService(connection).results("scene")["items"]] == [
+        "new-external-scene"
+    ]
+
+    connection.execute(
+        """
+        INSERT INTO direct_term_preference_history(
+            preference_id, term, value, occurred_at_ms, blocked
+        ) VALUES ('pref-block', 'romantic', 0, 1, 1)
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO direct_term_preference(
+            term, preference_id, value, occurred_at_ms, blocked
+        ) VALUES ('romantic', 'pref-block', 0, 1, 1)
+        """
+    )
+    connection.commit()
+    assert ExpandService(connection).results("scene")["items"] == []

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -99,6 +99,75 @@ def test_tag_preferences_validate_replace_clear_and_ignore_stale_retries(tmp_pat
     assert bool(row[1]) is True
 
 
+def test_term_preferences_validate_replace_clear_and_ignore_stale_retries(
+    tmp_path: Path,
+) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    store = InteractionStore(connection)
+    positive = {
+        "preference_id": "term-positive",
+        "term": "romantic",
+        "value": 1,
+        "occurred_at_ms": 20,
+    }
+    stale = {**positive, "preference_id": "term-stale", "value": -1, "occurred_at_ms": 10}
+    clear = {**positive, "preference_id": "term-clear", "value": None, "occurred_at_ms": 30}
+
+    assert store.submit_term_preferences([positive]) == 1
+    assert store.submit_term_preferences([positive]) == 0
+    assert store.submit_term_preferences([stale]) == 1
+    assert (
+        connection.execute(
+            "SELECT value FROM direct_term_preference WHERE term='romantic'"
+        ).fetchone()[0]
+        == 1
+    )
+    assert store.submit_term_preferences([clear]) == 1
+    assert (
+        connection.execute("SELECT 1 FROM direct_term_preference WHERE term='romantic'").fetchone()
+        is None
+    )
+    assert (
+        connection.execute(
+            "SELECT count(*) FROM direct_term_preference_history WHERE term='romantic'"
+        ).fetchone()[0]
+        == 3
+    )
+
+    with pytest.raises(ValueError, match="five-point"):
+        store.submit_term_preferences([{**positive, "preference_id": "bad", "value": 0.25}])
+    with pytest.raises(ValueError, match="token"):
+        store.submit_term_preferences([{**positive, "preference_id": "bad-term", "term": "a!"}])
+    with pytest.raises(ValueError, match="required"):
+        store.submit_term_preferences([{**positive, "preference_id": ""}])
+
+    # Terms are normalized to lowercase before storage.
+    assert (
+        store.submit_term_preferences([{**positive, "preference_id": "case", "term": "ROMANTIC"}])
+        == 1
+    )
+    assert (
+        connection.execute("SELECT 1 FROM direct_term_preference WHERE term='romantic'").fetchone()
+        is not None
+    )
+
+    blocked = {
+        "preference_id": "term-blocked",
+        "term": "romantic",
+        "value": 1,
+        "blocked": True,
+        "occurred_at_ms": 40,
+    }
+    assert store.submit_term_preferences([blocked]) == 1
+    row = connection.execute(
+        "SELECT value, blocked FROM direct_term_preference WHERE term='romantic'"
+    ).fetchone()
+    assert row is not None
+    assert float(row[0]) == -1.0
+    assert bool(row[1]) is True
+
+
 def test_direct_sessions_record_views_and_quick_replacement(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     store = InteractionStore(connection)


### PR DESCRIPTION
## Open-issues follow-up on the Slice 4 backend

Closes **#92**, **#93**, **#94**, **#95**, **#103**, **#109**, **#110**.

> Originally planned stacked on `feat/slice4-frontend-parity`; that branch merged
> as #114 and was deleted, so this PR now targets `main` directly (single commit,
> rebased onto the merged slice 4 + 0.7.0 release).

### Rating views for tags and description terms (#92, #93, #94)
- **#92**: compact sentiment rows reserve the Clear slot (`visibility: hidden`)
  so rated/unrated rows align; the card action row renders **above** the
  expanded list.
- **#93**: new `get_scene_tag_choices` op (classified scene tags, alphabetical,
  with direct preferences); the "Rate tags & terms" panel lands on
  recommendation lanes and library Similar cards, outside `card-section` (the
  SFW Switch contract holds).
- **#94**: migration `0028_direct_term_preferences.sql` (byte-identical in both
  migration dirs), `get_scene_description_tokens` + `submit_term_preferences`
  ops (Go core + Python oracle, byte-identical), the direct-term affinity
  blend in the model build, blocked-term enforcement (lanes via
  `entity_feature`, Similar, remote Expand via description tokenization; the
  eligibility fingerprint gained a `blocked_terms` digest), and a merged
  tags-and-terms expander on external, recommendation, and Similar cards.
  Displayed terms are the built model's — never re-tokenized.

### Remote ranking by description terms (#95)
Remote scenes gain a `0.10 * term_value` component (weights renormalized to
`0.40/0.10/0.25/0.10/0.15`); blocked terms exclude remote candidates whose
description tokens carry them; `_why`/`expandWhy` name positive term
contributions. Local Similar's content dot-product is intentionally unchanged.

### `database is locked` after the Go rewrite (#109)
Root cause found and reproduced: concurrent first opens of a WAL sidecar race
on the `-shm` recovery lock and fail *instantly* with `database is locked (5)`
— the busy handler does not cover that lock (30 s `busy_timeout` is honored
for ordinary contention; verified). The whole `openSidecar` phase plus
`withTxn`/`execImmediate` now retry busy failures with bounded backoff
(COMMIT failures are never retried), and the frontend maps surviving lock
errors to an actionable `databasePath`-on-local-storage message. A new
contention test pins zero lock errors under concurrent openers.

### Expand-refresh progress bar (#110)
Dense ticks through the previously markerless pre-work (external-links walk
`0.05→0.08`, taxonomy/seeds bracketed inside `0.08→0.98` — matched
Go/Python), and the task indicator shows a completed job at 100% ("Done")
for 15 s instead of freezing at the last sub-100% value.

### NFS layout docs (#103)
Two-path layout documented: working sidecar on **local** storage,
WAL-consistent backups via `backupPath` on the network share
(`docs/getting-started.md`, `docs/privacy.md`). No sync task in this package.

## Verification
- `scripts/verify full` passes (490 tests) — including 7 new byte-identical
  differential tests for the new ops, model-build artifact parity with term
  preferences, blocked-term eligibility/similarity/expand tests, remote
  ranking tests, and the concurrent-write contention test.
- Browser-verified against `integration-stash-1`: the panel renders with
  alphabetical tags + terms empty state; rating a tag persists to the sidecar
  and signals a model rebuild; rated/unrated rows have identical geometry;
  the task indicator shows the done state and expires to idle.
- Installed to the live mount (`scripts/install-local.sh`); live behavior
  takes effect after the next Stash restart (exec swap) — live verification
  is pending that restart.