### PR TITLE
perf: parallelize lane classification, scoring, feature construction, and the links walk

### DIFF
--- a/core/featurebuild.go
+++ b/core/featurebuild.go
@@ -439,6 +439,99 @@ func presenceCategory(value string) string {
 }
 
 // sceneFeatures mirrors FeatureBuilder._scene_features.
+// sceneFeatureRows constructs the content-family feature rows for one scene
+// (the FeatureBuilder._scene_features per-scene body): weighted tag +
+// description-term values, normalized, with confidence from document
+// frequency. Every input is a precomputed read-only map, so the scene pass
+// is row-independent: fixed-chunk parallel processing yields identical rows.
+func sceneFeatureRows(sceneID string, baseVectors map[string]map[string]float64,
+	documentFrequency map[string]int64, descByScene map[string][]string,
+	descIDF map[string]float64, descDocumentFrequency map[string]int64, tagNames map[string]string,
+	roles map[string]tagRoleResult, total int) []featureRow {
+	weighted := map[string]float64{}
+	for tagID, base := range baseVectors[sceneID] {
+		frequency := documentFrequency[tagID]
+		rarity := math.Min(idfCap, 1+idfStrength*math.Log(float64(total+1)/float64(frequency+1)))
+		shrinkage := float64(frequency) / (float64(frequency) + oneOffPrior)
+		weighted[tagID] = base * rarity * shrinkage
+	}
+	if terms, ok := descByScene[sceneID]; ok {
+		limit := descMaxTermsPerScene
+		if len(terms) < limit {
+			limit = len(terms)
+		}
+		for _, term := range terms[:limit] {
+			idf := descIDF[term]
+			if idf <= 0 {
+				continue
+			}
+			freq := descDocumentFrequency[term]
+			if freq == 0 {
+				freq = 1
+			}
+			weighted["desc:"+term] = descBoost * idf / (float64(freq) + oneOffPrior)
+		}
+	}
+	var normSquared float64
+	for _, value := range weighted {
+		normSquared += value * value
+	}
+	norm := math.Sqrt(normSquared)
+	if norm == 0 {
+		norm = 1.0
+	}
+	var features []featureRow
+	var tagKeys []string
+	for key := range weighted {
+		if !strings.HasPrefix(key, "desc:") {
+			tagKeys = append(tagKeys, key)
+		}
+	}
+	sort.Strings(tagKeys)
+	for _, tagID := range tagKeys {
+		frequency := documentFrequency[tagID]
+		confidence := math.Min(1.0, float64(frequency)/3)
+		features = append(features, featureRow{
+			entityType: "scene",
+			entityID:   sceneID,
+			family:     "content",
+			name:       "tag:" + tagID,
+			value:      weighted[tagID] / norm,
+			confidence: confidence,
+			metadata: jvObj(
+				jvKey("tag_id", jvStr(tagID)),
+				jvKey("tag_name", jvStr(tagNames[tagID])),
+				jvKey("document_frequency", jvInt(frequency)),
+				jvKey("role_reason", jvStr(roles[tagID].reason)),
+			),
+		})
+	}
+	var descKeys []string
+	for key := range weighted {
+		if strings.HasPrefix(key, "desc:") {
+			descKeys = append(descKeys, key)
+		}
+	}
+	sort.Strings(descKeys)
+	for _, key := range descKeys {
+		term := strings.TrimPrefix(key, "desc:")
+		frequency := descDocumentFrequency[term]
+		if frequency == 0 {
+			frequency = 1
+		}
+		features = append(features, featureRow{
+			entityType: "scene",
+			entityID:   sceneID,
+			family:     "content",
+			name:       key,
+			value:      weighted[key] / norm,
+			confidence: math.Min(1.0, float64(frequency)/3),
+			metadata:   jvObj(jvKey("document_frequency", jvInt(frequency))),
+		})
+	}
+	return features
+}
+
 func sceneFeatures(db dbx, roles map[string]tagRoleResult, progress func(fraction float64)) ([]featureRow, error) {
 	sceneRows, err := db.Query(`SELECT scene_id FROM source_scene ORDER BY scene_id`)
 	if err != nil {
@@ -615,92 +708,32 @@ ORDER BY scene_id, tag_id`)
 		}
 		descIDF[term] = math.Min(idfCap, 1+idfStrength*math.Log(float64(total+1)/float64(freq+1)))
 	}
+	// Each scene's content rows depend only on its own vector and the
+	// precomputed frequency maps, so the pass is row-independent: run it in
+	// fixed chunks (the kernel pattern) with progress ticks emitted in scene
+	// order.
 	var features []featureRow
-	for position, sceneID := range sceneIDs {
-		weighted := map[string]float64{}
-		for tagID, base := range baseVectors[sceneID] {
-			frequency := documentFrequency[tagID]
-			rarity := math.Min(idfCap, 1+idfStrength*math.Log(float64(total+1)/float64(frequency+1)))
-			shrinkage := float64(frequency) / (float64(frequency) + oneOffPrior)
-			weighted[tagID] = base * rarity * shrinkage
-		}
-		if terms, ok := descByScene[sceneID]; ok {
-			limit := descMaxTermsPerScene
-			if len(terms) < limit {
-				limit = len(terms)
+	sceneCount := len(sceneIDs)
+	progressReporter := newOrderedProgress()
+	reporterDone := make(chan struct{})
+	go func() {
+		defer close(reporterDone)
+		progressReporter.wait(reportPoints(sceneCount), func(completed int) {
+			if progress != nil {
+				progress(0.10 + 0.30*float64(completed)/float64(maxInt(1, sceneCount)))
 			}
-			for _, term := range terms[:limit] {
-				idf := descIDF[term]
-				if idf <= 0 {
-					continue
-				}
-				freq := descDocumentFrequency[term]
-				if freq == 0 {
-					freq = 1
-				}
-				weighted["desc:"+term] = descBoost * idf / (float64(freq) + oneOffPrior)
-			}
+		})
+	}()
+	features = parallelChunks(sceneCount, nthreads(0), func(start, end int) []featureRow {
+		var out []featureRow
+		for _, sceneID := range sceneIDs[start:end] {
+			out = append(out, sceneFeatureRows(sceneID, baseVectors, documentFrequency,
+				descByScene, descIDF, descDocumentFrequency, tagNames, roles, total)...)
+			progressReporter.done()
 		}
-		var normSquared float64
-		for _, value := range weighted {
-			normSquared += value * value
-		}
-		norm := math.Sqrt(normSquared)
-		if norm == 0 {
-			norm = 1.0
-		}
-		var tagKeys []string
-		for key := range weighted {
-			if !strings.HasPrefix(key, "desc:") {
-				tagKeys = append(tagKeys, key)
-			}
-		}
-		sort.Strings(tagKeys)
-		for _, tagID := range tagKeys {
-			frequency := documentFrequency[tagID]
-			confidence := math.Min(1.0, float64(frequency)/3)
-			features = append(features, featureRow{
-				entityType: "scene",
-				entityID:   sceneID,
-				family:     "content",
-				name:       "tag:" + tagID,
-				value:      weighted[tagID] / norm,
-				confidence: confidence,
-				metadata: jvObj(
-					jvKey("tag_id", jvStr(tagID)),
-					jvKey("tag_name", jvStr(tagNames[tagID])),
-					jvKey("document_frequency", jvInt(frequency)),
-					jvKey("role_reason", jvStr(roles[tagID].reason)),
-				),
-			})
-		}
-		var descKeys []string
-		for key := range weighted {
-			if strings.HasPrefix(key, "desc:") {
-				descKeys = append(descKeys, key)
-			}
-		}
-		sort.Strings(descKeys)
-		for _, key := range descKeys {
-			term := strings.TrimPrefix(key, "desc:")
-			frequency := descDocumentFrequency[term]
-			if frequency == 0 {
-				frequency = 1
-			}
-			features = append(features, featureRow{
-				entityType: "scene",
-				entityID:   sceneID,
-				family:     "content",
-				name:       key,
-				value:      weighted[key] / norm,
-				confidence: math.Min(1.0, float64(frequency)/3),
-				metadata:   jvObj(jvKey("document_frequency", jvInt(frequency))),
-			})
-		}
-		if progress != nil && (position+1 == len(sceneIDs) || (position+1)%250 == 0) {
-			progress(0.10 + 0.30*float64(position+1)/float64(maxInt(1, len(sceneIDs))))
-		}
-	}
+		return out
+	})
+	<-reporterDone
 	rows, err = db.Query(`SELECT scene_id, performer_id FROM scene_performer ORDER BY scene_id, performer_id`)
 	if err != nil {
 		return nil, err

--- a/core/laneclassify.go
+++ b/core/laneclassify.go
@@ -324,6 +324,173 @@ type builtLaneClassification struct {
 	qualification jVal
 }
 
+// laneContext carries the row-independent precomputed inputs for the
+// per-scene classification loop (ranks, adventure context, played set).
+type laneContext struct {
+	contentRanks      map[string]float64
+	neighborRanks     map[string]float64
+	similarityRanks   map[string]float64
+	performerRanks    map[string]float64
+	studioRanks       map[string]float64
+	fitRanks          map[string]float64
+	coverageRanks     map[string]float64
+	unknownPerformers map[string]float64
+	unknownStudios    map[string]float64
+	played            map[string]bool
+}
+
+// classifyScene computes the best_bets / revisit / discover / adventure
+// rows for one eligible scene (the LanePolicy.classify per-scene body). The
+// loop is row-independent: every input is a precomputed read-only map, so
+// fixed-chunk parallel processing yields identical rows.
+func (c *laneContext) classifyScene(sceneID string, score classificationScore) []builtLaneClassification {
+	var classifications []builtLaneClassification
+	reusable := map[string]float64{
+		"content":              componentValue(score.components, "content"),
+		"content_neighbor":     componentValue(score.components, "content_neighbor"),
+		"performer_identity":   componentValue(score.components, "performer_identity"),
+		"performer_similarity": componentValue(score.components, "performer_similarity"),
+		"studio":               componentValue(score.components, "studio"),
+		"structure":            componentValue(score.components, "structure"),
+	}
+	positives := map[string]float64{}
+	negatives := map[string]float64{}
+	for family, value := range reusable {
+		if value >= 0.025 {
+			positives[family] = value
+		} else if value <= -0.025 {
+			negatives[family] = value
+		}
+	}
+	strongestAnchor := 0.0
+	for _, value := range positives {
+		if value > strongestAnchor {
+			strongestAnchor = value
+		}
+	}
+	contentRank := c.contentRanks[sceneID]
+	neighborRank := c.neighborRanks[sceneID]
+	similarityRank := c.similarityRanks[sceneID]
+	performerRank := c.performerRanks[sceneID]
+	studioRank := c.studioRanks[sceneID]
+	relevance := (0.32*neighborRank + 0.10*similarityRank + 0.28*performerRank +
+		0.20*contentRank + 0.10*studioRank) * (0.90 + 0.10*score.metadataConfidence)
+	corroborated := neighborRank >= 0.60 && math.Max(performerRank, contentRank) >= 0.60
+	directReliable := score.directAppeal > 0.10 && score.directConfidence >= 0.50
+	bestBet := score.currentFit >= 0.18 && score.confidence >= 0.30 &&
+		score.metadataConfidence >= 0.35 && relevance >= 0.60 &&
+		(corroborated || directReliable) && !c.played[sceneID]
+	if bestBet {
+		classifications = append(classifications, builtLaneClassification{
+			sceneID: sceneID, lane: "best_bets",
+			laneValue: 0.55*relevance + 0.25*c.fitRanks[sceneID] + 0.20*score.confidence,
+			qualification: jvObj(
+				jvKey("current_fit", jvFloat(score.currentFit)),
+				jvKey("confidence", jvFloat(score.confidence)),
+				jvKey("metadata_confidence", jvFloat(score.metadataConfidence)),
+				jvKey("relevance", jvFloat(relevance)),
+				jvKey("content_percentile", jvFloat(contentRank)),
+				jvKey("neighbor_percentile", jvFloat(neighborRank)),
+				jvKey("neighbor_similarity_percentile", jvFloat(similarityRank)),
+				jvKey("performer_percentile", jvFloat(performerRank)),
+				jvKey("studio_percentile", jvFloat(studioRank)),
+				jvKey("corroborated", jvBool(corroborated)),
+				jvKey("direct_reliable", jvBool(directReliable)),
+				jvKey("unseen", jvBool(true)),
+			),
+		})
+	}
+	signals := []string{}
+	direct := score.components.get("direct")
+	if direct.kind == jObj {
+		for _, item := range direct.get("signals").arr {
+			signals = append(signals, item.asString())
+		}
+	}
+	durable := false
+	for _, signal := range signals {
+		if signal == "o" || signal == "thumb_up" || signal == "repeat" || signal == "scene_rating" {
+			durable = true
+			break
+		}
+	}
+	if score.directAppeal > 0.10 && score.directConfidence >= 0.35 &&
+		score.recovery >= 0.10 && durable && c.played[sceneID] {
+		durableSignals := jvArr()
+		seen := map[string]bool{}
+		for _, signal := range signals {
+			if !seen[signal] {
+				seen[signal] = true
+				durableSignals.arr = append(durableSignals.arr, jvStr(signal))
+			}
+		}
+		sort.SliceStable(durableSignals.arr, func(i, j int) bool {
+			return durableSignals.arr[i].asString() < durableSignals.arr[j].asString()
+		})
+		classifications = append(classifications, builtLaneClassification{
+			sceneID: sceneID, lane: "revisit",
+			laneValue: score.directAppeal*score.directConfidence*score.recovery +
+				0.25*score.currentFit,
+			qualification: jvObj(
+				jvKey("direct_appeal", jvFloat(score.directAppeal)),
+				jvKey("direct_confidence", jvFloat(score.directConfidence)),
+				jvKey("recovery", jvFloat(score.recovery)),
+				jvKey("durable_signals", durableSignals),
+			),
+		})
+	}
+	if !bestBet && score.directConfidence < 0.35 && strongestAnchor >= 0.08 {
+		subtype := "adjacent"
+		if len(negatives) == 1 {
+			subtype = "stretch"
+		} else if score.confidence < 0.35 || score.metadataConfidence < 0.30 {
+			subtype = "frontier"
+		}
+		var challenged jVal = jvNull()
+		if len(negatives) > 0 {
+			bestKey := ""
+			bestValue := 0.0
+			for family, value := range negatives {
+				if bestKey == "" || value < bestValue {
+					bestKey = family
+					bestValue = value
+				}
+			}
+			challenged = jvStr(bestKey)
+		}
+		classifications = append(classifications, builtLaneClassification{
+			sceneID: sceneID, lane: "discover", subtype: subtype,
+			laneValue: score.currentFit + 0.12*(1-score.confidence) + 0.5*strongestAnchor,
+			qualification: jvObj(
+				jvKey("positive_anchors", floatMapJVal(positives)),
+				jvKey("negative_assumptions", floatMapJVal(negatives)),
+				jvKey("challenged_assumption", challenged),
+				jvKey("uncertainty", jvFloat(1-score.confidence)),
+			),
+		})
+	}
+	subtype := adventureSubtype(score, positives, negatives,
+		reusable["structure"], c.coverageRanks[sceneID])
+	distanceRank := 1 - similarityRank
+	adventureValue := 0.38*c.coverageRanks[sceneID] + 0.25*distanceRank +
+		0.17*c.unknownPerformers[sceneID] + 0.08*c.unknownStudios[sceneID] +
+		0.12*score.metadataConfidence
+	classifications = append(classifications, builtLaneClassification{
+		sceneID: sceneID, lane: "adventure", subtype: subtype,
+		laneValue: adventureValue,
+		qualification: jvObj(
+			jvKey("positive_anchors", floatMapJVal(positives)),
+			jvKey("component_disagreement", floatMapJVal(negatives)),
+			jvKey("uncertainty", jvFloat(1-score.confidence)),
+			jvKey("coverage_gap_percentile", jvFloat(c.coverageRanks[sceneID])),
+			jvKey("content_distance_percentile", jvFloat(distanceRank)),
+			jvKey("unknown_performer_share", jvFloat(c.unknownPerformers[sceneID])),
+			jvKey("unknown_studio", jvFloat(c.unknownStudios[sceneID])),
+		),
+	})
+	return classifications
+}
+
 // laneClassify mirrors LanePolicy.classify and persists the rows.
 func laneClassify(db dbx, modelID string, featureVersion string, progress func(processed, total int)) ([]builtLaneClassification, error) {
 	scores, err := classificationData(db, modelID)
@@ -368,158 +535,45 @@ func laneClassify(db dbx, modelID string, featureVersion string, progress func(p
 	if err != nil {
 		return nil, err
 	}
+	sceneIDs := sortedStringKeys(eligibleScores)
+	total := len(sceneIDs)
 	var classifications []builtLaneClassification
-	total := len(eligibleScores)
-	position := 0
-	for _, sceneID := range sortedStringKeys(eligibleScores) {
-		position++
-		score := eligibleScores[sceneID]
-		reusable := map[string]float64{
-			"content":              componentValue(score.components, "content"),
-			"content_neighbor":     componentValue(score.components, "content_neighbor"),
-			"performer_identity":   componentValue(score.components, "performer_identity"),
-			"performer_similarity": componentValue(score.components, "performer_similarity"),
-			"studio":               componentValue(score.components, "studio"),
-			"structure":            componentValue(score.components, "structure"),
+	if total > 0 {
+		context := &laneContext{
+			contentRanks:      contentRanks,
+			neighborRanks:     neighborRanks,
+			similarityRanks:   similarityRanks,
+			performerRanks:    performerRanks,
+			studioRanks:       studioRanks,
+			fitRanks:          fitRanks,
+			coverageRanks:     coverageRanks,
+			unknownPerformers: unknownPerformers,
+			unknownStudios:    unknownStudios,
+			played:            played,
 		}
-		positives := map[string]float64{}
-		negatives := map[string]float64{}
-		for family, value := range reusable {
-			if value >= 0.025 {
-				positives[family] = value
-			} else if value <= -0.025 {
-				negatives[family] = value
-			}
-		}
-		strongestAnchor := 0.0
-		for _, value := range positives {
-			if value > strongestAnchor {
-				strongestAnchor = value
-			}
-		}
-		contentRank := contentRanks[sceneID]
-		neighborRank := neighborRanks[sceneID]
-		similarityRank := similarityRanks[sceneID]
-		performerRank := performerRanks[sceneID]
-		studioRank := studioRanks[sceneID]
-		relevance := (0.32*neighborRank + 0.10*similarityRank + 0.28*performerRank +
-			0.20*contentRank + 0.10*studioRank) * (0.90 + 0.10*score.metadataConfidence)
-		corroborated := neighborRank >= 0.60 && math.Max(performerRank, contentRank) >= 0.60
-		directReliable := score.directAppeal > 0.10 && score.directConfidence >= 0.50
-		bestBet := score.currentFit >= 0.18 && score.confidence >= 0.30 &&
-			score.metadataConfidence >= 0.35 && relevance >= 0.60 &&
-			(corroborated || directReliable) && !played[sceneID]
-		if bestBet {
-			classifications = append(classifications, builtLaneClassification{
-				sceneID: sceneID, lane: "best_bets",
-				laneValue: 0.55*relevance + 0.25*fitRanks[sceneID] + 0.20*score.confidence,
-				qualification: jvObj(
-					jvKey("current_fit", jvFloat(score.currentFit)),
-					jvKey("confidence", jvFloat(score.confidence)),
-					jvKey("metadata_confidence", jvFloat(score.metadataConfidence)),
-					jvKey("relevance", jvFloat(relevance)),
-					jvKey("content_percentile", jvFloat(contentRank)),
-					jvKey("neighbor_percentile", jvFloat(neighborRank)),
-					jvKey("neighbor_similarity_percentile", jvFloat(similarityRank)),
-					jvKey("performer_percentile", jvFloat(performerRank)),
-					jvKey("studio_percentile", jvFloat(studioRank)),
-					jvKey("corroborated", jvBool(corroborated)),
-					jvKey("direct_reliable", jvBool(directReliable)),
-					jvKey("unseen", jvBool(true)),
-				),
-			})
-		}
-		signals := []string{}
-		direct := score.components.get("direct")
-		if direct.kind == jObj {
-			for _, item := range direct.get("signals").arr {
-				signals = append(signals, item.asString())
-			}
-		}
-		durable := false
-		for _, signal := range signals {
-			if signal == "o" || signal == "thumb_up" || signal == "repeat" || signal == "scene_rating" {
-				durable = true
-				break
-			}
-		}
-		if score.directAppeal > 0.10 && score.directConfidence >= 0.35 &&
-			score.recovery >= 0.10 && durable && played[sceneID] {
-			durableSignals := jvArr()
-			seen := map[string]bool{}
-			for _, signal := range signals {
-				if !seen[signal] {
-					seen[signal] = true
-					durableSignals.arr = append(durableSignals.arr, jvStr(signal))
+		// Each scene's classification depends only on its own score and the
+		// precomputed ranks, so the loop is row-independent: run it in fixed
+		// chunks (the kernel pattern) with progress ticks emitted in scene
+		// order regardless of worker interleaving.
+		progressReporter := newOrderedProgress()
+		reporterDone := make(chan struct{})
+		go func() {
+			defer close(reporterDone)
+			progressReporter.wait(reportPoints(total), func(completed int) {
+				if progress != nil {
+					progress(completed, maxInt(1, total))
 				}
-			}
-			sort.SliceStable(durableSignals.arr, func(i, j int) bool {
-				return durableSignals.arr[i].asString() < durableSignals.arr[j].asString()
 			})
-			classifications = append(classifications, builtLaneClassification{
-				sceneID: sceneID, lane: "revisit",
-				laneValue: score.directAppeal*score.directConfidence*score.recovery +
-					0.25*score.currentFit,
-				qualification: jvObj(
-					jvKey("direct_appeal", jvFloat(score.directAppeal)),
-					jvKey("direct_confidence", jvFloat(score.directConfidence)),
-					jvKey("recovery", jvFloat(score.recovery)),
-					jvKey("durable_signals", durableSignals),
-				),
-			})
-		}
-		if !bestBet && score.directConfidence < 0.35 && strongestAnchor >= 0.08 {
-			subtype := "adjacent"
-			if len(negatives) == 1 {
-				subtype = "stretch"
-			} else if score.confidence < 0.35 || score.metadataConfidence < 0.30 {
-				subtype = "frontier"
+		}()
+		classifications = parallelChunks(total, nthreads(0), func(start, end int) []builtLaneClassification {
+			var out []builtLaneClassification
+			for _, sceneID := range sceneIDs[start:end] {
+				out = append(out, context.classifyScene(sceneID, eligibleScores[sceneID])...)
+				progressReporter.done()
 			}
-			var challenged jVal = jvNull()
-			if len(negatives) > 0 {
-				bestKey := ""
-				bestValue := 0.0
-				for family, value := range negatives {
-					if bestKey == "" || value < bestValue {
-						bestKey = family
-						bestValue = value
-					}
-				}
-				challenged = jvStr(bestKey)
-			}
-			classifications = append(classifications, builtLaneClassification{
-				sceneID: sceneID, lane: "discover", subtype: subtype,
-				laneValue: score.currentFit + 0.12*(1-score.confidence) + 0.5*strongestAnchor,
-				qualification: jvObj(
-					jvKey("positive_anchors", floatMapJVal(positives)),
-					jvKey("negative_assumptions", floatMapJVal(negatives)),
-					jvKey("challenged_assumption", challenged),
-					jvKey("uncertainty", jvFloat(1-score.confidence)),
-				),
-			})
-		}
-		subtype := adventureSubtype(score, positives, negatives,
-			reusable["structure"], coverageRanks[sceneID])
-		distanceRank := 1 - similarityRank
-		adventureValue := 0.38*coverageRanks[sceneID] + 0.25*distanceRank +
-			0.17*unknownPerformers[sceneID] + 0.08*unknownStudios[sceneID] +
-			0.12*score.metadataConfidence
-		classifications = append(classifications, builtLaneClassification{
-			sceneID: sceneID, lane: "adventure", subtype: subtype,
-			laneValue: adventureValue,
-			qualification: jvObj(
-				jvKey("positive_anchors", floatMapJVal(positives)),
-				jvKey("component_disagreement", floatMapJVal(negatives)),
-				jvKey("uncertainty", jvFloat(1-score.confidence)),
-				jvKey("coverage_gap_percentile", jvFloat(coverageRanks[sceneID])),
-				jvKey("content_distance_percentile", jvFloat(distanceRank)),
-				jvKey("unknown_performer_share", jvFloat(unknownPerformers[sceneID])),
-				jvKey("unknown_studio", jvFloat(unknownStudios[sceneID])),
-			),
+			return out
 		})
-		if progress != nil && (position == total || position%250 == 0) {
-			progress(position, maxInt(1, total))
-		}
+		<-reporterDone
 	}
 	if progress != nil && total == 0 {
 		progress(1, 1)

--- a/core/links.go
+++ b/core/links.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 const externalLinksCacheKey = "external_links"
@@ -93,6 +94,85 @@ func externalLinksRefresh(payload jVal, db dbx, progress func(processed, total i
 	return externalLinksImpl(payload, db, true, progress)
 }
 
+// linksPage is one externalLinksQuery page: the per-kind id->external maps
+// plus each collection's reported count (page 1's counts fix the page set).
+type linksPage struct {
+	page         int64
+	counts       map[string]int64
+	scenes       jVal
+	sceneIDs     jVal
+	scenePhashes jVal
+	performers   jVal
+	studios      jVal
+	err          error
+}
+
+// fetchLinksPage executes one externalLinksQuery page, merging each kind's
+// stash_id matches and scene phashes exactly like the sequential walk's
+// per-page body.
+func fetchLinksPage(base string, headers map[string]string, page int64) linksPage {
+	data, err := graphqlQuery(base, headers, externalLinksQuery,
+		jvObj(jvKey("page", jvInt(page)), jvKey("perPage", jvInt(500))))
+	if err != nil {
+		return linksPage{page: page, err: err}
+	}
+	result := linksPage{
+		page:         page,
+		counts:       map[string]int64{},
+		scenes:       jvObj(),
+		sceneIDs:     jvObj(),
+		scenePhashes: jvObj(),
+		performers:   jvObj(),
+		studios:      jvObj(),
+	}
+	for _, kind := range []string{"scenes", "performers", "studios"} {
+		collection := data.get(kind)
+		result.counts[kind] = pythonInt(collection.get("count"))
+		rows := collection.get(kind)
+		var target *jVal
+		switch kind {
+		case "scenes":
+			target = &result.scenes
+		case "performers":
+			target = &result.performers
+		default:
+			target = &result.studios
+		}
+		for _, row := range rows.arr {
+			external := ""
+			for _, item := range row.get("stash_ids").arr {
+				if strings.EqualFold(strings.TrimRight(item.get("endpoint").asString(), "/"),
+					strings.TrimRight(stashdbEndpoint, "/")) {
+					external = item.get("stash_id").asString()
+					break
+				}
+			}
+			if external != "" {
+				id := row.get("id").asString()
+				target.set(id, jvStr(external))
+				if kind == "scenes" {
+					result.sceneIDs.set(external, jvStr(id))
+				}
+			}
+			if kind == "scenes" {
+				for _, file := range row.get("files").arr {
+					for _, fingerprint := range file.get("fingerprints").arr {
+						if !strings.EqualFold(pythonStrOrEmpty(fingerprint.get("type")), "phash") {
+							continue
+						}
+						if value, ok := normalizePhash(fingerprint.get("value")); ok {
+							if !result.scenePhashes.has(value) { // setdefault
+								result.scenePhashes.set(value, jvStr(row.get("id").asString()))
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	return result
+}
+
 func externalLinksImpl(payload jVal, db dbx, refresh bool, progress func(processed, total int)) (jVal, error) {
 	state := ""
 	var err error
@@ -107,84 +187,85 @@ func externalLinksImpl(payload jVal, db dbx, refresh bool, progress func(process
 			return cached, nil
 		}
 	}
+	base, headers := stashConnection(payload)
+	// Page 1 is fetched synchronously: its counts fix the page set (the
+	// fetchParallel pattern). The remaining pages run over a bounded worker
+	// pool and merge in page order, so the aggregate is identical to the
+	// sequential loop (scene_phashes keeps first-seen semantics).
+	const pageSize = int64(500)
+	first := fetchLinksPage(base, headers, 1)
+	if first.err != nil {
+		return jvNull(), first.err
+	}
+	total := int64(0)
+	for _, kind := range []string{"scenes", "performers", "studios"} {
+		if count := first.counts[kind]; count > total {
+			total = count
+		}
+	}
+	pagesNeeded := (total + pageSize - 1) / pageSize
+	if pagesNeeded < 1 {
+		pagesNeeded = 1
+	}
+	pages := make([]linksPage, pagesNeeded)
+	pages[0] = first
+	if pagesNeeded > 1 {
+		workers := nthreads(0)
+		if workers < 1 {
+			workers = 1
+		}
+		pageCh := make(chan int64)
+		var wg sync.WaitGroup
+		for w := 0; w < workers; w++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for p := range pageCh {
+					pages[p-1] = fetchLinksPage(base, headers, p)
+				}
+			}()
+		}
+		for p := int64(2); p <= pagesNeeded; p++ {
+			pageCh <- p
+		}
+		close(pageCh)
+		wg.Wait()
+	}
 	scenes := jvObj()
 	sceneIDs := jvObj()
 	scenePhashes := jvObj()
 	performers := jvObj()
 	studios := jvObj()
-	base, headers := stashConnection(payload)
-	page := int64(1)
-	for {
-		data, err := graphqlQuery(base, headers, externalLinksQuery,
-			jvObj(jvKey("page", jvInt(page)), jvKey("perPage", jvInt(500))))
-		if err != nil {
-			return jvNull(), err
+	for index, page := range pages {
+		if page.err != nil {
+			return jvNull(), page.err
 		}
-		more := false
-		for _, kind := range []string{"scenes", "performers", "studios"} {
-			collection := data.get(kind)
-			rows := collection.get(kind)
-			var target *jVal
-			switch kind {
-			case "scenes":
-				target = &scenes
-			case "performers":
-				target = &performers
-			default:
-				target = &studios
+		// Merge in page order: per-kind maps take the last seen id mapping,
+		// scene_phashes keeps the first page that reported the value.
+		for _, pair := range page.scenes.obj {
+			scenes.set(pair.key, pair.val)
+		}
+		for _, pair := range page.sceneIDs.obj {
+			sceneIDs.set(pair.key, pair.val)
+		}
+		for _, pair := range page.scenePhashes.obj {
+			if !scenePhashes.has(pair.key) {
+				scenePhashes.set(pair.key, pair.val)
 			}
-			for _, row := range rows.arr {
-				external := ""
-				for _, item := range row.get("stash_ids").arr {
-					if strings.EqualFold(strings.TrimRight(item.get("endpoint").asString(), "/"),
-						strings.TrimRight(stashdbEndpoint, "/")) {
-						external = item.get("stash_id").asString()
-						break
-					}
-				}
-				if external != "" {
-					id := row.get("id").asString()
-					target.set(id, jvStr(external))
-					if kind == "scenes" {
-						sceneIDs.set(external, jvStr(id))
-					}
-				}
-				if kind == "scenes" {
-					for _, file := range row.get("files").arr {
-						for _, fingerprint := range file.get("fingerprints").arr {
-							if !strings.EqualFold(pythonStrOrEmpty(fingerprint.get("type")), "phash") {
-								continue
-							}
-							if value, ok := normalizePhash(fingerprint.get("value")); ok {
-								if !scenePhashes.has(value) { // setdefault
-									scenePhashes.set(value, jvStr(row.get("id").asString()))
-								}
-							}
-						}
-					}
-				}
-			}
-			if page*500 < pythonInt(collection.get("count")) {
-				more = true
-			}
+		}
+		for _, pair := range page.performers.obj {
+			performers.set(pair.key, pair.val)
+		}
+		for _, pair := range page.studios.obj {
+			studios.set(pair.key, pair.val)
 		}
 		if progress != nil {
-			total := int64(0)
-			for _, kind := range []string{"scenes", "performers", "studios"} {
-				if count := pythonInt(data.get(kind).get("count")); count > total {
-					total = count
-				}
-			}
-			processed := page * 500
+			processed := int64(index+1) * pageSize
 			if processed > total {
 				processed = total
 			}
 			progress(int(processed), int(total))
 		}
-		if !more {
-			break
-		}
-		page++
 	}
 	result := jvObj(
 		jvKey("scenes", scenes),

--- a/core/modelbuild2.go
+++ b/core/modelbuild2.go
@@ -432,7 +432,7 @@ WHERE p.played_at_ms >= ? GROUP BY p.scene_id ORDER BY played_at DESC LIMIT 200`
 }
 
 // satiation mirrors _satiation.
-func satiation(db dbx, sceneID string, appeal float64, context *recentContext) float64 {
+func satiation(sceneID string, appeal float64, context *recentContext) float64 {
 	if appeal <= 0 {
 		return 0.0
 	}
@@ -563,6 +563,359 @@ func edgeMatches(entry jVal) ([]jVal, error) {
 	return matches.arr, nil
 }
 
+// scoringContext carries the row-independent precomputed inputs for the
+// per-scene scoring loop (affinities, kernels' outputs, priors, recency).
+type scoringContext struct {
+	sceneFeatures       map[string][]storedFeature
+	affinities          map[string]modelAffinity
+	performerPriors     map[string]modelPrior
+	studioPriors        map[string]modelPrior
+	performerSimilarity jVal
+	neighbors           map[string]neighborEvidence
+	labels              map[string]sceneLabel
+	lastPlayed          map[string]int64
+	recentContext       *recentContext
+	eligibility         map[string]jVal
+	profiles            map[string]bool
+	vectors             map[string]map[string]float64
+	baseline            float64
+	labelMean           float64
+	baselineSupport     float64
+	discriminative      int
+	referenceAtMs       int64
+}
+
+type activeEvidence struct {
+	value      float64
+	confidence float64
+}
+
+// scoreScene computes the components, appeal, fit, and confidence for one
+// scene (the _scores per-scene body). Every input is a precomputed read-only
+// map, so the loop is row-independent: fixed-chunk parallel processing
+// yields identical scores.
+func (c *scoringContext) scoreScene(sceneID string) buildModelScore {
+	features := c.sceneFeatures[sceneID]
+	components := jvObj(jvKey("baseline", jvObj(
+		jvKey("raw", jvFloat(c.baseline)),
+		jvKey("value", jvFloat(c.baseline)),
+		jvKey("training_outcome_mean", jvFloat(c.labelMean)),
+		jvKey("effective_support", jvFloat(c.baselineSupport)),
+	)))
+	familyConfidences := map[string]float64{}
+	for _, family := range []struct {
+		name  string
+		bound float64
+	}{{"content", 0.35}, {"structure", 0.05}} {
+		var contributions jVal = jvArr()
+		for _, feature := range features {
+			if feature.family != family.name {
+				continue
+			}
+			affinity, ok := c.affinities[feature.featureID]
+			if !ok {
+				continue
+			}
+			value := feature.value * affinity.affinity * affinity.confidence
+			contributions.arr = append(contributions.arr, jvObj(
+				jvKey("feature_id", jvStr(feature.featureID)),
+				jvKey("name", jvStr(feature.name)),
+				jvKey("value", jvFloat(value)),
+				jvKey("affinity", jvFloat(affinity.affinity)),
+				jvKey("confidence", jvFloat(affinity.confidence)),
+				jvKey("metadata", feature.metadata),
+				jvKey("affinity_metadata", affinity.contexts),
+			))
+		}
+		contributionValues := make([]float64, 0, len(contributions.arr))
+		absValues := make([]float64, 0, len(contributions.arr))
+		for _, item := range contributions.arr {
+			value := numberValue(item.get("value"))
+			contributionValues = append(contributionValues, value)
+			absValues = append(absValues, math.Abs(value))
+		}
+		raw := sumFloats(contributionValues)
+		contributionMass := sumFloats(absValues)
+		var evidenceConfidence float64
+		if contributionMass != 0 {
+			weightedValues := make([]float64, 0, len(contributions.arr))
+			for _, item := range contributions.arr {
+				value := numberValue(item.get("value"))
+				weightedValues = append(weightedValues, math.Abs(value)*numberValue(item.get("confidence")))
+			}
+			evidenceConfidence = sumFloats(weightedValues) / contributionMass
+		}
+		familyConfidences[family.name] = evidenceConfidence
+		sorted := append([]jVal(nil), contributions.arr...)
+		sort.SliceStable(sorted, func(i, j int) bool {
+			a, b := sorted[i], sorted[j]
+			absA, absB := math.Abs(numberValue(a.get("value"))), math.Abs(numberValue(b.get("value")))
+			if absA != absB {
+				return absA > absB
+			}
+			return a.get("name").asString() < b.get("name").asString()
+		})
+		if len(sorted) > 5 {
+			sorted = sorted[:5]
+		}
+		top := jvArr(sorted...)
+		if len(contributionValues) == 0 {
+			components.set(family.name, jvObj(
+				jvKey("raw", jvInt(0)),
+				jvKey("value", jvInt(0)),
+				jvKey("evidence_confidence", jvFloat(evidenceConfidence)),
+				jvKey("top", top),
+			))
+		} else {
+			components.set(family.name, jvObj(
+				jvKey("raw", jvFloat(raw)),
+				jvKey("value", jvFloat(clampValue(raw, -family.bound, family.bound))),
+				jvKey("evidence_confidence", jvFloat(evidenceConfidence)),
+				jvKey("top", top),
+			))
+		}
+	}
+	var performerItems []storedFeature
+	for _, feature := range features {
+		if feature.family == "performer_identity" {
+			performerItems = append(performerItems, feature)
+		}
+	}
+	identityValues := jvArr()
+	similarityValues := jvArr()
+	var identityRaw, similarityRaw, identityConfidence, similarityConfidence float64
+	var identityValueList, similarityValueList []float64
+	for _, feature := range performerItems {
+		performerID := strings.TrimPrefix(feature.name, "performer:")
+		affinity, hasAffinity := c.affinities[feature.featureID]
+		learned := 0.0
+		affinityConfidence := 0.0
+		if hasAffinity {
+			learned = affinity.affinity * affinity.confidence
+			affinityConfidence = affinity.confidence
+		}
+		prior := c.performerPriors[performerID]
+		identityValues.arr = append(identityValues.arr, jvObj(
+			jvKey("performer_id", jvStr(performerID)),
+			jvKey("value", jvFloat(learned+prior.value)),
+			jvKey("learned", jvFloat(learned)),
+			jvKey("prior", jvFloat(prior.value)),
+			jvKey("confidence", jvFloat(math.Max(affinityConfidence, prior.confidence))),
+		))
+		identityConfidence = math.Max(identityConfidence, math.Max(affinityConfidence, prior.confidence))
+		identityValueList = append(identityValueList, learned+prior.value)
+		similarity := c.performerSimilarity.get(performerID)
+		var simValue, simConfidence float64
+		if similarity.kind == jObj {
+			simValue = numberValue(similarity.get("value"))
+			simConfidence = numberValue(similarity.get("confidence"))
+		}
+		noveltyWeight := math.Max(0.05, 1-identityConfidence)
+		similarityItem := jvObj()
+		for _, pair := range similarity.obj {
+			similarityItem.set(pair.key, pair.val)
+		}
+		similarityItem.set("performer_id", jvStr(performerID))
+		similarityItem.set("raw_value", jvFloat(simValue))
+		similarityItem.set("value", jvFloat(simValue*noveltyWeight))
+		similarityItem.set("confidence", jvFloat(simConfidence*noveltyWeight))
+		similarityItem.set("identity_confidence", jvFloat(identityConfidence))
+		similarityItem.set("novelty_weight", jvFloat(noveltyWeight))
+		similarityValues.arr = append(similarityValues.arr, similarityItem)
+		similarityValueList = append(similarityValueList, simValue*noveltyWeight)
+		similarityConfidence = math.Max(similarityConfidence, simConfidence*noveltyWeight)
+	}
+	identityRaw = asymmetric(identityValueList)
+	similarityRaw = asymmetric(similarityValueList)
+	familyConfidences["performer_identity"] = identityConfidence
+	familyConfidences["performer_similarity"] = similarityConfidence
+	components.set("performer_identity", jvObj(
+		jvKey("raw", jvFloat(identityRaw)),
+		jvKey("value", jvFloat(clampValue(identityRaw, -0.30, 0.30))),
+		jvKey("performers", identityValues),
+		jvKey("evidence_confidence", jvFloat(identityConfidence)),
+	))
+	components.set("performer_similarity", jvObj(
+		jvKey("raw", jvFloat(similarityRaw)),
+		jvKey("value", jvFloat(clampValue(similarityRaw, -0.16, 0.16))),
+		jvKey("performers", similarityValues),
+		jvKey("evidence_confidence", jvFloat(similarityConfidence)),
+	))
+	var studioItems jVal = jvArr()
+	var studioConfidence float64
+	for _, feature := range features {
+		if feature.family != "studio" {
+			continue
+		}
+		studioID := strings.TrimPrefix(feature.name, "studio:")
+		affinity, hasAffinity := c.affinities[feature.featureID]
+		learned := 0.0
+		affinityConfidence := 0.0
+		if hasAffinity {
+			learned = affinity.affinity * affinity.confidence
+			affinityConfidence = affinity.confidence
+		}
+		prior := c.studioPriors[studioID]
+		value := learned + prior.value
+		confidence := math.Max(affinityConfidence, prior.confidence)
+		studioItems.arr = append(studioItems.arr, jvObj(
+			jvKey("studio_id", jvStr(studioID)),
+			jvKey("value", jvFloat(value)),
+			jvKey("learned", jvFloat(learned)),
+			jvKey("prior", jvFloat(prior.value)),
+			jvKey("confidence", jvFloat(confidence)),
+		))
+		studioConfidence = math.Max(studioConfidence, confidence)
+	}
+	studioValues := make([]float64, 0, len(studioItems.arr))
+	for _, item := range studioItems.arr {
+		studioValues = append(studioValues, numberValue(item.get("value")))
+	}
+	studioRaw := sumFloats(studioValues)
+	familyConfidences["studio"] = studioConfidence
+	if len(studioItems.arr) == 0 {
+		components.set("studio", jvObj(
+			jvKey("raw", jvInt(0)),
+			jvKey("value", jvInt(0)),
+			jvKey("studios", studioItems),
+			jvKey("evidence_confidence", jvFloat(studioConfidence)),
+		))
+	} else {
+		components.set("studio", jvObj(
+			jvKey("raw", jvFloat(studioRaw)),
+			jvKey("value", jvFloat(clampValue(studioRaw, -0.12, 0.12))),
+			jvKey("studios", studioItems),
+			jvKey("evidence_confidence", jvFloat(studioConfidence)),
+		))
+	}
+	neighborData, hasNeighbors := c.neighbors[sceneID]
+	if !hasNeighbors {
+		neighborData = neighborEvidence{}
+	}
+	neighborValue := neighborData.value
+	neighborOutcomeMean := neighborData.outcomeMean
+	neighborLift := neighborData.lift
+	neighborConfidence := neighborData.confidence
+	neighborTotalWeight := neighborData.totalWeight
+	if !hasNeighbors {
+		neighborValue, neighborOutcomeMean, neighborLift, neighborConfidence, neighborTotalWeight = 0.0, c.labelMean, 0.0, 0.0, 0.0
+	}
+	familyConfidences["content_neighbor"] = neighborConfidence
+	components.set("content_neighbor", jvObj(
+		jvKey("raw", jvFloat(neighborValue)),
+		jvKey("value", jvFloat(clampValue(neighborValue, -0.20, 0.20))),
+		jvKey("outcome_mean", jvFloat(neighborOutcomeMean)),
+		jvKey("training_outcome_mean", jvFloat(c.labelMean)),
+		jvKey("lift", jvFloat(neighborLift)),
+		jvKey("evidence_confidence", jvFloat(neighborConfidence)),
+		jvKey("total_weight", jvFloat(neighborTotalWeight)),
+		jvKey("vector_mode", jvStr("preference_discriminative")),
+		jvKey("discriminative_tag_count", jvInt(int64(c.discriminative))),
+	))
+	var componentValues []float64
+	for _, pair := range components.obj {
+		if pair.val.kind == jObj {
+			if value := pair.val.get("value"); value.kind == jNum {
+				componentValues = append(componentValues, numberValue(value))
+			}
+		}
+	}
+	componentTotal := sumFloats(componentValues)
+	general := clamp(componentTotal)
+	direct := c.labels[sceneID]
+	exactConfidence := directConfidenceOf(direct.effectiveEvidence)
+	appeal := blendAppealOf(general, direct.outcome, exactConfidence)
+	last, played := c.lastPlayed[sceneID]
+	var recovery float64
+	if !played {
+		recovery = 1.0
+	} else {
+		days := math.Max(0, float64(c.referenceAtMs-last)/86_400_000)
+		recovery = sceneRecovery(days)
+	}
+	cooldown := math.Max(0, appeal) * (1 - recovery)
+	satiationValue := satiation(sceneID, appeal, c.recentContext)
+	notNow := notNowPenalty(sceneID, c.referenceAtMs, c.recentContext)
+	currentFit := clamp(appeal - cooldown - satiationValue - notNow)
+	contentCount := len(c.vectors[sceneID])
+	var performerProfileCount float64
+	for _, item := range identityValues.arr {
+		if c.profiles[item.get("performer_id").asString()] {
+			performerProfileCount++
+		}
+	}
+	metadataConfidence := 1 - math.Exp(-(float64(contentCount)+performerProfileCount+float64(len(studioItems.arr)))/5)
+	var active []activeEvidence
+	for _, family := range []string{"content", "structure", "performer_identity",
+		"performer_similarity", "studio", "content_neighbor"} {
+		familyConfidence := familyConfidences[family]
+		component := components.get(family)
+		if component.kind != jObj || familyConfidence <= 0 {
+			continue
+		}
+		componentValue := math.Abs(numberValue(component.get("value")))
+		if componentValue >= 0.005 {
+			active = append(active, activeEvidence{componentValue, familyConfidence})
+		}
+	}
+	activeValues := make([]float64, 0, len(active))
+	activeWeighted := make([]float64, 0, len(active))
+	for _, item := range active {
+		activeValues = append(activeValues, item.value)
+		activeWeighted = append(activeWeighted, item.value*item.confidence)
+	}
+	evidenceMass := sumFloats(activeValues)
+	var evidenceConfidence float64
+	if evidenceMass != 0 {
+		evidenceConfidence = sumFloats(activeWeighted) / evidenceMass
+	}
+	breadth := 1 - math.Exp(-float64(len(active))/2)
+	predictionConfidence := evidenceConfidence * (0.65 + 0.35*breadth)
+	confidence := clampValue(exactConfidence+(1-exactConfidence)*predictionConfidence, 0, 1)
+	directSignals := jvArr()
+	for _, signal := range direct.signalTypes {
+		directSignals.arr = append(directSignals.arr, jvStr(signal))
+	}
+	components.set("direct", jvObj(
+		jvKey("value", jvFloat(direct.outcome)),
+		jvKey("confidence", jvFloat(exactConfidence)),
+		jvKey("effective_evidence", jvFloat(direct.effectiveEvidence)),
+		jvKey("signals", directSignals),
+		jvKey("residual", jvFloat(clampValue(direct.outcome-general, -2, 2))),
+	))
+	components.set("fit", jvObj(
+		jvKey("cooldown", jvFloat(-cooldown)),
+		jvKey("satiation", jvFloat(-satiationValue)),
+		jvKey("not_now", jvFloat(-notNow)),
+		jvKey("recovery", jvFloat(recovery)),
+	))
+	eligibilityValue, ok := c.eligibility[sceneID]
+	if !ok {
+		eligibilityValue = jvObj(
+			jvKey("eligible", jvBool(false)),
+			jvKey("reasons", jvArr(jvStr("missing"))),
+		)
+	}
+	var neighborItems []jVal
+	if hasNeighbors {
+		neighborItems = neighborData.neighbors
+	}
+	return buildModelScore{
+		sceneID:            sceneID,
+		generalAppeal:      general,
+		directAppeal:       direct.outcome,
+		directConfidence:   exactConfidence,
+		appeal:             appeal,
+		currentFit:         currentFit,
+		confidence:         confidence,
+		metadataConfidence: metadataConfidence,
+		recovery:           recovery,
+		components:         components,
+		neighbors:          neighborItems,
+		eligibility:        eligibilityValue,
+	}
+}
+
 // modelScores runs the scoring stage (mirroring _scores).
 func buildModelScores(db dbx, featureVersion string, sceneFeatures map[string][]storedFeature,
 	affinities map[string]modelAffinity, labels map[string]sceneLabel,
@@ -647,334 +1000,50 @@ func buildModelScores(db dbx, featureVersion string, sceneFeatures map[string][]
 	}
 	var scores []buildModelScore
 	totalScenes := len(allSceneIDs)
-	for sceneIndex, sceneID := range allSceneIDs {
-		features := sceneFeatures[sceneID]
-		components := jvObj(jvKey("baseline", jvObj(
-			jvKey("raw", jvFloat(baseline)),
-			jvKey("value", jvFloat(baseline)),
-			jvKey("training_outcome_mean", jvFloat(labelMean)),
-			jvKey("effective_support", jvFloat(baselineSupport)),
-		)))
-		familyConfidences := map[string]float64{}
-		for _, family := range []struct {
-			name  string
-			bound float64
-		}{{"content", 0.35}, {"structure", 0.05}} {
-			var contributions jVal = jvArr()
-			for _, feature := range features {
-				if feature.family != family.name {
-					continue
+	if totalScenes > 0 {
+		context := &scoringContext{
+			sceneFeatures:       sceneFeatures,
+			affinities:          affinities,
+			performerPriors:     performerPriors,
+			studioPriors:        studioPriors,
+			performerSimilarity: performerSimilarity,
+			neighbors:           neighbors,
+			labels:              labels,
+			lastPlayed:          lastPlayed,
+			recentContext:       recentContext,
+			eligibility:         eligibility,
+			profiles:            profiles,
+			vectors:             vectors,
+			baseline:            baseline,
+			labelMean:           labelMean,
+			baselineSupport:     baselineSupport,
+			discriminative:      discriminative,
+			referenceAtMs:       referenceAtMs,
+		}
+		// Each scene's score depends only on its own features and the
+		// precomputed affinities/kernel outputs, so the loop is
+		// row-independent: run it in fixed chunks (the kernel pattern) with
+		// progress ticks emitted in scene order.
+		progressReporter := newOrderedProgress()
+		reporterDone := make(chan struct{})
+		go func() {
+			defer close(reporterDone)
+			progressReporter.wait(reportPoints(totalScenes), func(completed int) {
+				if report != nil {
+					progressIndex := len(preferenceVectors) + completed
+					report(0.35 + 0.40*float64(progressIndex)/float64(maxInt(1, progressTotal)))
 				}
-				affinity, ok := affinities[feature.featureID]
-				if !ok {
-					continue
-				}
-				value := feature.value * affinity.affinity * affinity.confidence
-				contributions.arr = append(contributions.arr, jvObj(
-					jvKey("feature_id", jvStr(feature.featureID)),
-					jvKey("name", jvStr(feature.name)),
-					jvKey("value", jvFloat(value)),
-					jvKey("affinity", jvFloat(affinity.affinity)),
-					jvKey("confidence", jvFloat(affinity.confidence)),
-					jvKey("metadata", feature.metadata),
-					jvKey("affinity_metadata", affinity.contexts),
-				))
-			}
-			contributionValues := make([]float64, 0, len(contributions.arr))
-			absValues := make([]float64, 0, len(contributions.arr))
-			for _, item := range contributions.arr {
-				value := numberValue(item.get("value"))
-				contributionValues = append(contributionValues, value)
-				absValues = append(absValues, math.Abs(value))
-			}
-			raw := sumFloats(contributionValues)
-			contributionMass := sumFloats(absValues)
-			var evidenceConfidence float64
-			if contributionMass != 0 {
-				weightedValues := make([]float64, 0, len(contributions.arr))
-				for _, item := range contributions.arr {
-					value := numberValue(item.get("value"))
-					weightedValues = append(weightedValues, math.Abs(value)*numberValue(item.get("confidence")))
-				}
-				evidenceConfidence = sumFloats(weightedValues) / contributionMass
-			}
-			familyConfidences[family.name] = evidenceConfidence
-			sorted := append([]jVal(nil), contributions.arr...)
-			sort.SliceStable(sorted, func(i, j int) bool {
-				a, b := sorted[i], sorted[j]
-				absA, absB := math.Abs(numberValue(a.get("value"))), math.Abs(numberValue(b.get("value")))
-				if absA != absB {
-					return absA > absB
-				}
-				return a.get("name").asString() < b.get("name").asString()
 			})
-			if len(sorted) > 5 {
-				sorted = sorted[:5]
+		}()
+		scores = parallelChunks(totalScenes, nthreads(0), func(start, end int) []buildModelScore {
+			out := make([]buildModelScore, 0, end-start)
+			for _, sceneID := range allSceneIDs[start:end] {
+				out = append(out, context.scoreScene(sceneID))
+				progressReporter.done()
 			}
-			top := jvArr(sorted...)
-			if len(contributionValues) == 0 {
-				components.set(family.name, jvObj(
-					jvKey("raw", jvInt(0)),
-					jvKey("value", jvInt(0)),
-					jvKey("evidence_confidence", jvFloat(evidenceConfidence)),
-					jvKey("top", top),
-				))
-			} else {
-				components.set(family.name, jvObj(
-					jvKey("raw", jvFloat(raw)),
-					jvKey("value", jvFloat(clampValue(raw, -family.bound, family.bound))),
-					jvKey("evidence_confidence", jvFloat(evidenceConfidence)),
-					jvKey("top", top),
-				))
-			}
-		}
-		var performerItems []storedFeature
-		for _, feature := range features {
-			if feature.family == "performer_identity" {
-				performerItems = append(performerItems, feature)
-			}
-		}
-		identityValues := jvArr()
-		similarityValues := jvArr()
-		var identityRaw, similarityRaw, identityConfidence, similarityConfidence float64
-		var identityValueList, similarityValueList []float64
-		for _, feature := range performerItems {
-			performerID := strings.TrimPrefix(feature.name, "performer:")
-			affinity, hasAffinity := affinities[feature.featureID]
-			learned := 0.0
-			affinityConfidence := 0.0
-			if hasAffinity {
-				learned = affinity.affinity * affinity.confidence
-				affinityConfidence = affinity.confidence
-			}
-			prior := performerPriors[performerID]
-			identityValues.arr = append(identityValues.arr, jvObj(
-				jvKey("performer_id", jvStr(performerID)),
-				jvKey("value", jvFloat(learned+prior.value)),
-				jvKey("learned", jvFloat(learned)),
-				jvKey("prior", jvFloat(prior.value)),
-				jvKey("confidence", jvFloat(math.Max(affinityConfidence, prior.confidence))),
-			))
-			identityConfidence = math.Max(identityConfidence, math.Max(affinityConfidence, prior.confidence))
-			identityValueList = append(identityValueList, learned+prior.value)
-			similarity := performerSimilarity.get(performerID)
-			var simValue, simConfidence float64
-			if similarity.kind == jObj {
-				simValue = numberValue(similarity.get("value"))
-				simConfidence = numberValue(similarity.get("confidence"))
-			}
-			noveltyWeight := math.Max(0.05, 1-identityConfidence)
-			similarityItem := jvObj()
-			for _, pair := range similarity.obj {
-				similarityItem.set(pair.key, pair.val)
-			}
-			similarityItem.set("performer_id", jvStr(performerID))
-			similarityItem.set("raw_value", jvFloat(simValue))
-			similarityItem.set("value", jvFloat(simValue*noveltyWeight))
-			similarityItem.set("confidence", jvFloat(simConfidence*noveltyWeight))
-			similarityItem.set("identity_confidence", jvFloat(identityConfidence))
-			similarityItem.set("novelty_weight", jvFloat(noveltyWeight))
-			similarityValues.arr = append(similarityValues.arr, similarityItem)
-			similarityValueList = append(similarityValueList, simValue*noveltyWeight)
-			similarityConfidence = math.Max(similarityConfidence, simConfidence*noveltyWeight)
-		}
-		identityRaw = asymmetric(identityValueList)
-		similarityRaw = asymmetric(similarityValueList)
-		familyConfidences["performer_identity"] = identityConfidence
-		familyConfidences["performer_similarity"] = similarityConfidence
-		components.set("performer_identity", jvObj(
-			jvKey("raw", jvFloat(identityRaw)),
-			jvKey("value", jvFloat(clampValue(identityRaw, -0.30, 0.30))),
-			jvKey("performers", identityValues),
-			jvKey("evidence_confidence", jvFloat(identityConfidence)),
-		))
-		components.set("performer_similarity", jvObj(
-			jvKey("raw", jvFloat(similarityRaw)),
-			jvKey("value", jvFloat(clampValue(similarityRaw, -0.16, 0.16))),
-			jvKey("performers", similarityValues),
-			jvKey("evidence_confidence", jvFloat(similarityConfidence)),
-		))
-		var studioItems jVal = jvArr()
-		var studioConfidence float64
-		for _, feature := range features {
-			if feature.family != "studio" {
-				continue
-			}
-			studioID := strings.TrimPrefix(feature.name, "studio:")
-			affinity, hasAffinity := affinities[feature.featureID]
-			learned := 0.0
-			affinityConfidence := 0.0
-			if hasAffinity {
-				learned = affinity.affinity * affinity.confidence
-				affinityConfidence = affinity.confidence
-			}
-			prior := studioPriors[studioID]
-			value := learned + prior.value
-			confidence := math.Max(affinityConfidence, prior.confidence)
-			studioItems.arr = append(studioItems.arr, jvObj(
-				jvKey("studio_id", jvStr(studioID)),
-				jvKey("value", jvFloat(value)),
-				jvKey("learned", jvFloat(learned)),
-				jvKey("prior", jvFloat(prior.value)),
-				jvKey("confidence", jvFloat(confidence)),
-			))
-			studioConfidence = math.Max(studioConfidence, confidence)
-		}
-		studioValues := make([]float64, 0, len(studioItems.arr))
-		for _, item := range studioItems.arr {
-			studioValues = append(studioValues, numberValue(item.get("value")))
-		}
-		studioRaw := sumFloats(studioValues)
-		familyConfidences["studio"] = studioConfidence
-		if len(studioItems.arr) == 0 {
-			components.set("studio", jvObj(
-				jvKey("raw", jvInt(0)),
-				jvKey("value", jvInt(0)),
-				jvKey("studios", studioItems),
-				jvKey("evidence_confidence", jvFloat(studioConfidence)),
-			))
-		} else {
-			components.set("studio", jvObj(
-				jvKey("raw", jvFloat(studioRaw)),
-				jvKey("value", jvFloat(clampValue(studioRaw, -0.12, 0.12))),
-				jvKey("studios", studioItems),
-				jvKey("evidence_confidence", jvFloat(studioConfidence)),
-			))
-		}
-		neighborData, hasNeighbors := neighbors[sceneID]
-		if !hasNeighbors {
-			neighborData = neighborEvidence{}
-		}
-		neighborValue := neighborData.value
-		neighborOutcomeMean := neighborData.outcomeMean
-		neighborLift := neighborData.lift
-		neighborConfidence := neighborData.confidence
-		neighborTotalWeight := neighborData.totalWeight
-		if !hasNeighbors {
-			neighborValue, neighborOutcomeMean, neighborLift, neighborConfidence, neighborTotalWeight = 0.0, labelMean, 0.0, 0.0, 0.0
-		}
-		familyConfidences["content_neighbor"] = neighborConfidence
-		components.set("content_neighbor", jvObj(
-			jvKey("raw", jvFloat(neighborValue)),
-			jvKey("value", jvFloat(clampValue(neighborValue, -0.20, 0.20))),
-			jvKey("outcome_mean", jvFloat(neighborOutcomeMean)),
-			jvKey("training_outcome_mean", jvFloat(labelMean)),
-			jvKey("lift", jvFloat(neighborLift)),
-			jvKey("evidence_confidence", jvFloat(neighborConfidence)),
-			jvKey("total_weight", jvFloat(neighborTotalWeight)),
-			jvKey("vector_mode", jvStr("preference_discriminative")),
-			jvKey("discriminative_tag_count", jvInt(int64(discriminative))),
-		))
-		var componentValues []float64
-		for _, pair := range components.obj {
-			if pair.val.kind == jObj {
-				if value := pair.val.get("value"); value.kind == jNum {
-					componentValues = append(componentValues, numberValue(value))
-				}
-			}
-		}
-		componentTotal := sumFloats(componentValues)
-		general := clamp(componentTotal)
-		direct := labels[sceneID]
-		exactConfidence := directConfidenceOf(direct.effectiveEvidence)
-		appeal := blendAppealOf(general, direct.outcome, exactConfidence)
-		last, played := lastPlayed[sceneID]
-		var recovery float64
-		if !played {
-			recovery = 1.0
-		} else {
-			days := math.Max(0, float64(referenceAtMs-last)/86_400_000)
-			recovery = sceneRecovery(days)
-		}
-		cooldown := math.Max(0, appeal) * (1 - recovery)
-		satiationValue := satiation(db, sceneID, appeal, recentContext)
-		notNow := notNowPenalty(sceneID, referenceAtMs, recentContext)
-		currentFit := clamp(appeal - cooldown - satiationValue - notNow)
-		contentCount := len(vectors[sceneID])
-		var performerProfileCount float64
-		for _, item := range identityValues.arr {
-			if profiles[item.get("performer_id").asString()] {
-				performerProfileCount++
-			}
-		}
-		metadataConfidence := 1 - math.Exp(-(float64(contentCount)+performerProfileCount+float64(len(studioItems.arr)))/5)
-		type activeEvidence struct {
-			value      float64
-			confidence float64
-		}
-		var active []activeEvidence
-		for _, family := range []string{"content", "structure", "performer_identity",
-			"performer_similarity", "studio", "content_neighbor"} {
-			familyConfidence := familyConfidences[family]
-			component := components.get(family)
-			if component.kind != jObj || familyConfidence <= 0 {
-				continue
-			}
-			componentValue := math.Abs(numberValue(component.get("value")))
-			if componentValue >= 0.005 {
-				active = append(active, activeEvidence{componentValue, familyConfidence})
-			}
-		}
-		activeValues := make([]float64, 0, len(active))
-		activeWeighted := make([]float64, 0, len(active))
-		for _, item := range active {
-			activeValues = append(activeValues, item.value)
-			activeWeighted = append(activeWeighted, item.value*item.confidence)
-		}
-		evidenceMass := sumFloats(activeValues)
-		var evidenceConfidence float64
-		if evidenceMass != 0 {
-			evidenceConfidence = sumFloats(activeWeighted) / evidenceMass
-		}
-		breadth := 1 - math.Exp(-float64(len(active))/2)
-		predictionConfidence := evidenceConfidence * (0.65 + 0.35*breadth)
-		confidence := clampValue(exactConfidence+(1-exactConfidence)*predictionConfidence, 0, 1)
-		directSignals := jvArr()
-		for _, signal := range direct.signalTypes {
-			directSignals.arr = append(directSignals.arr, jvStr(signal))
-		}
-		components.set("direct", jvObj(
-			jvKey("value", jvFloat(direct.outcome)),
-			jvKey("confidence", jvFloat(exactConfidence)),
-			jvKey("effective_evidence", jvFloat(direct.effectiveEvidence)),
-			jvKey("signals", directSignals),
-			jvKey("residual", jvFloat(clampValue(direct.outcome-general, -2, 2))),
-		))
-		components.set("fit", jvObj(
-			jvKey("cooldown", jvFloat(-cooldown)),
-			jvKey("satiation", jvFloat(-satiationValue)),
-			jvKey("not_now", jvFloat(-notNow)),
-			jvKey("recovery", jvFloat(recovery)),
-		))
-		eligibilityValue, ok := eligibility[sceneID]
-		if !ok {
-			eligibilityValue = jvObj(
-				jvKey("eligible", jvBool(false)),
-				jvKey("reasons", jvArr(jvStr("missing"))),
-			)
-		}
-		var neighborItems []jVal
-		if hasNeighbors {
-			neighborItems = neighborData.neighbors
-		}
-		scores = append(scores, buildModelScore{
-			sceneID:            sceneID,
-			generalAppeal:      general,
-			directAppeal:       direct.outcome,
-			directConfidence:   exactConfidence,
-			appeal:             appeal,
-			currentFit:         currentFit,
-			confidence:         confidence,
-			metadataConfidence: metadataConfidence,
-			recovery:           recovery,
-			components:         components,
-			neighbors:          neighborItems,
-			eligibility:        eligibilityValue,
+			return out
 		})
-		progressIndex := len(preferenceVectors) + sceneIndex + 1
-		if report != nil && (sceneIndex+1 == totalScenes || (sceneIndex+1)%250 == 0) {
-			report(0.35 + 0.40*float64(progressIndex)/float64(maxInt(1, progressTotal)))
-		}
+		<-reporterDone
 	}
 	return scores, performerSimilarity, nil
 }

--- a/core/parallel.go
+++ b/core/parallel.go
@@ -1,0 +1,78 @@
+package main
+
+// Deterministic fixed-chunking helpers shared by the parallelized build
+// stages. The content and performer kernels process rows in fixed chunks
+// with one goroutine per chunk and assemble results in chunk order, making
+// the output identical across goroutine counts (verified by the differential
+// gates); these helpers extend the same pattern to the serial per-scene
+// loops (lane classification, model scoring, feature construction).
+
+import "sync"
+
+// parallelChunks runs fn over fixed chunks of [0, n) with one goroutine per
+// chunk and returns the outputs concatenated in chunk order. fn returns the
+// outputs for its [start, end) items in order; chunks partition the item
+// sequence without overlap, so the aggregate is identical across goroutine
+// counts. n <= 0 returns nil.
+func parallelChunks[T any](n, threads int, fn func(start, end int) []T) []T {
+	if n <= 0 {
+		return nil
+	}
+	if threads > n {
+		threads = n
+	}
+	chunk := (n + threads - 1) / threads
+	nchunks := (n + chunk - 1) / chunk
+	results := make([][]T, nchunks)
+	var wg sync.WaitGroup
+	for w := 0; w < nchunks; w++ {
+		start := w * chunk
+		end := min(start+chunk, n)
+		wg.Add(1)
+		go func(w, start, end int) {
+			defer wg.Done()
+			results[w] = fn(start, end)
+		}(w, start, end)
+	}
+	wg.Wait()
+	var out []T
+	for _, part := range results {
+		out = append(out, part...)
+	}
+	return out
+}
+
+// orderedProgress emits progress ticks at the given points in point order
+// regardless of worker interleaving, mirroring the contentKernel reporter
+// (progress lines stay in strict item order). done must be called once per
+// completed item; wait reports each point once completed reaches it and
+// returns after the last point.
+type orderedProgress struct {
+	mu        sync.Mutex
+	completed int
+	cond      *sync.Cond
+}
+
+func newOrderedProgress() *orderedProgress {
+	p := &orderedProgress{}
+	p.cond = sync.NewCond(&p.mu)
+	return p
+}
+
+func (p *orderedProgress) done() {
+	p.mu.Lock()
+	p.completed++
+	p.cond.Signal()
+	p.mu.Unlock()
+}
+
+func (p *orderedProgress) wait(points []int, emit func(completed int)) {
+	for _, point := range points {
+		p.mu.Lock()
+		for p.completed < point {
+			p.cond.Wait()
+		}
+		p.mu.Unlock()
+		emit(point)
+	}
+}

--- a/core/parallel_test.go
+++ b/core/parallel_test.go
@@ -1,0 +1,90 @@
+package main
+
+// Self-verification for the shared fixed-chunking helper: the aggregate
+// output must be item-ordered and identical across goroutine counts (the
+// property the kernels and the parallelized build stages rely on).
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestParallelChunksOrderAndDeterminism(t *testing.T) {
+	n := 1000
+	// fn returns one output per item so the concatenation must be exactly
+	// the serial sequence.
+	serial := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		serial = append(serial, fmt.Sprintf("item-%04d", i))
+	}
+	for _, threads := range []int{1, 2, 3, 7, 8, 64, 1000, 2000} {
+		got := parallelChunks(n, threads, func(start, end int) []string {
+			out := make([]string, 0, end-start)
+			for i := start; i < end; i++ {
+				out = append(out, fmt.Sprintf("item-%04d", i))
+			}
+			return out
+		})
+		if !reflect.DeepEqual(got, serial) {
+			t.Fatalf("threads=%d: output differs from serial order", threads)
+		}
+	}
+}
+
+func TestParallelChunksEdgeCases(t *testing.T) {
+	if got := parallelChunks(0, 4, func(start, end int) []int { return []int{1} }); got != nil {
+		t.Fatalf("n=0 must return nil, got %v", got)
+	}
+	got := parallelChunks(5, 1, func(start, end int) []int {
+		out := make([]int, 0, end-start)
+		for i := start; i < end; i++ {
+			out = append(out, i)
+		}
+		return out
+	})
+	if !reflect.DeepEqual(got, []int{0, 1, 2, 3, 4}) {
+		t.Fatalf("single thread must reproduce the serial sequence, got %v", got)
+	}
+	// chunks must partition the range without overlap or gaps
+	covered := 0
+	for _, threads := range []int{2, 3, 5} {
+		out := parallelChunks(7, threads, func(start, end int) []int {
+			return []int{end - start}
+		})
+		for _, size := range out {
+			covered += size
+		}
+	}
+	if covered != 21 {
+		t.Fatalf("chunks covered %d items, want 21", covered)
+	}
+}
+
+func TestOrderedProgressEmitsPointsInOrder(t *testing.T) {
+	progress := newOrderedProgress()
+	emitted := []int{}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		progress.wait([]int{250, 500, 750}, func(completed int) {
+			emitted = append(emitted, completed)
+		})
+	}()
+	// Complete out of order: 300 items finish before 250's reporter window
+	// is observable, but the emitted sequence must stay strictly increasing.
+	for i := 0; i < 300; i++ {
+		progress.done()
+	}
+	for i := 0; i < 200; i++ {
+		progress.done()
+	}
+	progress.done() // 501
+	for i := 0; i < 249; i++ {
+		progress.done()
+	}
+	<-done
+	if !reflect.DeepEqual(emitted, []int{250, 500, 750}) {
+		t.Fatalf("emitted points %v, want [250 500 750]", emitted)
+	}
+}


### PR DESCRIPTION
## What

Parallelizes the remaining serial loops in the compiled core, per the **Parallelism (goroutines)** section of #123. The content/performer kernels already used deterministic fixed-chunk worker pools; the per-scene build loops did not.

- **Lane classification** (`core/laneclassify.go`) — the per-scene classification loop is row-independent given the precomputed ranks/adventure context; now runs in fixed chunks with progress ticks emitted in scene order.
- **Per-scene scoring** (`core/modelbuild2.go`) — the component/confidence loop extracted to a `scoringContext.scoreScene`, run in fixed chunks; same progress-tick order.
- **Feature construction** (`core/featurebuild.go`) — the scene content-row pass extracted to `sceneFeatureRows`, run in fixed chunks.
- **Expand links walk** (`core/links.go`) — `externalLinksImpl` paginated GraphQL serially (500/page across scenes+performers+studios); page 1 now fixes the page set synchronously and the rest run over a bounded worker pool, merging in page order (the `fetchParallel` pattern). `scene_phashes` keeps first-seen semantics.
- **Shared helper** (`core/parallel.go`) — `parallelChunks` (ordered, deterministic across goroutine counts) + `orderedProgress` (the contentKernel reporter pattern). Regression tests in `core/parallel_test.go`.

## Kernel re-exec item (5) — measured, not taken

Tried calling the kernels in-process instead of re-exec'ing the binary. The artifact-parity gates caught one typed-consumption bug during development (fixed), and the final state passed everything. But the wall-time win is **within noise** on the measured corpus (18.2s vs 18.4s best-of runs, medians identical), and the subprocess keeps the kernel working set out of the build process's peak memory and isolates stage failures. Kept the subprocess; the item's "measure before/after" verdict is documented here.

## Verification

- `scripts/verify full` — **490 passed** (includes the full Go-vs-Python artifact-parity gates for the model build, which now exercise the parallel loops).
- Determinism sweep: identical `model_id` (hash of the entire artifact) across `GOMAXPROCS` 1/2/4/8/16 on a 5,000-scene seeded synthetic sidecar; also identical to the pre-change binary's output.
- `go vet` + `go test ./...` clean (new helper tests run under `-race`).
- Measured on the 5,000-scene synthetic sidecar (shared, noisy dev box): the parallel loops' stage deltas at `GOMAXPROCS=8` vs `1` are scoring 9.2s→3.2s (mostly the already-parallel kernels), publication 7.8s→6.9s, features 7.9s→7.1s. The dominant stages (features ~7.1s, publication ~6.9s) are SQLite single-writer writes, index creation, and artifact copies — the issue's declared non-goals; the SQLite/storage items (6–10) are the remaining wall time.

Part of #123 (parallelism items 1–4); the SQLite/storage and misc items remain open there.
