### PR TITLE
feat: score-review op sorted by model appeal

### DIFF
--- a/core/backend.go
+++ b/core/backend.go
@@ -141,6 +141,8 @@ func dispatch(pluginDir string, payload jVal) (jVal, error) {
 		return opGetSlate(pluginDir, payload)
 	case "replace_item":
 		return opReplaceItem(pluginDir, payload)
+	case "get_score_review":
+		return opGetScoreReview(pluginDir, payload)
 	case "get_similar":
 		return opGetSimilar(pluginDir, payload)
 	case "get_explanation":

--- a/core/score_review.go
+++ b/core/score_review.go
@@ -1,0 +1,264 @@
+// get_score_review — review the bottom of the appeal distribution (the
+// sentiment check). A port of CuratorAPI.get_score_review +
+// SlateBuilder.score_review (curator/api.py, curator/ranking/slate.py) for
+// the model-scored read path. Candidates are model_scene_score rows ordered
+// by appeal ASC (tie-break scene_id), filtered appeal <= max_appeal, with
+// the same live eligibility applied as the slate path (stale/deleted scenes
+// excluded), paged by (page-1)*count. Impressions are recorded like
+// get_slate under the "score_review" lane so the existing
+// Feedback/qualified-impression plumbing works unchanged. Byte-identical
+// JSON to the Python backend for the same sidecar state.
+package main
+
+import "fmt"
+
+// scoreReviewLane is the item lane and impression lane for this op.
+const scoreReviewLane = "score_review"
+
+func opGetScoreReview(pluginDir string, payload jVal) (jVal, error) {
+	return profiledOperation(pluginDir, payload, "get_score_review",
+		func(settings jVal) (jVal, error) { return getScoreReviewBody(pluginDir, payload, settings) })
+}
+
+// getScoreReviewBody mirrors backend.py's get_score_review dispatch +
+// CuratorAPI.get_score_review.
+func getScoreReviewBody(pluginDir string, payload, settings jVal) (jVal, error) {
+	db, err := openAPISidecar(pluginDir, payload, settings)
+	if err != nil {
+		return jvNull(), err
+	}
+	defer db.Close()
+	config, err := sidecarConfig(db)
+	if err != nil {
+		return jvNull(), err
+	}
+	cfg := config.get("config")
+	args := payload.get("args")
+	page := argsInt(args, "page", 1)
+	count := argsInt(args, "count", pythonInt(cfg.get("page_size")))
+	maxAppeal := argsFloat(args, "max_appeal", 0)
+	return getScoreReviewCore(db, config, page, count, maxAppeal)
+}
+
+// getScoreReviewCore mirrors CuratorAPI.get_score_review after arg coercion.
+func getScoreReviewCore(db dbx, config jVal, page, count int64, maxAppeal float64) (jVal, error) {
+	if page < 1 || count < 1 || count > 500 {
+		return jvNull(), fmt.Errorf("invalid score review page")
+	}
+	modelID, err := currentModelID(db)
+	if err != nil {
+		return jvNull(), err
+	}
+	if modelID == "" {
+		return jvNull(), fmt.Errorf("no published model; run build-model first")
+	}
+	start := (page - 1) * count
+	end := page * count
+
+	total, err := scoreReviewTotal(db, modelID, maxAppeal)
+	if err != nil {
+		return jvNull(), err
+	}
+	built, err := scoreReviewLoad(db, modelID, end, maxAppeal)
+	if err != nil {
+		return jvNull(), err
+	}
+	var selected []*recommendationItem
+	if start < int64(len(built.items)) {
+		selEnd := minInt64(end, int64(len(built.items)))
+		for i := start; i < selEnd; i++ {
+			item := *built.items[i]
+			item.position = i
+			selected = append(selected, &item)
+		}
+	}
+	impressionID := jvStr(uuid4())
+	if err := recordImpression(db, impressionID.asString(), scoreReviewLane, modelID, selected, nowMs(), jvNull()); err != nil {
+		return jvNull(), err
+	}
+	items := jvArr()
+	for _, item := range selected {
+		items.arr = append(items.arr, recommendationItemJSON(item, impressionID))
+	}
+	return jvObj(
+		jvKey("items", items),
+		jvKey("total", jvInt(total)),
+		jvKey("page_size", jvInt(count)),
+		jvKey("has_more", jvBool(total > end)),
+		jvKey("page", jvInt(page)),
+		jvKey("model_version", jvStr(modelID)),
+	), nil
+}
+
+// scoreReviewTotal mirrors SlateBuilder.score_review_available_count: the
+// count of eligible model_scene_score rows with appeal <= max_appeal,
+// applying the same live eligibility as the slate path.
+func scoreReviewTotal(db dbx, modelID string, maxAppeal float64) (int64, error) {
+	rows, err := db.Query(`SELECT scene_id FROM model_scene_score
+WHERE model_id=? AND appeal <= ?`, modelID, maxAppeal)
+	if err != nil {
+		return 0, err
+	}
+	sceneIDs := make(map[string]bool)
+	for rows.Next() {
+		var sceneID string
+		if err := rows.Scan(&sceneID); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		sceneIDs[sceneID] = true
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+	eligibility, err := sceneEligibility(db, nowMs(), sceneIDs)
+	if err != nil {
+		return 0, err
+	}
+	total := int64(0)
+	for sceneID := range sceneIDs {
+		if state, ok := eligibility[sceneID]; ok && state.eligible {
+			total++
+		}
+	}
+	return total, nil
+}
+
+// scoreReviewRow carries one candidate row from the appeal-ordered scan.
+type scoreReviewRow struct {
+	sceneID string
+}
+
+// scoreReviewLoad mirrors SlateBuilder.score_review: candidates from
+// model_scene_score ordered by appeal ASC (tie-break scene_id), filtered
+// appeal <= max_appeal, the same live eligibility applied as the slate path,
+// hydrated into recommendation items with score-first semantics
+// (final_utility = appeal, the score-first zero penalties/bonuses, lane
+// "score_review").
+func scoreReviewLoad(db dbx, modelID string, count int64, maxAppeal float64) (builtSlate, error) {
+	now := nowMs()
+	var selectedRows []scoreReviewRow
+	offset := int64(0)
+	chunkSize := maxInt64(100, count)
+	for int64(len(selectedRows)) < count {
+		rows, err := db.Query(`SELECT scene_id FROM model_scene_score
+WHERE model_id=? AND appeal <= ?
+ORDER BY appeal ASC, scene_id
+LIMIT ? OFFSET ?`, modelID, maxAppeal, chunkSize, offset)
+		if err != nil {
+			return builtSlate{}, err
+		}
+		chunk := make([]scoreReviewRow, 0, chunkSize)
+		for rows.Next() {
+			var row scoreReviewRow
+			if err := rows.Scan(&row.sceneID); err != nil {
+				rows.Close()
+				return builtSlate{}, err
+			}
+			chunk = append(chunk, row)
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return builtSlate{}, err
+		}
+		if len(chunk) == 0 {
+			break
+		}
+		offset += int64(len(chunk))
+		sceneIDs := make(map[string]bool, len(chunk))
+		for _, row := range chunk {
+			sceneIDs[row.sceneID] = true
+		}
+		eligibility, err := sceneEligibility(db, now, sceneIDs)
+		if err != nil {
+			return builtSlate{}, err
+		}
+		for _, row := range chunk {
+			if state, ok := eligibility[row.sceneID]; ok && state.eligible {
+				selectedRows = append(selectedRows, row)
+			}
+		}
+		if int64(len(chunk)) < chunkSize {
+			break
+		}
+	}
+	if int64(len(selectedRows)) > count {
+		selectedRows = selectedRows[:count]
+	}
+	sceneIDs := make(map[string]bool, len(selectedRows))
+	for _, row := range selectedRows {
+		sceneIDs[row.sceneID] = true
+	}
+	scores, err := modelScores(db, modelID, sceneIDs)
+	if err != nil {
+		return builtSlate{}, err
+	}
+	penalties := scoreFirstPenalties()
+	bonuses := scoreFirstBonuses()
+	items := make([]*recommendationItem, 0, len(selectedRows))
+	for position, row := range selectedRows {
+		score, ok := scores[row.sceneID]
+		if !ok {
+			continue
+		}
+		items = append(items, &recommendationItem{
+			sceneID:       row.sceneID,
+			lane:          scoreReviewLane,
+			sourceLane:    scoreReviewLane,
+			subtype:       jvNull(),
+			position:      int64(position),
+			appeal:        score.appeal,
+			currentFit:    score.currentFit,
+			confidence:    score.confidence,
+			laneValue:     score.appeal,
+			finalUtility:  score.appeal,
+			penalties:     penalties,
+			bonuses:       bonuses,
+			components:    score.components,
+			neighbors:     score.neighbors,
+			eligibility:   score.eligibility,
+			qualification: jvObj(),
+			reasonIDs:     []string{"eligibility.lane"},
+		})
+	}
+	return builtSlate{
+		modelID:     modelID,
+		lane:        scoreReviewLane,
+		items:       items,
+		diagnostics: nil,
+		timingsMs:   map[string]int64{"materialized": 1, "selection": 0, "total": 0},
+	}, nil
+}
+
+// scoreFirstPenalties mirrors the penalties dict the materialized
+// score-first read path produces: the score-first ranking JSON with the
+// live_cooldown slot filled (0.0 — the score-review lane applies no
+// cooldown).
+func scoreFirstPenalties() jVal {
+	ranking, err := parseJSON([]byte(scoreFirstRankingJSON))
+	if err != nil {
+		return jvObj()
+	}
+	penalties := ranking.get("penalties")
+	if penalties.kind != jObj {
+		return jvObj()
+	}
+	copy := jVal{kind: jObj, obj: append([]jPair(nil), penalties.obj...)}
+	copy.set("live_cooldown", jvFloat(0))
+	return copy
+}
+
+// scoreFirstBonuses mirrors the bonuses dict of the score-first ranking
+// JSON.
+func scoreFirstBonuses() jVal {
+	ranking, err := parseJSON([]byte(scoreFirstRankingJSON))
+	if err != nil {
+		return jvObj()
+	}
+	bonuses := ranking.get("bonuses")
+	if bonuses.kind != jObj {
+		return jvObj()
+	}
+	return jVal{kind: jObj, obj: append([]jPair(nil), bonuses.obj...)}
+}

--- a/core/score_review.go
+++ b/core/score_review.go
@@ -15,6 +15,35 @@ import "fmt"
 // scoreReviewLane is the item lane and impression lane for this op.
 const scoreReviewLane = "score_review"
 
+// scoreReviewEligibility is sceneEligibility for the review surface: the
+// current_thumb_down reason does NOT exclude. Recommendation lanes hide
+// thumb-downed scenes so they are never re-recommended; the score-review
+// surface exists to inspect the bottom of the appeal distribution, and the
+// scenes the user explicitly disliked are exactly the ones it must show.
+// Every other reason (file_unavailable, hard_exclusion, pruning_*,
+// not_now, blocked_tag) still excludes.
+func scoreReviewEligibility(db dbx, referenceAtMs int64, sceneIDs map[string]bool) (map[string]eligibilityResult, error) {
+	eligibility, err := sceneEligibility(db, referenceAtMs, sceneIDs)
+	if err != nil {
+		return nil, err
+	}
+	for sceneID, state := range eligibility {
+		if state.eligible {
+			continue
+		}
+		reasons := state.reasons[:0]
+		for _, reason := range state.reasons {
+			if reason != "current_thumb_down" {
+				reasons = append(reasons, reason)
+			}
+		}
+		state.reasons = reasons
+		state.eligible = len(reasons) == 0
+		eligibility[sceneID] = state
+	}
+	return eligibility, nil
+}
+
 func opGetScoreReview(pluginDir string, payload jVal) (jVal, error) {
 	return profiledOperation(pluginDir, payload, "get_score_review",
 		func(settings jVal) (jVal, error) { return getScoreReviewBody(pluginDir, payload, settings) })
@@ -112,7 +141,7 @@ WHERE model_id=? AND appeal <= ?`, modelID, maxAppeal)
 	if err := rows.Err(); err != nil {
 		return 0, err
 	}
-	eligibility, err := sceneEligibility(db, nowMs(), sceneIDs)
+	eligibility, err := scoreReviewEligibility(db, nowMs(), sceneIDs)
 	if err != nil {
 		return 0, err
 	}
@@ -170,7 +199,7 @@ LIMIT ? OFFSET ?`, modelID, maxAppeal, chunkSize, offset)
 		for _, row := range chunk {
 			sceneIDs[row.sceneID] = true
 		}
-		eligibility, err := sceneEligibility(db, now, sceneIDs)
+		eligibility, err := scoreReviewEligibility(db, now, sceneIDs)
 		if err != nil {
 			return builtSlate{}, err
 		}

--- a/core/score_review_test.go
+++ b/core/score_review_test.go
@@ -11,8 +11,9 @@ import (
 
 // scoreReviewSeed seeds a published model with score rows covering the
 // review window, plus the rows sceneEligibility reads. s3 is hard-excluded,
-// s4 carries a current thumb_down, and s8 has no available file — all three
-// must be filtered from items and total.
+// s4 carries a current thumb_down, and s8 has no available file. The review
+// surface drops only current_thumb_down from eligibility: s4 is shown, s3
+// and s8 are filtered from items and total.
 func scoreReviewSeed(t *testing.T) dbx {
 	t.Helper()
 	db, _ := openTempDB(t)
@@ -79,13 +80,15 @@ func TestScoreReviewOrdersByAppealAscendingWithEligibility(t *testing.T) {
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
 	}
-	// s3 hard-excluded, s4 thumb_down, s8 no file; the eligible tail is
-	// s1 (-0.9), s2 (-0.6), s5 (0.0) in appeal-ascending order.
-	if got := scoreReviewIDs(t, out); strings.Join(got, ",") != "s1,s2,s5" {
-		t.Fatalf("items = %v, want [s1 s2 s5]", got)
+	// s3 hard-excluded, s8 no file; s4's current thumb_down does NOT exclude
+	// on the review surface (it is exactly what the review is for). The
+	// eligible tail is s1 (-0.9), s2 (-0.6), s4 (-0.2), s5 (0.0) in
+	// appeal-ascending order.
+	if got := scoreReviewIDs(t, out); strings.Join(got, ",") != "s1,s2,s4,s5" {
+		t.Fatalf("items = %v, want [s1 s2 s4 s5]", got)
 	}
-	if out.get("total").asString() != "3" {
-		t.Fatalf("total = %s, want 3", out.get("total").asString())
+	if out.get("total").asString() != "4" {
+		t.Fatalf("total = %s, want 4", out.get("total").asString())
 	}
 	if out.get("page_size").asString() != "20" || out.get("page").asString() != "1" {
 		t.Fatalf("page_size/page = %s/%s", out.get("page_size").asString(), out.get("page").asString())
@@ -105,6 +108,33 @@ func TestScoreReviewOrdersByAppealAscendingWithEligibility(t *testing.T) {
 	}
 	if len(out.obj) != len(wantKeys) {
 		t.Errorf("response has %d keys, want %d", len(out.obj), len(wantKeys))
+	}
+}
+
+func TestScoreReviewThumbDownDoesNotExcludeButOtherReasonsDo(t *testing.T) {
+	db := scoreReviewSeed(t)
+	exec := func(query string, args ...any) {
+		t.Helper()
+		if _, err := db.Exec(query, args...); err != nil {
+			t.Fatalf("seed %q: %v", query, err)
+		}
+	}
+	// s8 has no available file; adding a thumb_down on top must not make it
+	// eligible — the wrapper drops current_thumb_down only, never the other
+	// exclusion reasons.
+	exec(`INSERT INTO feedback(feedback_id, scene_id, feedback_type, value, occurred_at_ms, payload_json)
+VALUES ('fb-2', 's8', 'thumb_down', NULL, 1, '{}')`)
+	out, err := getScoreReviewCore(db, jvObj(), 1, 20, 0)
+	if err != nil {
+		t.Fatalf("getScoreReviewCore: %v", err)
+	}
+	// s4 (thumb_down only) is shown; s8 (thumb_down + file_unavailable) and
+	// s3 (hard exclusion) stay hidden.
+	if got := scoreReviewIDs(t, out); strings.Join(got, ",") != "s1,s2,s4,s5" {
+		t.Fatalf("items = %v, want [s1 s2 s4 s5]", got)
+	}
+	if out.get("total").asString() != "4" {
+		t.Fatalf("total = %s, want 4", out.get("total").asString())
 	}
 }
 
@@ -186,16 +216,17 @@ func TestScoreReviewMaxAppealCap(t *testing.T) {
 	if out.get("total").asString() != "2" {
 		t.Fatalf("total = %s, want 2", out.get("total").asString())
 	}
-	// A cap that admits s6 (0.1) but not s7 (0.3).
+	// A cap that admits s6 (0.1) but not s7 (0.3); s4 (thumb_down) is
+	// eligible on the review surface.
 	out, err = getScoreReviewCore(db, jvObj(), 1, 20, 0.1)
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
 	}
-	if got := scoreReviewIDs(t, out); strings.Join(got, ",") != "s1,s2,s5,s6" {
-		t.Fatalf("items = %v, want [s1 s2 s5 s6]", got)
+	if got := scoreReviewIDs(t, out); strings.Join(got, ",") != "s1,s2,s4,s5,s6" {
+		t.Fatalf("items = %v, want [s1 s2 s4 s5 s6]", got)
 	}
-	if out.get("total").asString() != "4" {
-		t.Fatalf("total = %s, want 4", out.get("total").asString())
+	if out.get("total").asString() != "5" {
+		t.Fatalf("total = %s, want 5", out.get("total").asString())
 	}
 	// A cap below every appeal yields an empty page.
 	out, err = getScoreReviewCore(db, jvObj(), 1, 20, -1.0)
@@ -213,7 +244,7 @@ func TestScoreReviewMaxAppealCap(t *testing.T) {
 
 func TestScoreReviewPagingMath(t *testing.T) {
 	db := scoreReviewSeed(t)
-	// page 1, count 2: s1, s2, has_more (3 > 2).
+	// page 1, count 2: s1, s2, has_more (4 > 2).
 	out, err := getScoreReviewCore(db, jvObj(), 1, 2, 0)
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
@@ -227,16 +258,17 @@ func TestScoreReviewPagingMath(t *testing.T) {
 	if got := out.get("items").arr[1].get("position").asString(); got != "1" {
 		t.Fatalf("page 1 second position = %s, want 1", got)
 	}
-	// page 2, count 2: s5 (position 2), has_more false (3 > 4 is false).
+	// page 2, count 2: s4, s5 (positions 2 and 3), has_more false (4 > 4 is
+	// false).
 	out, err = getScoreReviewCore(db, jvObj(), 2, 2, 0)
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
 	}
-	if got := scoreReviewIDs(t, out); strings.Join(got, ",") != "s5" {
+	if got := scoreReviewIDs(t, out); strings.Join(got, ",") != "s4,s5" {
 		t.Fatalf("page 2 items = %v", got)
 	}
 	if got := out.get("items").arr[0].get("position").asString(); got != "2" {
-		t.Fatalf("page 2 position = %s, want 2", got)
+		t.Fatalf("page 2 first position = %s, want 2", got)
 	}
 	if out.get("has_more").b {
 		t.Fatalf("page 2 has_more = %s, want false", out.get("has_more").asString())
@@ -249,8 +281,8 @@ func TestScoreReviewPagingMath(t *testing.T) {
 	if len(out.get("items").arr) != 0 {
 		t.Fatalf("page 3 items = %v, want empty", scoreReviewIDs(t, out))
 	}
-	if out.get("total").asString() != "3" {
-		t.Fatalf("page 3 total = %s, want 3", out.get("total").asString())
+	if out.get("total").asString() != "4" {
+		t.Fatalf("page 3 total = %s, want 4", out.get("total").asString())
 	}
 }
 

--- a/core/score_review_test.go
+++ b/core/score_review_test.go
@@ -1,0 +1,350 @@
+package main
+
+// Unit tests for get_score_review (core/score_review.go): appeal-ascending
+// ordering, the max_appeal cap, paging math, live eligibility, impression
+// recording, item shape, and the validation/model-required error paths.
+
+import (
+	"strings"
+	"testing"
+)
+
+// scoreReviewSeed seeds a published model with score rows covering the
+// review window, plus the rows sceneEligibility reads. s3 is hard-excluded,
+// s4 carries a current thumb_down, and s8 has no available file — all three
+// must be filtered from items and total.
+func scoreReviewSeed(t *testing.T) dbx {
+	t.Helper()
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	exec := func(query string, args ...any) {
+		t.Helper()
+		if _, err := db.Exec(query, args...); err != nil {
+			t.Fatalf("seed %q: %v", query, err)
+		}
+	}
+	exec(`INSERT INTO model_version(model_id, status, feature_version, config_json, created_at_ms, published_at_ms)
+VALUES ('model', 'published', 'features', '{}', 1, 1)`)
+	exec(`INSERT INTO feature_build(feature_version, status, config_json, source_fingerprint, created_at_ms, published_at_ms)
+VALUES ('features', 'published', '{}', 'source', 1, 1)`)
+	scenes := []struct {
+		id     string
+		appeal float64
+		file   bool
+	}{
+		{"s1", -0.9, true},
+		{"s2", -0.6, true},
+		{"s3", -0.4, true},
+		{"s4", -0.2, true},
+		{"s5", 0.0, true},
+		{"s6", 0.1, true},
+		{"s7", 0.3, true},
+		{"s8", -0.5, false}, // no available file -> file_unavailable
+	}
+	for _, s := range scenes {
+		exec(`INSERT INTO source_scene(scene_id, title, source_hash) VALUES (?, ?, ?)`, s.id, s.id, s.id)
+		if s.file {
+			exec(`INSERT INTO source_file(file_id, scene_id, available, source_hash) VALUES (?, ?, 1, ?)`, "f-"+s.id, s.id, s.id)
+		}
+		exec(`INSERT INTO model_scene_score(
+model_id, scene_id, general_appeal, direct_appeal, direct_confidence, appeal,
+current_fit, confidence, metadata_confidence, recovery, components_json, eligibility_json
+) VALUES ('model', ?, ?, ?, 0.5, ?, ?, 0.8, 0.8, 0.5, ?, ?)`,
+			s.id, s.appeal, s.appeal, s.appeal, s.appeal*0.5,
+			`{"baseline":{"raw":0.0,"value":0.0}}`, `{"eligible":true}`)
+	}
+	exec(`INSERT INTO exclusion(exclusion_id, entity_type, entity_id, exclusion_type, created_at_ms, reversed_at_ms, expires_at_ms)
+VALUES ('ex-1', 'scene', 's3', 'hard', 1, NULL, NULL)`)
+	exec(`INSERT INTO feedback(feedback_id, scene_id, feedback_type, value, occurred_at_ms, payload_json)
+VALUES ('fb-1', 's4', 'thumb_down', NULL, 1, '{}')`)
+	return db
+}
+
+// scoreReviewIDs returns the scene_id of each item in the response.
+func scoreReviewIDs(t *testing.T, out jVal) []string {
+	t.Helper()
+	items := out.get("items")
+	var ids []string
+	for _, item := range items.arr {
+		ids = append(ids, item.get("scene_id").asString())
+	}
+	return ids
+}
+
+func TestScoreReviewOrdersByAppealAscendingWithEligibility(t *testing.T) {
+	db := scoreReviewSeed(t)
+	out, err := getScoreReviewCore(db, jvObj(), 1, 20, 0)
+	if err != nil {
+		t.Fatalf("getScoreReviewCore: %v", err)
+	}
+	// s3 hard-excluded, s4 thumb_down, s8 no file; the eligible tail is
+	// s1 (-0.9), s2 (-0.6), s5 (0.0) in appeal-ascending order.
+	if got := scoreReviewIDs(t, out); strings.Join(got, ",") != "s1,s2,s5" {
+		t.Fatalf("items = %v, want [s1 s2 s5]", got)
+	}
+	if out.get("total").asString() != "3" {
+		t.Fatalf("total = %s, want 3", out.get("total").asString())
+	}
+	if out.get("page_size").asString() != "20" || out.get("page").asString() != "1" {
+		t.Fatalf("page_size/page = %s/%s", out.get("page_size").asString(), out.get("page").asString())
+	}
+	if out.get("has_more").b {
+		t.Fatalf("has_more = %s, want false", out.get("has_more").asString())
+	}
+	if out.get("model_version").asString() != "model" {
+		t.Fatalf("model_version = %s, want model", out.get("model_version").asString())
+	}
+	// The response carries exactly the contract keys.
+	wantKeys := []string{"items", "total", "page_size", "has_more", "page", "model_version"}
+	for _, key := range wantKeys {
+		if !out.has(key) {
+			t.Errorf("response missing key %s", key)
+		}
+	}
+	if len(out.obj) != len(wantKeys) {
+		t.Errorf("response has %d keys, want %d", len(out.obj), len(wantKeys))
+	}
+}
+
+func TestScoreReviewItemsMirrorSlateShape(t *testing.T) {
+	db := scoreReviewSeed(t)
+	out, err := getScoreReviewCore(db, jvObj(), 1, 20, 0)
+	if err != nil {
+		t.Fatalf("getScoreReviewCore: %v", err)
+	}
+	items := out.get("items")
+	if len(items.arr) == 0 {
+		t.Fatal("no items")
+	}
+	item := items.arr[0]
+	// First item: s1 with appeal -0.9.
+	if item.get("scene_id").asString() != "s1" {
+		t.Fatalf("first scene = %s", item.get("scene_id").asString())
+	}
+	if item.get("lane").asString() != "score_review" {
+		t.Errorf("lane = %s", item.get("lane").asString())
+	}
+	if item.get("source_lane").asString() != "score_review" {
+		t.Errorf("source_lane = %s", item.get("source_lane").asString())
+	}
+	if item.get("position").asString() != "0" {
+		t.Errorf("position = %s", item.get("position").asString())
+	}
+	if item.get("final_utility").asString() != "-0.9" {
+		t.Errorf("final_utility = %s, want -0.9 (the appeal)", item.get("final_utility").asString())
+	}
+	if item.get("appeal").asString() != "-0.9" {
+		t.Errorf("appeal = %s", item.get("appeal").asString())
+	}
+	if item.get("current_fit").asString() != "-0.45" {
+		t.Errorf("current_fit = %s", item.get("current_fit").asString())
+	}
+	if item.get("confidence").asString() != "0.8" {
+		t.Errorf("confidence = %s", item.get("confidence").asString())
+	}
+	if item.get("lane_value").asString() != "-0.9" {
+		t.Errorf("lane_value = %s", item.get("lane_value").asString())
+	}
+	if item.get("subtype").kind != jNull {
+		t.Errorf("subtype = %s, want null", item.get("subtype").marshalCompact())
+	}
+	if item.get("qualification").marshalCompact() != "{}" {
+		t.Errorf("qualification = %s", item.get("qualification").marshalCompact())
+	}
+	if item.get("penalties").marshalCompact() != `{"performer":0.0,"studio":0.0,"content":0.0,"history":0.0,"live_cooldown":0.0}` {
+		t.Errorf("penalties = %s", item.get("penalties").marshalCompact())
+	}
+	if item.get("bonuses").marshalCompact() != `{"uncovered_content":0.0}` {
+		t.Errorf("bonuses = %s", item.get("bonuses").marshalCompact())
+	}
+	if item.get("components").get("baseline").get("value").asString() != "0.0" {
+		t.Errorf("components = %s", item.get("components").marshalCompact())
+	}
+	if item.get("eligibility").marshalCompact() != `{"eligible":true}` {
+		t.Errorf("eligibility = %s", item.get("eligibility").marshalCompact())
+	}
+	if item.get("reason_ids").marshalCompact() != `["eligibility.lane"]` {
+		t.Errorf("reason_ids = %s", item.get("reason_ids").marshalCompact())
+	}
+	if item.get("impression_id").kind != jStr || item.get("impression_id").asString() == "" {
+		t.Errorf("impression_id = %s", item.get("impression_id").marshalCompact())
+	}
+}
+
+func TestScoreReviewMaxAppealCap(t *testing.T) {
+	db := scoreReviewSeed(t)
+	out, err := getScoreReviewCore(db, jvObj(), 1, 20, -0.4)
+	if err != nil {
+		t.Fatalf("getScoreReviewCore: %v", err)
+	}
+	// Only appeals <= -0.4: s1, s2 (s5 at 0.0 is above the cap).
+	if got := scoreReviewIDs(t, out); strings.Join(got, ",") != "s1,s2" {
+		t.Fatalf("items = %v, want [s1 s2]", got)
+	}
+	if out.get("total").asString() != "2" {
+		t.Fatalf("total = %s, want 2", out.get("total").asString())
+	}
+	// A cap that admits s6 (0.1) but not s7 (0.3).
+	out, err = getScoreReviewCore(db, jvObj(), 1, 20, 0.1)
+	if err != nil {
+		t.Fatalf("getScoreReviewCore: %v", err)
+	}
+	if got := scoreReviewIDs(t, out); strings.Join(got, ",") != "s1,s2,s5,s6" {
+		t.Fatalf("items = %v, want [s1 s2 s5 s6]", got)
+	}
+	if out.get("total").asString() != "4" {
+		t.Fatalf("total = %s, want 4", out.get("total").asString())
+	}
+	// A cap below every appeal yields an empty page.
+	out, err = getScoreReviewCore(db, jvObj(), 1, 20, -1.0)
+	if err != nil {
+		t.Fatalf("getScoreReviewCore: %v", err)
+	}
+	if len(out.get("items").arr) != 0 || out.get("total").asString() != "0" {
+		t.Fatalf("expected empty review, got items=%d total=%s",
+			len(out.get("items").arr), out.get("total").asString())
+	}
+	if out.get("has_more").b {
+		t.Fatalf("has_more = %s, want false", out.get("has_more").asString())
+	}
+}
+
+func TestScoreReviewPagingMath(t *testing.T) {
+	db := scoreReviewSeed(t)
+	// page 1, count 2: s1, s2, has_more (3 > 2).
+	out, err := getScoreReviewCore(db, jvObj(), 1, 2, 0)
+	if err != nil {
+		t.Fatalf("getScoreReviewCore: %v", err)
+	}
+	if got := scoreReviewIDs(t, out); strings.Join(got, ",") != "s1,s2" {
+		t.Fatalf("page 1 items = %v", got)
+	}
+	if !out.get("has_more").b {
+		t.Fatalf("page 1 has_more = %s, want true", out.get("has_more").asString())
+	}
+	if got := out.get("items").arr[1].get("position").asString(); got != "1" {
+		t.Fatalf("page 1 second position = %s, want 1", got)
+	}
+	// page 2, count 2: s5 (position 2), has_more false (3 > 4 is false).
+	out, err = getScoreReviewCore(db, jvObj(), 2, 2, 0)
+	if err != nil {
+		t.Fatalf("getScoreReviewCore: %v", err)
+	}
+	if got := scoreReviewIDs(t, out); strings.Join(got, ",") != "s5" {
+		t.Fatalf("page 2 items = %v", got)
+	}
+	if got := out.get("items").arr[0].get("position").asString(); got != "2" {
+		t.Fatalf("page 2 position = %s, want 2", got)
+	}
+	if out.get("has_more").b {
+		t.Fatalf("page 2 has_more = %s, want false", out.get("has_more").asString())
+	}
+	// page 3, count 2: past the end -> empty items.
+	out, err = getScoreReviewCore(db, jvObj(), 3, 2, 0)
+	if err != nil {
+		t.Fatalf("getScoreReviewCore: %v", err)
+	}
+	if len(out.get("items").arr) != 0 {
+		t.Fatalf("page 3 items = %v, want empty", scoreReviewIDs(t, out))
+	}
+	if out.get("total").asString() != "3" {
+		t.Fatalf("page 3 total = %s, want 3", out.get("total").asString())
+	}
+}
+
+func TestScoreReviewRecordsImpression(t *testing.T) {
+	db := scoreReviewSeed(t)
+	out, err := getScoreReviewCore(db, jvObj(), 1, 2, 0)
+	if err != nil {
+		t.Fatalf("getScoreReviewCore: %v", err)
+	}
+	impressionID := out.get("items").arr[0].get("impression_id").asString()
+	if impressionID == "" {
+		t.Fatal("empty impression_id")
+	}
+	var lane, modelID, configVersion string
+	if err := db.QueryRow(`SELECT lane, model_id, config_version FROM impression WHERE impression_id=?`,
+		impressionID).Scan(&lane, &modelID, &configVersion); err != nil {
+		t.Fatalf("impression row: %v", err)
+	}
+	if lane != "score_review" || modelID != "model" || configVersion != "builtin" {
+		t.Fatalf("impression row = %s/%s/%s", lane, modelID, configVersion)
+	}
+	rows, err := db.Query(`SELECT scene_id, position, policy_score, reason_snapshot_json
+FROM impression_item WHERE impression_id=? ORDER BY position`, impressionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	type itemRow struct {
+		sceneID string
+		pos     int64
+		score   float64
+		reasons string
+	}
+	var got []itemRow
+	for rows.Next() {
+		var r itemRow
+		if err := rows.Scan(&r.sceneID, &r.pos, &r.score, &r.reasons); err != nil {
+			t.Fatal(err)
+		}
+		got = append(got, r)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	want := []itemRow{
+		{"s1", 0, -0.9, `["eligibility.lane"]`},
+		{"s2", 1, -0.6, `["eligibility.lane"]`},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("impression_item rows = %+v, want %+v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("impression_item[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+	// A second request with the same page records a distinct impression
+	// (uuid4 per request, INSERT OR IGNORE keyed by impression_id).
+	second, err := getScoreReviewCore(db, jvObj(), 1, 2, 0)
+	if err != nil {
+		t.Fatalf("getScoreReviewCore: %v", err)
+	}
+	secondID := second.get("items").arr[0].get("impression_id").asString()
+	if secondID == impressionID {
+		t.Fatal("second request reused the impression_id")
+	}
+	var count int
+	if err := db.QueryRow(`SELECT count(*) FROM impression WHERE lane='score_review'`).Scan(&count); err != nil {
+		t.Fatal(err)
+	}
+	if count != 2 {
+		t.Fatalf("score_review impressions = %d, want 2", count)
+	}
+}
+
+func TestScoreReviewValidationAndModelRequired(t *testing.T) {
+	db := scoreReviewSeed(t)
+	for _, tc := range []struct {
+		page, count int64
+	}{
+		{0, 20}, {1, 0}, {1, 501},
+	} {
+		if _, err := getScoreReviewCore(db, jvObj(), tc.page, tc.count, 0); err == nil ||
+			err.Error() != "invalid score review page" {
+			t.Fatalf("page=%d count=%d: err = %v, want invalid score review page", tc.page, tc.count, err)
+		}
+	}
+	// No published model -> the slate path's exact error.
+	db2, _ := openTempDB(t)
+	if err := migrate(db2, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := getScoreReviewCore(db2, jvObj(), 1, 20, 0); err == nil ||
+		err.Error() != "no published model; run build-model first" {
+		t.Fatalf("err = %v, want no published model", err)
+	}
+}

--- a/curator/api.py
+++ b/curator/api.py
@@ -149,6 +149,48 @@ class CuratorAPI:
             "ranking_timings_ms": slate.timings_ms,
         }
 
+    def get_score_review(
+        self,
+        page: int = 1,
+        count: int = 20,
+        *,
+        max_appeal: float = 0.0,
+        now_ms: int | None = None,
+    ) -> dict[str, object]:
+        if page < 1 or not 1 <= count <= 500:
+            raise ValueError("invalid score review page")
+        model_id = RecommendationModelStore(self.connection).current_model_id()
+        if model_id is None:
+            raise RuntimeError("no published model; run build-model first")
+        start = (page - 1) * count
+        end = page * count
+        builder = SlateBuilder(self.connection)
+        total = builder.score_review_available_count(model_id, max_appeal)
+        built = builder.score_review(model_id, end, max_appeal=max_appeal)
+        selected = built.items[start:end]
+        slate = Slate(
+            built.model_id,
+            built.lane,
+            tuple(
+                replace(item, position=position)
+                for position, item in enumerate(selected, start=start)
+            ),
+            built.diagnostics,
+            built.timings_ms,
+        )
+        impression_id = str(uuid4())
+        now_ms = now_ms if now_ms is not None else time.time_ns() // 1_000_000
+        InteractionStore(self.connection).record_impression(impression_id, slate, now_ms, None)
+        items = [{**asdict(item), "impression_id": impression_id} for item in slate.items]
+        return {
+            "items": items,
+            "total": total,
+            "page_size": count,
+            "has_more": total > end,
+            "page": page,
+            "model_version": model_id,
+        }
+
     def inspector(self, entity_type: str, entity_id: str) -> dict[str, object]:
         model_id = RecommendationModelStore(self.connection).current_model_id()
         if model_id is None:

--- a/curator/ranking/slate.py
+++ b/curator/ranking/slate.py
@@ -904,6 +904,28 @@ class SlateBuilder:
         )
         return sum(1 for scene_id in excluded if eligibility.get(scene_id, {}).get("eligible"))
 
+    def _score_review_eligibility(
+        self, now_ms: int, scene_ids: set[str]
+    ) -> dict[str, dict[str, object]]:
+        """scene_eligibility for the review surface: the current_thumb_down
+        reason does NOT exclude. Recommendation lanes hide thumb-downed
+        scenes so they are never re-recommended; the score-review surface
+        exists to inspect the bottom of the appeal distribution, and the
+        scenes the user explicitly disliked are exactly the ones it must
+        show. Every other reason (file_unavailable, hard_exclusion,
+        pruning_*, not_now, blocked_tag) still excludes. Mirrors the Go
+        core's scoreReviewEligibility exactly."""
+        eligibility = scene_eligibility(self.connection, now_ms, self.config, scene_ids=scene_ids)
+        for state in eligibility.values():
+            if state.get("eligible"):
+                continue
+            reasons = state.get("reasons", [])
+            if not isinstance(reasons, list):
+                continue
+            state["reasons"] = [r for r in reasons if r != "current_thumb_down"]
+            state["eligible"] = not state["reasons"]
+        return eligibility
+
     def score_review_available_count(self, model_id: str, max_appeal: float = 0.0) -> int:
         """Count eligible scenes at the bottom of the appeal distribution
         (appeal <= max_appeal) without hydrating items, applying the same
@@ -918,9 +940,7 @@ class SlateBuilder:
                 (model_id, max_appeal),
             )
         }
-        eligibility = scene_eligibility(
-            self.connection, time.time_ns() // 1_000_000, self.config, scene_ids=scene_ids
-        )
+        eligibility = self._score_review_eligibility(time.time_ns() // 1_000_000, scene_ids)
         return sum(1 for scene_id in scene_ids if eligibility.get(scene_id, {}).get("eligible"))
 
     def score_review(self, model_id: str, count: int, *, max_appeal: float = 0.0) -> Slate:
@@ -951,9 +971,7 @@ class SlateBuilder:
                 break
             offset += len(rows)
             scene_ids = {str(row["scene_id"]) for row in rows}
-            eligibility = scene_eligibility(
-                self.connection, now_ms, self.config, scene_ids=scene_ids
-            )
+            eligibility = self._score_review_eligibility(now_ms, scene_ids)
             selected_rows.extend(
                 row for row in rows if eligibility.get(str(row["scene_id"]), {}).get("eligible")
             )

--- a/curator/ranking/slate.py
+++ b/curator/ranking/slate.py
@@ -904,6 +904,102 @@ class SlateBuilder:
         )
         return sum(1 for scene_id in excluded if eligibility.get(scene_id, {}).get("eligible"))
 
+    def score_review_available_count(self, model_id: str, max_appeal: float = 0.0) -> int:
+        """Count eligible scenes at the bottom of the appeal distribution
+        (appeal <= max_appeal) without hydrating items, applying the same
+        live eligibility as the slate path."""
+        scene_ids = {
+            str(row[0])
+            for row in self.connection.execute(
+                """
+                SELECT scene_id FROM model_scene_score
+                WHERE model_id=? AND appeal <= ?
+                """,
+                (model_id, max_appeal),
+            )
+        }
+        eligibility = scene_eligibility(
+            self.connection, time.time_ns() // 1_000_000, self.config, scene_ids=scene_ids
+        )
+        return sum(1 for scene_id in scene_ids if eligibility.get(scene_id, {}).get("eligible"))
+
+    def score_review(self, model_id: str, count: int, *, max_appeal: float = 0.0) -> Slate:
+        """The bottom of the appeal distribution: model_scene_score rows
+        ordered by appeal ASC (tie-break scene_id), filtered appeal <=
+        max_appeal, the same live eligibility applied as the slate path,
+        hydrated into recommendation items with score-first semantics
+        (final_utility = appeal, the score-first zero penalties/bonuses, lane
+        "score_review")."""
+        if model_id is None:
+            raise RuntimeError("no published model; run build-model first")
+        started = time.perf_counter()
+        now_ms = time.time_ns() // 1_000_000
+        selected_rows: list[sqlite3.Row] = []
+        offset = 0
+        chunk_size = max(100, count)
+        while len(selected_rows) < count:
+            rows = self.connection.execute(
+                """
+                SELECT scene_id FROM model_scene_score
+                WHERE model_id=? AND appeal <= ?
+                ORDER BY appeal ASC, scene_id
+                LIMIT ? OFFSET ?
+                """,
+                (model_id, max_appeal, chunk_size, offset),
+            ).fetchall()
+            if not rows:
+                break
+            offset += len(rows)
+            scene_ids = {str(row["scene_id"]) for row in rows}
+            eligibility = scene_eligibility(
+                self.connection, now_ms, self.config, scene_ids=scene_ids
+            )
+            selected_rows.extend(
+                row for row in rows if eligibility.get(str(row["scene_id"]), {}).get("eligible")
+            )
+            if len(rows) < chunk_size:
+                break
+        selected_rows = selected_rows[:count]
+        scene_ids = {str(row["scene_id"]) for row in selected_rows}
+        scores = RecommendationModelStore(self.connection).scores(model_id, scene_ids)
+        penalties = json.loads(SCORE_FIRST_RANKING_JSON)["penalties"]
+        penalties["live_cooldown"] = 0.0
+        bonuses = json.loads(SCORE_FIRST_RANKING_JSON)["bonuses"]
+        items = []
+        for position, row in enumerate(selected_rows):
+            scene_id = str(row["scene_id"])
+            score = scores[scene_id]
+            items.append(
+                RecommendationItem(
+                    scene_id,
+                    "score_review",
+                    "score_review",
+                    None,
+                    position,
+                    score.appeal,
+                    score.current_fit,
+                    score.confidence,
+                    score.appeal,
+                    score.appeal,
+                    dict(penalties),
+                    dict(bonuses),
+                    score.components,
+                    score.neighbors,
+                    score.eligibility,
+                    {},
+                    ("eligibility.lane",),
+                )
+            )
+        elapsed = round((time.perf_counter() - started) * 1_000)
+        record_duration("python", "ranking.score_review", elapsed)
+        return Slate(
+            model_id,
+            "score_review",
+            tuple(items),
+            (),
+            {"materialized": 1, "selection": elapsed, "total": elapsed},
+        )
+
     def _direct_play_filters(self, now_ms: int) -> tuple[dict[str, int], set[str]]:
         direct_plays = {
             str(row["scene_id"]): int(row["last_played"])

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -713,6 +713,17 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
                 exclude_scene_ids={str(value) for value in excluded},
                 exploration=float(args.get("exploration") or 0),
             )
+        if operation == "get_score_review":
+            config = api.config()["config"]
+            count = int(
+                args.get("count")
+                or (config.get("page_size", 20) if isinstance(config, dict) else 20)
+            )
+            return api.get_score_review(
+                page=int(args.get("page") or 1),
+                count=count,
+                max_appeal=float(args.get("max_appeal") or 0),
+            )
         if operation == "replace_item":
             excluded = args.get("exclude_scene_ids")
             if not isinstance(excluded, list):

--- a/tests/core/test_backend_slice5.py
+++ b/tests/core/test_backend_slice5.py
@@ -1,0 +1,303 @@
+"""Slice-5 backend differential harness: the get_score_review read-path op.
+
+get_score_review runs through the Go binary and plugin/backend.py on fresh
+sidecar copies, and the stdout must be byte-identical once the uuid4
+impression_id (per-request, never accepted in args) is normalized. The
+response shape is exactly the fixed contract {items, total, page_size,
+has_more, page, model_version}; items mirror a get_slate recommendation item
+with lane "score_review" and final_utility = appeal. The read-path write
+(the "score_review" impression rows) leaves identical sidecar state on both
+implementations, and the error paths (invalid page, no published model)
+match byte for byte.
+
+Synthetic sidecars only — never a live sidecar.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from curator.core import core_binary
+from tests.core.test_backend import PLUGIN_DIR, make_sidecar, payload
+from tests.core.test_backend_slice3_backups import assert_slice3_identical
+
+MODEL_ID = "model-x"
+
+
+class _StubSlice5(BaseHTTPRequestHandler):
+    """Stash stub answering the settings query (empty plugin settings)."""
+
+    def do_POST(self) -> None:
+        length = int(self.headers.get("Content-Length") or 0)
+        body = self.rfile.read(length).decode("utf-8")
+        if "CuratorPluginSettings" in body:
+            data: dict[str, object] = {"data": {"configuration": {"plugins": {}}}}
+        else:
+            data = {"errors": [{"message": f"no stub for {body[:80]}"}]}
+        payload_bytes = json.dumps(data).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload_bytes)))
+        self.end_headers()
+        self.wfile.write(payload_bytes)
+
+    def log_message(self, *args: object) -> None:  # silence the stub
+        pass
+
+
+@pytest.fixture(scope="module")
+def binary() -> Path:
+    path = core_binary()
+    if path is None:
+        pytest.skip("curator-core binary not built; run scripts/verify core")
+    return path
+
+
+@pytest.fixture(scope="module")
+def stub_stash() -> str:
+    server = HTTPServer(("127.0.0.1", 0), _StubSlice5)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_port}"
+    server.shutdown()
+
+
+def make_score_review_sidecar(path: Path) -> None:
+    """A migrated sidecar exercising get_score_review: a published model whose
+    score rows cover the review window (s3 hard-excluded, s4 carries a
+    current thumb_down, s8 has no available file), with a neighbor row for
+    s1."""
+    make_sidecar(path, with_jobs=True)
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(
+            """
+            INSERT INTO source_scene(scene_id, title, play_count, play_duration_seconds,
+                updated_at, source_hash) VALUES
+                ('s1', 'Scene One', 0, 0, NULL, 'h-s1'),
+                ('s2', 'Scene Two', 0, 0, NULL, 'h-s2'),
+                ('s3', 'Scene Three', 0, 0, NULL, 'h-s3'),
+                ('s4', 'Scene Four', 0, 0, NULL, 'h-s4'),
+                ('s5', 'Scene Five', 0, 0, NULL, 'h-s5'),
+                ('s6', 'Scene Six', 0, 0, NULL, 'h-s6'),
+                ('s7', 'Scene Seven', 0, 0, NULL, 'h-s7'),
+                ('s8', 'Scene Eight', 0, 0, NULL, 'h-s8')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO source_file(file_id, scene_id, available, source_hash) VALUES
+                ('f-s1', 's1', 1, 'h-s1'), ('f-s2', 's2', 1, 'h-s2'),
+                ('f-s3', 's3', 1, 'h-s3'), ('f-s4', 's4', 1, 'h-s4'),
+                ('f-s5', 's5', 1, 'h-s5'), ('f-s6', 's6', 1, 'h-s6'),
+                ('f-s7', 's7', 1, 'h-s7'), ('f-s8', 's8', 0, 'h-s8')
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO model_version(
+                model_id, status, feature_version, config_json, created_at_ms, validation_status
+            ) VALUES (?, 'published', 'fv-x', '{}', 1, 'valid')
+            """,
+            (MODEL_ID,),
+        )
+        connection.execute(
+            """
+            INSERT INTO model_scene_score(
+                model_id, scene_id, general_appeal, direct_appeal, direct_confidence,
+                appeal, current_fit, confidence, metadata_confidence, recovery,
+                components_json, eligibility_json
+            ) VALUES
+                (?, 's1', -0.9, -0.9, 0.9, -0.90, -0.45, 0.90, 0.9, 0.0,
+                 '{"baseline": {"raw": 0.2, "value": 0.2}}', '{"eligible": true}'),
+                (?, 's2', -0.6, -0.6, 0.8, -0.60, -0.30, 0.80, 0.8, 0.0, '{}', '{}'),
+                (?, 's3', -0.4, -0.4, 0.7, -0.40, -0.20, 0.70, 0.7, 0.0, '{}', '{}'),
+                (?, 's4', -0.2, -0.2, 0.6, -0.20, -0.10, 0.60, 0.6, 0.0, '{}', '{}'),
+                (?, 's5', 0.0, 0.0, 0.5, 0.00, 0.00, 0.50, 0.5, 0.0, '{}', '{}'),
+                (?, 's6', 0.1, 0.1, 0.5, 0.10, 0.05, 0.50, 0.5, 0.0, '{}', '{}'),
+                (?, 's7', 0.3, 0.3, 0.5, 0.30, 0.15, 0.50, 0.5, 0.0, '{}', '{}'),
+                (?, 's8', -0.5, -0.5, 0.7, -0.50, -0.25, 0.70, 0.7, 0.0, '{}', '{}')
+            """,
+            (MODEL_ID,) * 8,
+        )
+        connection.execute(
+            """
+            INSERT INTO model_scene_neighbor(
+                model_id, scene_id, neighbor_scene_id, similarity, weight, outcome, rank
+            ) VALUES (?, 's1', 's2', 0.45, 0.5, 0.1, 0),
+                     (?, 's1', 's3', 0.30, 0.5, 0.05, 1)
+            """,
+            (MODEL_ID, MODEL_ID),
+        )
+        connection.execute(
+            """
+            INSERT INTO exclusion(
+                exclusion_id, entity_type, entity_id, exclusion_type, created_at_ms,
+                reversed_at_ms, expires_at_ms
+            ) VALUES ('ex-s3', 'scene', 's3', 'hard', 1, NULL, NULL)
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO feedback(
+                feedback_id, scene_id, feedback_type, value, occurred_at_ms, payload_json
+            ) VALUES ('fb-s4', 's4', 'thumb_down', NULL, 1, '{}')
+            """
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+@pytest.fixture(scope="module")
+def score_review_sidecar(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    path = tmp_path_factory.mktemp("score-review-sidecar") / "curator.sqlite3"
+    make_score_review_sidecar(path)
+    return path
+
+
+def assert_score_review_identical(
+    binary: Path, raw: bytes, same_path: Path, *, normalize: tuple[str, ...] = ()
+) -> None:
+    """Run both backends on fresh sidecar copies and compare stdout with the
+    tolerance comparator (structure exact, floats within rel 1e-9)."""
+    assert_slice3_identical(binary, raw, same_path, normalize=normalize)
+
+
+# ── get_score_review ────────────────────────────────────────────────────────
+
+
+def test_score_review_default_byte_identical(
+    tmp_path: Path, binary: Path, stub_stash: str, score_review_sidecar: Path
+) -> None:
+    # Defaults: page 1, count 20, max_appeal 0. Eligible tail is s1 (-0.9),
+    # s2 (-0.6), s5 (0.0) — s3 hard-excluded, s4 thumb_down, s8 no file.
+    raw = payload("get_score_review", score_review_sidecar, stub_stash)
+    assert_score_review_identical(binary, raw, score_review_sidecar, normalize=("impression_id",))
+
+
+def test_score_review_paging_byte_identical(
+    tmp_path: Path, binary: Path, stub_stash: str, score_review_sidecar: Path
+) -> None:
+    raw = payload(
+        "get_score_review", score_review_sidecar, stub_stash, page=2, count=2, max_appeal=0.0
+    )
+    assert_score_review_identical(binary, raw, score_review_sidecar, normalize=("impression_id",))
+
+
+def test_score_review_max_appeal_byte_identical(
+    tmp_path: Path, binary: Path, stub_stash: str, score_review_sidecar: Path
+) -> None:
+    raw = payload(
+        "get_score_review", score_review_sidecar, stub_stash, page=1, count=5, max_appeal=-0.4
+    )
+    assert_score_review_identical(binary, raw, score_review_sidecar, normalize=("impression_id",))
+
+
+def test_score_review_empty_byte_identical(
+    tmp_path: Path, binary: Path, stub_stash: str, score_review_sidecar: Path
+) -> None:
+    raw = payload(
+        "get_score_review", score_review_sidecar, stub_stash, page=3, count=2, max_appeal=0.0
+    )
+    assert_score_review_identical(binary, raw, score_review_sidecar, normalize=("impression_id",))
+
+
+def test_score_review_validation_errors_byte_identical(
+    tmp_path: Path, binary: Path, stub_stash: str, score_review_sidecar: Path
+) -> None:
+    # page/count outside 1..500 error; zero is coerced by the Python `or`
+    # fallback on both sides (see test_score_review_zero_args_coerced).
+    assert_score_review_identical(
+        binary,
+        payload("get_score_review", score_review_sidecar, stub_stash, page=-1),
+        score_review_sidecar,
+    )
+    assert_score_review_identical(
+        binary,
+        payload("get_score_review", score_review_sidecar, stub_stash, count=-1),
+        score_review_sidecar,
+    )
+    assert_score_review_identical(
+        binary,
+        payload("get_score_review", score_review_sidecar, stub_stash, count=501),
+        score_review_sidecar,
+    )
+
+
+def test_score_review_zero_args_coerced_byte_identical(
+    tmp_path: Path, binary: Path, stub_stash: str, score_review_sidecar: Path
+) -> None:
+    """page=0 and count=0 fall back to 1 / the config page_size on both
+    implementations (mirroring get_slate's arg coercion)."""
+    raw = payload(
+        "get_score_review", score_review_sidecar, stub_stash, page=0, count=0, max_appeal=0.0
+    )
+    assert_score_review_identical(binary, raw, score_review_sidecar, normalize=("impression_id",))
+
+
+def test_score_review_requires_model_byte_identical(
+    tmp_path: Path, binary: Path, stub_stash: str
+) -> None:
+    bare = tmp_path / "bare.sqlite3"
+    make_sidecar(bare, with_jobs=True)  # migrated, but no published model
+    raw = payload("get_score_review", bare, stub_stash)
+    assert_score_review_identical(binary, raw, bare)
+
+
+def test_score_review_write_state_parity(
+    tmp_path: Path, binary: Path, stub_stash: str, score_review_sidecar: Path
+) -> None:
+    """get_score_review's read-path write (the "score_review" impression
+    rows) leaves identical sidecar state on both implementations; only the
+    requested_at_ms timestamp and the uuid4 impression_id may differ."""
+    from tests.core.test_backend_slice1 import _run_once_on_copy
+
+    raw = payload(
+        "get_score_review", score_review_sidecar, stub_stash, page=1, count=2, max_appeal=0.0
+    )
+    python_db = _run_once_on_copy(None, PLUGIN_DIR, raw, score_review_sidecar)
+    go_db = _run_once_on_copy(binary, PLUGIN_DIR, raw, score_review_sidecar)
+
+    def impressions(path: Path) -> tuple[list[tuple[object, ...]], list[tuple[object, ...]]]:
+        connection = sqlite3.connect(path)
+        try:
+            items = sorted(
+                connection.execute(
+                    """
+                    SELECT impression_id, scene_id, position, policy_score, reason_snapshot_json
+                    FROM impression_item WHERE impression_id IN (
+                        SELECT impression_id FROM impression WHERE lane='score_review'
+                    ) ORDER BY impression_id, position
+                    """
+                ).fetchall()
+            )
+            rows = connection.execute(
+                "SELECT impression_id, lane, model_id, config_version, request_context_json"
+                " FROM impression WHERE lane='score_review'"
+            ).fetchall()
+            return rows, items
+        finally:
+            connection.close()
+
+    python_rows, python_items = impressions(python_db)
+    go_rows, go_items = impressions(go_db)
+    assert {row[0] for row in python_rows} == {row[0] for row in go_rows}
+    assert len(go_rows) == 1
+    assert len(go_items) == 2
+    for python_row, go_row in zip(sorted(python_rows), sorted(go_rows), strict=True):
+        # Everything except impression_id and requested_at_ms must match.
+        assert python_row[1:] == go_row[1:]
+        assert go_row[1] == "score_review"
+        assert go_row[2] == MODEL_ID
+    assert sorted((row[1], row[2], row[3], row[4]) for row in python_items) == sorted(
+        (row[1], row[2], row[3], row[4]) for row in go_items
+    )
+    assert {row[3] for row in go_items} == {-0.9, -0.6}  # policy_score = appeal
+    assert all(row[4] == '["eligibility.lane"]' for row in go_items)

--- a/tests/core/test_backend_slice5.py
+++ b/tests/core/test_backend_slice5.py
@@ -71,8 +71,8 @@ def stub_stash() -> str:
 def make_score_review_sidecar(path: Path) -> None:
     """A migrated sidecar exercising get_score_review: a published model whose
     score rows cover the review window (s3 hard-excluded, s4 carries a
-    current thumb_down, s8 has no available file), with a neighbor row for
-    s1."""
+    current thumb_down — shown on the review surface, s8 has no available
+    file), with a neighbor row for s1."""
     make_sidecar(path, with_jobs=True)
     connection = sqlite3.connect(path)
     try:
@@ -177,7 +177,8 @@ def test_score_review_default_byte_identical(
     tmp_path: Path, binary: Path, stub_stash: str, score_review_sidecar: Path
 ) -> None:
     # Defaults: page 1, count 20, max_appeal 0. Eligible tail is s1 (-0.9),
-    # s2 (-0.6), s5 (0.0) — s3 hard-excluded, s4 thumb_down, s8 no file.
+    # s2 (-0.6), s4 (-0.2), s5 (0.0) — s3 hard-excluded, s8 no file; s4's
+    # current thumb_down does NOT exclude on the review surface.
     raw = payload("get_score_review", score_review_sidecar, stub_stash)
     assert_score_review_identical(binary, raw, score_review_sidecar, normalize=("impression_id",))
 

--- a/tests/ranking/test_slate.py
+++ b/tests/ranking/test_slate.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import pytest
 
+from curator.api import CuratorAPI
 from curator.cli import run
 from curator.ranking import LanePolicy, SlateBuilder
 from curator.storage import MigrationRunner, connect_database
@@ -915,3 +916,204 @@ def test_available_count_probes_are_batched_not_per_scene(tmp_path: Path) -> Non
     statements.clear()
     assert builder.available_count("model", "best_bets") == total
     assert not [statement for statement in statements if "FROM scene_tag" in statement]
+
+
+# ── get_score_review (score-first read path) ────────────────────────────────
+
+
+def _set_appeal(connection: sqlite3.Connection, scene_id: str, appeal: float) -> None:
+    """Pin a scene's appeal (and its general/direct mirrors) so the review
+    window is deterministic."""
+    connection.execute(
+        """
+        UPDATE model_scene_score SET appeal=?, general_appeal=?, direct_appeal=?
+        WHERE model_id='model' AND scene_id=?
+        """,
+        (appeal, appeal, appeal, scene_id),
+    )
+
+
+def _score_review_db(path: Path) -> sqlite3.Connection:
+    """A sidecar whose appeals cover the review window: x-excluded at the
+    bottom (built eligibility_json says ineligible — live eligibility is what
+    gates the review), then a-best/b-best/c-best/d-revisit/e-frontier."""
+    connection = _database(path)
+    _set_appeal(connection, "x-excluded", -0.9)
+    _set_appeal(connection, "a-best", -0.8)
+    _set_appeal(connection, "b-best", -0.5)
+    _set_appeal(connection, "c-best", -0.2)
+    _set_appeal(connection, "d-revisit", 0.0)
+    _set_appeal(connection, "e-frontier", 0.4)
+    _set_appeal(connection, "f-stretch", 0.3)
+    _set_appeal(connection, "g-combination", 0.2)
+    _set_appeal(connection, "h-probe", 0.1)
+    _set_appeal(connection, "i-island", 0.05)
+    connection.commit()
+    return connection
+
+
+def test_score_review_orders_by_appeal_ascending(tmp_path: Path) -> None:
+    connection = _score_review_db(tmp_path / "curator.sqlite3")
+    result = CuratorAPI(connection).get_score_review(page=1, count=20, max_appeal=0.0)
+    scene_ids = [item["scene_id"] for item in result["items"]]
+    assert scene_ids == ["x-excluded", "a-best", "b-best", "c-best", "d-revisit"]
+    assert result["total"] == 5
+    assert result["page_size"] == 20
+    assert result["page"] == 1
+    assert result["has_more"] is False
+    assert result["model_version"] == "model"
+    assert set(result) == {"items", "total", "page_size", "has_more", "page", "model_version"}
+    # The built eligibility_json flag does not gate the review — live
+    # eligibility does (the slate path behaves the same way).
+    assert result["items"][0]["scene_id"] == "x-excluded"
+    assert result["items"][0]["eligibility"] == {"eligible": False, "reasons": ["excluded"]}
+    # Positions are page-relative to the full distribution.
+    assert [item["position"] for item in result["items"]] == [0, 1, 2, 3, 4]
+
+
+def test_score_review_items_mirror_slate_shape(tmp_path: Path) -> None:
+    connection = _score_review_db(tmp_path / "curator.sqlite3")
+    result = CuratorAPI(connection).get_score_review(page=1, count=20, max_appeal=0.0)
+    item = result["items"][1]  # a-best at -0.8
+    assert item["scene_id"] == "a-best"
+    assert item["lane"] == "score_review"
+    assert item["source_lane"] == "score_review"
+    assert item["subtype"] is None
+    assert item["final_utility"] == item["appeal"] == -0.8
+    assert item["lane_value"] == -0.8
+    assert item["current_fit"] == pytest.approx(0.80)
+    assert item["confidence"] == 0.9
+    assert item["penalties"] == {
+        "performer": 0.0,
+        "studio": 0.0,
+        "content": 0.0,
+        "history": 0.0,
+        "live_cooldown": 0.0,
+    }
+    assert item["bonuses"] == {"uncovered_content": 0.0}
+    assert item["components"]["content"]["value"] == pytest.approx(0.20)
+    assert item["reason_ids"] == ("eligibility.lane",)
+    assert item["qualification"] == {}
+    assert isinstance(item["impression_id"], str) and item["impression_id"]
+    assert set(item) == {
+        "scene_id",
+        "lane",
+        "source_lane",
+        "subtype",
+        "position",
+        "appeal",
+        "current_fit",
+        "confidence",
+        "lane_value",
+        "final_utility",
+        "penalties",
+        "bonuses",
+        "components",
+        "neighbors",
+        "eligibility",
+        "qualification",
+        "reason_ids",
+        "impression_id",
+    }
+
+
+def test_score_review_max_appeal_cap(tmp_path: Path) -> None:
+    connection = _score_review_db(tmp_path / "curator.sqlite3")
+    api = CuratorAPI(connection)
+    result = api.get_score_review(page=1, count=20, max_appeal=-0.4)
+    assert [item["scene_id"] for item in result["items"]] == ["x-excluded", "a-best", "b-best"]
+    assert result["total"] == 3
+    # A cap below the whole window yields an empty page.
+    result = api.get_score_review(page=1, count=20, max_appeal=-1.0)
+    assert result["items"] == []
+    assert result["total"] == 0
+    assert result["has_more"] is False
+
+
+def test_score_review_paging_math(tmp_path: Path) -> None:
+    connection = _score_review_db(tmp_path / "curator.sqlite3")
+    api = CuratorAPI(connection)
+    first = api.get_score_review(page=1, count=2, max_appeal=0.0)
+    assert [item["scene_id"] for item in first["items"]] == ["x-excluded", "a-best"]
+    assert first["has_more"] is True
+    assert [item["position"] for item in first["items"]] == [0, 1]
+    second = api.get_score_review(page=2, count=2, max_appeal=0.0)
+    assert [item["scene_id"] for item in second["items"]] == ["b-best", "c-best"]
+    assert second["has_more"] is True
+    assert [item["position"] for item in second["items"]] == [2, 3]
+    third = api.get_score_review(page=3, count=2, max_appeal=0.0)
+    assert [item["scene_id"] for item in third["items"]] == ["d-revisit"]
+    assert third["has_more"] is False
+    assert [item["position"] for item in third["items"]] == [4]
+
+
+def test_score_review_applies_live_eligibility(tmp_path: Path) -> None:
+    connection = _score_review_db(tmp_path / "curator.sqlite3")
+    connection.execute(
+        """
+        INSERT INTO exclusion(exclusion_id, entity_type, entity_id, exclusion_type,
+            created_at_ms, reversed_at_ms, expires_at_ms)
+        VALUES ('ex-c', 'scene', 'c-best', 'hard', 1, NULL, NULL)
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO feedback(
+            feedback_id, scene_id, feedback_type, value, occurred_at_ms, payload_json
+        ) VALUES ('fb-b', 'b-best', 'thumb_down', NULL, 1, '{}')
+        """
+    )
+    connection.commit()
+    result = CuratorAPI(connection).get_score_review(page=1, count=20, max_appeal=0.0)
+    assert [item["scene_id"] for item in result["items"]] == [
+        "x-excluded",
+        "a-best",
+        "d-revisit",
+    ]
+    assert result["total"] == 3
+
+
+def test_score_review_records_impression_like_get_slate(tmp_path: Path) -> None:
+    connection = _score_review_db(tmp_path / "curator.sqlite3")
+    result = CuratorAPI(connection).get_score_review(
+        page=2, count=2, max_appeal=0.0, now_ms=1_700_000_000_000
+    )
+    impression_id = result["items"][0]["impression_id"]
+    lane, model_id, config_version = connection.execute(
+        "SELECT lane, model_id, config_version FROM impression WHERE impression_id=?",
+        (impression_id,),
+    ).fetchone()
+    assert (lane, model_id, config_version) == ("score_review", "model", "builtin")
+    rows = connection.execute(
+        """
+        SELECT scene_id, position, policy_score, reason_snapshot_json
+        FROM impression_item WHERE impression_id=? ORDER BY position
+        """,
+        (impression_id,),
+    ).fetchall()
+    assert [tuple(row) for row in rows] == [
+        ("b-best", 2, -0.5, '["eligibility.lane"]'),
+        ("c-best", 3, -0.2, '["eligibility.lane"]'),
+    ]
+    # A fresh request records a distinct impression (uuid4 per request).
+    second = CuratorAPI(connection).get_score_review(page=1, count=2, max_appeal=0.0)
+    assert second["items"][0]["impression_id"] != impression_id
+
+
+def test_score_review_validation_and_model_required(tmp_path: Path) -> None:
+    connection = _score_review_db(tmp_path / "curator.sqlite3")
+    api = CuratorAPI(connection)
+    for page, count in ((0, 20), (1, 0), (1, 501)):
+        with pytest.raises(ValueError, match="invalid score review page"):
+            api.get_score_review(page=page, count=count)
+    # The SlateBuilder mirror exposes the same count/eligibility semantics.
+    builder = SlateBuilder(connection)
+    assert builder.score_review_available_count("model", 0.0) == 5
+    assert builder.score_review_available_count("model", -0.4) == 3
+    assert builder.score_review("model", 2, max_appeal=0.0).items[0].scene_id == "x-excluded"
+    assert builder.score_review("model", 2, max_appeal=0.0).items[1].final_utility == -0.8
+    # No published model errors with the slate path's exact message.
+    bare = connect_database(tmp_path / "bare.sqlite3")
+    MigrationRunner(bare).migrate(applied_at_ms=1)
+    with pytest.raises(RuntimeError, match="no published model; run build-model first"):
+        CuratorAPI(bare).get_score_review()

--- a/tests/ranking/test_slate.py
+++ b/tests/ranking/test_slate.py
@@ -1065,12 +1065,40 @@ def test_score_review_applies_live_eligibility(tmp_path: Path) -> None:
     )
     connection.commit()
     result = CuratorAPI(connection).get_score_review(page=1, count=20, max_appeal=0.0)
+    # c-best hard-excluded stays out; b-best's current thumb_down does NOT
+    # exclude on the review surface.
     assert [item["scene_id"] for item in result["items"]] == [
         "x-excluded",
         "a-best",
+        "b-best",
         "d-revisit",
     ]
-    assert result["total"] == 3
+    assert result["total"] == 4
+
+
+def test_score_review_thumb_down_does_not_exclude(tmp_path: Path) -> None:
+    """The review surface drops the current_thumb_down reason: scenes the
+    user disliked are exactly what the bottom-of-distribution review must
+    show. Other reasons (file_unavailable, hard exclusion) still exclude."""
+    connection = _score_review_db(tmp_path / "curator.sqlite3")
+    for scene_id in ("a-best", "x-excluded"):
+        connection.execute(
+            """
+            INSERT INTO feedback(feedback_id, scene_id, feedback_type, value,
+                                 occurred_at_ms, payload_json)
+            VALUES (?, ?, 'thumb_down', NULL, 1, '{}')
+            """,
+            (f"fb-{scene_id}", scene_id),
+        )
+    connection.commit()
+    result = CuratorAPI(connection).get_score_review(page=1, count=20, max_appeal=0.0)
+    scene_ids = [item["scene_id"] for item in result["items"]]
+    # a-best (thumb_down only) stays; x-excluded (thumb_down on top of a
+    # built ineligible row) stays out.
+    assert scene_ids == ["x-excluded", "a-best", "b-best", "c-best", "d-revisit"]
+    assert result["total"] == 5
+    builder = SlateBuilder(connection)
+    assert builder.score_review_available_count("model", 0.0) == 5
 
 
 def test_score_review_records_impression_like_get_slate(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #120 — backend op `get_score_review` (sentiment check): review the bottom of the appeal distribution.

## Contract (fixed; the #134 frontend depends on it)
- Request: `{operation: "get_score_review", page, count, max_appeal}` — defaults page 1, count 20 (config `page_size` when absent), max_appeal 0.
- Response: exactly `{items, total, page_size, has_more, page, model_version}`.
- Items mirror a get_slate recommendation item exactly: `scene_id`, `final_utility` = the scene's appeal, `appeal`, `current_fit`, `confidence`, `impression_id`, `lane: "score_review"` — plus the full slate item shape (`source_lane "score_review"`, page-relative `position`, `lane_value` = appeal, score-first zero penalties/bonuses, components, neighbors, eligibility, `reason_ids ["eligibility.lane"]`).
- Impressions recorded like get_slate via `recordImpression` under lane `score_review` (config_version `builtin`, request_context `{}`), so the Feedback/qualified-impression plumbing works unchanged.
- Live eligibility identical to the slate path (exclusions, current thumb_down, pruning, blocked tags/terms, unavailable files — stale/deleted scenes excluded).

## Where the score-first read path lives in Go
`core/score_review.go` — `getScoreReviewCore` / `scoreReviewLoad` / `scoreReviewTotal` mirror `CuratorAPI.get_score_review` + `SlateBuilder.score_review` (`curator/api.py`, `curator/ranking/slate.py`): candidates from `model_scene_score` ordered by appeal ASC (tie-break scene_id), filtered `appeal <= max_appeal`, chunked paging with per-chunk live eligibility (same shape as `loadMaterializedSlate`'s chunked read), hydrated via the shared `modelScores` helper.

## Files
- `core/score_review.go` (new) — the op; `core/backend.go` — dispatch registration
- `curator/api.py` + `curator/ranking/slate.py` — Python oracle mirror
- `plugin/backend.py` — Python oracle dispatch + differential test added (pattern match with get_slate): the tests/core harness runs the oracle via plugin/backend.py, so a byte-identical differential test requires it
- `core/score_review_test.go` (new) — Go unit tests: appeal-ASC ordering, max_appeal cap, paging math, eligibility, impression recording, item shape, validation/model-required errors
- `tests/ranking/test_slate.py` — Python mirror tests (same coverage through `CuratorAPI` + `SlateBuilder`)
- `tests/core/test_backend_slice5.py` (new) — differential harness: Go binary vs plugin/backend.py byte-identical (uuid4 impression_id normalized), incl. write-state parity of the score_review impression rows

## Verification
- `scripts/build_core.sh` built `core/bin/curator-core` (0.9.2); `go vet` + `go test ./...` green (full core suite incl. the 6 new score-review unit tests)
- Differential gates: `CURATOR_CORE`-pinned `pytest tests/core` → 180 passed (incl. 8 new slice5 tests); `tests/ranking/test_slate.py` → 38 passed (incl. 7 new mirror tests); ruff check/format + `mypy curator plugin/backend.py` clean
- Smoke: ran `get_score_review` through the built binary against a synthetic sidecar — output matches the fixed contract exactly (6 top-level keys; items mirror the slate shape; `final_utility == appeal`; lane `score_review`; lowest-appeal scene first)
- Pre-push hook (`scripts/verify full`, first run): all stages green — build, go vet/test, ruff, mypy, packaging, full pytest **507 passed / 20 deselected** — except the perf gate, which failed under concurrent agent pushes on this 8-core host (contention signature: feature_indexing 5612 ms > 2185 ms, database_writing 7494 ms > 6585 ms, ...). Per the batch protocol the retry was skipped and the branch was pushed with `--no-verify`; CI is the authority for the perf gate (known host-noise issue, candidate for #124).

## Release coupling
The UI half (new "Score review" nav view consuming this op) is delivered in PR #134 (frontend). Both must merge together in the same release — the backend op and the view ship as one feature.

## Notes / deviations
- `plugin/backend.py` was outside my nominal file list; Main approved the addition because the differential harness compares the Go binary against plugin/backend.py as the Python oracle. fix134's file (`plugin/stash-curator.js`) was not touched.
- `count` defaults to the config `page_size` (20 by default), matching get_slate's arg handling; `page=0`/`count=0` coerce to 1/page_size via the Python `or` fallback on both sides.
- `current_fit` is the built stored value (no live-fit override — the score-review lane has no direct-play lane rule; eligibility is live, fit is not).
- Tested on synthetic sidecars only; no private data.


---

### Follow-up (92dfda1): review surface drops `current_thumb_down` eligibility

Live verification on the integration instance (synthetic corpus, 66 scenes) exposed a structural gap: `get_score_review` applied the recommendation-lane eligibility verbatim, and `current_thumb_down` makes a scene ineligible there. A library with real thumbs-down history therefore hides exactly the scenes the review exists to inspect — the bottom of the appeal distribution. On the corpus all 19 negative-appeal scenes were thumb-downed (and, on this tiny corpus, also pruning suspects), so the view was permanently empty.

Change: the review surface is not a recommendation lane — its eligibility drops only the `current_thumb_down` reason. Every other exclusion (file_unavailable, hard_exclusion, pruning_*, not_now, blocked_tag) still applies. Implemented as `scoreReviewEligibility` (Go) / `SlateBuilder._score_review_eligibility` (Python oracle) so the byte-identical differential stays green; regression tests added on both sides + the slice-5 differential. Verified live: after dismissing 8 pruning suspects (state `keep`), the view renders them worst-first despite their thumb_down feedback; the 11 remaining pruning-review suspects stay partitioned to the Prune surface.

Verified locally: `scripts/verify core` 186 passed; full non-integration pytest 508 passed; pre-push `scripts/verify full` green including the perf gate (23797ms < 103232ms budget).
