### PR TITLE
feat: sentiment-review surface with sort direction and appeal threshold

### DIFF
--- a/core/score_review.go
+++ b/core/score_review.go
@@ -66,11 +66,18 @@ func getScoreReviewBody(pluginDir string, payload, settings jVal) (jVal, error) 
 	page := argsInt(args, "page", 1)
 	count := argsInt(args, "count", pythonInt(cfg.get("page_size")))
 	maxAppeal := argsFloat(args, "max_appeal", 0)
-	return getScoreReviewCore(db, config, page, count, maxAppeal)
+	order := pythonStrOrEmpty(args.get("order"))
+	if order == "" {
+		order = "asc"
+	}
+	if order != "asc" && order != "desc" {
+		return jvNull(), fmt.Errorf("invalid score review order")
+	}
+	return getScoreReviewCore(db, config, page, count, maxAppeal, order)
 }
 
 // getScoreReviewCore mirrors CuratorAPI.get_score_review after arg coercion.
-func getScoreReviewCore(db dbx, config jVal, page, count int64, maxAppeal float64) (jVal, error) {
+func getScoreReviewCore(db dbx, config jVal, page, count int64, maxAppeal float64, order string) (jVal, error) {
 	if page < 1 || count < 1 || count > 500 {
 		return jvNull(), fmt.Errorf("invalid score review page")
 	}
@@ -88,7 +95,7 @@ func getScoreReviewCore(db dbx, config jVal, page, count int64, maxAppeal float6
 	if err != nil {
 		return jvNull(), err
 	}
-	built, err := scoreReviewLoad(db, modelID, end, maxAppeal)
+	built, err := scoreReviewLoad(db, modelID, end, maxAppeal, order)
 	if err != nil {
 		return jvNull(), err
 	}
@@ -165,15 +172,19 @@ type scoreReviewRow struct {
 // hydrated into recommendation items with score-first semantics
 // (final_utility = appeal, the score-first zero penalties/bonuses, lane
 // "score_review").
-func scoreReviewLoad(db dbx, modelID string, count int64, maxAppeal float64) (builtSlate, error) {
+func scoreReviewLoad(db dbx, modelID string, count int64, maxAppeal float64, order string) (builtSlate, error) {
 	now := nowMs()
 	var selectedRows []scoreReviewRow
 	offset := int64(0)
 	chunkSize := maxInt64(100, count)
+	direction := "ASC"
+	if order == "desc" {
+		direction = "DESC"
+	}
 	for int64(len(selectedRows)) < count {
 		rows, err := db.Query(`SELECT scene_id FROM model_scene_score
 WHERE model_id=? AND appeal <= ?
-ORDER BY appeal ASC, scene_id
+ORDER BY appeal `+direction+`, scene_id
 LIMIT ? OFFSET ?`, modelID, maxAppeal, chunkSize, offset)
 		if err != nil {
 			return builtSlate{}, err

--- a/core/score_review_test.go
+++ b/core/score_review_test.go
@@ -76,7 +76,7 @@ func scoreReviewIDs(t *testing.T, out jVal) []string {
 
 func TestScoreReviewOrdersByAppealAscendingWithEligibility(t *testing.T) {
 	db := scoreReviewSeed(t)
-	out, err := getScoreReviewCore(db, jvObj(), 1, 20, 0)
+	out, err := getScoreReviewCore(db, jvObj(), 1, 20, 0, "asc")
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestScoreReviewThumbDownDoesNotExcludeButOtherReasonsDo(t *testing.T) {
 	// exclusion reasons.
 	exec(`INSERT INTO feedback(feedback_id, scene_id, feedback_type, value, occurred_at_ms, payload_json)
 VALUES ('fb-2', 's8', 'thumb_down', NULL, 1, '{}')`)
-	out, err := getScoreReviewCore(db, jvObj(), 1, 20, 0)
+	out, err := getScoreReviewCore(db, jvObj(), 1, 20, 0, "asc")
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
 	}
@@ -138,9 +138,36 @@ VALUES ('fb-2', 's8', 'thumb_down', NULL, 1, '{}')`)
 	}
 }
 
+func TestScoreReviewOrdersDescending(t *testing.T) {
+	db := scoreReviewSeed(t)
+	out, err := getScoreReviewCore(db, jvObj(), 1, 20, 0, "desc")
+	if err != nil {
+		t.Fatalf("getScoreReviewCore: %v", err)
+	}
+	// Descending within the window (appeal <= 0): s5 (0.0), s4 (-0.2),
+	// s2 (-0.6), s1 (-0.9). s3 hard-excluded, s8 no file.
+	if got := scoreReviewIDs(t, out); strings.Join(got, ",") != "s5,s4,s2,s1" {
+		t.Fatalf("items = %v, want [s5 s4 s2 s1]", got)
+	}
+	if out.get("total").asString() != "4" {
+		t.Fatalf("total = %s, want 4", out.get("total").asString())
+	}
+	// Descending paging: page 1 count 2 = s5, s4 (positions 0, 1).
+	out, err = getScoreReviewCore(db, jvObj(), 1, 2, 0, "desc")
+	if err != nil {
+		t.Fatalf("getScoreReviewCore: %v", err)
+	}
+	if got := scoreReviewIDs(t, out); strings.Join(got, ",") != "s5,s4" {
+		t.Fatalf("desc page 1 items = %v, want [s5 s4]", got)
+	}
+	if got := out.get("items").arr[1].get("position").asString(); got != "1" {
+		t.Fatalf("desc page 1 second position = %s, want 1", got)
+	}
+}
+
 func TestScoreReviewItemsMirrorSlateShape(t *testing.T) {
 	db := scoreReviewSeed(t)
-	out, err := getScoreReviewCore(db, jvObj(), 1, 20, 0)
+	out, err := getScoreReviewCore(db, jvObj(), 1, 20, 0, "asc")
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
 	}
@@ -205,7 +232,7 @@ func TestScoreReviewItemsMirrorSlateShape(t *testing.T) {
 
 func TestScoreReviewMaxAppealCap(t *testing.T) {
 	db := scoreReviewSeed(t)
-	out, err := getScoreReviewCore(db, jvObj(), 1, 20, -0.4)
+	out, err := getScoreReviewCore(db, jvObj(), 1, 20, -0.4, "asc")
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
 	}
@@ -218,7 +245,7 @@ func TestScoreReviewMaxAppealCap(t *testing.T) {
 	}
 	// A cap that admits s6 (0.1) but not s7 (0.3); s4 (thumb_down) is
 	// eligible on the review surface.
-	out, err = getScoreReviewCore(db, jvObj(), 1, 20, 0.1)
+	out, err = getScoreReviewCore(db, jvObj(), 1, 20, 0.1, "asc")
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
 	}
@@ -229,7 +256,7 @@ func TestScoreReviewMaxAppealCap(t *testing.T) {
 		t.Fatalf("total = %s, want 5", out.get("total").asString())
 	}
 	// A cap below every appeal yields an empty page.
-	out, err = getScoreReviewCore(db, jvObj(), 1, 20, -1.0)
+	out, err = getScoreReviewCore(db, jvObj(), 1, 20, -1.0, "asc")
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
 	}
@@ -245,7 +272,7 @@ func TestScoreReviewMaxAppealCap(t *testing.T) {
 func TestScoreReviewPagingMath(t *testing.T) {
 	db := scoreReviewSeed(t)
 	// page 1, count 2: s1, s2, has_more (4 > 2).
-	out, err := getScoreReviewCore(db, jvObj(), 1, 2, 0)
+	out, err := getScoreReviewCore(db, jvObj(), 1, 2, 0, "asc")
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
 	}
@@ -260,7 +287,7 @@ func TestScoreReviewPagingMath(t *testing.T) {
 	}
 	// page 2, count 2: s4, s5 (positions 2 and 3), has_more false (4 > 4 is
 	// false).
-	out, err = getScoreReviewCore(db, jvObj(), 2, 2, 0)
+	out, err = getScoreReviewCore(db, jvObj(), 2, 2, 0, "asc")
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
 	}
@@ -274,7 +301,7 @@ func TestScoreReviewPagingMath(t *testing.T) {
 		t.Fatalf("page 2 has_more = %s, want false", out.get("has_more").asString())
 	}
 	// page 3, count 2: past the end -> empty items.
-	out, err = getScoreReviewCore(db, jvObj(), 3, 2, 0)
+	out, err = getScoreReviewCore(db, jvObj(), 3, 2, 0, "asc")
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
 	}
@@ -288,7 +315,7 @@ func TestScoreReviewPagingMath(t *testing.T) {
 
 func TestScoreReviewRecordsImpression(t *testing.T) {
 	db := scoreReviewSeed(t)
-	out, err := getScoreReviewCore(db, jvObj(), 1, 2, 0)
+	out, err := getScoreReviewCore(db, jvObj(), 1, 2, 0, "asc")
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
 	}
@@ -341,7 +368,7 @@ FROM impression_item WHERE impression_id=? ORDER BY position`, impressionID)
 	}
 	// A second request with the same page records a distinct impression
 	// (uuid4 per request, INSERT OR IGNORE keyed by impression_id).
-	second, err := getScoreReviewCore(db, jvObj(), 1, 2, 0)
+	second, err := getScoreReviewCore(db, jvObj(), 1, 2, 0, "asc")
 	if err != nil {
 		t.Fatalf("getScoreReviewCore: %v", err)
 	}
@@ -365,7 +392,7 @@ func TestScoreReviewValidationAndModelRequired(t *testing.T) {
 	}{
 		{0, 20}, {1, 0}, {1, 501},
 	} {
-		if _, err := getScoreReviewCore(db, jvObj(), tc.page, tc.count, 0); err == nil ||
+		if _, err := getScoreReviewCore(db, jvObj(), tc.page, tc.count, 0, "asc"); err == nil ||
 			err.Error() != "invalid score review page" {
 			t.Fatalf("page=%d count=%d: err = %v, want invalid score review page", tc.page, tc.count, err)
 		}
@@ -375,7 +402,7 @@ func TestScoreReviewValidationAndModelRequired(t *testing.T) {
 	if err := migrate(db2, 1_700_000_000_000); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := getScoreReviewCore(db2, jvObj(), 1, 20, 0); err == nil ||
+	if _, err := getScoreReviewCore(db2, jvObj(), 1, 20, 0, "asc"); err == nil ||
 		err.Error() != "no published model; run build-model first" {
 		t.Fatalf("err = %v, want no published model", err)
 	}

--- a/curator/api.py
+++ b/curator/api.py
@@ -155,10 +155,13 @@ class CuratorAPI:
         count: int = 20,
         *,
         max_appeal: float = 0.0,
+        order: str = "asc",
         now_ms: int | None = None,
     ) -> dict[str, object]:
         if page < 1 or not 1 <= count <= 500:
             raise ValueError("invalid score review page")
+        if order not in ("asc", "desc"):
+            raise ValueError("invalid score review order")
         model_id = RecommendationModelStore(self.connection).current_model_id()
         if model_id is None:
             raise RuntimeError("no published model; run build-model first")
@@ -166,7 +169,7 @@ class CuratorAPI:
         end = page * count
         builder = SlateBuilder(self.connection)
         total = builder.score_review_available_count(model_id, max_appeal)
-        built = builder.score_review(model_id, end, max_appeal=max_appeal)
+        built = builder.score_review(model_id, end, max_appeal=max_appeal, order=order)
         selected = built.items[start:end]
         slate = Slate(
             built.model_id,

--- a/curator/ranking/slate.py
+++ b/curator/ranking/slate.py
@@ -943,26 +943,30 @@ class SlateBuilder:
         eligibility = self._score_review_eligibility(time.time_ns() // 1_000_000, scene_ids)
         return sum(1 for scene_id in scene_ids if eligibility.get(scene_id, {}).get("eligible"))
 
-    def score_review(self, model_id: str, count: int, *, max_appeal: float = 0.0) -> Slate:
+    def score_review(
+        self, model_id: str, count: int, *, max_appeal: float = 0.0, order: str = "asc"
+    ) -> Slate:
         """The bottom of the appeal distribution: model_scene_score rows
-        ordered by appeal ASC (tie-break scene_id), filtered appeal <=
-        max_appeal, the same live eligibility applied as the slate path,
-        hydrated into recommendation items with score-first semantics
+        ordered by appeal (ASC = least-appealing first, the default review
+        direction; DESC = most-appealing within the window first), filtered
+        appeal <= max_appeal, the same live eligibility applied as the slate
+        path, hydrated into recommendation items with score-first semantics
         (final_utility = appeal, the score-first zero penalties/bonuses, lane
         "score_review")."""
         if model_id is None:
             raise RuntimeError("no published model; run build-model first")
         started = time.perf_counter()
         now_ms = time.time_ns() // 1_000_000
+        direction = "ASC" if order == "asc" else "DESC"
         selected_rows: list[sqlite3.Row] = []
         offset = 0
         chunk_size = max(100, count)
         while len(selected_rows) < count:
             rows = self.connection.execute(
-                """
+                f"""
                 SELECT scene_id FROM model_scene_score
                 WHERE model_id=? AND appeal <= ?
-                ORDER BY appeal ASC, scene_id
+                ORDER BY appeal {direction}, scene_id
                 LIMIT ? OFFSET ?
                 """,
                 (model_id, max_appeal, chunk_size, offset),

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -723,6 +723,7 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
                 page=int(args.get("page") or 1),
                 count=count,
                 max_appeal=float(args.get("max_appeal") or 0),
+                order=args.get("order") or "asc",
             )
         if operation == "replace_item":
             excluded = args.get("exclude_scene_ids")

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -65,10 +65,11 @@
       description: "Choose a scene or performer, then compare preference-aware matches from your Library or StashDB.",
     },
     {
-      value: "scores",
-      label: "Score review",
-      icon: faCheckCircle,
-      description: "Inspect the bottom of the model's score distribution: every scored scene ranked least-appealing first, with reasons and feedback on each card.",
+      value: "sentiment",
+      label: "Sentiment review",
+      icon: faBalanceScale,
+      maintenance: true,
+      description: "Review the model's sentiment estimates: least-appealing scenes first, with reasons and feedback on each card.",
     },
     {
       value: "history",
@@ -2765,28 +2766,42 @@
   // pages through the bottom of the model's score distribution (least
   // appealing first) and reuses the slate card, so reasons, "Why this?", and
   // feedback work unchanged. Items mirror get_slate items; the backend op
-  // get_score_review is the score-review half of issue #120.
+  // get_score_review is the score-review half of issue #120. The surface
+  // reviews the model's sentiment estimates (appeal, -1..1): least-appealing
+  // scenes first by default, with a sort direction and an appeal threshold
+  // control. URL state (sent_order / sent_max / page_sentiment) is the full
+  // source of truth, per the URL-as-truth convention.
   function ScoreReviewPanel() {
-    const [page, setPage] = useUrlPage("page_scores");
+    const sentimentSpec = React.useMemo(() => ({
+      defaults: { order: "asc", maxAppeal: 0, page: 1 },
+      fields: {
+        order: urlStringField("sent_order", "asc", (value) => value === "asc" || value === "desc"),
+        maxAppeal: urlNumberField("sent_max", 0),
+      },
+      page: urlPageSpec("page_sentiment"),
+    }), []);
+    const [urlState, updateUrl] = useUrlState(sentimentSpec);
+    const { order, maxAppeal, page } = urlState;
+    const threshold = Math.min(1, Math.max(-1, maxAppeal));
     const [data, setData] = React.useState(null);
     const [loading, setLoading] = React.useState(true);
     const [error, setError] = React.useState("");
     const [followUps, setFollowUps] = React.useState([]);
-    useCuratorActivity("score-review", loading, "Loading score review…");
+    useCuratorActivity("score-review", loading, "Loading sentiment review…");
     React.useEffect(() => {
       let active = true;
       setLoading(true);
       setError("");
-      operation({ operation: "get_score_review", page, count: 20, max_appeal: 0 }).then(
+      operation({ operation: "get_score_review", page, count: 20, max_appeal: threshold, order }).then(
         (result) => active && (setData(result), setLoading(false)),
         (failure) => active && (setError(failure.message), setLoading(false))
       );
       return () => { active = false; };
-    }, [page]);
+    }, [page, order, threshold]);
     React.useEffect(() => {
       if (data?.page === page) {
         const last = Math.max(1, Math.ceil(data.total / data.page_size));
-        if (page > last) setPage(last, { replace: true });
+        if (page > last) updateUrl((s) => ({ ...s, page: last }), { replace: true });
       }
     }, [data, page]);
     const ids = data?.items.map((item) => item.scene_id) || [];
@@ -2810,16 +2825,22 @@
     return React.createElement(
       "section",
       { className: "curator-score-review" },
-      loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Loading score review…")),
+      React.createElement(
+        "div",
+        { className: "curator-expand-toolbar" },
+        React.createElement("label", { className: "curator-toolbar-select" }, React.createElement(FontAwesomeIcon, { icon: faSortAmountDown }), React.createElement("select", { value: order, onChange: (event) => updateUrl((s) => ({ ...s, order: event.target.value, page: 1 })), "aria-label": "Sort sentiment review" }, React.createElement("option", { value: "asc" }, "Least appealing first"), React.createElement("option", { value: "desc" }, "Most appealing first"))),
+        React.createElement("label", { className: "curator-prune-aggressiveness", title: "Show scenes at or below this appeal threshold." }, React.createElement("span", null, `Appeal ≤ ${threshold.toFixed(2)}`), React.createElement("input", { type: "range", min: -1, max: 1, step: 0.05, value: threshold, onChange: (event) => updateUrl((s) => ({ ...s, maxAppeal: Number(event.target.value), page: 1 })), "aria-label": "Maximum appeal threshold" }))
+      ),
+      loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Loading sentiment review…")),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
       followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),
-      data && !loading && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No scenes scored below the current threshold."),
+      data && !loading && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No scenes below the current appeal threshold."),
       data && !loading && React.createElement(
         "section",
         { className: "curator-grid", "aria-live": "polite" },
         visibleItems.map((item) => React.createElement(RecommendationCard, { key: `${item.impression_id}:${item.scene_id}`, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp }))
       ),
-      data && React.createElement(Pager, { page, total: data.total, pageSize: data.page_size, hasMore: data.has_more, loading, onPage: setPage, label: "Score review pages" })
+      data && React.createElement(Pager, { page, total: data.total, pageSize: data.page_size, hasMore: data.has_more, loading, onPage: (value) => updateUrl((s) => ({ ...s, page: value })), label: "Sentiment review pages" })
     );
   }
 
@@ -3034,7 +3055,7 @@
       lane === "history" && React.createElement(RecommendationHistoryPanel),
       lane === "prune" && !loadingComponents && React.createElement(PrunePanel),
       lane === "taste" && React.createElement(TasteProfilePanel),
-      lane === "scores" && React.createElement(ScoreReviewPanel),
+      lane === "sentiment" && React.createElement(ScoreReviewPanel),
       lane === "expand" && React.createElement(ExpandPanel, { key: "expand" }),
       lane === "backups" && React.createElement(BackupPanel),
       lane === "hunt" && React.createElement(ExpandPanel, { key: "hunt", initialType: "hunt", huntOnly: true }),

--- a/tests/core/test_backend_slice5.py
+++ b/tests/core/test_backend_slice5.py
@@ -243,6 +243,23 @@ def test_score_review_zero_args_coerced_byte_identical(
     assert_score_review_identical(binary, raw, score_review_sidecar, normalize=("impression_id",))
 
 
+def test_score_review_desc_byte_identical(
+    tmp_path: Path, binary: Path, stub_stash: str, score_review_sidecar: Path
+) -> None:
+    # order=desc: the same window (appeal <= 0) ranked most-appealing first.
+    raw = payload("get_score_review", score_review_sidecar, stub_stash, order="desc")
+    assert_score_review_identical(binary, raw, score_review_sidecar, normalize=("impression_id",))
+
+
+def test_score_review_invalid_order_byte_identical(
+    tmp_path: Path, binary: Path, stub_stash: str, score_review_sidecar: Path
+) -> None:
+    # Any order other than asc/desc errors identically on both backends
+    # (no impression is recorded on the error path).
+    raw = payload("get_score_review", score_review_sidecar, stub_stash, order="sideways")
+    assert_score_review_identical(binary, raw, score_review_sidecar)
+
+
 def test_score_review_requires_model_byte_identical(
     tmp_path: Path, binary: Path, stub_stash: str
 ) -> None:

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -555,7 +555,7 @@ def test_plugin_pages_generated_results_without_repeating_external_searches() ->
         "page_prune_",
         "page_expand_",
         "page_hunt",
-        "page_scores",
+        "page_sentiment",
     ):
         assert param in source
     # The URL-backed page keys stay canonical: prune/expand derive theirs from
@@ -660,16 +660,17 @@ def test_panels_serialize_full_view_state_to_the_url() -> None:
     assert 'history[options.replace ? "replace" : "push"]' in source
 
 
-def test_score_review_view_is_a_nav_item_and_uses_the_slate_card() -> None:
+def test_score_review_view_is_a_maintenance_nav_item_and_uses_the_slate_card() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
 
-    assert 'value: "scores"' in source
-    assert 'label: "Score review"' in source
-    assert "icon: faCheckCircle" in source
+    assert 'value: "sentiment"' in source
+    assert 'label: "Sentiment review"' in source
+    assert "icon: faBalanceScale" in source
+    assert "maintenance: true" in source
     assert "function ScoreReviewPanel" in source
     assert 'operation: "get_score_review"' in source
-    assert 'useUrlPage("page_scores")' in source
-    assert 'lane === "scores" && React.createElement(ScoreReviewPanel)' in source
+    assert 'urlPageSpec("page_sentiment")' in source
+    assert 'lane === "sentiment" && React.createElement(ScoreReviewPanel)' in source
     # The review surface reuses the slate card (Score, Why this?, thumbs) and
     # the pager, mirroring CuratorPage's slate rendering.
     assert (
@@ -678,8 +679,12 @@ def test_score_review_view_is_a_nav_item_and_uses_the_slate_card() -> None:
     )
     assert "source_lane: item.lane || item.source_lane" in source
     assert "model_id: data.model_version" in source
-    assert "max_appeal: 0" in source
-    assert 'label: "Score review pages"' in source
+    # The review direction and the appeal threshold are URL-backed state and
+    # flow into the op.
+    assert 'urlStringField("sent_order", "asc"' in source
+    assert 'urlNumberField("sent_max", 0)' in source
+    assert "max_appeal: threshold, order" in source
+    assert 'label: "Sentiment review pages"' in source
 
 
 def test_plugin_reads_local_file_phashes_for_external_matching() -> None:

--- a/tests/ranking/test_slate.py
+++ b/tests/ranking/test_slate.py
@@ -1101,6 +1101,23 @@ def test_score_review_thumb_down_does_not_exclude(tmp_path: Path) -> None:
     assert builder.score_review_available_count("model", 0.0) == 5
 
 
+def test_score_review_orders_descending(tmp_path: Path) -> None:
+    connection = _score_review_db(tmp_path / "curator.sqlite3")
+    result = CuratorAPI(connection).get_score_review(page=1, count=20, max_appeal=0.0, order="desc")
+    scene_ids = [item["scene_id"] for item in result["items"]]
+    assert scene_ids == ["d-revisit", "c-best", "b-best", "a-best", "x-excluded"]
+    assert result["total"] == 5
+    assert [item["position"] for item in result["items"]] == [0, 1, 2, 3, 4]
+    # The builder mirror exposes the same direction.
+    builder = SlateBuilder(connection)
+    assert (
+        builder.score_review("model", 3, max_appeal=0.0, order="desc").items[0].scene_id
+        == "d-revisit"
+    )
+    with pytest.raises(ValueError, match="invalid score review order"):
+        CuratorAPI(connection).get_score_review(order="sideways")
+
+
 def test_score_review_records_impression_like_get_slate(tmp_path: Path) -> None:
     connection = _score_review_db(tmp_path / "curator.sqlite3")
     result = CuratorAPI(connection).get_score_review(


### PR DESCRIPTION
Product follow-up on the score-review view shipped in #138/#139, from review feedback:

1. **Rename + placement**: Score review -> **Sentiment review**, moved under the Maintenance (spanner) submenu. The surface reviews the model's sentiment estimates (appeal, -1..1), not a score, and is an inspection tool like Prune — not a recommendation surface. URL key changed `view=scores` -> `view=sentiment` (`page_scores` -> `page_sentiment`); nothing shipped with the old key beyond the 0.10.0 release minutes earlier.
2. **Sort both directions**: `get_score_review` gains `order` (asc|desc, default asc) — worst-first (default) or most-appealing-first. Validated at the op boundary on both backends; slice-5 differential extended with desc + invalid-order byte-parity.
3. **Appeal threshold slider**: `sent_max` (default 0) exposed as a range control so 'Highest first' is meaningful and the full distribution is reachable. Sort + threshold are URL-backed state (`sent_order`/`sent_max`) per the URL-as-truth convention.

Verified: go test (desc ordering + validation), mirror + slice-5 differential (19), plugin runtime suite (44), ruff/mypy/format, node --check; browser-verified on the integration instance (tab under Maintenance, desc sort flips the list, threshold widens the window with paging). Pushed with --no-verify per the hook-decoupling decision (CI runs the full matrix on this PR).

Internal names stay stable: op `get_score_review`, lane `score_review` (impressions).