### PR TITLE
feat: server-side filtering for Recommendations lanes

### DIFF
--- a/core/slate.go
+++ b/core/slate.go
@@ -76,7 +76,25 @@ func getSlateBody(pluginDir string, payload, settings jVal) (jVal, error) {
 		context = c
 	}
 	exploration := argsFloat(args, "exploration", 0)
-	return getSlateCore(db, config, lane, count, page, impressionID, context, excludedSet, exploration)
+	includeTags, err := stringList(args.get("include_tags"))
+	if err != nil {
+		return jvNull(), err
+	}
+	excludeTags, err := stringList(args.get("exclude_tags"))
+	if err != nil {
+		return jvNull(), err
+	}
+	performerIDs, err := stringList(args.get("performer_ids"))
+	if err != nil {
+		return jvNull(), err
+	}
+	studioIDs, err := stringList(args.get("studio_ids"))
+	if err != nil {
+		return jvNull(), err
+	}
+	gender := argsString(args, "gender", "")
+	return getSlateCore(db, config, lane, count, page, impressionID, context, excludedSet, exploration,
+		includeTags, excludeTags, performerIDs, studioIDs, gender)
 }
 
 // replaceItemBody mirrors backend.py's replace_item: get_slate(lane, 1,
@@ -104,11 +122,17 @@ func replaceItemBody(pluginDir string, payload, settings jVal) (jVal, error) {
 	lane := argsString(args, "lane", "for_you")
 	exploration := argsFloat(args, "exploration", 0)
 	return getSlateCore(db, config, lane, 1, 1, jvNull(),
-		jvObj(jvKey("replacement", jvBool(true))), excludedSet, exploration)
+		jvObj(jvKey("replacement", jvBool(true))), excludedSet, exploration, nil, nil, nil, nil, "")
 }
 
-// getSlateCore mirrors CuratorAPI.get_slate after arg coercion.
-func getSlateCore(db dbx, config jVal, lane string, count, page int64, impressionID, context jVal, excluded map[string]bool, exploration float64) (jVal, error) {
+// getSlateCore mirrors CuratorAPI.get_slate after arg coercion. The filter
+// args (includeTags/excludeTags/performerIDs/studioIDs/gender) narrow the
+// lane's already-classified candidates the same way get_similar narrows its
+// candidates; they don't change ranking. A filtered request always
+// recomputes total from a full candidate fetch, the same way an exploration
+// request does, since the cached eligibility count doesn't know about
+// filters.
+func getSlateCore(db dbx, config jVal, lane string, count, page int64, impressionID, context jVal, excluded map[string]bool, exploration float64, includeTags, excludeTags, performerIDs, studioIDs []string, gender string) (jVal, error) {
 	if page < 1 || count < 1 || count > 500 {
 		return jvNull(), fmt.Errorf("invalid recommendation page")
 	}
@@ -125,12 +149,18 @@ func getSlateCore(db dbx, config jVal, lane string, count, page int64, impressio
 	end := page * count
 	diversityEnabled := cfg.get("diversity_enabled").truthy()
 
-	total, err := availableCount(db, modelID, lane, diversityEnabled, excluded)
+	sceneFilter, err := buildSceneFilter(db, includeTags, excludeTags, performerIDs, studioIDs, gender)
 	if err != nil {
 		return jvNull(), err
 	}
-	if exploration != 0 {
-		total = -1
+	hasFilters := sceneFilter != nil
+
+	var total int64 = -1
+	if exploration == 0 && !hasFilters {
+		total, err = availableCount(db, modelID, lane, diversityEnabled, excluded)
+		if err != nil {
+			return jvNull(), err
+		}
 	}
 	var requestCount int64
 	if total >= 0 {
@@ -144,7 +174,7 @@ func getSlateCore(db dbx, config jVal, lane string, count, page int64, impressio
 		}
 		requestCount = maxInt64(end+int64(len(excluded)), candidateCount+int64(len(excluded)))
 	}
-	built, err := recommend(db, modelID, lane, requestCount, diversityEnabled, exploration)
+	built, err := recommend(db, modelID, lane, requestCount, diversityEnabled, exploration, sceneFilter)
 	if err != nil {
 		return jvNull(), err
 	}
@@ -346,7 +376,7 @@ func materializedRowIsEligible(sceneID, sourceLane string, eligibility map[strin
 // model with materialized lanes, exploration == 0) is the read interface the
 // build task serves; the greedy recompute path is ported for byte parity when
 // lanes are not materialized or exploration is non-zero.
-func recommend(db dbx, modelID, lane string, count int64, diversityEnabled bool, exploration float64) (builtSlate, error) {
+func recommend(db dbx, modelID, lane string, count int64, diversityEnabled bool, exploration float64, sceneFilter func(string) bool) (builtSlate, error) {
 	if !slateLanes[lane] {
 		return builtSlate{}, fmt.Errorf("unknown lane: %s", lane)
 	}
@@ -360,7 +390,7 @@ func recommend(db dbx, modelID, lane string, count int64, diversityEnabled bool,
 		return builtSlate{}, fmt.Errorf("no published model; run build-model first")
 	}
 	if exploration == 0 {
-		slate, ok, err := loadMaterializedSlate(db, modelID, lane, count, diversityEnabled)
+		slate, ok, err := loadMaterializedSlate(db, modelID, lane, count, diversityEnabled, sceneFilter)
 		if err != nil {
 			return builtSlate{}, err
 		}
@@ -368,14 +398,16 @@ func recommend(db dbx, modelID, lane string, count int64, diversityEnabled bool,
 			return slate, nil
 		}
 	}
-	return recommendGreedy(db, modelID, lane, count, diversityEnabled, exploration)
+	return recommendGreedy(db, modelID, lane, count, diversityEnabled, exploration, sceneFilter)
 }
 
 func isFinite(f float64) bool { return !math.IsInf(f, 0) && !math.IsNaN(f) }
 
 // loadMaterializedSlate mirrors SlateBuilder._load_materialized_slate. The
 // second return value is false when the model has no materialized lanes.
-func loadMaterializedSlate(db dbx, modelID, lane string, count int64, diversityEnabled bool) (builtSlate, bool, error) {
+// sceneFilter, when non-nil, additionally gates each row (get_slate's
+// include/exclude tag, performer, studio, and gender filters).
+func loadMaterializedSlate(db dbx, modelID, lane string, count int64, diversityEnabled bool, sceneFilter func(string) bool) (builtSlate, bool, error) {
 	exists, err := scanExists(db, `SELECT 1 FROM model_lane_order_state WHERE model_id=?`, modelID)
 	if err != nil || !exists {
 		return builtSlate{}, false, err
@@ -444,7 +476,8 @@ func loadMaterializedSlate(db dbx, modelID, lane string, count int64, diversityE
 			return builtSlate{}, false, err
 		}
 		for _, row := range chunk {
-			if materializedRowIsEligible(row.sceneID, row.sourceLane, eligibility, filter) {
+			if materializedRowIsEligible(row.sceneID, row.sourceLane, eligibility, filter) &&
+				(sceneFilter == nil || sceneFilter(row.sceneID)) {
 				selectedRows = append(selectedRows, row)
 			}
 		}
@@ -991,4 +1024,111 @@ func attachedGenerationID(db dbx, kind string) string {
 		return ""
 	}
 	return generationID
+}
+
+// buildSceneFilter returns a predicate for get_slate's include/exclude tag,
+// performer, studio, and gender filters, or nil when none are set. It mirrors
+// the corresponding per-candidate checks in similarCore/similarityService.scenes
+// (core/similar.go), narrowed to the fields that make sense for a lane that's
+// already been classified by the model: no minimum-similarity or
+// favorite-only knob, since those are about ranking a candidate against a
+// source entity, not about narrowing a pre-picked set.
+func buildSceneFilter(db dbx, includeTags, excludeTags, performerIDs, studioIDs []string, gender string) (func(string) bool, error) {
+	if len(includeTags) == 0 && len(excludeTags) == 0 && len(performerIDs) == 0 && len(studioIDs) == 0 && gender == "" {
+		return nil, nil
+	}
+	performers, err := scenePerformers(db)
+	if err != nil {
+		return nil, err
+	}
+	var genders map[string]string
+	if gender != "" {
+		genders, err = performerGenders(db)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var studioByScene map[string]string
+	if len(studioIDs) > 0 {
+		studioByScene, err = studios(db)
+		if err != nil {
+			return nil, err
+		}
+	}
+	included, err := equivalentTagNames(db, includeTags)
+	if err != nil {
+		return nil, err
+	}
+	excluded, err := equivalentTagNames(db, excludeTags)
+	if err != nil {
+		return nil, err
+	}
+	filterNames := make(map[string]bool)
+	for _, group := range included {
+		for name := range group {
+			filterNames[name] = true
+		}
+	}
+	for _, group := range excluded {
+		for name := range group {
+			filterNames[name] = true
+		}
+	}
+	var sceneTags map[string]map[string]bool
+	if len(filterNames) > 0 {
+		sceneTags, err = sceneTagNames(db, filterNames)
+		if err != nil {
+			return nil, err
+		}
+	}
+	performerIDSet := make(map[string]bool, len(performerIDs))
+	for _, id := range performerIDs {
+		performerIDSet[id] = true
+	}
+	studioIDSet := make(map[string]bool, len(studioIDs))
+	for _, id := range studioIDs {
+		studioIDSet[id] = true
+	}
+	return func(sceneID string) bool {
+		candidatePerformers := performers[sceneID]
+		if gender != "" {
+			matched := false
+			for _, p := range candidatePerformers {
+				if genders[p] == gender {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return false
+			}
+		}
+		candidateTags := sceneTags[sceneID]
+		for _, group := range included {
+			has := false
+			for name := range group {
+				if candidateTags[name] {
+					has = true
+					break
+				}
+			}
+			if !has {
+				return false
+			}
+		}
+		for _, group := range excluded {
+			for name := range group {
+				if candidateTags[name] {
+					return false
+				}
+			}
+		}
+		if len(performerIDSet) > 0 && !containsAll(candidatePerformers, performerIDSet) {
+			return false
+		}
+		if len(studioIDSet) > 0 && !studioIDSet[studioByScene[sceneID]] {
+			return false
+		}
+		return true
+	}, nil
 }

--- a/core/slate_greedy.go
+++ b/core/slate_greedy.go
@@ -63,9 +63,15 @@ type greedyCandidate struct {
 }
 
 // recommendGreedy mirrors SlateBuilder.recommend's recompute branch.
-func recommendGreedy(db dbx, modelID, lane string, count int64, diversityEnabled bool, exploration float64) (builtSlate, error) {
+// sceneFilter, when non-nil, additionally gates the live candidate pool
+// (get_slate's include/exclude tag, performer, studio, and gender filters);
+// the prepared-slate cache (a previous unfiltered recommend()'s saved
+// result) is bypassed on both read and write when a filter is active, since
+// it isn't filter-keyed and would otherwise leak an unfiltered slate into a
+// filtered response or vice versa.
+func recommendGreedy(db dbx, modelID, lane string, count int64, diversityEnabled bool, exploration float64, sceneFilter func(string) bool) (builtSlate, error) {
 	var preparedSlate *builtSlate
-	if exploration == 0 {
+	if exploration == 0 && sceneFilter == nil {
 		slate, ok, err := loadPreparedSlate(db, modelID, lane, count, diversityEnabled)
 		if err != nil {
 			return builtSlate{}, err
@@ -144,7 +150,8 @@ WHERE provenance='direct_player' GROUP BY scene_id`)
 		_, played := directPlays[c.sceneID]
 		if !state.eligible ||
 			(c.lane == "best_bets" && played) ||
-			(c.lane == "revisit" && unrecovered[c.sceneID]) {
+			(c.lane == "revisit" && unrecovered[c.sceneID]) ||
+			(sceneFilter != nil && !sceneFilter(c.sceneID)) {
 			continue
 		}
 		live = append(live, c)
@@ -378,7 +385,7 @@ WHERE provenance='direct_player' GROUP BY scene_id`)
 			"history": 0, "selection": 0, "items": 0, "total": 0,
 		},
 	}
-	if exploration == 0 {
+	if exploration == 0 && sceneFilter == nil {
 		if err := savePreparedSlate(db, modelID, lane, diversityEnabled, &slate); err != nil {
 			return builtSlate{}, err
 		}

--- a/curator/api.py
+++ b/curator/api.py
@@ -53,6 +53,11 @@ class CuratorAPI:
         now_ms: int | None = None,
         exclude_scene_ids: set[str] | None = None,
         exploration: float = 0,
+        include_tags: tuple[str, ...] = (),
+        exclude_tags: tuple[str, ...] = (),
+        performer_ids: tuple[str, ...] = (),
+        studio_ids: tuple[str, ...] = (),
+        gender: str = "",
     ) -> dict[str, object]:
         if page < 1 or not 1 <= count <= 500:
             raise ValueError("invalid recommendation page")
@@ -73,9 +78,13 @@ class CuratorAPI:
         start = (page - 1) * count
         end = page * count
         builder = SlateBuilder(self.connection, diversity_enabled=bool(config["diversity_enabled"]))
+        has_filters = bool(include_tags or exclude_tags or performer_ids or studio_ids or gender)
+        # A filtered request always recomputes total from a full candidate
+        # fetch, the same way an exploration request does, since the cached
+        # eligibility count doesn't know about filters.
         total = (
             builder.available_count(model_id, lane, exclude_scene_ids=excluded)
-            if exploration == 0
+            if exploration == 0 and not has_filters
             else None
         )
         if total is None:
@@ -99,7 +108,16 @@ class CuratorAPI:
             request_count = max(end + len(excluded), candidate_count + len(excluded))
         else:
             request_count = end + len(excluded)
-        built = builder.recommend(lane, request_count, exploration=exploration)
+        built = builder.recommend(
+            lane,
+            request_count,
+            exploration=exploration,
+            include_tags=include_tags,
+            exclude_tags=exclude_tags,
+            performer_ids=performer_ids,
+            studio_ids=studio_ids,
+            gender=gender,
+        )
         available = tuple(item for item in built.items if item.scene_id not in excluded)
         if total is None:
             total = len(available)

--- a/curator/ranking/slate.py
+++ b/curator/ranking/slate.py
@@ -22,6 +22,7 @@ from curator.model.curves import scene_recovery
 from curator.profiling import record_duration
 from curator.ranking.policy import LANES, LaneClassification, LanePolicy
 from curator.storage import transaction
+from curator.taxonomy import equivalent_tag_names
 
 FAMILIAR_PATTERN = (
     "best_bets",
@@ -406,7 +407,18 @@ class SlateBuilder:
                 push(affected)
         return ordered
 
-    def recommend(self, lane: str, count: int, *, exploration: float = 0) -> Slate:
+    def recommend(
+        self,
+        lane: str,
+        count: int,
+        *,
+        exploration: float = 0,
+        include_tags: tuple[str, ...] = (),
+        exclude_tags: tuple[str, ...] = (),
+        performer_ids: tuple[str, ...] = (),
+        studio_ids: tuple[str, ...] = (),
+        gender: str = "",
+    ) -> Slate:
         started = time.perf_counter()
         timings: dict[str, int] = {}
         if lane not in {"for_you", "best_bets", "revisit", "discover", "adventure"}:
@@ -418,12 +430,15 @@ class SlateBuilder:
         model_id = RecommendationModelStore(self.connection).current_model_id()
         if model_id is None:
             raise RuntimeError("no published model; run build-model first")
+        scene_filter = self._scene_filter(
+            include_tags, exclude_tags, performer_ids, studio_ids, gender
+        )
         if exploration == 0:
-            materialized = self._load_materialized_slate(model_id, lane, count)
+            materialized = self._load_materialized_slate(model_id, lane, count, scene_filter)
             if materialized is not None:
                 return materialized
         prepared_slate = None
-        if exploration == 0:
+        if exploration == 0 and scene_filter is None:
             prepared_slate = self._load_prepared_slate(model_id, lane, count)
             if prepared_slate is not None and len(prepared_slate.items) >= count:
                 return prepared_slate
@@ -489,6 +504,7 @@ class SlateBuilder:
                 candidate.classification.lane == "revisit"
                 and candidate.classification.scene_id in unrecovered_direct_plays
             )
+            and (scene_filter is None or scene_filter(candidate.classification.scene_id))
         )
         self._live_fit, self._live_cooldown = self._live_current_fit(model_id, direct_plays, now_ms)
         timings["eligibility"] = round((time.perf_counter() - stage_started) * 1000)
@@ -648,11 +664,17 @@ class SlateBuilder:
         record_duration("python", "ranking.items", timings["items"])
         timings["total"] = round((time.perf_counter() - started) * 1000)
         slate = Slate(model_id, lane, tuple(items), tuple(diagnostics), timings)
-        if exploration == 0:
+        if exploration == 0 and scene_filter is None:
             self._save_prepared_slate(slate)
         return slate
 
-    def _load_materialized_slate(self, model_id: str, lane: str, count: int) -> Slate | None:
+    def _load_materialized_slate(
+        self,
+        model_id: str,
+        lane: str,
+        count: int,
+        scene_filter: Callable[[str], bool] | None = None,
+    ) -> Slate | None:
         started = time.perf_counter()
         if not self.connection.execute(
             "SELECT 1 FROM model_lane_order_state WHERE model_id=?", (model_id,)
@@ -699,7 +721,7 @@ class SlateBuilder:
                 row
                 for row in rows
                 if self._materialized_row_is_eligible(
-                    row, eligibility, direct_plays, unrecovered_direct_plays
+                    row, eligibility, direct_plays, unrecovered_direct_plays, scene_filter
                 )
             )
             if len(rows) < chunk_size:
@@ -1042,12 +1064,94 @@ class SlateBuilder:
         }
         return direct_plays, unrecovered_direct_plays
 
+    def _scene_filter(
+        self,
+        include_tags: tuple[str, ...],
+        exclude_tags: tuple[str, ...],
+        performer_ids: tuple[str, ...],
+        studio_ids: tuple[str, ...],
+        gender: str,
+    ) -> Callable[[str], bool] | None:
+        """A predicate for get_slate's include/exclude tag, performer,
+        studio, and gender filters, or None when none are set. Mirrors the
+        corresponding per-candidate checks in SimilarityService.scenes
+        (curator/similarity.py), narrowed to the fields that make sense for a
+        lane that's already been classified by the model: no
+        minimum-similarity or favorite-only knob, since those are about
+        ranking a candidate against a source entity, not about narrowing a
+        pre-picked set.
+        """
+        if not (include_tags or exclude_tags or performer_ids or studio_ids or gender):
+            return None
+        performers = self._scene_performers()
+        genders = self._performer_genders() if gender else {}
+        studios = self._studios() if studio_ids else {}
+        included = equivalent_tag_names(self.connection, include_tags)
+        excluded = equivalent_tag_names(self.connection, exclude_tags)
+        filter_names = set().union(*included, *excluded)
+        scene_tags = self._scene_tags(filter_names) if filter_names else {}
+        performer_id_set = set(performer_ids)
+        studio_id_set = set(studio_ids)
+
+        def matches(scene_id: str) -> bool:
+            candidate_performers = performers.get(scene_id, set())
+            if gender and not any(genders.get(value) == gender for value in candidate_performers):
+                return False
+            candidate_tags = scene_tags.get(scene_id, set())
+            if any(not group & candidate_tags for group in included):
+                return False
+            if any(group & candidate_tags for group in excluded):
+                return False
+            if performer_id_set and not performer_id_set <= candidate_performers:
+                return False
+            if studio_id_set and studios.get(scene_id) not in studio_id_set:
+                return False
+            return True
+
+        return matches
+
+    def _performer_genders(self) -> dict[str, str]:
+        return {
+            str(row["performer_id"]): str(row["gender"] or "")
+            for row in self.connection.execute("SELECT performer_id, gender FROM source_performer")
+        }
+
+    def _scene_performers(self) -> dict[str, set[str]]:
+        result: dict[str, set[str]] = {}
+        for row in self.connection.execute(
+            "SELECT scene_id, performer_id FROM scene_performer ORDER BY scene_id, performer_id"
+        ):
+            result.setdefault(str(row["scene_id"]), set()).add(str(row["performer_id"]))
+        return result
+
+    def _scene_tags(self, names: set[str]) -> dict[str, set[str]]:
+        result: dict[str, set[str]] = {}
+        for row in self.connection.execute(
+            f"""
+            SELECT st.scene_id, t.name FROM scene_tag st
+            JOIN source_tag t USING(tag_id) WHERE lower(t.name) IN
+            ({",".join("?" for _ in names)})
+            """,
+            sorted(names),
+        ):
+            result.setdefault(str(row["scene_id"]), set()).add(str(row["name"]).casefold())
+        return result
+
+    def _studios(self) -> dict[str, str]:
+        return {
+            str(row["scene_id"]): str(row["studio_id"])
+            for row in self.connection.execute(
+                "SELECT scene_id, studio_id FROM source_scene WHERE studio_id IS NOT NULL"
+            )
+        }
+
     @staticmethod
     def _materialized_row_is_eligible(
         row: sqlite3.Row,
         eligibility: dict[str, dict[str, object]],
         direct_plays: dict[str, int],
         unrecovered_direct_plays: set[str],
+        scene_filter: Callable[[str], bool] | None = None,
     ) -> bool:
         scene_id = str(row["scene_id"])
         source_lane = str(row["source_lane"])
@@ -1055,6 +1159,7 @@ class SlateBuilder:
             bool(eligibility.get(scene_id, {}).get("eligible", False))
             and not (source_lane == "best_bets" and scene_id in direct_plays)
             and not (source_lane == "revisit" and scene_id in unrecovered_direct_plays)
+            and (scene_filter is None or scene_filter(scene_id))
         )
 
     def _save_prepared_slate(self, slate: Slate) -> None:

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -712,6 +712,11 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
                 context=args.get("context") if isinstance(args.get("context"), dict) else None,
                 exclude_scene_ids={str(value) for value in excluded},
                 exploration=float(args.get("exploration") or 0),
+                include_tags=_string_list(args.get("include_tags")),
+                exclude_tags=_string_list(args.get("exclude_tags")),
+                performer_ids=_string_list(args.get("performer_ids")),
+                studio_ids=_string_list(args.get("studio_ids")),
+                gender=str(args.get("gender") or ""),
             )
         if operation == "get_score_review":
             config = api.config()["config"]

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -552,10 +552,18 @@
     if (!copied) throw new Error("Copy failed");
   }
 
-  function loadSlate(lane, page = 1, prefetched = false) {
+  // filters narrow a lane's already-classified candidates server-side (same
+  // include/exclude tag, performer, studio, and gender shape as Similar).
+  // Filtered slates aren't cached: the persistent slateCache is keyed only
+  // by lane+page, and filter combinations change too often relative to how
+  // long they stay open to be worth a filter-aware cache key.
+  function loadSlate(lane, page = 1, prefetched = false, filters = null) {
+    const hasFilters = Boolean(filters && (filters.includeTags?.length || filters.excludeTags?.length || filters.performers?.length || filters.studios?.length || filters.gender));
     const key = slateKey(lane, page);
-    if (slateCache.has(key)) return Promise.resolve(slateCache.get(key));
-    if (slateRequests.has(key)) return slateRequests.get(key);
+    if (!hasFilters) {
+      if (slateCache.has(key)) return Promise.resolve(slateCache.get(key));
+      if (slateRequests.has(key)) return slateRequests.get(key);
+    }
     const generation = cacheGeneration;
     const request = operation({
       operation: "get_slate",
@@ -564,6 +572,13 @@
       exclude_scene_ids: [...(laneExclusions.get(lane) || [])],
       exploration: 0,
       context: { route: location.pathname, prefetched },
+      ...(hasFilters ? {
+        include_tags: filters.includeTags || [],
+        exclude_tags: filters.excludeTags || [],
+        performer_ids: filters.performers || [],
+        studio_ids: filters.studios || [],
+        gender: filters.gender || "",
+      } : {}),
     })
       .then((data) => {
         if (generation !== cacheGeneration) return data;
@@ -575,12 +590,14 @@
         }
         cachedModelId = data.model_id;
         cachedConfigUpdatedAtMs = data.config_updated_at_ms;
-        slateCache.set(slateKey(lane, page), data);
-        persistSlateCache();
+        if (!hasFilters) {
+          slateCache.set(slateKey(lane, page), data);
+          persistSlateCache();
+        }
         return data;
       })
       .finally(() => slateRequests.delete(key));
-    slateRequests.set(key, request);
+    if (!hasFilters) slateRequests.set(key, request);
     return request;
   }
 
@@ -2315,6 +2332,12 @@
   }) {
     const sceneGated = variant !== "hunt";
     const showScene = !sceneGated || entityType === "scene";
+    // Recommendations narrows a lane's already-classified local scenes: no
+    // StashDB-only concept (hide-phash), similarity score (minimum match),
+    // or the "boost favorited performers" ranking knob (favorite-only) — all
+    // three are about ranking a candidate against a source entity or a
+    // remote catalog, not about narrowing a pre-picked set.
+    const rankingOnly = variant !== "recommendations";
     const minimumMin = variant === "expand" ? "-0.2" : "0";
     const genderAriaLabel = variant === "expand" ? "External performer gender" : "Performer gender";
     const favoriteExtra = variant === "expand" ? { title: "Show only scenes containing a performer favorited in your local library", "aria-pressed": favoriteOnly } : {};
@@ -2328,10 +2351,10 @@
         showScene && React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: onExcludeTagsChange }),
         sceneGated && showScene && React.createElement(FilterTokens, { kind: "performer", label: "Performers", values: performers, onChange: onPerformersChange }),
         sceneGated && showScene && React.createElement(FilterTokens, { kind: "studio", label: "Studios", values: studios, onChange: onStudiosChange }),
-        sceneGated && showScene && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", ...favoriteExtra, onClick: onToggleFavorite }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"),
-        showScene && React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: onToggleHidePhash }, React.createElement(FontAwesomeIcon, { icon: faClone }), " Hide exact PHash matches"),
+        rankingOnly && sceneGated && showScene && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", ...favoriteExtra, onClick: onToggleFavorite }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"),
+        rankingOnly && showScene && React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: onToggleHidePhash }, React.createElement(FontAwesomeIcon, { icon: faClone }), " Hide exact PHash matches"),
         sceneGated && React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: onGenderChange, "aria-label": genderAriaLabel }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))),
-        sceneGated && showScene && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimum.toFixed(2)}`), React.createElement("input", { type: "range", min: minimumMin, max: "0.8", step: "0.05", value: minimum, onChange: onMinimumChange })),
+        rankingOnly && sceneGated && showScene && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimum.toFixed(2)}`), React.createElement("input", { type: "range", min: minimumMin, max: "0.8", step: "0.05", value: minimum, onChange: onMinimumChange })),
         applyVisible && React.createElement(Button, { size: "sm", variant: "primary", onClick: onApply }, "Apply")
       )
     );
@@ -3796,6 +3819,23 @@
     const [refreshKey, setRefreshKey] = React.useState(0);
     const [page, setPage] = useUrlPage(laneByValue.has(lane) ? `page_${lane}` : "page_for_you");
     const [configReady, setConfigReady] = React.useState(false);
+    const initialSlateFilters = React.useMemo(() => defaultFilters("recommendations"), []);
+    const [filtersOpen, setFiltersOpen] = React.useState(false);
+    const [filterIncludeTags, setFilterIncludeTags] = React.useState(initialSlateFilters.includeTags || []);
+    const [filterExcludeTags, setFilterExcludeTags] = React.useState(initialSlateFilters.excludeTags || []);
+    const [filterPerformers, setFilterPerformers] = React.useState(initialSlateFilters.performers || []);
+    const [filterStudios, setFilterStudios] = React.useState(initialSlateFilters.studios || []);
+    const [filterGender, setFilterGender] = React.useState(initialSlateFilters.gender || "");
+    const slateFilters = { includeTags: filterIncludeTags, excludeTags: filterExcludeTags, performers: filterPerformers, studios: filterStudios, gender: filterGender };
+    const activeSlateFilterCount = filterIncludeTags.length + filterExcludeTags.length + filterPerformers.length + filterStudios.length + (filterGender ? 1 : 0);
+    function applySavedSlateFilters(value) {
+      setFilterIncludeTags(value.includeTags || []);
+      setFilterExcludeTags(value.excludeTags || []);
+      setFilterPerformers(value.performers || []);
+      setFilterStudios(value.studios || []);
+      setFilterGender(value.gender || "");
+      setPage(1);
+    }
     const [diversityEnabled, setDiversityEnabled] = React.useState(null);
     const [diversitySaving, setDiversitySaving] = React.useState(false);
     const [followUps, setFollowUps] = React.useState([]);
@@ -3846,11 +3886,11 @@
         setError("");
         return () => { active = false; };
       }
-      const cached = slateCache.get(slateKey(lane, page));
+      const cached = activeSlateFilterCount === 0 ? slateCache.get(slateKey(lane, page)) : null;
       setSlate(cached || null);
       setLoading(!cached);
       setError("");
-      loadSlate(lane, page).then(
+      loadSlate(lane, page, false, slateFilters).then(
         (data) => {
           if (!active) return;
           setSlate(data);
@@ -3861,7 +3901,7 @@
       return () => {
         active = false;
       };
-    }, [lane, page, refreshKey, configReady]);
+    }, [lane, page, refreshKey, configReady, filterIncludeTags, filterExcludeTags, filterPerformers, filterStudios, filterGender]);
     React.useEffect(() => {
       if (slate?.page === page) {
         const last = Math.max(1, Math.ceil(slate.total / slate.page_size));
@@ -4030,9 +4070,21 @@
             },
             React.createElement(FontAwesomeIcon, { icon: faBalanceScale }),
             diversityEnabled ? " Balanced" : " Score-first"
-          )
+          ),
+          laneByValue.has(lane) && React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters", activeSlateFilterCount > 0 && React.createElement("span", { className: "curator-filter-count" }, activeSlateFilterCount)),
+          laneByValue.has(lane) && React.createElement(SavedFilters, { scope: "recommendations", current: { includeTags: filterIncludeTags, excludeTags: filterExcludeTags, performers: filterPerformers, studios: filterStudios, gender: filterGender }, onApply: applySavedSlateFilters })
         )
       ),
+      laneByValue.has(lane) && filtersOpen && React.createElement(FilterBar, {
+        variant: "recommendations",
+        entityType: "scene",
+        includeTags: filterIncludeTags, onIncludeTagsChange: (value) => setFilterIncludeTags(value),
+        excludeTags: filterExcludeTags, onExcludeTagsChange: (value) => setFilterExcludeTags(value),
+        performers: filterPerformers, onPerformersChange: (value) => setFilterPerformers(value),
+        studios: filterStudios, onStudiosChange: (value) => setFilterStudios(value),
+        gender: filterGender, onGenderChange: (event) => setFilterGender(event.target.value),
+        onApply: () => { setPage(1); setFiltersOpen(false); },
+      }),
       followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),
       lane === "similar" && !loadingComponents && React.createElement(SimilarityPanel),
       lane === "curate" && React.createElement(CuratePanel),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -573,10 +573,10 @@
       exploration: 0,
       context: { route: location.pathname, prefetched },
       ...(hasFilters ? {
-        include_tags: filters.includeTags || [],
-        exclude_tags: filters.excludeTags || [],
-        performer_ids: filters.performers || [],
-        studio_ids: filters.studios || [],
+        include_tags: (filters.includeTags || []).map((item) => item.name),
+        exclude_tags: (filters.excludeTags || []).map((item) => item.name),
+        performer_ids: (filters.performers || []).map((item) => String(item.id)),
+        studio_ids: (filters.studios || []).map((item) => String(item.id)),
         gender: filters.gender || "",
       } : {}),
     })

--- a/tests/core/test_backend_slice1.py
+++ b/tests/core/test_backend_slice1.py
@@ -268,6 +268,53 @@ def test_get_slate_page_exclusions_byte_identical(
     )
 
 
+def test_get_slate_performer_and_tag_filters_byte_identical(
+    model_sidecar: Path, binary: Path, stub_stash: str
+) -> None:
+    raw = payload(
+        "get_slate",
+        model_sidecar,
+        stub_stash,
+        lane="for_you",
+        count=5,
+        page=1,
+        performer_ids=["p1"],
+        include_tags=["Familiar Scenario"],
+        impression_id="fixed-impression-slate-filters",
+    )
+    assert_slice1_identical(
+        binary,
+        PLUGIN_DIR,
+        raw,
+        same_path=model_sidecar,
+        timing_fields=("timings_ms", "ranking_timings_ms"),
+    )
+
+
+def test_get_slate_studio_and_gender_filters_byte_identical(
+    model_sidecar: Path, binary: Path, stub_stash: str
+) -> None:
+    raw = payload(
+        "get_slate",
+        model_sidecar,
+        stub_stash,
+        lane="for_you",
+        count=5,
+        page=1,
+        studio_ids=["studio-2"],
+        exclude_tags=["nonexistent-tag"],
+        gender="FEMALE",
+        impression_id="fixed-impression-slate-filters-2",
+    )
+    assert_slice1_identical(
+        binary,
+        PLUGIN_DIR,
+        raw,
+        same_path=model_sidecar,
+        timing_fields=("timings_ms", "ranking_timings_ms"),
+    )
+
+
 def test_replace_item_byte_identical(model_sidecar: Path, binary: Path, stub_stash: str) -> None:
     raw = payload(
         "replace_item", model_sidecar, stub_stash, lane="for_you", exclude_scene_ids=["old-good"]

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -695,11 +695,14 @@ def test_recommendations_filter_bar_wired() -> None:
     # Recommendations is FilterBar's 4th call site, alongside similar/hunt/expand.
     assert 'React.createElement(FilterBar, {\n        variant: "recommendations"' in source
     assert 'const rankingOnly = variant !== "recommendations";' in source
-    # get_slate gets the same filter arg shape as get_similar/get_expand.
-    assert "include_tags: filters.includeTags || []" in source
-    assert "exclude_tags: filters.excludeTags || []" in source
-    assert "performer_ids: filters.performers || []" in source
-    assert "studio_ids: filters.studios || []" in source
+    # get_slate gets the same filter arg shape as get_similar/get_expand —
+    # FilterTokens stores {id, name} objects for chip display, so these
+    # must extract the field the backend actually wants (tag name, or
+    # performer/studio id as a string), not pass the object through raw.
+    assert 'include_tags: (filters.includeTags || []).map((item) => item.name)' in source
+    assert 'exclude_tags: (filters.excludeTags || []).map((item) => item.name)' in source
+    assert 'performer_ids: (filters.performers || []).map((item) => String(item.id))' in source
+    assert 'studio_ids: (filters.studios || []).map((item) => String(item.id))' in source
     assert "gender: filters.gender || \"\"" in source
     # Filtered slates bypass the persistent lane+page cache rather than
     # polluting it with a filter-blind key.

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -610,7 +610,7 @@ def test_curator_prefetches_only_the_intended_lane() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
     assert "function prefetchLanes" not in source
     assert "if (!laneByValue.has(lane) || cachedConfigUpdatedAtMs === null) return;" in source
-    assert "loadSlate(lane, page).then(" in source
+    assert "loadSlate(lane, page, false, slateFilters).then(" in source
     assert "loadSlate(lane, 1, true).catch(" in source
     # Prefetch now hangs off the lane-switcher cards inside the collapsed
     # Recommendations tab, not the (now removed) flat per-lane nav pills
@@ -687,6 +687,25 @@ def test_plugin_performer_hunt_keeps_results_and_reuses_external_cards() -> None
     assert "data?.truncated" in source
     assert "(failure) => active && (setError(failure.message), setLoading(false))" in source
     assert 'entityType === "hunt" ? "scene" : entityType' in source
+
+
+def test_recommendations_filter_bar_wired() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
+
+    # Recommendations is FilterBar's 4th call site, alongside similar/hunt/expand.
+    assert 'React.createElement(FilterBar, {\n        variant: "recommendations"' in source
+    assert 'const rankingOnly = variant !== "recommendations";' in source
+    # get_slate gets the same filter arg shape as get_similar/get_expand.
+    assert "include_tags: filters.includeTags || []" in source
+    assert "exclude_tags: filters.excludeTags || []" in source
+    assert "performer_ids: filters.performers || []" in source
+    assert "studio_ids: filters.studios || []" in source
+    assert "gender: filters.gender || \"\"" in source
+    # Filtered slates bypass the persistent lane+page cache rather than
+    # polluting it with a filter-blind key.
+    assert "const hasFilters = Boolean(filters &&" in source
+    assert "if (!hasFilters) slateRequests.set(key, request);" in source
+    assert 'scope: "recommendations"' in source
 
 
 def test_panels_serialize_full_view_state_to_the_url() -> None:

--- a/tests/ranking/test_slate.py
+++ b/tests/ranking/test_slate.py
@@ -363,6 +363,70 @@ def test_available_count_matches_live_materialized_slate(tmp_path: Path) -> None
             )
 
 
+def test_scene_filter_narrows_materialized_and_greedy_slates(tmp_path: Path) -> None:
+    """get_slate's include/exclude tag, performer, studio, and gender filters
+    narrow a lane's already-classified candidates in place, the same way
+    get_similar's filters narrow its candidate set — not a client-side trim
+    of an already-paged response.
+
+    diversity_enabled=False here: with it on, the greedy path's adjacency
+    rule (never place two same-performer scenes back to back, unrelated to
+    filtering) would legitimately drop b-best after a filter narrows the
+    live candidate pool down to just the two p1 scenes with nothing else to
+    interleave with — a real diversity/filter interaction, not what this
+    test is isolating.
+    """
+    connection = _database(tmp_path / "curator.sqlite3")
+    LanePolicy(connection).classify("model")
+    builder = SlateBuilder(connection, diversity_enabled=False)
+    unfiltered = builder.recommend("best_bets", 100)
+    unfiltered_ids = {item.scene_id for item in unfiltered.items}
+    # a-best/b-best are performer p1; c-best is performer p2 (all studio st1).
+    assert {"a-best", "b-best", "c-best"} <= unfiltered_ids
+
+    filtered = builder.recommend("best_bets", 100, performer_ids=("p1",))
+    filtered_ids = {item.scene_id for item in filtered.items}
+    assert {"a-best", "b-best"} <= filtered_ids
+    assert "c-best" not in filtered_ids
+    assert filtered_ids < unfiltered_ids
+
+    # Same narrowing through the materialized fast path (a fresh builder so
+    # the greedy path above didn't warm any per-instance candidate cache).
+    # Diversity stays on here: filtering only narrows the row list read back
+    # from an already-computed full-lane ordering, it doesn't re-run greedy
+    # selection, so it isn't subject to the adjacency rule above.
+    materialized_builder = SlateBuilder(connection)
+    materialized_builder.materialize("model", force=True)
+    materialized = materialized_builder._load_materialized_slate(
+        "model", "best_bets", 100, materialized_builder._scene_filter((), (), ("p1",), (), "")
+    )
+    assert materialized is not None
+    materialized_ids = {item.scene_id for item in materialized.items}
+    assert {"a-best", "b-best"} <= materialized_ids
+    assert "c-best" not in materialized_ids
+
+
+def test_get_slate_filter_total_reflects_filtered_count(tmp_path: Path) -> None:
+    """A filtered request's total/has_more/page come from the filtered
+    candidate set, not the full lane — the same page-integrity guarantee
+    exclude_scene_ids already gets, not a naive trim after pagination."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    LanePolicy(connection).classify("model")
+    SlateBuilder(connection).materialize("model", force=True)
+    api = CuratorAPI(connection)
+
+    full = api.get_slate("best_bets", 100, now_ms=1)
+    filtered = api.get_slate("best_bets", 1, now_ms=1, performer_ids=("p1",))
+
+    assert filtered["total"] < full["total"]
+    assert filtered["total"] == 2  # a-best, b-best
+    assert filtered["has_more"] is True
+    assert {item["scene_id"] for item in filtered["items"]} <= {"a-best", "b-best"}
+    second_page = api.get_slate("best_bets", 1, page=2, now_ms=1, performer_ids=("p1",))
+    assert second_page["items"][0]["scene_id"] != filtered["items"][0]["scene_id"]
+    assert {item["scene_id"] for item in second_page["items"]} <= {"a-best", "b-best"}
+
+
 def test_new_slate_builder_reuses_persisted_lane_classifications(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -156,9 +156,30 @@ def test_slate_api_materializes_only_through_requested_page(
     requested_counts: list[int] = []
     recommend = SlateBuilder.recommend
 
-    def observed(self: SlateBuilder, lane: str, count: int, *, exploration: float = 0) -> Slate:
+    def observed(
+        self: SlateBuilder,
+        lane: str,
+        count: int,
+        *,
+        exploration: float = 0,
+        include_tags: tuple[str, ...] = (),
+        exclude_tags: tuple[str, ...] = (),
+        performer_ids: tuple[str, ...] = (),
+        studio_ids: tuple[str, ...] = (),
+        gender: str = "",
+    ) -> Slate:
         requested_counts.append(count)
-        return recommend(self, lane, count, exploration=exploration)
+        return recommend(
+            self,
+            lane,
+            count,
+            exploration=exploration,
+            include_tags=include_tags,
+            exclude_tags=exclude_tags,
+            performer_ids=performer_ids,
+            studio_ids=studio_ids,
+            gender=gender,
+        )
 
     monkeypatch.setattr(SlateBuilder, "recommend", observed)
 


### PR DESCRIPTION
## Summary
- Extends `get_slate` (Go core, kept byte-identical against the Python differential gate in `tests/core/test_backend_slice1.py`) to accept the same include/exclude tag, performer, studio, and gender filters `get_similar` already supports, narrowing a lane's already-classified candidates before ranking/pagination rather than trimming the paged response after the fact.
- Skips the cached eligibility count and the prepared-slate cache for filtered requests (both are filter-blind), recomputing total from a full candidate fetch the same way an `exploration != 0` request already does, so `total`/`has_more`/paging stay correct under a filter.
- Wires `FilterBar`'s 4th call site into Recommendations (tags/performers/studios/gender only — no favorite-only/hide-phash/minimum-match, which don't map onto a lane), adds a `"recommendations"` `SavedFilters` scope, and bypasses the persistent cross-session slate cache for filtered fetches (it's keyed only by lane+page).

## Test plan
- [x] `cd core && go build ./... && go vet ./... && go test ./...`
- [x] `pytest tests/ranking/test_slate.py tests/test_api.py tests/core/test_backend_slice1.py tests/plugin/test_runtime.py` — includes 2 new differential (Go/Python byte-identical) filter cases and 2 new behavioral tests asserting real narrowing + correct pagination under a filter
- [x] Full suite: 560/561 passing; the one failure (`tests/integration/test_hooks.py`) is a pre-existing, unrelated `STASH_CONFIG` env/mount mismatch on the shared synthetic instance
- [x] Deployed to a local synthetic Stash instance end-to-end (GraphQL → launcher → Go binary); confirmed filtered `get_slate` requests are accepted with no errors
- [ ] Not yet verified against the live instance