### PR TITLE
feat(plugin): close the #150/#152 visual and UX redesign gap

### DIFF
--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -167,15 +167,23 @@ Artifacts:
       rail entirely while scrolling. Fixes the symptom, not the cause;
       consider pagination/virtualization on Taste Profile instead (see UX
       suggestions).
-- [ ] **Raw enum leak regression**: Manage → Recently Recommended's "Lane"
-      column shows `score_review` verbatim for Sentiment-review-sourced rows,
-      while other rows correctly show "For You" etc. (Feedback-history/
-      Sentiment badges were already fixed for this class of bug — this is a
-      spot that was missed.)
-- [ ] **"Reason shown" column is dead** in Manage → Recently Recommended —
-      every row shows the literal string "Lane" regardless of scene, while
-      the adjacent "Why this now?" expandable text does show real per-scene
-      reasoning. Either wire it up or remove the column.
+- [x] **Raw enum leak regression**: Manage → Recently Recommended's "Lane"
+      column showed `score_review` verbatim for Sentiment-review-sourced
+      rows. `RecommendationHistoryRow` had its own separate lane→label
+      lookup (`laneByValue.get(item.lane)?.label || item.lane`) that never
+      got the `score_review` → "Sentiment review" special case already
+      applied elsewhere (e.g. the Sentiment-review card badge) — added it
+      here too. Verified via screenshot.
+- [x] **"Reason shown" column is dead** — not actually dead: every row
+      showing the literal string "Lane" was `reasonLabel()`'s naive fallback
+      (last dot-segment, title-cased) mangling `"eligibility.lane"`, the
+      baseline reason code every impression gets seeded with regardless of
+      lane (`core/slate.go`, `slate_greedy.go`, `score_review.go` all start
+      `reasonIDs` with it; richer reasons like `appeal.performer_identity`
+      are appended when they apply, but plenty of items have nothing beyond
+      the baseline). Added `"eligibility.lane": "Eligible for this lane"` to
+      the existing label map, same pattern as the other two entries.
+      Verified via screenshot — column now reads sensibly on every row.
 - [ ] **No loading affordance for slow async actions** (systemic gap, not
       just Curate): Generate has 4–8s of dead air (confirmed ~8s GraphQL
       round-trip via network trace) with only a subtly-dimmed button; Expand's

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -188,6 +188,19 @@ Artifacts:
          `NavLink` pattern used for scene titles elsewhere), so you can jump
          straight to that tag's scenes instead of round-tripping through
          Stash's own Tags page. Verified the link navigates correctly.
+- [x] **Follow-up 4 (user feedback: row alignment + Clear answer styling)**:
+      standalone (non-compact) rows only rendered a "Clear answer" button
+      when `rated` — unlike compact mode, which already reserved layout
+      space with an invisible placeholder for exactly this reason, the
+      standalone path omitted the element entirely when unrated, so rated
+      and unrated rows had different widths and misaligned. Always render
+      the button now (both compact and standalone), applying the existing
+      `.curator-sentiment-clear-placeholder` (`visibility: hidden`, space
+      still reserved) whenever unrated. Also changed the button from
+      `variant="link"` (plain underlined text) to `variant="secondary"`
+      (the bordered/outline treatment used elsewhere in the app) per
+      request. Verified row alignment and button styling via screenshot in
+      both standalone and compact contexts.
 
 ## Buttons / icons
 

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -193,10 +193,14 @@ Artifacts:
       `1.17`/`1.16`/`1.15` render at essentially the same bar width as `0.95`.
       Either normalize fill to the actual observed max or drop the bar and
       show only the number for these cases.
-- [ ] **Sentiment badges carry no color signal** — "I think you like this,"
-      "I think you dislike this," and "I'm unsure" all render in identical
-      cyan `badge-info`, removing the one signal (like vs. dislike) that
-      would most help scanning a 949-row Taste Profile list.
+- [x] **Sentiment badges carry no color signal** — reused the existing
+      sentiment-tier classes (`.curator-sentiment-love`/`-danger`/`-neutral`,
+      which already set `--sc`) on the badge instead of Bootstrap's
+      `badge-info`, plus one small CSS rule giving `.badge` context a tinted
+      background/border/text from `--sc` (those classes previously only had
+      a button treatment: transparent fill, border-only). Like now reads
+      green, dislike red, unsure gray — no new design work, per the UX
+      suggestion below. Verified via screenshot.
 - [ ] **Mobile primary nav hides 5 of 6 tabs off-screen with no affordance** —
       `.curator-tabs` is horizontally scrollable with the scrollbar hidden and
       no fade/chevron hint; only "Recommendations" is visible on load at a
@@ -223,9 +227,9 @@ Artifacts:
 - [ ] Move **Profiling** out of the primary Manage nav rail behind a debug
       flag / `?debug=1` — it exposes raw `.pprof` CPU-trace downloads, which
       reads as developer tooling leaking into end-user navigation.
-- [ ] Color-code sentiment badges using the sentiment-tier color system the
-      slider thumb already has (`--sc` custom property) — reuse, not new
-      design work.
+- [x] Color-code sentiment badges using the sentiment-tier color system the
+      slider thumb already has (`--sc` custom property) — done, see the
+      "Other bugs / quirks" entry above.
 - [ ] Add pagination or virtualization to Taste Profile (fixes the Manage
       height problem at the root).
 - [ ] Add loading skeletons for lane switches and Curate generation.

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -437,6 +437,16 @@ Artifacts:
       reads via `minmax(var(...), 1fr)` — no backend change, affects every
       card grid in the app (Recommendations/Similar/Expand/Prune) at once.
       Verified 4→5 cards/row (Compact) and 4→3 (Spacious) at 1440px.
+      **Follow-up (user feedback): cycling was unclear, icon read as
+      "fullscreen."** Confirmed the underlying 3-step cycle itself worked
+      correctly (each click produced a genuinely different column count),
+      so the complaint was about the *interaction*, not a bug — clicking
+      blind through 3 states makes it hard to tell how many sizes exist,
+      and `faExpand` reads as a fullscreen/maximize action, not "resize
+      cards." Replaced with a hover-revealed `HoverPopover` panel
+      containing a continuous slider (14–32rem, reusing `.curator-range`)
+      instead of 3 fixed steps, and swapped the icon to `faThLarge`.
+      Verified drag-to-resize end to end (30rem → 3 cols/row at 1440px).
 - [x] **Native SceneCard's tag/performer/organized overlay buttons were
       solid blue**, same root cause as two earlier `.minimal` fixes this
       pass (#152 round 16, round "Follow-up 1" above): no explicit variant
@@ -454,6 +464,41 @@ Artifacts:
       trigger's actual look, which is just plain `.btn-secondary`
       (`var(--curator-surface)` + a visible border), not a dark overlay.
       Switched to that exact treatment for a true match.
+      **Follow-up 2 (user feedback): still no visible border, and
+      misaligned with the date.** Two separate bugs: (1) `.minimal`'s own
+      `border: none` shorthand collapses border-width/style even once
+      border-color is overridden — border-color alone is invisible without
+      them, so the "border" was never actually rendering; needed the full
+      `border: 1px solid ...` shorthand, not just a recolor. (2)
+      `.card-popovers` (a child of `.scene-card`) and `.scene-card__date`
+      (nested inside a *sibling* `.card-section`) aren't in a flex/grid
+      relationship with each other, so the `bottom: 0.2rem` offset was
+      tuned against the card's bottom edge, not the date row — measured
+      the actual centerY gap (10px) and retuned to `bottom: 0.92rem`,
+      confirmed via computed geometry (both now within 1px of the same
+      centerY) and screenshot.
+- [x] **Lane corner badges (BEST BETS/DISCOVER/REVISIT/ADVENTURE/etc.) used
+      flat vivid hue backgrounds that all failed WCAG AA** — per user
+      request to extend the primary-button gradient treatment to these too;
+      turned up a real, previously-undiscovered instance of the same
+      systemic bug this whole pass has repeatedly found (round 14's
+      button-contrast fix, round 30's relationship-chips fix, the Manage
+      active-nav-item fix): every single one of the 9 lane hues measured
+      1.99–3.42:1 against white text (Similar and Discover the worst,
+      *below* the original button bug's worst case). Applied the same
+      technique as the original fix rather than a flat recolor: a 145deg
+      two-stop gradient per lane, reusing light theme's already-AA-passing
+      hue as the lighter stop where it qualified (for_you/similar/hunt/
+      revisit/expand), and computing new darker literals for the four that
+      didn't (best_bets/discover/adventure/prune — light theme's own
+      versions only measured 3.83–4.48:1, still short of 4.5). Each
+      gradient's second stop is the first darkened ~22% further, which can
+      only raise contrast, never lower it — kept on a separate
+      `--lane-badge-gradient` property rather than changing `--lane-color`/
+      `--curator-hue-*` directly, since those still back non-text uses
+      (nav-pill icon color, card left-border accents) that don't need this
+      constraint. Verified via computed-style dump of the actual rendered
+      gradients and screenshot.
 - [x] **"Default" checkbox in SavedFilters** looked out of place next to the
       Save button row — converted to Bootstrap's native `.custom-switch`
       toggle (already bundled in Stash's own CSS, no new styling needed),

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -115,25 +115,40 @@ Artifacts:
 
 ## Buttons / icons
 
-- [ ] Add explicit `variant` to the ~26 buttons currently defaulting to
-      Bootstrap `primary` (see contrast item above — same root cause, listing
-      separately here as the styling-system fix vs. the accessibility bug).
-- [ ] Reconcile the two parallel icon-button patterns:
-      `.curator-icon-button` (header sync/rebuild/theme/settings — hardened
-      with `!important` to the muted "surface" look) vs.
-      `.curator-icon-action` (ExternalCard's row — no such override, silently
-      inherits whatever variant it was given). Currently "Copy StashDB ID" is
-      bright blue while its siblings "Open on StashDB" / "Add to shortlist"
-      in the same row are muted dark — one button group, two visual styles.
-- [ ] Unify the two "Save" button treatments: Feedback-history's inline
-      replace-row Save is `variant="link"` (text-only); the filter-bar Save
-      (Recommendations/Similar/Expand/Hunt) is a solid primary button. Same
-      action, different weight.
-- [ ] Drop the icon on **"Hide exact PHash matches"** toggle (Similar) — the
-      clone/copy icon doesn't intuitively map to "phash duplicate," label
-      alone is already clear.
-- [ ] Drop the icon on **"Local"** (include-owned) toggle — metaphor mismatch
-      (user-check icon ≠ "include library items").
+- [x] Add explicit `variant` to the ~26 buttons currently defaulting to
+      Bootstrap `primary`. Audited every `React.createElement(Button, ...)`
+      call site without an explicit `variant`. Kept `primary` only where a
+      screen genuinely has one true CTA (Curate's pick buttons and Submit,
+      the first-run "Sync and build recommendations", Search, Create
+      backup, Apply, Generate) — assigned `secondary` to utility/navigation
+      buttons (pagination Previous/Next, Profiling/Diagnostics Refresh/View/
+      Download/Copy/Export/Back-to-root, the filter-bar Save, the "minimal"
+      ExternalCard tag/performer/studio count popover trigger, which turned
+      out to have the same bug: no explicit variant meant `.btn-primary`'s
+      gradient — at higher specificity than Stash's own `.minimal` reset —
+      painted over what should read as a plain ghost trigger) and `link` to
+      Curate's "More" dropdown-menu items (Not now/Never show/Metadata is
+      wrong/Mark for pruning, previously solid primary blocks stacked in a
+      small popover).
+- [x] Reconcile the two parallel icon-button patterns:
+      `.curator-icon-button` (header sync/rebuild/theme/settings) vs.
+      `.curator-icon-action` (ExternalCard's row). "Copy StashDB ID" and
+      "Show this performer's scenes" had no explicit variant (defaulting to
+      bright-blue primary) while their siblings were explicitly secondary/
+      state-toggled — now `variant: "secondary"` on both, consistent with
+      "Open on StashDB" and the unselected state of "Add to shortlist"/
+      "Rate tags & terms". Verified via screenshot on Expand results.
+- [x] Unify the two "Save" button treatments: feedback-history's inline
+      replace-row Save stays `variant="link"` (correct for a compact table-
+      row micro-action alongside its "Undo" sibling); the filter-bar Save
+      changed from an implicit solid-primary default to explicit
+      `variant="secondary"` — neither now competes with each screen's real
+      primary action (Apply/Submit), even though the two treatments still
+      differ in weight (link vs. bordered button) since they sit in
+      genuinely different-density contexts.
+- [x] Drop the icon on **"Hide exact PHash matches"** toggle (Similar).
+- [x] Drop the icon on **"Local"** (include-owned) toggle. Removed the
+      now-unused `faUserCheck` import.
 - [ ] Redesign the **ExternalCard action row** (5 icon-only buttons —
       external-link, copy-ID, shortlist, rate-tags, refresh-Whisparr — on
       every Similar/Expand/Hunt result card, 20+ per page): no labels, same

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -237,9 +237,11 @@ Artifacts:
       neither that check nor the list map, so nothing showed at all for the
       whole fetch. Added a `suggestions === null` branch rendering "Loading
       hypotheses…". Verified via screenshot mid-fetch and after resolution.
-- [ ] Similar's free-text scene search results render as a bare, unstyled
-      inline list of link-colored text — no card/border/container, visually
-      inconsistent with the app's card-heavy aesthetic elsewhere.
+- [x] Similar's free-text scene search results render as a bare, unstyled
+      inline list of link-colored text — changed from `variant: "link"` to
+      `variant: "secondary"` (small), giving each result the same bordered-
+      chip treatment used elsewhere in the app instead of plain underlined
+      text. Verified via screenshot.
 - [x] Minor: Backups' directory path uses an alarm-colored magenta/pink
       `curator-mono` style for what's just informational text. Root cause:
       `.curator-mono` only ever set `font-family`, so Bootstrap's default

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -205,10 +205,15 @@ Artifacts:
       a button treatment: transparent fill, border-only). Like now reads
       green, dislike red, unsure gray — no new design work, per the UX
       suggestion below. Verified via screenshot.
-- [ ] **Mobile primary nav hides 5 of 6 tabs off-screen with no affordance** —
-      `.curator-tabs` is horizontally scrollable with the scrollbar hidden and
-      no fade/chevron hint; only "Recommendations" is visible on load at a
-      420px viewport.
+- [x] **Mobile primary nav hides 5 of 6 tabs off-screen with no affordance** —
+      a fade mask was already in place (`.curator-tabs`'s `mask-image`) but
+      wasn't enough of a cue on its own: at a 420px viewport the active
+      "Recommendations" pill fills the visible strip edge-to-edge with no
+      sliver of the next pill peeking through, so the faded edge alone read
+      as "this is the whole nav," not "scroll for more." Added a small
+      persistent chevron (`.curator-navigation::after`) that doesn't depend
+      on scroll position or which pill happens to be active. Verified via
+      screenshot at 420px.
 - [x] **Prune still shows plain text** ("Appeal −0.94 · confidence 0.99")
       where Recommendations/Sentiment review show a MATCH bar for the same
       underlying data. Swapped to the shared `EvidenceScore`/`utilityBar`

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -1,7 +1,7 @@
 # Curator plugin — review checklist (living doc)
 
 Consolidated from two independent review passes against the live instance
-(`http://192.168.1.100:9999/plugins/stash-curator`), cross-checked against the
+(`/plugins/stash-curator`), cross-checked against the
 design mockup (`https://claude.ai/code/artifact/0e341da5-9b63-4ffc-ac60-05ee0df6174a`)
 and, for pass 2, against this worktree at commit `78da835` (round 13,
 `feat/plugin-visual-overhaul`). Tracks GH issue #152 (follow-up to #150);

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -170,6 +170,24 @@ Artifacts:
          "this is fake" affordance and repurposing "Neutral"'s own gray for
          both meanings would just move the ambiguity elsewhere. Verified
          all five via screenshot/computed-value checks on live data.
+- [x] **Follow-up 3 (user feedback on the round-27 fixes)**: three more.
+      1. "I think you slightly dislike/like this" badges were only
+         half-colored — the badge-coloring rule listed love/danger/neutral
+         (from when the badge was still binary) but not warning/like, which
+         round 27 added as real badge outcomes. They still got a tinted
+         *border* from the separate button-oriented tier rule, just not the
+         matching background/text, reading as inconsistent next to the
+         fully-colored strong tiers. Added the two missing tiers.
+      2. The "blue dot" turned out to be a second bug beyond round 27's
+         thumb fix: the *tick* at stop 3 ("Neutral") was rendering with the
+         `-active` (accent-colored) treatment purely because
+         `stopIndex === stop` for the unrated placeholder position too,
+         independent of whether the item was actually rated — the active-
+         stop highlight needed `rated &&`, not just a position match.
+      3. Taste Profile's tag name is now a link to `/tags/{tag_id}` (same
+         `NavLink` pattern used for scene titles elsewhere), so you can jump
+         straight to that tag's scenes instead of round-tripping through
+         Stash's own Tags page. Verified the link navigates correctly.
 
 ## Buttons / icons
 

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -230,8 +230,11 @@ Artifacts:
 - [ ] Similar's free-text scene search results render as a bare, unstyled
       inline list of link-colored text — no card/border/container, visually
       inconsistent with the app's card-heavy aesthetic elsewhere.
-- [ ] Minor: Backups' directory path uses an alarm-colored magenta/pink
-      `curator-mono` style for what's just informational text.
+- [x] Minor: Backups' directory path uses an alarm-colored magenta/pink
+      `curator-mono` style for what's just informational text. Root cause:
+      `.curator-mono` only ever set `font-family`, so Bootstrap's default
+      `code{color:#e83e8c}` (meant for inline code snippets) showed through
+      unopposed. Added `color: var(--curator-text-muted)`.
 
 ## UX suggestions (independent judgment, not defects — discuss before building)
 

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -81,19 +81,37 @@ Artifacts:
 
 ## Sliders
 
-- [ ] **All 4 sliders render as plain unstyled native browser range inputs**
+- [x] **All 4 sliders render as plain unstyled native browser range inputs**
       (Taste Profile sentiment, Similar/Expand "Minimum match", Prune
-      "aggressiveness", Sentiment-review "Appeal ≤" threshold) — generic
-      Bootstrap-blue fill, near-invisible thumb, no differentiation between
-      filled/unfilled track. Root cause for the sentiment slider specifically:
-      Stash's own global `input[type="range"] { background-color: transparent;
-      ... }` (specificity 0,0,1,1) beats the plugin's
-      `.curator-sentiment-range { background: ... }` (0,0,1,0) — the intended
-      themed styling (thin bordered track, per-sentiment-colored 0.9rem
-      thumb) exists in CSS but never actually applies. The other 3 sliders
-      have essentially zero styling rules at all (only `width` is set).
-- [ ] **Taste Profile slider shows unrated items as already-filled** (~60%
-      blue) — misleading, reads as "already answered" when it isn't.
+      "aggressiveness", Sentiment-review "Appeal ≤" threshold). Root cause
+      was broader than the sentiment slider's own specificity fight: Stash's
+      global `input[type="range"]` base rule *and* its
+      `::-webkit-slider-thumb`/`::-webkit-slider-runnable-track` pseudo-
+      element rules all beat a bare `.curator-sentiment-range` class — and
+      critically, curator's CSS never had `::-webkit-slider-runnable-track`/
+      `::-moz-range-track` rules at all (only a base `background` that
+      WebKit ignores for track rendering), so the intended thin bordered
+      track never rendered in Chrome/Safari even before the specificity
+      question. The other 3 sliders (Minimum match, Prune aggressiveness,
+      Appeal ≤ threshold) had zero color/track/thumb styling of their own —
+      only `width`.
+      **Fix**: introduced a shared `.curator-page .curator-range` class
+      (opt-in via `className="curator-range"`) covering base/track/thumb for
+      both WebKit and Gecko, applied to all 4 sliders. Thumb color reads
+      `var(--sc, var(--curator-accent))` so the sentiment slider's existing
+      tier-color wrapper (`--sc`) recolors it for free with no separate
+      override rule. Verified via computed-style dump (confirms Stash's
+      rules no longer win) and screenshots of all 4 sliders in both themes.
+- [x] **Taste Profile slider shows unrated items as already-filled** (~60%
+      blue) — resolved as a side effect of the fix above: the "filled" look
+      was Stash's own saturated `rgb(0,123,255)` track color rendering
+      identically regardless of value/rated-state (native range tracks don't
+      show a filled/unfilled split), combined with the unrated default
+      thumb position (stop 3 of 5, i.e. ~60%). Now that curator's own neutral
+      `--curator-border-strong` track and dimmed (`opacity: 0.45`,
+      previously inert) unrated thumb actually render, an unrated slider
+      reads as neutral/unanswered rather than pre-filled — confirmed via
+      screenshot.
 
 ## Buttons / icons
 

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -229,9 +229,14 @@ Artifacts:
       sentiment via the separate Taste Profile panel. (Old handover #6,
       confirmed still open — deliberately deferred pending discussion per
       prior triage.)
-- [ ] **Curate's "Pick-test a hypothesis" list renders empty on first paint**
-      with no loading/empty-state messaging, looks broken before it
-      populates.
+- [x] **Curate's "Pick-test a hypothesis" list renders empty on first paint**
+      — confirmed the fetch genuinely takes several seconds (it's up to 5
+      parallel `get_tag_context_candidates` calls), so the gap was real, not
+      imagined. `suggestions` starts `null`, and the render only handled the
+      "loaded and empty" case (`suggestions.length === 0`) — `null` matched
+      neither that check nor the list map, so nothing showed at all for the
+      whole fetch. Added a `suggestions === null` branch rendering "Loading
+      hypotheses…". Verified via screenshot mid-fetch and after resolution.
 - [ ] Similar's free-text scene search results render as a bare, unstyled
       inline list of link-colored text — no card/border/container, visually
       inconsistent with the app's card-heavy aesthetic elsewhere.

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -189,10 +189,14 @@ Artifacts:
       round-trip via network trace) with only a subtly-dimmed button; Expand's
       candidate list is blank for up to 10s with zero spinner/skeleton. Reads
       as frozen, not slow.
-- [ ] **MATCH bar clips/misrepresents scores >1.0** — cards showing
-      `1.17`/`1.16`/`1.15` render at essentially the same bar width as `0.95`.
-      Either normalize fill to the actual observed max or drop the bar and
-      show only the number for these cases.
+- [x] **MATCH bar clips/misrepresents scores >1.0** — `utilityBar()` clamped
+      fill to `[0, 1]`, so any overflow above 1.0 (final_utility can exceed
+      1.0 via bonuses like uncovered-content) rendered at the same ~100%
+      width as a plain 0.95. Rescaled against a wider ceiling (1.2) so that
+      range is visible, with a distinct striped treatment for the rare case
+      that still exceeds it. Verified on live data: 1.171/1.160/1.154/1.140
+      now render at 98%/97%/96%/95% vs. 0.95's 79% — clearly distinguishable
+      (previously all ≈100%).
 - [x] **Sentiment badges carry no color signal** — reused the existing
       sentiment-tier classes (`.curator-sentiment-love`/`-danger`/`-neutral`,
       which already set `--sc`) on the badge instead of Bootstrap's

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -112,6 +112,31 @@ Artifacts:
       previously inert) unrated thumb actually render, an unrated slider
       reads as neutral/unanswered rather than pre-filled — confirmed via
       screenshot.
+- [x] **Follow-up (user feedback, post-round-15): sentiment slider still
+      didn't match the design mockup** — the round-15 fix made the native
+      `<input type="range">` render *something* coherent, but the mockup
+      (`.rs-track`/`.rs-stop`/`.rs-thumb` — a compact ~10rem fixed-width
+      track with visible per-stop tick dots, not a full-row-width plain bar)
+      was never actually built; that gap is what "no ticks, line too wide"
+      was pointing at. Rebuilt `TagSentimentControl` per the mockup: a
+      decorative rail (`.curator-sentiment-rail`) with 6 tick-stop dots
+      (`.curator-sentiment-stop`, the "Never" stop distinctly shaped/
+      colored) and a 14px thumb, fixed-width (10rem standalone / 6rem
+      compact) instead of stretching to fill the row. A fully transparent
+      native range input sits on top at the same geometry so clicking/
+      dragging/keyboard/screen-reader semantics stay free (no hand-rolled
+      pointer math like the mockup's own static-HTML JS), with a
+      `:focus-visible` ring redirected onto the decorative thumb since the
+      real input is invisible. Also adds a feature beyond the mockup itself:
+      Taste Profile's model-inferred sentiment (`item.inferred_value`,
+      previously only shown as text) now renders as a small hollow ring on
+      the same track (`.curator-sentiment-model-dot`), distinct from the
+      solid direct-rating thumb, so the two can be compared at a glance —
+      the other two `TagSentimentControl` call sites (ExternalCard's "Rate
+      tags & terms", Curate's thumbs-down follow-up) don't have an inferred
+      value available client-side, so no dot renders there, gracefully.
+      Verified via screenshot in both themes, compact and standalone modes,
+      mouse-click and keyboard interaction.
 
 ## Buttons / icons
 

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -137,6 +137,39 @@ Artifacts:
       value available client-side, so no dot renders there, gracefully.
       Verified via screenshot in both themes, compact and standalone modes,
       mouse-click and keyboard interaction.
+- [x] **Follow-up 2 (user feedback on the round-26 redesign)**: five more
+      issues from a hands-on pass over the new slider.
+      1. Model-estimate marker changed from a hollow ring to a small filled
+         tick in `--curator-accent-secondary` (the existing amber token,
+         already used for the Best Bets lane hue) — reads more clearly as
+         "a third kind of marker" than a smaller/fainter thumb did.
+      2. Belief badges ("I think you dislike this") only ever checked the
+         sign of `inferred_value`, collapsing 4 of the 5 tiers into "like"/
+         "dislike" — now uses the same nearest-tier lookup the model dot's
+         tooltip already had, giving "I think you slightly/strongly like/
+         dislike this" (and "feel neutral about"), with the badge color
+         matching the specific tier instead of a plain binary green/red.
+      3. Added the mockup's confidence pips (`ConfidencePips`: 5 bars filled
+         left-to-right from `item.confidence`, previously only shown as
+         text) — this existed in the mockup but was never built.
+      4. **Real bug**: clicking dead-center on "Neutral" silently did
+         nothing for an unrated tag. An unrated item displays its thumb
+         parked at stop 3 ("Neutral")'s position as a resting point with no
+         real value yet — a native range input only fires `input`/`change`
+         when its value *changes*, so a click resolving to that same stop
+         is indistinguishable from a no-op to the browser. Added a narrow
+         `onClick` fallback that recomputes the intended stop from click
+         position and commits directly whenever it matches the value
+         already showing (the one case the native event won't fire for).
+      5. The unrated placeholder thumb fell back to the blue accent color
+         (no tier class means no `--sc`), which read as an actual (if
+         faint) vote sitting at "Neutral" rather than "nothing set yet" —
+         especially confusing since real "Neutral" votes are gray, not
+         blue. Removed the thumb entirely when unrated instead of
+         recoloring it, since the existing tier-color system doesn't have a
+         "this is fake" affordance and repurposing "Neutral"'s own gray for
+         both meanings would just move the ambiguity elsewhere. Verified
+         all five via screenshot/computed-value checks on live data.
 
 ## Buttons / icons
 

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -78,6 +78,43 @@ Artifacts:
       *consistency* items below (icon-button reconciliation, Save
       unification, dropping mismatched icons) are separate, still open —
       this item was specifically the AA contrast failure.
+- [x] **Relationship chips (Similar/Expand results — "Same performer",
+      "Shared content", "Same studio", etc.) also failed WCAG AA**, same
+      root cause as the primary-button item above but a separate component
+      that fix never touched. Found in review, not in either original pass.
+      `same_performer`/`shared_content`/`same_studio` were solid hex
+      literals paired with `color: #fff` measuring **3.34:1/2.50:1/2.85:1**
+      — all fail 4.5:1 (green worst of all, below even the primary-button
+      bug's worst measurement). Their `similar_performer`/`similar_structure`
+      counterparts used the same hue at ~67% alpha to signal "weaker match",
+      which made contrast depend on whatever's behind the chip (a card
+      surface that's white in light theme) rather than guaranteeing AA.
+      `multi_hop` (`#9b59b6`) already passed (4.67:1), left unchanged.
+      **Fix**: replaced with darker solid literals for the "same_X" chips
+      (`#1d5fb8`/`#1e7e34`/`#a0530a`, 6.21:1/5.14:1/5.62:1) and a lighter
+      but still independently AA-passing solid (not alpha) for "similar_X"
+      (`#316bb0`/`#278041`, 5.44:1/4.94:1) — same visual distinction,
+      contrast now holds regardless of backdrop. Verified via independent
+      relative-luminance calculation for all 6 chip colors.
+- [x] **Manage panel's active left-nav item also failed WCAG AA in dark
+      theme** — reported by the user as "still hard to read" after the
+      button/chip fixes. Third instance of the same root cause: the
+      selected `.curator-manage-item[aria-current="page"]` used
+      `background: var(--curator-accent)` directly (dark theme's vivid
+      `#4f8ce0`), same 3.41:1 failure as the original button bug, and worse
+      for its child text: the description's `rgba(255,255,255,0.78)` and
+      the icon badge's `rgba(255,255,255,0.2)` both blend toward the vivid
+      background rather than white, measuring **2.69:1** and effectively
+      **2.59:1** — both well below AA. **Fix**: background now the literal
+      `#1d5fb8` (6.21:1 with white text; light theme's `--curator-accent`
+      already equals this literal, so light theme was unaffected).
+      Re-measured the child elements against the new background: title
+      6.21:1 (unchanged, already solid white), description bumped from
+      0.78 to 0.85 alpha (4.46:1 → 4.97:1, the old alpha would still have
+      failed against the darker background), icon badge unchanged at
+      4.08:1 (already clears the 3:1 non-text minimum against the new
+      background). Verified via independent relative-luminance calculation
+      for all three elements.
 
 ## Sliders
 

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -319,11 +319,18 @@ Artifacts:
       the baseline). Added `"eligibility.lane": "Eligible for this lane"` to
       the existing label map, same pattern as the other two entries.
       Verified via screenshot — column now reads sensibly on every row.
-- [ ] **No loading affordance for slow async actions** (systemic gap, not
-      just Curate): Generate has 4–8s of dead air (confirmed ~8s GraphQL
-      round-trip via network trace) with only a subtly-dimmed button; Expand's
-      candidate list is blank for up to 10s with zero spinner/skeleton. Reads
-      as frozen, not slow.
+- [x] **No loading affordance for slow async actions** (systemic gap, not
+      just Curate) — per user request, added a real spinner (CSS `::before`
+      ring animation) to the shared `.curator-loading` element used by every
+      async panel, so the fix is one CSS change rather than per-view work.
+      Also added `.curator-loading` where it was entirely missing:
+      Recommendations' lane-switch grid (previously no indicator at all —
+      the whole grid section was gated on `!loading`, so switching lanes
+      showed a blank gap), Expand/Hunt/Shortlist's candidate grid (same gap,
+      confirmed ~10s blank on this dataset), and Similar's free-text search
+      (scene/performer search-in-progress had no indicator either). Verified
+      via screenshot on Prune (pre-existing spot) and the two newly-added
+      spots (lane switch, Expand).
 - [x] **MATCH bar clips/misrepresents scores >1.0** — `utilityBar()` clamped
       fill to `[0, 1]`, so any overflow above 1.0 (final_utility can exceed
       1.0 via bonuses like uncovered-content) rendered at the same ~100%
@@ -393,9 +400,64 @@ Artifacts:
       "Other bugs / quirks" entry above.
 - [x] Add pagination or virtualization to Taste Profile (fixes the Manage
       height problem at the root) — done, see "Other bugs / quirks" above.
-- [ ] Add loading skeletons for lane switches and Curate generation.
+- [x] Add loading skeletons for lane switches and Curate generation — done as
+      a spinner (not a skeleton) applied consistently app-wide, see "Other
+      bugs / quirks" above.
 - [ ] Add empty-state copy to Curate's hypothesis list explaining the blank
       state instead of leaving it silent.
+
+## User feedback round (direct requests, not sourced from the original review pass)
+
+- [x] **Header was 2 rows on every width above 36rem** (brand+controls on
+      row 1, nav spanning full-width on row 2), unlike the design mockup's
+      single-row `app-header-inner` — an old `.curator-navigation` base rule
+      (`grid-column: 1/-1; grid-row: 2`) predates this pass and was never
+      actually matched to the mockup on desktop, only overridden back to one
+      row at the ≤36rem phone breakpoint. Changed `.curator-header` from a
+      2-row grid to a single-row flex layout at every width; shortened
+      "Stash Curator" → "Curator" (kept as a `title` tooltip on the brand)
+      to help it fit, matching the mockup's own `.brand-word` text exactly.
+      Verified across 1440/1000/800/420px.
+- [x] **Card-size control**: added a header icon-button (cycles Compact/
+      Comfortable/Spacious, localStorage-persisted like theme) driving a new
+      `--curator-card-min-width` CSS variable that `.curator-grid` already
+      reads via `minmax(var(...), 1fr)` — no backend change, affects every
+      card grid in the app (Recommendations/Similar/Expand/Prune) at once.
+      Verified 4→5 cards/row (Compact) and 4→3 (Spacious) at 1440px.
+- [x] **Native SceneCard's tag/performer/organized overlay buttons were
+      solid blue**, same root cause as two earlier `.minimal` fixes this
+      pass (#152 round 16, round "Follow-up 1" above): no explicit variant
+      on Stash's own markup means Bootstrap's "primary" default fights
+      Stash's `.minimal` reset, and `.curator-page .btn-primary` wins on
+      specificity. Scoped a discreet outline-style override to
+      `.curator-card .card-popovers .btn.minimal` (this is the third
+      instance of this exact bug pattern — worth remembering if a fourth
+      turns up: any native/uncontrolled `.minimal.btn` inside `.curator-
+      page` needs this same treatment). Verified resting and hover states.
+- [x] **"Default" checkbox in SavedFilters** looked out of place next to the
+      Save button row — converted to Bootstrap's native `.custom-switch`
+      toggle (already bundled in Stash's own CSS, no new styling needed),
+      with a stable per-instance id via the existing `uuid()` helper.
+- [x] **Thin grey bar between Stash's navbar and Curator's own background**
+      — second instance of the round-11 gutter-bleed bug: Stash's
+      `.main.container-fluid` wrapper has an *undocumented* 7px top padding
+      (only the 15px horizontal gutter was compensated for originally),
+      transparent, letting `<body>`'s background color show through as a
+      thin bar between the (differently-colored) navbar and this page's own
+      background. Extended the existing negative-margin/matching-padding
+      technique to the top edge. Confirmed via computed-geometry dump
+      against the live instance before fixing.
+- [x] **No spinner during loading** — see "Other bugs / quirks" above (same
+      item as "No loading affordance for slow async actions").
+- [x] **"Synced" pill never indicated pending/rebuild-needed state** — it
+      only ever showed Running/Synced/Not-synced (has a sync ever
+      completed), never surfacing `model_pending`/`model_rebuilding` outside
+      the hover popover. Added those as two more pill states (amber pulse,
+      "N pending" / "Rebuilding" label) so the at-a-glance status is
+      actually informative. Considered moving Sync/Rebuild into the hover
+      popover per the initial ask, but recommended against it (burying the
+      two most frequently-used actions behind a hover interaction that
+      doesn't work well on touch) in favor of this — not yet revisited.
 
 ## Deliberately out of scope (tracked elsewhere — listed for completeness)
 

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -418,6 +418,19 @@ Artifacts:
       "Stash Curator" → "Curator" (kept as a `title` tooltip on the brand)
       to help it fit, matching the mockup's own `.brand-word` text exactly.
       Verified across 1440/1000/800/420px.
+      **Follow-up (user feedback): still visibly misaligned.** Root cause
+      was separate from the row-layout change: the Nav component renders
+      `className="curator-tabs nav nav-tabs"`, and Bootstrap's own
+      `.nav-tabs` rule sets `margin: auto` then `margin-bottom: 1.5rem`
+      (same specificity, same selector, so the second declaration wins for
+      that one property) — a fixed 21px bottom margin leaves no free space
+      for the auto top margin to distribute, so the tabs strip sat flush
+      against the header's top edge with 21px of dead space below it
+      instead of being centered like every other header control. Curator's
+      own `.curator-tabs` rule only neutralized the horizontal margins
+      (`margin-inline: 0`), never the vertical ones. Changed to `margin: 0`.
+      Verified via computed-geometry dump: tabs/controls/brand now share
+      the same centerY (~84.4px) at 1440px width.
 - [x] **Card-size control**: added a header icon-button (cycles Compact/
       Comfortable/Spacious, localStorage-persisted like theme) driving a new
       `--curator-card-min-width` CSS variable that `.curator-grid` already
@@ -434,6 +447,13 @@ Artifacts:
       instance of this exact bug pattern — worth remembering if a fourth
       turns up: any native/uncontrolled `.minimal.btn` inside `.curator-
       page` needs this same treatment). Verified resting and hover states.
+      **Follow-up (user feedback): read as "solid black," not discreet.**
+      The first attempt used `var(--curator-overlay)` (a dark translucent
+      scrim, chosen for sitting over an image) — reasonable in isolation,
+      but the user specifically wanted it to match the "More" menu
+      trigger's actual look, which is just plain `.btn-secondary`
+      (`var(--curator-surface)` + a visible border), not a dark overlay.
+      Switched to that exact treatment for a true match.
 - [x] **"Default" checkbox in SavedFilters** looked out of place next to the
       Save button row — converted to Bootstrap's native `.custom-switch`
       toggle (already bundled in Stash's own CSS, no new styling needed),

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -158,15 +158,24 @@ Artifacts:
 
 ## Other bugs / quirks
 
-- [ ] **Manage page height still unbounded** — round 11's sticky section list
-      stops the scroll-to-top pain on desktop, but the document itself is
-      still ~76,700px tall (Taste Profile renders all 949 tags unpaginated/
-      unvirtualized) and **worse on mobile at ~142,000px**, where
-      `@media (max-width:860px) { .curator-manage-list { position: static } }`
-      explicitly disables the sticky list — mobile users lose the section
-      rail entirely while scrolling. Fixes the symptom, not the cause;
-      consider pagination/virtualization on Taste Profile instead (see UX
-      suggestions).
+- [x] **Manage page height still unbounded** — fixed at the root per the UX
+      suggestion below rather than patching the symptom further: Taste
+      Profile now paginates client-side (30 rows/page, `useUrlPage`-backed
+      so pages are bookmarkable/back-button-able, same convention as
+      Feedback history/Recommendation history's server-side pagers) instead
+      of rendering all ~1,000 tags at once. `get_taste_profile` already
+      returns the full set in one call, so this needed no backend change —
+      just slicing the already-in-memory filtered/sorted array and adding
+      the existing `Pager` component. Measured on live data: desktop
+      76,700px → 3,032px, mobile 142,000px → 5,547px. Every other Manage
+      section (Recently Recommended, Sentiment review, Prune, Feedback
+      history) was already paginated server-side; Taste Profile was the one
+      unbounded list. The mobile `position: static` override for
+      `.curator-manage-list` is unrelated to this — it exists because the
+      layout drops to one column below 860px (list and detail stack instead
+      of sitting side by side), where sticky positioning doesn't apply
+      regardless of page length, not because of the height problem — left
+      as is.
 - [x] **Raw enum leak regression**: Manage → Recently Recommended's "Lane"
       column showed `score_review` verbatim for Sentiment-review-sourced
       rows. `RecommendationHistoryRow` had its own separate lane→label
@@ -256,8 +265,8 @@ Artifacts:
 - [x] Color-code sentiment badges using the sentiment-tier color system the
       slider thumb already has (`--sc` custom property) — done, see the
       "Other bugs / quirks" entry above.
-- [ ] Add pagination or virtualization to Taste Profile (fixes the Manage
-      height problem at the root).
+- [x] Add pagination or virtualization to Taste Profile (fixes the Manage
+      height problem at the root) — done, see "Other bugs / quirks" above.
 - [ ] Add loading skeletons for lane switches and Curate generation.
 - [ ] Add empty-state copy to Curate's hypothesis list explaining the blank
       state instead of leaving it silent.

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -1,0 +1,208 @@
+# Curator plugin — review checklist (living doc)
+
+Consolidated from two independent review passes against the live instance
+(`http://192.168.1.100:9999/plugins/stash-curator`), cross-checked against the
+design mockup (`https://claude.ai/code/artifact/0e341da5-9b63-4ffc-ac60-05ee0df6174a`)
+and, for pass 2, against this worktree at commit `78da835` (round 13,
+`feat/plugin-visual-overhaul`). Tracks GH issue #152 (follow-up to #150);
+Settings-in-Manage is deliberately out of scope here, tracked as #151.
+
+Tick items off as they land. Add new findings at the bottom of the relevant
+section rather than renumbering, so this stays a stable reference.
+
+Artifacts:
+- Pass 1 (mockup-fidelity): `/tmp/curator-review/` — `HANDOVER.md`, cached
+  `mockup.html`, live bundle snapshot as of that pass, ~45 screenshots.
+- Pass 2 (critical UX audit): `/tmp/curator-review2/` — screenshots + probe
+  scripts, including `lane_bug_clean.py` / `lane_bug_directurl.py` /
+  `lane_bug_fromrevisit.py` which reproduce the lane-switch bug below.
+
+---
+
+## Critical / high severity
+
+- [x] **Recommendations lane switching broken for Revisit/Discover/Adventure
+      when clicked in-app.** Investigated end-to-end (element-level and
+      document-capture-phase event listeners, `history.pushState`
+      instrumentation, temporary logging inside the real `openView` source,
+      direct GraphQL calls, and a real-click DOM diff of rendered scene IDs).
+      **Not a real bug — two independent test artifacts in the two repro
+      scripts:**
+      1. Revisit/Discover/Best Bets: `lane_bug_clean.py` (and this doc's own
+         repro list) locate the lane card with
+         `.curator-lane-card:has-text('Revisit')` etc. — Playwright's
+         `:has-text()` is a case-insensitive **substring** match against the
+         full element text, and "For You"'s own description ("...timely
+         **revisits**, and a little **discovery**.") contains "revisits" and
+         "discovery" as substrings. `.first` silently resolved to the wrong
+         card (For You) instead of the intended lane. Re-run with precise
+         `page.get_by_text(lane, exact=True)` locators: all three switch
+         correctly (Best Bets 23908→5442, Revisit 23908→130, Discover
+         23908→14054).
+      2. Adventure: the repro's correctness oracle was the "N in rotation"
+         count text, which is the lane's *eligible candidate pool size*, not
+         its result set. In this dataset Adventure's pool happens to be
+         identical to For You's (23908, both draw from nearly the whole
+         library) purely by data coincidence, so the count didn't move even
+         though the click worked. Verified directly: `get_slate` for
+         `adventure` returns a completely different, correctly-ranked item
+         set (1/20 scene-ID overlap with `for_you`, distinct `appeal`
+         scores), and a real Playwright click swaps the rendered scene cards
+         (1/20 overlap) and updates the URL to `?view=adventure` — all
+         correctly.
+      No application code changed. Removed the temporary `console.log`
+      debug lines added to `openView` during this investigation and
+      redeployed the clean build to both the live instance and the local
+      test instance.
+- [x] **Primary-button text contrast fails WCAG AA in dark theme (the
+      default).** Root cause: `--curator-gradient-brand` (dark theme:
+      `linear-gradient(145deg, #4f8ce0, #6cc4dc)`, driven by
+      `--curator-accent`/`--curator-hue-similar`) paired with `color: #fff`
+      measured **3.41:1** at the dark end, **1.99:1** at the light end — both
+      fail 4.5:1. This affects every `.btn-primary` in dark theme, whether
+      `variant="primary"` is explicit (Curate Left/Right, Submit picks,
+      Generate) or an omitted-prop Bootstrap default (pagination, Copy
+      StashDB ID, Profiling buttons, etc.) — same root cause either way, so
+      fixed once at the token instead of auditing ~26+ call sites and
+      guessing which were meant to read as the "one true primary action" per
+      screen (many, like the Curate pick buttons, legitimately are).
+      **Fix**: `--curator-gradient-brand` now uses literal `#1d5fb8`/
+      `#1f7f96` — the same darker blue/teal already used as light theme's
+      accent/hue-similar (measured 6.21:1/4.63:1, both pass AA) — reused as
+      dark-theme-only literals so the vivid `--curator-accent`/
+      `--curator-hue-similar` tokens (lane-hue dots, focus rings, etc.) are
+      untouched. Verified via computed-style dump against the live instance
+      (`getComputedStyle` on every `.curator-page .btn-primary`, confirmed
+      `rgb(29, 95, 184)`/`rgb(31, 127, 150)` site-wide) and visually via
+      screenshot on Recommendations and Curate. The JS-side button-variant
+      *consistency* items below (icon-button reconciliation, Save
+      unification, dropping mismatched icons) are separate, still open —
+      this item was specifically the AA contrast failure.
+
+## Sliders
+
+- [ ] **All 4 sliders render as plain unstyled native browser range inputs**
+      (Taste Profile sentiment, Similar/Expand "Minimum match", Prune
+      "aggressiveness", Sentiment-review "Appeal ≤" threshold) — generic
+      Bootstrap-blue fill, near-invisible thumb, no differentiation between
+      filled/unfilled track. Root cause for the sentiment slider specifically:
+      Stash's own global `input[type="range"] { background-color: transparent;
+      ... }` (specificity 0,0,1,1) beats the plugin's
+      `.curator-sentiment-range { background: ... }` (0,0,1,0) — the intended
+      themed styling (thin bordered track, per-sentiment-colored 0.9rem
+      thumb) exists in CSS but never actually applies. The other 3 sliders
+      have essentially zero styling rules at all (only `width` is set).
+- [ ] **Taste Profile slider shows unrated items as already-filled** (~60%
+      blue) — misleading, reads as "already answered" when it isn't.
+
+## Buttons / icons
+
+- [ ] Add explicit `variant` to the ~26 buttons currently defaulting to
+      Bootstrap `primary` (see contrast item above — same root cause, listing
+      separately here as the styling-system fix vs. the accessibility bug).
+- [ ] Reconcile the two parallel icon-button patterns:
+      `.curator-icon-button` (header sync/rebuild/theme/settings — hardened
+      with `!important` to the muted "surface" look) vs.
+      `.curator-icon-action` (ExternalCard's row — no such override, silently
+      inherits whatever variant it was given). Currently "Copy StashDB ID" is
+      bright blue while its siblings "Open on StashDB" / "Add to shortlist"
+      in the same row are muted dark — one button group, two visual styles.
+- [ ] Unify the two "Save" button treatments: Feedback-history's inline
+      replace-row Save is `variant="link"` (text-only); the filter-bar Save
+      (Recommendations/Similar/Expand/Hunt) is a solid primary button. Same
+      action, different weight.
+- [ ] Drop the icon on **"Hide exact PHash matches"** toggle (Similar) — the
+      clone/copy icon doesn't intuitively map to "phash duplicate," label
+      alone is already clear.
+- [ ] Drop the icon on **"Local"** (include-owned) toggle — metaphor mismatch
+      (user-check icon ≠ "include library items").
+- [ ] Redesign the **ExternalCard action row** (5 icon-only buttons —
+      external-link, copy-ID, shortlist, rate-tags, refresh-Whisparr — on
+      every Similar/Expand/Hunt result card, 20+ per page): no labels, same
+      size/weight, requires hovering each to learn what it does. Recommend
+      collapsing to 2 visible actions + an overflow ("⋯") menu, or labeling
+      the most-used 1–2.
+
+## Other bugs / quirks
+
+- [ ] **Manage page height still unbounded** — round 11's sticky section list
+      stops the scroll-to-top pain on desktop, but the document itself is
+      still ~76,700px tall (Taste Profile renders all 949 tags unpaginated/
+      unvirtualized) and **worse on mobile at ~142,000px**, where
+      `@media (max-width:860px) { .curator-manage-list { position: static } }`
+      explicitly disables the sticky list — mobile users lose the section
+      rail entirely while scrolling. Fixes the symptom, not the cause;
+      consider pagination/virtualization on Taste Profile instead (see UX
+      suggestions).
+- [ ] **Raw enum leak regression**: Manage → Recently Recommended's "Lane"
+      column shows `score_review` verbatim for Sentiment-review-sourced rows,
+      while other rows correctly show "For You" etc. (Feedback-history/
+      Sentiment badges were already fixed for this class of bug — this is a
+      spot that was missed.)
+- [ ] **"Reason shown" column is dead** in Manage → Recently Recommended —
+      every row shows the literal string "Lane" regardless of scene, while
+      the adjacent "Why this now?" expandable text does show real per-scene
+      reasoning. Either wire it up or remove the column.
+- [ ] **No loading affordance for slow async actions** (systemic gap, not
+      just Curate): Generate has 4–8s of dead air (confirmed ~8s GraphQL
+      round-trip via network trace) with only a subtly-dimmed button; Expand's
+      candidate list is blank for up to 10s with zero spinner/skeleton. Reads
+      as frozen, not slow.
+- [ ] **MATCH bar clips/misrepresents scores >1.0** — cards showing
+      `1.17`/`1.16`/`1.15` render at essentially the same bar width as `0.95`.
+      Either normalize fill to the actual observed max or drop the bar and
+      show only the number for these cases.
+- [ ] **Sentiment badges carry no color signal** — "I think you like this,"
+      "I think you dislike this," and "I'm unsure" all render in identical
+      cyan `badge-info`, removing the one signal (like vs. dislike) that
+      would most help scanning a 949-row Taste Profile list.
+- [ ] **Mobile primary nav hides 5 of 6 tabs off-screen with no affordance** —
+      `.curator-tabs` is horizontally scrollable with the scrollbar hidden and
+      no fade/chevron hint; only "Recommendations" is visible on load at a
+      420px viewport.
+- [ ] **Prune still shows plain text** ("Appeal −0.94 · confidence 0.99")
+      where Recommendations/Sentiment review show a MATCH bar for the same
+      underlying data — cross-surface inconsistency.
+- [ ] **No inline sentiment slider on the Curate pair-comparison screen** —
+      mockup has a rate-strip directly under the pair; live only exposes tag
+      sentiment via the separate Taste Profile panel. (Old handover #6,
+      confirmed still open — deliberately deferred pending discussion per
+      prior triage.)
+- [ ] **Curate's "Pick-test a hypothesis" list renders empty on first paint**
+      with no loading/empty-state messaging, looks broken before it
+      populates.
+- [ ] Similar's free-text scene search results render as a bare, unstyled
+      inline list of link-colored text — no card/border/container, visually
+      inconsistent with the app's card-heavy aesthetic elsewhere.
+- [ ] Minor: Backups' directory path uses an alarm-colored magenta/pink
+      `curator-mono` style for what's just informational text.
+
+## UX suggestions (independent judgment, not defects — discuss before building)
+
+- [ ] Move **Profiling** out of the primary Manage nav rail behind a debug
+      flag / `?debug=1` — it exposes raw `.pprof` CPU-trace downloads, which
+      reads as developer tooling leaking into end-user navigation.
+- [ ] Color-code sentiment badges using the sentiment-tier color system the
+      slider thumb already has (`--sc` custom property) — reuse, not new
+      design work.
+- [ ] Add pagination or virtualization to Taste Profile (fixes the Manage
+      height problem at the root).
+- [ ] Add loading skeletons for lane switches and Curate generation.
+- [ ] Add empty-state copy to Curate's hypothesis list explaining the blank
+      state instead of leaving it silent.
+
+## Deliberately out of scope (tracked elsewhere — listed for completeness)
+
+- [ ] Settings panel in Manage — tracked as issue #151, not #152. Gear icon
+      intentionally routes to Stash's native `/settings?tab=plugins`.
+
+## Already fixed — verified in pass 2, no action needed
+
+- [x] Recommendations was missing a filter bar entirely — now has full
+      Score-first/Filters/Saved filters/Save/tag-performer-studio filters.
+- [x] Backups/Feedback history used plain HTML tables — now proper icon+
+      title+meta record-row styling.
+- [x] Theme toggle didn't re-theme scene/performer cards — now confirmed
+      light theme properly re-themes them (round 13 commit).
+- [x] `Api.components.HoverPopover` cold-load fragility — health pill popover
+      confirmed working on true cold direct navigation, zero console errors.

--- a/REVIEW_CHECKLIST.md
+++ b/REVIEW_CHECKLIST.md
@@ -209,9 +209,16 @@ Artifacts:
       `.curator-tabs` is horizontally scrollable with the scrollbar hidden and
       no fade/chevron hint; only "Recommendations" is visible on load at a
       420px viewport.
-- [ ] **Prune still shows plain text** ("Appeal −0.94 · confidence 0.99")
+- [x] **Prune still shows plain text** ("Appeal −0.94 · confidence 0.99")
       where Recommendations/Sentiment review show a MATCH bar for the same
-      underlying data — cross-surface inconsistency.
+      underlying data. Swapped to the shared `EvidenceScore`/`utilityBar`
+      used elsewhere (`item.appeal` is the same raw-appeal value
+      score_review's bar already renders, confirming this was genuinely
+      the same underlying data): the evidence line ("Low predicted Appeal
+      with supporting evidence") stays always-visible above the card body
+      as before, appeal now gets the MATCH bar row, and confidence moved
+      into the "Score breakdown" collapsible. Verified via screenshot,
+      including the expanded breakdown.
 - [ ] **No inline sentiment slider on the Curate pair-comparison screen** —
       mockup has a rate-strip directly under the pair; live only exposes tag
       sentiment via the separate Taste Profile panel. (Old handover #6,

--- a/core/slate.go
+++ b/core/slate.go
@@ -76,7 +76,25 @@ func getSlateBody(pluginDir string, payload, settings jVal) (jVal, error) {
 		context = c
 	}
 	exploration := argsFloat(args, "exploration", 0)
-	return getSlateCore(db, config, lane, count, page, impressionID, context, excludedSet, exploration)
+	includeTags, err := stringList(args.get("include_tags"))
+	if err != nil {
+		return jvNull(), err
+	}
+	excludeTags, err := stringList(args.get("exclude_tags"))
+	if err != nil {
+		return jvNull(), err
+	}
+	performerIDs, err := stringList(args.get("performer_ids"))
+	if err != nil {
+		return jvNull(), err
+	}
+	studioIDs, err := stringList(args.get("studio_ids"))
+	if err != nil {
+		return jvNull(), err
+	}
+	gender := argsString(args, "gender", "")
+	return getSlateCore(db, config, lane, count, page, impressionID, context, excludedSet, exploration,
+		includeTags, excludeTags, performerIDs, studioIDs, gender)
 }
 
 // replaceItemBody mirrors backend.py's replace_item: get_slate(lane, 1,
@@ -104,11 +122,17 @@ func replaceItemBody(pluginDir string, payload, settings jVal) (jVal, error) {
 	lane := argsString(args, "lane", "for_you")
 	exploration := argsFloat(args, "exploration", 0)
 	return getSlateCore(db, config, lane, 1, 1, jvNull(),
-		jvObj(jvKey("replacement", jvBool(true))), excludedSet, exploration)
+		jvObj(jvKey("replacement", jvBool(true))), excludedSet, exploration, nil, nil, nil, nil, "")
 }
 
-// getSlateCore mirrors CuratorAPI.get_slate after arg coercion.
-func getSlateCore(db dbx, config jVal, lane string, count, page int64, impressionID, context jVal, excluded map[string]bool, exploration float64) (jVal, error) {
+// getSlateCore mirrors CuratorAPI.get_slate after arg coercion. The filter
+// args (includeTags/excludeTags/performerIDs/studioIDs/gender) narrow the
+// lane's already-classified candidates the same way get_similar narrows its
+// candidates; they don't change ranking. A filtered request always
+// recomputes total from a full candidate fetch, the same way an exploration
+// request does, since the cached eligibility count doesn't know about
+// filters.
+func getSlateCore(db dbx, config jVal, lane string, count, page int64, impressionID, context jVal, excluded map[string]bool, exploration float64, includeTags, excludeTags, performerIDs, studioIDs []string, gender string) (jVal, error) {
 	if page < 1 || count < 1 || count > 500 {
 		return jvNull(), fmt.Errorf("invalid recommendation page")
 	}
@@ -125,12 +149,18 @@ func getSlateCore(db dbx, config jVal, lane string, count, page int64, impressio
 	end := page * count
 	diversityEnabled := cfg.get("diversity_enabled").truthy()
 
-	total, err := availableCount(db, modelID, lane, diversityEnabled, excluded)
+	sceneFilter, err := buildSceneFilter(db, includeTags, excludeTags, performerIDs, studioIDs, gender)
 	if err != nil {
 		return jvNull(), err
 	}
-	if exploration != 0 {
-		total = -1
+	hasFilters := sceneFilter != nil
+
+	var total int64 = -1
+	if exploration == 0 && !hasFilters {
+		total, err = availableCount(db, modelID, lane, diversityEnabled, excluded)
+		if err != nil {
+			return jvNull(), err
+		}
 	}
 	var requestCount int64
 	if total >= 0 {
@@ -144,7 +174,7 @@ func getSlateCore(db dbx, config jVal, lane string, count, page int64, impressio
 		}
 		requestCount = maxInt64(end+int64(len(excluded)), candidateCount+int64(len(excluded)))
 	}
-	built, err := recommend(db, modelID, lane, requestCount, diversityEnabled, exploration)
+	built, err := recommend(db, modelID, lane, requestCount, diversityEnabled, exploration, sceneFilter)
 	if err != nil {
 		return jvNull(), err
 	}
@@ -346,7 +376,7 @@ func materializedRowIsEligible(sceneID, sourceLane string, eligibility map[strin
 // model with materialized lanes, exploration == 0) is the read interface the
 // build task serves; the greedy recompute path is ported for byte parity when
 // lanes are not materialized or exploration is non-zero.
-func recommend(db dbx, modelID, lane string, count int64, diversityEnabled bool, exploration float64) (builtSlate, error) {
+func recommend(db dbx, modelID, lane string, count int64, diversityEnabled bool, exploration float64, sceneFilter func(string) bool) (builtSlate, error) {
 	if !slateLanes[lane] {
 		return builtSlate{}, fmt.Errorf("unknown lane: %s", lane)
 	}
@@ -360,7 +390,7 @@ func recommend(db dbx, modelID, lane string, count int64, diversityEnabled bool,
 		return builtSlate{}, fmt.Errorf("no published model; run build-model first")
 	}
 	if exploration == 0 {
-		slate, ok, err := loadMaterializedSlate(db, modelID, lane, count, diversityEnabled)
+		slate, ok, err := loadMaterializedSlate(db, modelID, lane, count, diversityEnabled, sceneFilter)
 		if err != nil {
 			return builtSlate{}, err
 		}
@@ -368,14 +398,16 @@ func recommend(db dbx, modelID, lane string, count int64, diversityEnabled bool,
 			return slate, nil
 		}
 	}
-	return recommendGreedy(db, modelID, lane, count, diversityEnabled, exploration)
+	return recommendGreedy(db, modelID, lane, count, diversityEnabled, exploration, sceneFilter)
 }
 
 func isFinite(f float64) bool { return !math.IsInf(f, 0) && !math.IsNaN(f) }
 
 // loadMaterializedSlate mirrors SlateBuilder._load_materialized_slate. The
 // second return value is false when the model has no materialized lanes.
-func loadMaterializedSlate(db dbx, modelID, lane string, count int64, diversityEnabled bool) (builtSlate, bool, error) {
+// sceneFilter, when non-nil, additionally gates each row (get_slate's
+// include/exclude tag, performer, studio, and gender filters).
+func loadMaterializedSlate(db dbx, modelID, lane string, count int64, diversityEnabled bool, sceneFilter func(string) bool) (builtSlate, bool, error) {
 	exists, err := scanExists(db, `SELECT 1 FROM model_lane_order_state WHERE model_id=?`, modelID)
 	if err != nil || !exists {
 		return builtSlate{}, false, err
@@ -444,7 +476,8 @@ func loadMaterializedSlate(db dbx, modelID, lane string, count int64, diversityE
 			return builtSlate{}, false, err
 		}
 		for _, row := range chunk {
-			if materializedRowIsEligible(row.sceneID, row.sourceLane, eligibility, filter) {
+			if materializedRowIsEligible(row.sceneID, row.sourceLane, eligibility, filter) &&
+				(sceneFilter == nil || sceneFilter(row.sceneID)) {
 				selectedRows = append(selectedRows, row)
 			}
 		}
@@ -991,4 +1024,111 @@ func attachedGenerationID(db dbx, kind string) string {
 		return ""
 	}
 	return generationID
+}
+
+// buildSceneFilter returns a predicate for get_slate's include/exclude tag,
+// performer, studio, and gender filters, or nil when none are set. It mirrors
+// the corresponding per-candidate checks in similarCore/similarityService.scenes
+// (core/similar.go), narrowed to the fields that make sense for a lane that's
+// already been classified by the model: no minimum-similarity or
+// favorite-only knob, since those are about ranking a candidate against a
+// source entity, not about narrowing a pre-picked set.
+func buildSceneFilter(db dbx, includeTags, excludeTags, performerIDs, studioIDs []string, gender string) (func(string) bool, error) {
+	if len(includeTags) == 0 && len(excludeTags) == 0 && len(performerIDs) == 0 && len(studioIDs) == 0 && gender == "" {
+		return nil, nil
+	}
+	performers, err := scenePerformers(db)
+	if err != nil {
+		return nil, err
+	}
+	var genders map[string]string
+	if gender != "" {
+		genders, err = performerGenders(db)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var studioByScene map[string]string
+	if len(studioIDs) > 0 {
+		studioByScene, err = studios(db)
+		if err != nil {
+			return nil, err
+		}
+	}
+	included, err := equivalentTagNames(db, includeTags)
+	if err != nil {
+		return nil, err
+	}
+	excluded, err := equivalentTagNames(db, excludeTags)
+	if err != nil {
+		return nil, err
+	}
+	filterNames := make(map[string]bool)
+	for _, group := range included {
+		for name := range group {
+			filterNames[name] = true
+		}
+	}
+	for _, group := range excluded {
+		for name := range group {
+			filterNames[name] = true
+		}
+	}
+	var sceneTags map[string]map[string]bool
+	if len(filterNames) > 0 {
+		sceneTags, err = sceneTagNames(db, filterNames)
+		if err != nil {
+			return nil, err
+		}
+	}
+	performerIDSet := make(map[string]bool, len(performerIDs))
+	for _, id := range performerIDs {
+		performerIDSet[id] = true
+	}
+	studioIDSet := make(map[string]bool, len(studioIDs))
+	for _, id := range studioIDs {
+		studioIDSet[id] = true
+	}
+	return func(sceneID string) bool {
+		candidatePerformers := performers[sceneID]
+		if gender != "" {
+			matched := false
+			for _, p := range candidatePerformers {
+				if genders[p] == gender {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return false
+			}
+		}
+		candidateTags := sceneTags[sceneID]
+		for _, group := range included {
+			has := false
+			for name := range group {
+				if candidateTags[name] {
+					has = true
+					break
+				}
+			}
+			if !has {
+				return false
+			}
+		}
+		for _, group := range excluded {
+			for name := range group {
+				if candidateTags[name] {
+					return false
+				}
+			}
+		}
+		if len(performerIDSet) > 0 && !containsAll(candidatePerformers, performerIDSet) {
+			return false
+		}
+		if len(studioIDSet) > 0 && !studioIDSet[studioByScene[sceneID]] {
+			return false
+		}
+		return true
+	}, nil
 }

--- a/core/slate_greedy.go
+++ b/core/slate_greedy.go
@@ -63,9 +63,15 @@ type greedyCandidate struct {
 }
 
 // recommendGreedy mirrors SlateBuilder.recommend's recompute branch.
-func recommendGreedy(db dbx, modelID, lane string, count int64, diversityEnabled bool, exploration float64) (builtSlate, error) {
+// sceneFilter, when non-nil, additionally gates the live candidate pool
+// (get_slate's include/exclude tag, performer, studio, and gender filters);
+// the prepared-slate cache (a previous unfiltered recommend()'s saved
+// result) is bypassed on both read and write when a filter is active, since
+// it isn't filter-keyed and would otherwise leak an unfiltered slate into a
+// filtered response or vice versa.
+func recommendGreedy(db dbx, modelID, lane string, count int64, diversityEnabled bool, exploration float64, sceneFilter func(string) bool) (builtSlate, error) {
 	var preparedSlate *builtSlate
-	if exploration == 0 {
+	if exploration == 0 && sceneFilter == nil {
 		slate, ok, err := loadPreparedSlate(db, modelID, lane, count, diversityEnabled)
 		if err != nil {
 			return builtSlate{}, err
@@ -144,7 +150,8 @@ WHERE provenance='direct_player' GROUP BY scene_id`)
 		_, played := directPlays[c.sceneID]
 		if !state.eligible ||
 			(c.lane == "best_bets" && played) ||
-			(c.lane == "revisit" && unrecovered[c.sceneID]) {
+			(c.lane == "revisit" && unrecovered[c.sceneID]) ||
+			(sceneFilter != nil && !sceneFilter(c.sceneID)) {
 			continue
 		}
 		live = append(live, c)
@@ -378,7 +385,7 @@ WHERE provenance='direct_player' GROUP BY scene_id`)
 			"history": 0, "selection": 0, "items": 0, "total": 0,
 		},
 	}
-	if exploration == 0 {
+	if exploration == 0 && sceneFilter == nil {
 		if err := savePreparedSlate(db, modelID, lane, diversityEnabled, &slate); err != nil {
 			return builtSlate{}, err
 		}

--- a/curator/api.py
+++ b/curator/api.py
@@ -53,6 +53,11 @@ class CuratorAPI:
         now_ms: int | None = None,
         exclude_scene_ids: set[str] | None = None,
         exploration: float = 0,
+        include_tags: tuple[str, ...] = (),
+        exclude_tags: tuple[str, ...] = (),
+        performer_ids: tuple[str, ...] = (),
+        studio_ids: tuple[str, ...] = (),
+        gender: str = "",
     ) -> dict[str, object]:
         if page < 1 or not 1 <= count <= 500:
             raise ValueError("invalid recommendation page")
@@ -73,9 +78,13 @@ class CuratorAPI:
         start = (page - 1) * count
         end = page * count
         builder = SlateBuilder(self.connection, diversity_enabled=bool(config["diversity_enabled"]))
+        has_filters = bool(include_tags or exclude_tags or performer_ids or studio_ids or gender)
+        # A filtered request always recomputes total from a full candidate
+        # fetch, the same way an exploration request does, since the cached
+        # eligibility count doesn't know about filters.
         total = (
             builder.available_count(model_id, lane, exclude_scene_ids=excluded)
-            if exploration == 0
+            if exploration == 0 and not has_filters
             else None
         )
         if total is None:
@@ -99,7 +108,16 @@ class CuratorAPI:
             request_count = max(end + len(excluded), candidate_count + len(excluded))
         else:
             request_count = end + len(excluded)
-        built = builder.recommend(lane, request_count, exploration=exploration)
+        built = builder.recommend(
+            lane,
+            request_count,
+            exploration=exploration,
+            include_tags=include_tags,
+            exclude_tags=exclude_tags,
+            performer_ids=performer_ids,
+            studio_ids=studio_ids,
+            gender=gender,
+        )
         available = tuple(item for item in built.items if item.scene_id not in excluded)
         if total is None:
             total = len(available)

--- a/curator/ranking/slate.py
+++ b/curator/ranking/slate.py
@@ -1104,9 +1104,7 @@ class SlateBuilder:
                 return False
             if performer_id_set and not performer_id_set <= candidate_performers:
                 return False
-            if studio_id_set and studios.get(scene_id) not in studio_id_set:
-                return False
-            return True
+            return not (studio_id_set and studios.get(scene_id) not in studio_id_set)
 
         return matches
 

--- a/curator/ranking/slate.py
+++ b/curator/ranking/slate.py
@@ -22,6 +22,7 @@ from curator.model.curves import scene_recovery
 from curator.profiling import record_duration
 from curator.ranking.policy import LANES, LaneClassification, LanePolicy
 from curator.storage import transaction
+from curator.taxonomy import equivalent_tag_names
 
 FAMILIAR_PATTERN = (
     "best_bets",
@@ -406,7 +407,18 @@ class SlateBuilder:
                 push(affected)
         return ordered
 
-    def recommend(self, lane: str, count: int, *, exploration: float = 0) -> Slate:
+    def recommend(
+        self,
+        lane: str,
+        count: int,
+        *,
+        exploration: float = 0,
+        include_tags: tuple[str, ...] = (),
+        exclude_tags: tuple[str, ...] = (),
+        performer_ids: tuple[str, ...] = (),
+        studio_ids: tuple[str, ...] = (),
+        gender: str = "",
+    ) -> Slate:
         started = time.perf_counter()
         timings: dict[str, int] = {}
         if lane not in {"for_you", "best_bets", "revisit", "discover", "adventure"}:
@@ -418,12 +430,15 @@ class SlateBuilder:
         model_id = RecommendationModelStore(self.connection).current_model_id()
         if model_id is None:
             raise RuntimeError("no published model; run build-model first")
+        scene_filter = self._scene_filter(
+            include_tags, exclude_tags, performer_ids, studio_ids, gender
+        )
         if exploration == 0:
-            materialized = self._load_materialized_slate(model_id, lane, count)
+            materialized = self._load_materialized_slate(model_id, lane, count, scene_filter)
             if materialized is not None:
                 return materialized
         prepared_slate = None
-        if exploration == 0:
+        if exploration == 0 and scene_filter is None:
             prepared_slate = self._load_prepared_slate(model_id, lane, count)
             if prepared_slate is not None and len(prepared_slate.items) >= count:
                 return prepared_slate
@@ -489,6 +504,7 @@ class SlateBuilder:
                 candidate.classification.lane == "revisit"
                 and candidate.classification.scene_id in unrecovered_direct_plays
             )
+            and (scene_filter is None or scene_filter(candidate.classification.scene_id))
         )
         self._live_fit, self._live_cooldown = self._live_current_fit(model_id, direct_plays, now_ms)
         timings["eligibility"] = round((time.perf_counter() - stage_started) * 1000)
@@ -648,11 +664,17 @@ class SlateBuilder:
         record_duration("python", "ranking.items", timings["items"])
         timings["total"] = round((time.perf_counter() - started) * 1000)
         slate = Slate(model_id, lane, tuple(items), tuple(diagnostics), timings)
-        if exploration == 0:
+        if exploration == 0 and scene_filter is None:
             self._save_prepared_slate(slate)
         return slate
 
-    def _load_materialized_slate(self, model_id: str, lane: str, count: int) -> Slate | None:
+    def _load_materialized_slate(
+        self,
+        model_id: str,
+        lane: str,
+        count: int,
+        scene_filter: Callable[[str], bool] | None = None,
+    ) -> Slate | None:
         started = time.perf_counter()
         if not self.connection.execute(
             "SELECT 1 FROM model_lane_order_state WHERE model_id=?", (model_id,)
@@ -699,7 +721,7 @@ class SlateBuilder:
                 row
                 for row in rows
                 if self._materialized_row_is_eligible(
-                    row, eligibility, direct_plays, unrecovered_direct_plays
+                    row, eligibility, direct_plays, unrecovered_direct_plays, scene_filter
                 )
             )
             if len(rows) < chunk_size:
@@ -1042,12 +1064,94 @@ class SlateBuilder:
         }
         return direct_plays, unrecovered_direct_plays
 
+    def _scene_filter(
+        self,
+        include_tags: tuple[str, ...],
+        exclude_tags: tuple[str, ...],
+        performer_ids: tuple[str, ...],
+        studio_ids: tuple[str, ...],
+        gender: str,
+    ) -> Callable[[str], bool] | None:
+        """A predicate for get_slate's include/exclude tag, performer,
+        studio, and gender filters, or None when none are set. Mirrors the
+        corresponding per-candidate checks in SimilarityService.scenes
+        (curator/similarity.py), narrowed to the fields that make sense for a
+        lane that's already been classified by the model: no
+        minimum-similarity or favorite-only knob, since those are about
+        ranking a candidate against a source entity, not about narrowing a
+        pre-picked set.
+        """
+        if not (include_tags or exclude_tags or performer_ids or studio_ids or gender):
+            return None
+        performers = self._scene_performers()
+        genders = self._performer_genders() if gender else {}
+        studios = self._studios() if studio_ids else {}
+        included = equivalent_tag_names(self.connection, include_tags)
+        excluded = equivalent_tag_names(self.connection, exclude_tags)
+        filter_names = set().union(*included, *excluded)
+        scene_tags = self._scene_tags(filter_names) if filter_names else {}
+        performer_id_set = set(performer_ids)
+        studio_id_set = set(studio_ids)
+
+        def matches(scene_id: str) -> bool:
+            candidate_performers = performers.get(scene_id, set())
+            if gender and not any(genders.get(value) == gender for value in candidate_performers):
+                return False
+            candidate_tags = scene_tags.get(scene_id, set())
+            if any(not group & candidate_tags for group in included):
+                return False
+            if any(group & candidate_tags for group in excluded):
+                return False
+            if performer_id_set and not performer_id_set <= candidate_performers:
+                return False
+            if studio_id_set and studios.get(scene_id) not in studio_id_set:
+                return False
+            return True
+
+        return matches
+
+    def _performer_genders(self) -> dict[str, str]:
+        return {
+            str(row["performer_id"]): str(row["gender"] or "")
+            for row in self.connection.execute("SELECT performer_id, gender FROM source_performer")
+        }
+
+    def _scene_performers(self) -> dict[str, set[str]]:
+        result: dict[str, set[str]] = {}
+        for row in self.connection.execute(
+            "SELECT scene_id, performer_id FROM scene_performer ORDER BY scene_id, performer_id"
+        ):
+            result.setdefault(str(row["scene_id"]), set()).add(str(row["performer_id"]))
+        return result
+
+    def _scene_tags(self, names: set[str]) -> dict[str, set[str]]:
+        result: dict[str, set[str]] = {}
+        for row in self.connection.execute(
+            f"""
+            SELECT st.scene_id, t.name FROM scene_tag st
+            JOIN source_tag t USING(tag_id) WHERE lower(t.name) IN
+            ({",".join("?" for _ in names)})
+            """,
+            sorted(names),
+        ):
+            result.setdefault(str(row["scene_id"]), set()).add(str(row["name"]).casefold())
+        return result
+
+    def _studios(self) -> dict[str, str]:
+        return {
+            str(row["scene_id"]): str(row["studio_id"])
+            for row in self.connection.execute(
+                "SELECT scene_id, studio_id FROM source_scene WHERE studio_id IS NOT NULL"
+            )
+        }
+
     @staticmethod
     def _materialized_row_is_eligible(
         row: sqlite3.Row,
         eligibility: dict[str, dict[str, object]],
         direct_plays: dict[str, int],
         unrecovered_direct_plays: set[str],
+        scene_filter: Callable[[str], bool] | None = None,
     ) -> bool:
         scene_id = str(row["scene_id"])
         source_lane = str(row["source_lane"])
@@ -1055,6 +1159,7 @@ class SlateBuilder:
             bool(eligibility.get(scene_id, {}).get("eligible", False))
             and not (source_lane == "best_bets" and scene_id in direct_plays)
             and not (source_lane == "revisit" and scene_id in unrecovered_direct_plays)
+            and (scene_filter is None or scene_filter(scene_id))
         )
 
     def _save_prepared_slate(self, slate: Slate) -> None:

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -712,6 +712,11 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
                 context=args.get("context") if isinstance(args.get("context"), dict) else None,
                 exclude_scene_ids={str(value) for value in excluded},
                 exploration=float(args.get("exploration") or 0),
+                include_tags=_string_list(args.get("include_tags")),
+                exclude_tags=_string_list(args.get("exclude_tags")),
+                performer_ids=_string_list(args.get("performer_ids")),
+                studio_ids=_string_list(args.get("studio_ids")),
+                gender=str(args.get("gender") or ""),
             )
         if operation == "get_score_review":
             config = api.config()["config"]

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -513,22 +513,12 @@
 .curator-sentiment-like             { --sc: #6b8e23; border-color: var(--sc); }
 .curator-sentiment-love             { --sc: #198754; border-color: var(--sc); }
 
-.curator-sentiment-never.curator-sentiment-active,
-.curator-sentiment-danger.curator-sentiment-active,
-.curator-sentiment-warning.curator-sentiment-active,
-.curator-sentiment-neutral.curator-sentiment-active,
-.curator-sentiment-like.curator-sentiment-active,
-.curator-sentiment-love.curator-sentiment-active {
-  background: var(--sc);
-  border-color: var(--sc);
-  color: #fff;
-}
-
-/* Sentiment slider: the 5-point spectrum from curator-sentiment-danger to
-   -love. The wrapping label carries the current tier's className (reusing
-   the --sc custom property declared above) so the thumb inherits the right
-   color; when the tier classes above are used here, their border-color
-   assignment is a harmless no-op since this wrapper draws no border. */
+/* Sentiment slider: a single 6-stop track, "Never" at position 0 then the
+   5-point spectrum from curator-sentiment-danger to -love. The wrapping
+   label carries the current tier's className (reusing the --sc custom
+   property declared above) so the thumb inherits the right color; when the
+   tier classes above are used here, their border-color assignment is a
+   harmless no-op since this wrapper draws no border. */
 .curator-sentiment-range-wrap {
   align-items: center;
   display: flex;
@@ -544,15 +534,31 @@
   min-width: 5.5rem;
 }
 
+.curator-sentiment-track {
+  flex: 1 1 auto;
+  min-width: 4rem;
+  position: relative;
+}
+
+.curator-sentiment-divider {
+  background: var(--curator-card-border-strong);
+  bottom: 0;
+  left: 10%;
+  position: absolute;
+  top: 0;
+  transform: translateX(-1px);
+  width: 2px;
+}
+
 .curator-sentiment-range {
   appearance: none;
   -webkit-appearance: none;
-  background: linear-gradient(90deg, #dc3545, #fd7e14, #6c757d, #6b8e23, #198754);
+  background: linear-gradient(90deg, #212529, #212529 10%, #dc3545 12%, #fd7e14, #6c757d, #6b8e23, #198754);
   border-radius: var(--curator-radius-lg);
-  flex: 1 1 auto;
+  display: block;
   height: 0.35rem;
-  min-width: 4rem;
   outline: none;
+  width: 100%;
 }
 
 .curator-sentiment-range::-webkit-slider-thumb {
@@ -591,7 +597,7 @@
   min-width: 4rem;
 }
 
-.curator-sentiment-compact .curator-sentiment-range {
+.curator-sentiment-compact .curator-sentiment-track {
   min-width: 3rem;
 }
 

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -730,6 +730,15 @@
   display: block;
 }
 
+.curator-taste-item strong a {
+  color: var(--curator-text);
+  text-decoration: none;
+}
+
+.curator-taste-item strong a:hover {
+  text-decoration: underline;
+}
+
 .curator-taste-item .badge {
   margin-left: 0.5rem;
 }
@@ -811,13 +820,20 @@
 .curator-sentiment-like             { --sc: #6b8e23; border-color: var(--sc); }
 .curator-sentiment-love             { --sc: #198754; border-color: var(--sc); }
 
-/* Taste Profile's belief badge ("I think you like/dislike this" / "I'm
-   unsure") reuses these same tier classes for their --sc value instead of
-   Bootstrap's one-size-fits-all badge-info cyan, which gave "like" and
-   "dislike" (the one signal worth scanning 949 rows for) identical color. */
+/* Taste Profile's belief badge ("I think you slightly/strongly like/
+   dislike this" / "I'm unsure") reuses these same tier classes for their
+   --sc value instead of Bootstrap's one-size-fits-all badge-info cyan,
+   which gave every tier identical color. All 5 sentiment tiers are listed
+   (not just love/danger/neutral) since the badge text is now the specific
+   nearest tier, not a plain like/dislike binary — warning/like badges were
+   only getting the tier's border-color (from the button-oriented rule
+   above) without this rule's tinted background/text, reading as half-
+   colored next to the fully-colored strong tiers. */
 .badge.curator-sentiment-love,
-.badge.curator-sentiment-danger,
-.badge.curator-sentiment-neutral {
+.badge.curator-sentiment-like,
+.badge.curator-sentiment-neutral,
+.badge.curator-sentiment-warning,
+.badge.curator-sentiment-danger {
   background: color-mix(in srgb, var(--sc) 18%, transparent);
   border: 1px solid var(--sc);
   color: var(--sc);

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -158,13 +158,25 @@
   color: var(--curator-text);
   font-family: var(--curator-font-ui);
   box-sizing: border-box;
-  margin: 0 auto;
-  max-width: 112rem;
+  /* Stash's own route wrapper (.main.container-fluid, outside anything
+     this stylesheet controls) carries a fixed 15px horizontal gutter with
+     a transparent background — Stash's real page background (a different
+     blue-grey, not --curator-bg) was showing through that gutter on every
+     side, most visibly on narrow/mobile widths where 15px is a much
+     bigger fraction of the screen. Same root cause as min-height above
+     (Stash's chrome bleeding through where this page doesn't reach), just
+     the horizontal axis instead of vertical — extend past the gutter with
+     matching negative margin, matched by extra inline padding so the
+     visible content inset is unchanged.
+  */
+  margin: 0 auto 0;
+  margin-inline: -15px;
+  max-width: calc(112rem + 30px);
   min-height: 100vh;
   min-width: 0;
   overflow-x: clip;
-  padding: 0.55rem 1.25rem 2rem;
-  width: 100%;
+  padding: 0.55rem calc(1.25rem + 15px) 2rem;
+  width: calc(100% + 30px);
 }
 
 /* Bootstrap's stock .alert-* colors (35 call sites across every screen —
@@ -267,7 +279,7 @@
 
 .curator-tagline,
 .curator-feedback small {
-  color: var(--text-muted, var(--curator-card-text-muted));
+  color: var(--curator-text-muted);
 }
 
 .curator-tagline {
@@ -277,7 +289,7 @@
 
 .curator-view-guidance {
   align-items: center;
-  color: var(--text-muted, var(--curator-card-text-muted));
+  color: var(--curator-text-muted);
   display: flex;
   font-size: 0.82rem;
   gap: 0.75rem;
@@ -423,7 +435,7 @@
 }
 
 .curator-lane-card-desc {
-  color: var(--text-muted, var(--curator-card-text-muted));
+  color: var(--curator-text-muted);
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
@@ -455,6 +467,15 @@
 @media (max-width: 860px) {
   .curator-manage-shell {
     grid-template-columns: 1fr;
+  }
+
+  /* Below 860px the shell drops to one column — list and detail stack in
+     document order instead of sitting side by side, so a sticky list would
+     freeze partway down the page and visually overlap the detail content
+     scrolling underneath it (the sticky fix only makes sense for the
+     two-column layout it was built for). */
+  .curator-manage-list {
+    position: static;
   }
 }
 
@@ -520,7 +541,7 @@
 }
 
 .curator-manage-item-desc {
-  color: var(--text-muted, var(--curator-card-text-muted));
+  color: var(--curator-text-muted);
   font-size: 0.72rem;
   line-height: 1.35;
 }
@@ -547,7 +568,7 @@
 }
 
 .curator-manage-detail-head p {
-  color: var(--text-muted, var(--curator-card-text-muted));
+  color: var(--curator-text-muted);
   font-size: 0.8rem;
   margin: 0;
 }
@@ -654,7 +675,7 @@
 .curator-taste-item {
   align-items: center;
   background: var(--curator-wash-raised);
-  border: 1px solid var(--curator-card-border);
+  border: 1px solid var(--curator-border);
   border-radius: var(--curator-radius);
   display: flex;
   flex-wrap: wrap;
@@ -673,7 +694,7 @@
 }
 
 .curator-taste-item small {
-  color: var(--text-muted, var(--curator-card-text-muted));
+  color: var(--curator-text-muted);
 }
 
 .curator-sentiment {
@@ -704,7 +725,7 @@
 .curator-sentiment-like,
 .curator-sentiment-love {
   background: transparent;
-  color: var(--curator-card-text);
+  color: var(--curator-text);
 }
 
 .curator-sentiment-never            { --sc: #212529; border-color: var(--sc); }
@@ -729,7 +750,7 @@
 }
 
 .curator-sentiment-current {
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
   flex: 0 0 auto;
   font-size: 0.72rem;
   min-width: 5.5rem;
@@ -742,7 +763,7 @@
 }
 
 .curator-sentiment-divider {
-  background: var(--curator-card-border-strong);
+  background: var(--curator-border-strong);
   bottom: 0;
   left: 10%;
   position: absolute;
@@ -754,7 +775,7 @@
 .curator-sentiment-range {
   appearance: none;
   -webkit-appearance: none;
-  background: var(--curator-card-border-strong);
+  background: var(--curator-border-strong);
   border-radius: var(--curator-radius-lg);
   display: block;
   height: 0.35rem;
@@ -766,7 +787,7 @@
   appearance: none;
   -webkit-appearance: none;
   background: var(--sc, var(--curator-accent));
-  border: 2px solid var(--curator-card-text);
+  border: 2px solid var(--curator-text);
   border-radius: 50%;
   cursor: pointer;
   height: 0.9rem;
@@ -775,7 +796,7 @@
 
 .curator-sentiment-range::-moz-range-thumb {
   background: var(--sc, var(--curator-accent));
-  border: 2px solid var(--curator-card-text);
+  border: 2px solid var(--curator-text);
   border-radius: 50%;
   cursor: pointer;
   height: 0.9rem;
@@ -801,6 +822,25 @@
 .curator-sentiment-compact .curator-sentiment-track {
   min-width: 3rem;
 }
+
+/* TagSentimentControl renders in two different contexts: standalone on the
+   page (Taste Profile, Curate's suggestion detail — the base rules above
+   are theme-responsive for these) and nested inside ExternalCard's "Rate
+   tags & terms" panel (.curator-external-tag-rating), which sits on the
+   deliberately-always-dark --curator-card-surface. Force the pinned-dark
+   card tokens back on specifically for that nested case so the slider
+   doesn't go light-on-dark there in light mode. */
+.curator-external-tag-rating .curator-sentiment-never,
+.curator-external-tag-rating .curator-sentiment-danger,
+.curator-external-tag-rating .curator-sentiment-warning,
+.curator-external-tag-rating .curator-sentiment-neutral,
+.curator-external-tag-rating .curator-sentiment-like,
+.curator-external-tag-rating .curator-sentiment-love { color: var(--curator-card-text); }
+.curator-external-tag-rating .curator-sentiment-current { color: var(--curator-card-text-muted); }
+.curator-external-tag-rating .curator-sentiment-divider { background: var(--curator-card-border-strong); }
+.curator-external-tag-rating .curator-sentiment-range { background: var(--curator-card-border-strong); }
+.curator-external-tag-rating .curator-sentiment-range::-webkit-slider-thumb { border-color: var(--curator-card-text); }
+.curator-external-tag-rating .curator-sentiment-range::-moz-range-thumb { border-color: var(--curator-card-text); }
 
 @media (max-width: 480px) {
   .curator-sentiment .btn-sm {
@@ -916,9 +956,9 @@
 
 .curator-profile-list button {
   background: var(--curator-wash-raised);
-  border: 1px solid var(--curator-card-border);
+  border: 1px solid var(--curator-border);
   border-radius: var(--curator-radius);
-  color: var(--curator-card-text);
+  color: var(--curator-text);
   display: flex;
   flex-direction: column;
   padding: 0.45rem 0.6rem;
@@ -931,7 +971,7 @@
 
 .curator-profile-list span,
 .curator-profile-list small {
-  color: var(--text-muted, var(--curator-card-text-muted));
+  color: var(--curator-text-muted);
 }
 
 .curator-profile-timeline {
@@ -1051,7 +1091,7 @@
   background: var(--curator-surface);
   border: 1px solid var(--curator-border-strong);
   border-radius: var(--curator-radius-sm);
-  color: var(--text-muted, var(--curator-card-text-muted));
+  color: var(--curator-text-muted);
   display: inline-flex;
   font-size: 0.78rem;
   gap: 0.4rem;
@@ -1081,7 +1121,7 @@
 }
 
 .curator-health-pulse-idle {
-  background: var(--curator-card-border-strong);
+  background: var(--curator-border-strong);
 }
 
 .curator-health-panel {
@@ -1106,7 +1146,7 @@
 }
 
 .curator-health-row b {
-  color: var(--curator-card-text);
+  color: var(--curator-text);
   font-weight: 600;
   text-align: right;
 }
@@ -1138,13 +1178,13 @@
 }
 
 .curator-task-progress-meta strong {
-  color: var(--text-muted, var(--curator-card-text-muted));
+  color: var(--curator-text-muted);
   font-size: 0.72rem;
 }
 
 .curator-task-progress-meta span,
 .curator-task-progress-detail {
-  color: var(--text-muted, var(--curator-card-text-muted));
+  color: var(--curator-text-muted);
   font-size: 0.65rem;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1152,7 +1192,7 @@
 }
 
 .curator-task-progress-track {
-  background: var(--curator-card-border-strong);
+  background: var(--curator-border-strong);
   border-radius: var(--curator-radius-lg);
   display: block;
   height: 0.32rem;
@@ -1272,7 +1312,7 @@
 }
 
 .curator-loading > span {
-  color: var(--text-muted, var(--curator-card-text-muted));
+  color: var(--curator-text-muted);
   display: block;
   margin-bottom: 0.4rem;
 }
@@ -1607,7 +1647,7 @@
 }
 
 .curator-shortlist-tab {
-  border-left: 1px solid var(--curator-card-border);
+  border-left: 1px solid var(--curator-border);
   margin-left: 0.35rem;
 }
 
@@ -2034,7 +2074,7 @@
   background: var(--curator-gradient-brand) !important;
   border-radius: var(--curator-radius-lg);
   box-shadow: var(--curator-shadow-glow);
-  color: var(--text-color, var(--curator-card-text));
+  color: var(--curator-text);
   height: 1.9rem;
   padding: 0;
   width: 1.9rem;
@@ -2073,7 +2113,7 @@
 
 @media (max-width: 75rem) {
   .curator-page {
-    padding-inline: 0.65rem;
+    padding-inline: calc(0.65rem + 15px);
   }
 
   /* The header stays one row (brand | scrollable nav | controls) at every
@@ -2315,12 +2355,12 @@
 
 .curator-curate-rated {
   font-size: 0.8rem;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
 }
 
 .curator-curate-policy {
   font-size: 0.8rem;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
   margin: 0.25rem 0 0;
 }
 
@@ -2333,17 +2373,17 @@
 .curator-curate-verdict {
   margin-top: 1rem;
   padding: 0.75rem;
-  border: 1px solid var(--curator-card-border);
+  border: 1px solid var(--curator-border);
   border-radius: var(--curator-radius-sm);
 }
 
 .curator-curate-verdict {
-  color: var(--curator-card-text);
+  color: var(--curator-text);
 }
 
 .curator-curate-verdict h3 {
   font-size: 1rem;
-  color: var(--curator-card-text);
+  color: var(--curator-text);
 }
 
 .curator-curate-started {
@@ -2384,7 +2424,7 @@
 }
 
 .curator-curate-suggestion-text small {
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
 }
 
 .curator-curate-custom {
@@ -2405,7 +2445,7 @@
 
 .curator-curate-meta {
   font-size: 0.8rem;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
   display: flex;
   gap: 0.5rem;
 }
@@ -2433,7 +2473,7 @@
 
 .curator-curate-details {
   font-size: 0.8rem;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
@@ -2475,9 +2515,9 @@
 .curator-pick-vs {
   align-items: center;
   background: var(--curator-surface-raised);
-  border: 1px solid var(--curator-card-border-strong);
+  border: 1px solid var(--curator-border-strong);
   border-radius: 50%;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
   display: flex;
   font-size: 0.7rem;
   font-weight: 700;
@@ -2509,7 +2549,7 @@
   flex-direction: column;
   gap: 0.25rem;
   background: transparent;
-  border: 2px solid var(--curator-card-border);
+  border: 2px solid var(--curator-border);
   border-radius: var(--curator-radius-sm);
   padding: 0;
   overflow: hidden;
@@ -2533,7 +2573,7 @@
   flex-wrap: wrap;
   gap: 0.25rem;
   font-size: 0.75rem;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
   padding: 0 0.4rem;
 }
 
@@ -2543,7 +2583,7 @@
 
 .curator-pick-tally {
   font-size: 0.85rem;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
 }
 
 .curator-pick-controls {
@@ -2558,7 +2598,7 @@
   gap: 0.25rem;
   margin-right: 0.75rem;
   padding-right: 0.75rem;
-  border-right: 1px solid var(--curator-card-border);
+  border-right: 1px solid var(--curator-border);
 }
 
 .curator-pick-answer-group {
@@ -2574,7 +2614,7 @@
 }
 
 .curator-pick-verdict-card {
-  border: 1px solid var(--curator-card-border);
+  border: 1px solid var(--curator-border);
   border-radius: var(--curator-radius-sm);
   padding: 0.35rem;
   display: flex;
@@ -2584,7 +2624,7 @@
 
 .curator-pick-verdict-label {
   font-size: 0.8rem;
-  color: var(--curator-card-text);
+  color: var(--curator-text);
 }
 
 .curator-pick-verdict-track {
@@ -2601,11 +2641,11 @@
 
 .curator-pick-verdict-count {
   font-size: 0.7rem;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
 }
 
 .curator-pick-title {
-  color: var(--curator-card-text);
+  color: var(--curator-text);
 }
 
 .curator-pick-performers {
@@ -2618,7 +2658,7 @@
 
 .curator-pick-details {
   font-size: 0.78rem;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -2654,7 +2694,7 @@
   height: 3.5rem;
   object-fit: cover;
   border-radius: var(--curator-radius-sm);
-  border: 1px solid var(--curator-card-border-strong);
+  border: 1px solid var(--curator-border-strong);
   flex-shrink: 0;
 }
 
@@ -2667,13 +2707,13 @@
 
 .curator-pick-verdict-summary {
   font-size: 0.85rem;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
   margin: 0.25rem 0 0.5rem;
 }
 
 .curator-pick-verdict-note {
   font-size: 0.8rem;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
   margin-top: 0.5rem;
 }
 
@@ -2696,7 +2736,7 @@
 
 .curator-pick-verdict-headline {
   font-size: 1rem;
-  color: var(--curator-card-text);
+  color: var(--curator-text);
   font-weight: 600;
   margin: 0 0 0.6rem;
 }
@@ -2717,7 +2757,7 @@
 
 .curator-pick-verdict-row-label {
   font-size: 0.85rem;
-  color: var(--curator-card-text);
+  color: var(--curator-text);
 }
 
 .curator-pick-verdict-row .curator-pick-verdict-count {
@@ -2751,7 +2791,7 @@
 .curator-curate-nudge-body p {
   margin: 0.15rem 0 0;
   font-size: 0.85rem;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
 }
 
 /* ── Impact report (verdict) ────────────────────────────────────────────── */
@@ -2759,7 +2799,7 @@
 .curator-impact {
   margin-top: 1.25rem;
   padding-top: 1rem;
-  border-top: 1px solid var(--curator-card-border);
+  border-top: 1px solid var(--curator-border);
 }
 
 .curator-impact-heading {
@@ -2769,7 +2809,7 @@
 
 .curator-impact-ago {
   font-size: 0.8rem;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
   margin: 0 0 0.75rem;
 }
 
@@ -2783,7 +2823,7 @@
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
   margin-bottom: 0.4rem;
 }
 
@@ -2823,7 +2863,7 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border: 1px solid var(--curator-card-border);
+  border: 1px solid var(--curator-border);
   border-radius: var(--curator-radius-sm);
   padding: 0.35rem;
   color: inherit;
@@ -2831,7 +2871,7 @@
 }
 
 .curator-impact-scene:hover {
-  border-color: var(--curator-card-border-strong);
+  border-color: var(--curator-border-strong);
   background: var(--curator-wash-raised);
 }
 
@@ -2851,7 +2891,7 @@
 
 .curator-impact-scene-title {
   font-size: 0.8rem;
-  color: var(--curator-card-text);
+  color: var(--curator-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2859,7 +2899,7 @@
 
 .curator-impact-scene-meta {
   font-size: 0.68rem;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2869,7 +2909,7 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border: 1px solid var(--curator-card-border);
+  border: 1px solid var(--curator-border);
   border-radius: var(--curator-radius-sm);
   padding: 0.3rem 0.45rem;
   color: inherit;
@@ -2877,7 +2917,7 @@
 }
 
 .curator-impact-person:hover {
-  border-color: var(--curator-card-border-strong);
+  border-color: var(--curator-border-strong);
   background: var(--curator-wash-raised);
 }
 
@@ -2894,7 +2934,7 @@
   flex: 1;
   min-width: 0;
   font-size: 0.8rem;
-  color: var(--curator-card-text);
+  color: var(--curator-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2904,7 +2944,7 @@
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  border: 1px solid var(--curator-card-border);
+  border: 1px solid var(--curator-border);
   border-radius: var(--curator-radius-lg);
   padding: 0.15rem 0.5rem;
   color: inherit;
@@ -2913,13 +2953,13 @@
 }
 
 .curator-impact-tag:hover {
-  border-color: var(--curator-card-border-strong);
+  border-color: var(--curator-border-strong);
   background: var(--curator-wash-raised);
 }
 
 .curator-impact-tag-name {
   font-size: 0.78rem;
-  color: var(--curator-card-text);
+  color: var(--curator-text);
 }
 
 .curator-impact-delta {
@@ -2939,7 +2979,7 @@
 
 .curator-impact-scene-why {
   font-size: 0.68rem;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2955,7 +2995,7 @@
   align-self: flex-start;
   background: transparent;
   border: none;
-  color: var(--curator-card-text-muted);
+  color: var(--curator-text-muted);
   cursor: pointer;
   font-size: 0.85rem;
   padding: 0.2rem 0.3rem;
@@ -2964,6 +3004,6 @@
 }
 
 .curator-curate-nudge-dismiss:hover {
-  color: var(--curator-card-text);
+  color: var(--curator-text);
   background: var(--curator-wash-raised);
 }

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -552,6 +552,74 @@
   margin: 0;
 }
 
+/* Record list (Backups, Feedback history) — was a plain <table>, replaced
+   with the mockup's icon+title+meta row pattern (.record-row). */
+.curator-record-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.curator-record-row {
+  align-items: center;
+  border-bottom: 1px solid var(--curator-border);
+  display: flex;
+  gap: 0.7rem;
+  padding: 0.65rem 0.1rem;
+}
+
+.curator-record-row:last-child {
+  border-bottom: 0;
+}
+
+.curator-record-icon {
+  align-items: center;
+  background: var(--curator-surface-raised);
+  border-radius: var(--curator-radius-sm);
+  color: var(--curator-text-muted);
+  display: inline-flex;
+  flex: none;
+  height: 1.9rem;
+  justify-content: center;
+  width: 1.9rem;
+}
+
+.curator-record-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.curator-record-title {
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.curator-record-meta {
+  color: var(--curator-text-muted);
+  font-size: 0.72rem;
+  margin-top: 0.1rem;
+}
+
+.curator-record-row .btn {
+  color: var(--curator-accent);
+  flex: none;
+  font-weight: 700;
+}
+
+.curator-record-row .curator-record-destructive {
+  color: #e0645c;
+}
+
+.curator-feedback-row {
+  align-items: flex-start;
+}
+
+.curator-feedback-correction {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
 .curator-profiling {
   margin-top: 1rem;
 }

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -235,6 +235,7 @@
 }
 
 .curator-view-copy h1 {
+  color: var(--curator-text);
   font-size: 1.5rem;
   margin: 0 0 0.2rem;
 }
@@ -916,10 +917,16 @@
 }
 
 .curator-health-panel {
+  background: var(--curator-surface);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius);
+  box-shadow: var(--curator-shadow-lg);
+  color: var(--curator-text);
   display: flex;
   flex-direction: column;
-  gap: 0.3rem;
+  gap: 0.45rem;
   min-width: 14rem;
+  padding: 0.75rem 0.85rem;
 }
 
 .curator-health-row {
@@ -1043,9 +1050,15 @@
 }
 
 .curator-header-message {
+  background: var(--curator-surface);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius-sm);
+  color: var(--curator-text-muted);
+  font-size: 0.78rem;
   grid-column: 1 / -1;
   margin: 0;
   order: 3;
+  padding: 0.35rem 0.6rem;
 }
 
 .curator-setup-checklist {

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -1884,35 +1884,12 @@
     padding-inline: 0.65rem;
   }
 
-  .curator-header {
-    grid-template-columns: 1fr;
-  }
-
-  .curator-navigation {
-    grid-column: 1;
-    grid-row: auto;
-  }
-
-  .curator-tabs {
-    flex-basis: 100%;
-    overflow-x: auto;
-    width: 100%;
-  }
-
+  /* The header stays one row (brand | scrollable nav | controls) at every
+     width, matching the mockup's primary-nav — it never drops to a second
+     row of its own. .curator-tabs already scrolls horizontally (see base
+     rule above), so the middle grid column just shrinks instead. */
   .curator-tabs .nav-link {
     white-space: nowrap;
-  }
-
-  .curator-controls {
-    align-items: center;
-    flex-direction: row;
-    flex-wrap: wrap;
-    height: auto;
-    grid-column: 1;
-    grid-row: auto;
-    justify-content: flex-start;
-    margin-left: 0;
-    width: 100%;
   }
 
   .curator-grid {
@@ -1932,6 +1909,31 @@
   .curator-view-guidance {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  /* Brand shrinks to its icon mark only, freeing width for the scrollable
+     nav strip next to it — same trade the mockup makes at this width. */
+  .curator-tagline {
+    display: none;
+  }
+
+  .curator-header h1 {
+    font-size: 1.1rem;
+  }
+
+  /* .curator-navigation's base rule (grid-column: 1 / -1; grid-row: 2)
+     always gives the nav its own full-width row below brand+controls —
+     fine with room to spare, but on a phone the mockup instead keeps nav
+     inline as a horizontally-scrollable strip between the brand and
+     controls, one row total. Only override the placement at this width;
+     the desktop two-row header is intentional and unaffected. */
+  .curator-navigation {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .curator-health-pill-label {
+    display: none;
   }
 
   .curator-tabs .nav-link {

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -6,10 +6,12 @@
    :root, matching the app it's embedded in and every existing install);
    light is an explicit opt-in via [data-theme="light"], flipped by the
    header's theme toggle rather than by OS preference.
-   --curator-card-* is a separate, always-dark family: it backs Stash's
-   native scene-card/performer-card internals, whose title and detail text
-   is hardcoded light-on-dark with no theming hook, so those surfaces stay
-   pinned dark in both themes. */
+   --curator-card-* backs Stash's native scene-card/performer-card
+   internals and curator's own adjacent card-body content — its colors
+   *are* theme-responsive (see the light block below), Stash's own
+   hardcoded card CSS just isn't, so that half needs direct selector
+   overrides instead of a token swap (see the .curator-card .card rules
+   below the light-theme block). */
 :root {
   --curator-bg: #101216;
   --curator-surface: #182126;
@@ -64,6 +66,11 @@
   --curator-bg: #f1f2f5;
   --curator-surface: #ffffff;
   --curator-surface-raised: #e9ebef;
+  --curator-card-surface: #ffffff;
+  --curator-card-border: rgba(16, 18, 22, 0.14);
+  --curator-card-border-strong: rgba(16, 18, 22, 0.24);
+  --curator-card-text: #16181c;
+  --curator-card-text-muted: #5b6470;
   --curator-border: rgba(16, 18, 22, 0.14);
   --curator-border-strong: rgba(16, 18, 22, 0.24);
   --curator-text: #16181c;
@@ -86,6 +93,33 @@
   --curator-hue-revisit: #7452ad;
   --curator-hue-expand: #b83f4c;
   --curator-hue-prune: #7c838c;
+}
+
+/* Stash's own native scene/performer card (Api.components.SceneCard,
+   rendered inside .curator-card) was previously assumed un-themeable and
+   pinned dark to match — but its background/title-color rules are plain
+   CSS, not inline styles, so they're just as overridable as the
+   Bootstrap .btn-primary/.alert-* overrides above. Restyle the card body
+   (thumbnail + its own overlays are left alone — badges over arbitrary
+   video/image content should stay legible regardless of page theme, the
+   same convention this component already uses) for light mode. .text-muted
+   carries !important in Stash's own stylesheet, so the override needs it
+   too, not just higher specificity. */
+.curator-page[data-theme="light"] .curator-card .card {
+  background-color: var(--curator-surface);
+  color: var(--curator-text);
+}
+
+.curator-page[data-theme="light"] .curator-card .card-section-title {
+  color: var(--curator-text);
+}
+
+.curator-page[data-theme="light"] .curator-card .text-muted {
+  color: var(--curator-text-muted) !important;
+}
+
+.curator-page[data-theme="light"] .curator-card hr {
+  border-color: var(--curator-border);
 }
 
 /* Bare <button>s don't inherit color from their parent by default in most

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -183,6 +183,11 @@
   min-width: 0;
 }
 
+.curator-view-copy h1 {
+  font-size: 1.5rem;
+  margin: 0 0 0.2rem;
+}
+
 .curator-view-copy p {
   display: inline;
   margin: 0;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -55,7 +55,14 @@
   --curator-shadow-lg: 0 0.4rem 1rem var(--curator-shadow-color);
   --curator-shadow-glow: 0 0.25rem 0.8rem var(--curator-glow-color);
 
-  --curator-gradient-brand: linear-gradient(145deg, var(--curator-accent), var(--curator-hue-similar));
+  /* Deliberately NOT var(--curator-accent)/var(--curator-hue-similar) — those
+     vivid hues measure 3.41:1/1.99:1 against white text, both failing WCAG
+     AA (4.5:1). These are the same darker blue/teal already used as the
+     *light*-theme accent/hue-similar values (6.21:1/4.63:1) — reused here
+     as literals so dark theme's primary-button gradient passes AA too,
+     without darkening the vivid accent everywhere else it's used
+     (lane-hue dots, focus rings, etc). */
+  --curator-gradient-brand: linear-gradient(145deg, #1d5fb8, #1f7f96);
 
   --curator-font-display: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
   --curator-font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -894,6 +894,10 @@
   overflow-wrap: anywhere;
 }
 
+.curator-mono {
+  font-family: var(--curator-font-mono);
+}
+
 .curator-diagnostics-preview {
   max-height: 60vh;
   overflow: auto;
@@ -910,9 +914,12 @@
 .curator-lane-hunt { --lane-color: var(--curator-hue-hunt); }
 .curator-lane-prune { --lane-color: var(--curator-hue-prune); }
 
-.curator-tabs .nav-link svg,
-.curator-source-badge svg {
+.curator-tabs .nav-link svg {
   color: var(--lane-color);
+}
+
+.curator-source-badge svg {
+  color: #fff;
 }
 
 .curator-controls {
@@ -1210,19 +1217,11 @@
   transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
-.curator-source-best_bets { --lane-color: var(--curator-hue-best_bets); }
-.curator-source-revisit { --lane-color: var(--curator-hue-revisit); }
-.curator-source-discover { --lane-color: var(--curator-hue-discover); }
-.curator-source-adventure { --lane-color: var(--curator-hue-adventure); }
-
 .curator-card:hover {
   border-color: var(--curator-card-border-strong);
   box-shadow: var(--curator-card-shadow-lg);
 }
 
-.curator-card[class*="curator-source-"] {
-  border-left: 3px solid var(--lane-color, var(--curator-card-border));
-}
 
 .curator-similar { --surface-color: var(--curator-hue-similar); }
 .curator-expand { --surface-color: var(--curator-hue-expand); }
@@ -1300,16 +1299,21 @@
 
 .curator-source-badge {
   align-items: center;
-  background: var(--curator-overlay);
+  background: var(--lane-color, var(--curator-overlay));
   border-radius: var(--curator-radius-sm);
+  color: #fff;
   display: inline-flex;
-  font-size: 0.9rem;
-  height: 1.8rem;
+  font-size: 0.65rem;
+  font-weight: 700;
+  gap: 0.3rem;
+  height: auto;
   justify-content: center;
   left: 0.5rem;
+  letter-spacing: 0.03em;
+  padding: 0.3rem 0.5rem;
   position: absolute;
   top: 0.5rem;
-  width: 1.8rem;
+  width: auto;
   z-index: 3;
 }
 
@@ -2080,6 +2084,35 @@
 }
 
 /* ---- Score bar ---- */
+.curator-match-row {
+  align-items: center;
+  display: flex;
+  flex: 1 1 100%;
+  gap: 0.5rem;
+  margin: 0.3rem 0;
+  width: 100%;
+}
+
+.curator-match-label {
+  color: var(--curator-card-text-muted);
+  flex: 0 0 auto;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.curator-match-value {
+  color: var(--curator-card-text-muted);
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+}
+
+.curator-match-row .curator-score-bar {
+  flex: 1 1 auto;
+  margin: 0;
+}
+
 .curator-score-bar {
   display: flex;
   height: 6px;
@@ -2093,9 +2126,7 @@
   height: 100%;
   transition: width 0.3s ease;
 }
-.curator-score-sim { background: #4a90d9; }
 .curator-score-app { background: #50b86c; }
-.curator-score-mh { background: #9b59b6; }
 
 /* ---- Relationship chips ---- */
 .curator-chips {
@@ -2582,23 +2613,6 @@
 .curator-pick-flag:hover {
   background: rgba(216, 162, 74, 0.18);
   border-color: var(--curator-accent-secondary);
-}
-
-.curator-pick-hint {
-  font-size: 0.72rem;
-  color: var(--curator-card-text-muted);
-  margin-left: 0.4rem;
-}
-
-.curator-pick-hint kbd {
-  font-family: var(--curator-font-mono);
-  font-size: 0.68rem;
-  background: var(--curator-wash-raised);
-  border: 1px solid var(--curator-card-border-strong);
-  border-bottom-width: 2px;
-  border-radius: var(--curator-radius-sm);
-  padding: 0.05rem 0.3rem;
-  color: var(--curator-card-text-muted);
 }
 
 .curator-pick-verdict-headline {

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -199,81 +199,193 @@
   display: none;
 }
 
+/* Collapsed primary nav (GH #150 Package 3): Recommendations / Curate /
+   Similar / Expand / Hunt / Manage — replaces the old flat PRIMARY_NAV_ITEMS
+   tab row (which surfaced all 5 recommendation lanes as separate top-level
+   tabs) and the <details> maintenance flyout below it. No full-pill (999px)
+   shapes, per the #150 design brief — rounded rectangles only. */
 .curator-tabs .nav-link {
   align-items: center;
+  border-radius: var(--curator-radius-sm);
   color: inherit;
   display: inline-flex;
   gap: 0.4rem;
   height: 100%;
   padding: 0.55rem 0.7rem;
+  transition: background 0.15s ease, color 0.15s ease;
 }
 
-.curator-tabs .curator-lane-similar {
-  border-left: 1px solid var(--curator-card-border);
-  margin-left: 0.45rem;
+.curator-tabs .nav-link.active {
+  background: var(--curator-gradient-brand);
+  color: #fff;
 }
 
-.curator-tabs .curator-lane-prune {
-  border-left: 1px solid var(--curator-card-border);
-  margin-left: 0.45rem;
+/* ---------- lane switcher (Recommendations tab, inside the page body) ---------- */
+.curator-lane-switcher {
+  display: flex;
+  gap: 0.6rem;
+  margin: 0.35rem 0 0.8rem;
+  overflow-x: auto;
+  padding-bottom: 0.2rem;
 }
 
-.curator-maintenance-menu {
-  flex: 0 0 auto;
-  position: relative;
-}
-
-.curator-maintenance-menu summary {
-  align-items: center;
-  color: inherit;
+.curator-lane-card {
+  --lc: var(--curator-accent);
+  background: var(--curator-surface);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius);
   cursor: pointer;
   display: flex;
-  gap: 0.4rem;
-  height: 3rem;
-  list-style: none;
-  padding: 0.55rem 0.7rem;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.55rem 0.65rem 0.6rem;
+  text-align: left;
+  width: 13rem;
 }
 
-.curator-maintenance-menu summary::-webkit-details-marker {
-  display: none;
+.curator-lane-card:hover {
+  border-color: var(--curator-border-strong);
 }
 
-.curator-maintenance-menu summary.active,
-.curator-maintenance-menu[open] summary {
-  background: var(--curator-card-border);
-  color: var(--curator-card-text);
+.curator-lane-card[aria-pressed="true"] {
+  background: color-mix(in srgb, var(--lc) 12%, var(--curator-surface));
+  border-color: var(--lc);
 }
 
-.curator-maintenance-items {
-  background: var(--curator-surface-raised);
-  border: 1px solid var(--curator-border);
-  border-radius: var(--curator-radius-sm);
-  box-shadow: var(--curator-shadow-lg);
-  display: grid;
-  min-width: 13rem;
-  padding: 0.35rem;
-  position: absolute;
-  right: 0;
-  top: calc(100% + 0.25rem);
-  z-index: 20;
-}
-
-.curator-maintenance-items button {
+.curator-lane-card-icon {
   align-items: center;
+  background: color-mix(in srgb, var(--lc) 18%, var(--curator-surface));
+  border-radius: var(--curator-radius-sm);
+  color: var(--lc);
+  display: inline-flex;
+  height: 1.6rem;
+  justify-content: center;
+  width: 1.6rem;
+}
+
+.curator-lane-card-name {
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.curator-lane-card-desc {
+  color: var(--text-muted, var(--curator-card-text-muted));
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  font-size: 0.72rem;
+  line-height: 1.35;
+  overflow: hidden;
+}
+
+/* ---------- Manage shell (two-pane list + detail) ---------- */
+.curator-manage-shell {
+  align-items: start;
+  display: grid;
+  gap: 1.1rem;
+  grid-template-columns: 16rem 1fr;
+  margin-top: 0.5rem;
+}
+
+@media (max-width: 860px) {
+  .curator-manage-shell {
+    grid-template-columns: 1fr;
+  }
+}
+
+.curator-manage-list {
+  background: var(--curator-surface);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius);
+  overflow: hidden;
+}
+
+.curator-manage-item {
+  align-items: flex-start;
   background: transparent;
   border: 0;
-  border-radius: var(--curator-radius-sm);
-  color: var(--curator-text);
+  border-bottom: 1px solid var(--curator-border);
+  cursor: pointer;
   display: flex;
-  gap: 0.5rem;
-  padding: 0.5rem 0.65rem;
+  gap: 0.55rem;
+  padding: 0.65rem 0.7rem;
   text-align: left;
+  width: 100%;
 }
 
-.curator-maintenance-items button:hover,
-.curator-maintenance-items button:focus,
-.curator-maintenance-items button.active {
-  background: var(--curator-border-strong);
+.curator-manage-item:last-child {
+  border-bottom: 0;
+}
+
+.curator-manage-item:hover {
+  background: var(--curator-wash-raised);
+}
+
+.curator-manage-item[aria-current="page"] {
+  background: var(--curator-accent);
+  color: #fff;
+}
+
+.curator-manage-item-icon {
+  align-items: center;
+  background: var(--curator-wash-raised);
+  border-radius: var(--curator-radius-sm);
+  display: inline-flex;
+  flex: none;
+  height: 1.7rem;
+  justify-content: center;
+  width: 1.7rem;
+}
+
+.curator-manage-item[aria-current="page"] .curator-manage-item-icon {
+  background: rgba(255, 255, 255, 0.2);
+  color: #fff;
+}
+
+.curator-manage-item-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.curator-manage-item-title {
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.curator-manage-item-desc {
+  color: var(--text-muted, var(--curator-card-text-muted));
+  font-size: 0.72rem;
+  line-height: 1.35;
+}
+
+.curator-manage-item[aria-current="page"] .curator-manage-item-desc {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.curator-manage-detail {
+  background: var(--curator-surface);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius);
+  min-width: 0;
+  padding: 1rem 1.1rem;
+}
+
+.curator-manage-detail-head {
+  margin-bottom: 0.9rem;
+}
+
+.curator-manage-detail-head h2 {
+  font-size: 1.15rem;
+  margin: 0 0 0.2rem;
+}
+
+.curator-manage-detail-head p {
+  color: var(--text-muted, var(--curator-card-text-muted));
+  font-size: 0.8rem;
+  margin: 0;
 }
 
 .curator-profiling {
@@ -677,19 +789,66 @@
   font-size: 0.78rem;
 }
 
-.curator-status {
+/* Health/sync status popover (GH #150 Package 3): replaces the always-open
+   row of inline status spans with a single compact pill; full detail lives
+   in the HoverPopover content instead. */
+.curator-health-pill {
   align-items: center;
+  background: var(--curator-surface);
+  border: 1px solid var(--curator-border-strong);
+  border-radius: var(--curator-radius-sm);
   color: var(--text-muted, var(--curator-card-text-muted));
-  display: flex;
-  flex-wrap: wrap;
+  display: inline-flex;
   font-size: 0.78rem;
-  gap: 0.25rem 0.65rem;
+  gap: 0.4rem;
+  padding: 0.3rem 0.7rem 0.3rem 0.55rem;
 }
 
-.curator-status > span:not(.curator-task-indicator) {
+.curator-health-pulse {
+  border-radius: 50%;
+  display: inline-block;
+  height: 0.45rem;
+  width: 0.45rem;
+}
+
+.curator-health-pulse-ready {
+  background: #4fb08a;
+  box-shadow: 0 0 0 0.18rem rgba(79, 176, 138, 0.18);
+}
+
+.curator-health-pulse-running {
+  background: var(--curator-accent);
+  box-shadow: 0 0 0 0.18rem var(--curator-glow-color);
+}
+
+.curator-health-pulse-failed {
+  background: #e0645c;
+  box-shadow: 0 0 0 0.18rem rgba(224, 100, 92, 0.2);
+}
+
+.curator-health-pulse-idle {
+  background: var(--curator-card-border-strong);
+}
+
+.curator-health-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  min-width: 14rem;
+}
+
+.curator-health-row {
   align-items: center;
-  display: inline-flex;
-  gap: 0.25rem;
+  display: flex;
+  font-size: 0.75rem;
+  gap: 0.6rem;
+  justify-content: space-between;
+}
+
+.curator-health-row b {
+  color: var(--curator-card-text);
+  font-weight: 600;
+  text-align: right;
 }
 
 .curator-task-indicator {
@@ -1263,6 +1422,21 @@
   padding: 0.55rem;
 }
 
+.curator-filter-count {
+  align-items: center;
+  background: var(--curator-accent);
+  border-radius: var(--curator-radius-sm);
+  color: #fff;
+  display: inline-flex;
+  font-size: 0.68rem;
+  font-weight: 700;
+  height: 1rem;
+  justify-content: center;
+  margin-left: 0.3rem;
+  min-width: 1rem;
+  padding: 0 0.25rem;
+}
+
 .curator-saved-filters {
   align-items: center;
   display: flex;
@@ -1698,18 +1872,12 @@
     display: none;
   }
 
-  .curator-maintenance-menu summary {
-    justify-content: center;
-    padding-inline: 0.45rem;
+  .curator-lane-switcher {
+    gap: 0.4rem;
   }
 
-  .curator-maintenance-menu summary span {
-    display: none;
-  }
-
-  .curator-tabs .curator-lane-similar,
-  .curator-tabs .curator-lane-prune {
-    margin-left: 0;
+  .curator-lane-card {
+    width: 10.5rem;
   }
 
   .curator-similar-search form {

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -1098,6 +1098,10 @@
 }
 
 .curator-mono {
+  /* Bootstrap's default <code> color (#e83e8c, alarm-colored magenta,
+     meant for inline code snippets) reads as an error/warning for what's
+     just an informational file path here. */
+  color: var(--curator-text-muted);
   font-family: var(--curator-font-mono);
 }
 

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -1,3 +1,76 @@
+/* Design tokens (GH #150 Package 1). Stash's own chrome (navbar, page
+   background) has no light theme at all — confirmed against the running
+   app, not just its default SCSS — so a viewer's prefers-color-scheme
+   can't be used to drive Curator's palette: a light-calibrated accent
+   sitting in Stash's permanently-dark navbar just reads as washed out,
+   not "light mode". Every token below is therefore the dark column from
+   the #150 design brief, applied unconditionally. The light column
+   (bg #f1f2f5, accent #1d5fb8, secondary #a56f2a, lane hues at the same
+   62/46 S/L recipe as the dark set below) is preserved here for whenever
+   Stash ships a real light theme:
+     --curator-bg: #f1f2f5; --curator-accent: #1d5fb8;
+     --curator-accent-secondary: #a56f2a;
+     --curator-hue-for_you: #2d6cbe; --curator-hue-similar: #2d9cbe;
+     --curator-hue-best_bets: #2dbe8e; --curator-hue-hunt: #2dbe45;
+     --curator-hue-discover: #be9c2d; --curator-hue-adventure: #be5d2d;
+     --curator-hue-revisit: #692dbe; --curator-hue-expand: #be2d75;
+     --curator-hue-prune: #be392d; --curator-surface: #ffffff;
+     --curator-surface-raised: #e9ebef; --curator-border: rgba(16,18,22,.14);
+     --curator-border-strong: rgba(16,18,22,.24); --curator-text: #16181c;
+     --curator-text-muted: #5b6470; --curator-wash-raised: rgba(16,18,22,.04);
+     --curator-wash-recessed: rgba(16,18,22,.06);
+     --curator-shadow-color: rgba(16,18,22,.16);
+     --curator-glow-color: rgba(29,95,184,.22).
+   --curator-card-* stays a separate, identical-today family: it backs
+   Stash's native scene-card/performer-card internals, whose title and
+   detail text is hardcoded light-on-dark with no theming hook, so those
+   surfaces must stay pinned dark even after Stash grows a light theme. */
+:root {
+  --curator-bg: #101216;
+  --curator-surface: #182126;
+  --curator-surface-raised: #252a30;
+  --curator-card-surface: #182126;
+  --curator-card-border: rgba(255, 255, 255, 0.12);
+  --curator-card-border-strong: rgba(255, 255, 255, 0.22);
+  --curator-card-shadow: 0 0.25rem 0.8rem rgba(0, 0, 0, 0.2);
+  --curator-card-shadow-lg: 0 0.4rem 1rem rgba(0, 0, 0, 0.3);
+  --curator-card-text: #f8f9fa;
+  --curator-card-text-muted: #adb5bd;
+  --curator-border: rgba(255, 255, 255, 0.14);
+  --curator-border-strong: rgba(255, 255, 255, 0.22);
+  --curator-text: #f8f9fa;
+  --curator-text-muted: #adb5bd;
+  --curator-overlay: rgba(16, 18, 22, 0.82);
+  --curator-wash-raised: rgba(255, 255, 255, 0.04);
+  --curator-wash-recessed: rgba(0, 0, 0, 0.18);
+  --curator-shadow-color: rgba(0, 0, 0, 0.3);
+  --curator-glow-color: rgba(51, 154, 240, 0.24);
+
+  --curator-accent: #4f8ce0;
+  --curator-accent-secondary: #d59a52;
+
+  --curator-hue-for_you: #6e9cd8;
+  --curator-hue-similar: #6ec0d8;
+  --curator-hue-best_bets: #6ed8b5;
+  --curator-hue-hunt: #6ed880;
+  --curator-hue-discover: #d8c06e;
+  --curator-hue-adventure: #d8916e;
+  --curator-hue-revisit: #9a6ed8;
+  --curator-hue-expand: #d86ea3;
+  --curator-hue-prune: #d8776e;
+
+  --curator-radius-sm: 4px;
+  --curator-radius: 7px;
+  --curator-radius-lg: 10px;
+
+  --curator-shadow-sm: 0 0.2rem 0.55rem var(--curator-shadow-color);
+  --curator-shadow-md: 0 0.25rem 0.8rem var(--curator-shadow-color);
+  --curator-shadow-lg: 0 0.4rem 1rem var(--curator-shadow-color);
+  --curator-shadow-glow: 0 0.25rem 0.8rem var(--curator-glow-color);
+
+  --curator-gradient-brand: linear-gradient(145deg, var(--curator-accent), var(--curator-hue-similar));
+}
+
 .curator-page {
   box-sizing: border-box;
   margin: 0 auto;
@@ -44,9 +117,9 @@
 
 .curator-brand-mark {
   align-items: center;
-  background: linear-gradient(145deg, #339af0, #7950f2);
-  border-radius: 0.65rem;
-  box-shadow: 0 0.25rem 0.8rem rgba(51, 154, 240, 0.22);
+  background: var(--curator-gradient-brand);
+  border-radius: var(--curator-radius-lg);
+  box-shadow: var(--curator-shadow-glow);
   display: inline-flex;
   font-size: 1.15rem;
   height: 2.35rem;
@@ -62,7 +135,7 @@
 
 .curator-tagline,
 .curator-feedback small {
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted, var(--curator-card-text-muted));
 }
 
 .curator-tagline {
@@ -72,7 +145,7 @@
 
 .curator-view-guidance {
   align-items: center;
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted, var(--curator-card-text-muted));
   display: flex;
   font-size: 0.82rem;
   gap: 0.75rem;
@@ -136,12 +209,12 @@
 }
 
 .curator-tabs .curator-lane-similar {
-  border-left: 1px solid rgba(255, 255, 255, 0.18);
+  border-left: 1px solid var(--curator-card-border);
   margin-left: 0.45rem;
 }
 
 .curator-tabs .curator-lane-prune {
-  border-left: 1px solid rgba(255, 255, 255, 0.18);
+  border-left: 1px solid var(--curator-card-border);
   margin-left: 0.45rem;
 }
 
@@ -167,15 +240,15 @@
 
 .curator-maintenance-menu summary.active,
 .curator-maintenance-menu[open] summary {
-  background: rgba(255, 255, 255, 0.08);
-  color: #fff;
+  background: var(--curator-card-border);
+  color: var(--curator-card-text);
 }
 
 .curator-maintenance-items {
-  background: #343a40;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 0.3rem;
-  box-shadow: 0 0.35rem 1rem rgba(0, 0, 0, 0.35);
+  background: var(--curator-surface-raised);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius-sm);
+  box-shadow: var(--curator-shadow-lg);
   display: grid;
   min-width: 13rem;
   padding: 0.35rem;
@@ -189,8 +262,8 @@
   align-items: center;
   background: transparent;
   border: 0;
-  border-radius: 0.2rem;
-  color: #fff;
+  border-radius: var(--curator-radius-sm);
+  color: var(--curator-text);
   display: flex;
   gap: 0.5rem;
   padding: 0.5rem 0.65rem;
@@ -200,7 +273,7 @@
 .curator-maintenance-items button:hover,
 .curator-maintenance-items button:focus,
 .curator-maintenance-items button.active {
-  background: rgba(255, 255, 255, 0.12);
+  background: var(--curator-border-strong);
 }
 
 .curator-profiling {
@@ -236,9 +309,9 @@
 
 .curator-taste-item {
   align-items: center;
-  background: rgba(255, 255, 255, 0.04);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 0.4rem;
+  background: var(--curator-wash-raised);
+  border: 1px solid var(--curator-card-border);
+  border-radius: var(--curator-radius);
   display: flex;
   flex-wrap: wrap;
   gap: 0.6rem 1rem;
@@ -256,7 +329,7 @@
 }
 
 .curator-taste-item small {
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted, var(--curator-card-text-muted));
 }
 
 .curator-sentiment {
@@ -287,7 +360,7 @@
 .curator-sentiment-like,
 .curator-sentiment-love {
   background: transparent;
-  color: #fff;
+  color: var(--curator-card-text);
 }
 
 .curator-sentiment-never            { --sc: #212529; border-color: var(--sc); }
@@ -341,7 +414,7 @@
 }
 
 .curator-external-tag-rating {
-  background: rgba(255, 255, 255, 0.04);
+  background: var(--curator-wash-raised);
   display: grid;
   gap: 0.5rem;
   padding: 0.6rem;
@@ -364,7 +437,7 @@
 }
 
 .curator-external-tag-name {
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted, var(--curator-card-text-muted));
   flex: 1 1 8rem;
   font-size: 0.82rem;
   min-width: 0;
@@ -387,7 +460,7 @@
 }
 
 .curator-rating-section-title {
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted, var(--curator-card-text-muted));
   font-size: 0.75rem;
   font-weight: 600;
 }
@@ -421,10 +494,10 @@
 }
 
 .curator-profile-list button {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 0.35rem;
-  color: inherit;
+  background: var(--curator-wash-raised);
+  border: 1px solid var(--curator-card-border);
+  border-radius: var(--curator-radius);
+  color: var(--curator-card-text);
   display: flex;
   flex-direction: column;
   padding: 0.45rem 0.6rem;
@@ -437,12 +510,12 @@
 
 .curator-profile-list span,
 .curator-profile-list small {
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted, var(--curator-card-text-muted));
 }
 
 .curator-profile-timeline {
-  background: rgba(0, 0, 0, 0.18);
-  border-radius: 0.35rem;
+  background: var(--curator-wash-recessed);
+  border-radius: var(--curator-radius);
   display: flex;
   flex-direction: column;
   gap: 2px;
@@ -485,15 +558,15 @@
   white-space: pre-wrap;
 }
 
-.curator-lane-for_you { --lane-color: #4dabf7; }
-.curator-lane-best_bets { --lane-color: #20c997; }
-.curator-lane-revisit { --lane-color: #b197fc; }
-.curator-lane-discover { --lane-color: #ffd43b; }
-.curator-lane-adventure { --lane-color: #ff922b; }
-.curator-lane-similar { --lane-color: #66d9e8; }
-.curator-lane-expand { --lane-color: #f783ac; }
-.curator-lane-hunt { --lane-color: #69db7c; }
-.curator-lane-prune { --lane-color: #ff6b6b; }
+.curator-lane-for_you { --lane-color: var(--curator-hue-for_you); }
+.curator-lane-best_bets { --lane-color: var(--curator-hue-best_bets); }
+.curator-lane-revisit { --lane-color: var(--curator-hue-revisit); }
+.curator-lane-discover { --lane-color: var(--curator-hue-discover); }
+.curator-lane-adventure { --lane-color: var(--curator-hue-adventure); }
+.curator-lane-similar { --lane-color: var(--curator-hue-similar); }
+.curator-lane-expand { --lane-color: var(--curator-hue-expand); }
+.curator-lane-hunt { --lane-color: var(--curator-hue-hunt); }
+.curator-lane-prune { --lane-color: var(--curator-hue-prune); }
 
 .curator-tabs .nav-link svg,
 .curator-source-badge svg {
@@ -535,7 +608,7 @@
 
 .curator-status {
   align-items: center;
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted, var(--curator-card-text-muted));
   display: flex;
   flex-wrap: wrap;
   font-size: 0.78rem;
@@ -575,13 +648,13 @@
 }
 
 .curator-task-progress-meta strong {
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted, var(--curator-card-text-muted));
   font-size: 0.72rem;
 }
 
 .curator-task-progress-meta span,
 .curator-task-progress-detail {
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted, var(--curator-card-text-muted));
   font-size: 0.65rem;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -589,8 +662,8 @@
 }
 
 .curator-task-progress-track {
-  background: rgba(255, 255, 255, 0.14);
-  border-radius: 999px;
+  background: var(--curator-card-border-strong);
+  border-radius: var(--curator-radius-lg);
   display: block;
   height: 0.32rem;
   overflow: hidden;
@@ -703,7 +776,7 @@
 }
 
 .curator-loading > span {
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted, var(--curator-card-text-muted));
   display: block;
   margin-bottom: 0.4rem;
 }
@@ -715,10 +788,10 @@
 }
 
 .curator-card {
-  background: #182126;
-  border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 0.55rem;
-  box-shadow: 0 0.25rem 0.8rem rgba(0, 0, 0, 0.2);
+  background: var(--curator-card-surface);
+  border: 1px solid var(--curator-card-border);
+  border-radius: var(--curator-radius-lg);
+  box-shadow: var(--curator-card-shadow);
   display: flex;
   flex-direction: column;
   min-width: 0;
@@ -727,24 +800,24 @@
   transition: border-color 120ms ease, box-shadow 120ms ease;
 }
 
-.curator-source-best_bets { --lane-color: #20c997; }
-.curator-source-revisit { --lane-color: #b197fc; }
-.curator-source-discover { --lane-color: #ffd43b; }
-.curator-source-adventure { --lane-color: #ff922b; }
+.curator-source-best_bets { --lane-color: var(--curator-hue-best_bets); }
+.curator-source-revisit { --lane-color: var(--curator-hue-revisit); }
+.curator-source-discover { --lane-color: var(--curator-hue-discover); }
+.curator-source-adventure { --lane-color: var(--curator-hue-adventure); }
 
 .curator-card:hover {
-  border-color: rgba(255, 255, 255, 0.22);
-  box-shadow: 0 0.4rem 1rem rgba(0, 0, 0, 0.3);
+  border-color: var(--curator-card-border-strong);
+  box-shadow: var(--curator-card-shadow-lg);
 }
 
 .curator-card[class*="curator-source-"] {
-  border-left: 3px solid var(--lane-color, rgba(255, 255, 255, 0.12));
+  border-left: 3px solid var(--lane-color, var(--curator-card-border));
 }
 
-.curator-similar { --surface-color: #4dabf7; }
-.curator-expand { --surface-color: #ff922b; }
-.curator-hunt { --surface-color: #69db7c; }
-.curator-prune-page { --surface-color: #fa5252; }
+.curator-similar { --surface-color: var(--curator-hue-similar); }
+.curator-expand { --surface-color: var(--curator-hue-expand); }
+.curator-hunt { --surface-color: var(--curator-hue-hunt); }
+.curator-prune-page { --surface-color: var(--curator-hue-prune); }
 
 .curator-similar .curator-card,
 .curator-expand .curator-card,
@@ -754,7 +827,7 @@
 }
 
 .curator-card > .scene-card {
-  background: #182126;
+  background: var(--curator-card-surface);
   border: 0;
   border-radius: 0;
   margin: 0;
@@ -763,7 +836,7 @@
 }
 
 .curator-card .card-section {
-  background: #182126;
+  background: var(--curator-card-surface);
   padding-bottom: 0.35rem;
 }
 
@@ -807,8 +880,8 @@
 }
 
 .curator-card-body {
-  background: #182126;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  background: var(--curator-card-surface);
+  border-top: 1px solid var(--curator-card-border);
   display: flex;
   flex-direction: column;
   flex: 1;
@@ -817,8 +890,8 @@
 
 .curator-source-badge {
   align-items: center;
-  background: rgba(18, 24, 28, 0.88);
-  border-radius: 0.3rem;
+  background: var(--curator-overlay);
+  border-radius: var(--curator-radius-sm);
   display: inline-flex;
   font-size: 0.9rem;
   height: 1.8rem;
@@ -873,7 +946,7 @@
 }
 
 .curator-score-children {
-  border-left: 1px solid rgba(255, 255, 255, 0.18);
+  border-left: 1px solid var(--curator-card-border);
   margin-left: 0.4rem;
   padding-left: 0.7rem;
 }
@@ -898,7 +971,7 @@
 .curator-feedback-button.btn-link {
   background: transparent;
   border: 0;
-  color: #fff;
+  color: var(--curator-card-text);
   padding: 0.2rem 0.35rem;
 }
 
@@ -939,7 +1012,7 @@
 }
 
 .curator-similar-feedback {
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  border-top: 1px solid var(--curator-card-border);
   padding: 0.35rem 0.7rem;
 }
 
@@ -982,7 +1055,7 @@
 }
 
 .curator-prune-actions {
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  border-top: 1px solid var(--curator-card-border);
   padding: 0.4rem 0.7rem;
 }
 
@@ -1010,9 +1083,9 @@
 
 .curator-toolbar-select {
   align-items: center;
-  background: #343a40;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 0.25rem;
+  background: var(--curator-surface-raised);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius-sm);
   display: inline-flex;
   gap: 0.35rem;
   height: 2.15rem;
@@ -1024,7 +1097,7 @@
 .curator-toolbar-select select {
   background: transparent;
   border: 0;
-  color: #fff;
+  color: var(--curator-text);
   height: 100%;
   padding: 0 1.7rem 0 0.15rem;
   width: auto;
@@ -1036,12 +1109,12 @@
 }
 
 .curator-toolbar-select option {
-  background: #343a40;
-  color: #fff;
+  background: var(--curator-surface-raised);
+  color: var(--curator-text);
 }
 
 .curator-shortlist-tab {
-  border-left: 1px solid rgba(255, 255, 255, 0.2);
+  border-left: 1px solid var(--curator-card-border);
   margin-left: 0.35rem;
 }
 
@@ -1074,9 +1147,9 @@
 
 .curator-token-input {
   align-items: center;
-  background: #344550;
-  border: 1px solid #53636e;
-  border-radius: 0.25rem;
+  background: var(--curator-surface-raised);
+  border: 1px solid var(--curator-border-strong);
+  border-radius: var(--curator-radius-sm);
   display: flex;
   flex-wrap: wrap;
   gap: 0.2rem;
@@ -1085,10 +1158,10 @@
 }
 
 .curator-token-input button {
-  background: #495057;
+  background: var(--curator-surface-raised);
   border: 0;
-  border-radius: 0.2rem;
-  color: #fff;
+  border-radius: var(--curator-radius-sm);
+  color: var(--curator-text);
   font-size: 0.75rem;
 }
 
@@ -1098,24 +1171,24 @@
   flex: 1 1 5rem;
   min-width: 4rem;
   outline: 0;
-  color: #fff;
+  color: var(--curator-text);
 }
 
 .curator-page .form-control,
 .curator-saved-filters input:not([type="checkbox"]),
 .curator-saved-filters select {
-  background: #344550;
-  border: 1px solid #53636e;
-  color: #fff;
+  background: var(--curator-surface-raised);
+  border: 1px solid var(--curator-border-strong);
+  color: var(--curator-text);
 }
 
 .curator-page input::placeholder {
-  color: #aab4ba;
+  color: var(--curator-text-muted);
 }
 
 .curator-filter-panel {
-  background: rgba(0, 0, 0, 0.1);
-  border-radius: 0.35rem;
+  background: var(--curator-wash-recessed);
+  border-radius: var(--curator-radius);
   padding: 0.55rem;
 }
 
@@ -1129,7 +1202,7 @@
 
 .curator-saved-filters input:not([type="checkbox"]),
 .curator-saved-filters select {
-  border-radius: 0.25rem;
+  border-radius: var(--curator-radius-sm);
   min-height: 2rem;
   padding: 0.25rem 0.45rem;
 }
@@ -1141,9 +1214,9 @@
 }
 
 .curator-token-options {
-  background: #252a30;
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  border-radius: 0.25rem;
+  background: var(--curator-surface-raised);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius-sm);
   display: flex;
   flex-direction: column;
   left: 0;
@@ -1158,13 +1231,13 @@
 .curator-token-options button {
   background: transparent;
   border: 0;
-  color: inherit;
+  color: var(--curator-text);
   padding: 0.35rem 0.5rem;
   text-align: left;
 }
 
 .curator-token-options button:hover {
-  background: #343a40;
+  background: var(--curator-surface-raised);
 }
 
 .curator-match-filter input {
@@ -1228,10 +1301,10 @@
 
 .curator-source-reference {
   align-items: center;
-  background: #182126;
-  border: 1px solid rgba(255, 255, 255, 0.14);
-  border-radius: 0.45rem;
-  color: inherit;
+  background: var(--curator-surface);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius);
+  color: var(--curator-text);
   display: flex;
   gap: 0.7rem;
   min-height: 4.5rem;
@@ -1241,8 +1314,8 @@
 }
 
 .curator-source-reference:hover {
-  border-color: #339af0;
-  color: inherit;
+  border-color: var(--curator-accent);
+  color: var(--curator-text);
   text-decoration: none;
 }
 
@@ -1273,13 +1346,13 @@
 }
 
 .curator-source-reference small {
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted, var(--curator-text-muted));
   margin-top: 0.2rem;
 }
 
 .curator-external-thumbnail {
   aspect-ratio: 16 / 9;
-  background: rgba(0, 0, 0, 0.18);
+  background: var(--curator-wash-recessed);
   overflow: hidden;
   position: relative;
 }
@@ -1312,7 +1385,7 @@
 
 .curator-external-details,
 .curator-external-card .scene-card__details {
-  color: var(--text-muted, #adb5bd);
+  color: var(--text-muted, var(--curator-card-text-muted));
   display: flex;
   justify-content: space-between;
   min-height: 1.4rem;
@@ -1323,7 +1396,7 @@
 }
 
 .curator-external-card .card-section a {
-  color: inherit;
+  color: var(--curator-card-text);
   text-decoration: none;
 }
 
@@ -1407,7 +1480,7 @@
 
 .curator-wildcard-badge {
   background: #e67700;
-  border-radius: 0.3rem;
+  border-radius: var(--curator-radius-sm);
   font-size: 0.75rem;
   padding: 0.25rem 0.4rem;
   position: absolute;
@@ -1418,7 +1491,7 @@
 
 .curator-phash-badge {
   background: #2b8a3e;
-  border-radius: 0.3rem;
+  border-radius: var(--curator-radius-sm);
   font-size: 0.75rem;
   left: 0.5rem;
   padding: 0.25rem 0.4rem;
@@ -1429,7 +1502,7 @@
 
 .curator-local-badge {
   background: #2b8a3e;
-  border-radius: 0.3rem;
+  border-radius: var(--curator-radius-sm);
   font-size: 0.7rem;
   left: 0.5rem;
   padding: 0.2rem 0.35rem;
@@ -1450,17 +1523,17 @@
 }
 
 .curator-context-link {
-  background: linear-gradient(145deg, #339af0, #7950f2) !important;
-  border-radius: 0.5rem;
-  box-shadow: 0 0.2rem 0.55rem rgba(51, 154, 240, 0.24);
-  color: var(--text-color, #f8f9fa);
+  background: var(--curator-gradient-brand) !important;
+  border-radius: var(--curator-radius-lg);
+  box-shadow: var(--curator-shadow-glow);
+  color: var(--text-color, var(--curator-card-text));
   height: 1.9rem;
   padding: 0;
   width: 1.9rem;
 }
 
 .curator-card > .performer-card {
-  background: #182126;
+  background: var(--curator-card-surface);
   border: 0;
   margin: 0;
   padding-bottom: 0;
@@ -1476,9 +1549,9 @@
 }
 
 .curator-more-menu {
-  background: #252a30;
-  border-radius: 0.3rem;
-  box-shadow: 0 0.4rem 1rem rgba(0, 0, 0, 0.4);
+  background: var(--curator-surface-raised);
+  border-radius: var(--curator-radius-sm);
+  box-shadow: var(--curator-shadow-lg);
   bottom: calc(100% + 0.35rem);
   display: flex;
   flex-direction: column;
@@ -1577,7 +1650,7 @@
 .curator-score-bar {
   display: flex;
   height: 6px;
-  border-radius: 3px;
+  border-radius: var(--curator-radius-sm);
   overflow: hidden;
   margin: 6px 0 4px;
   background: var(--bs-secondary-bg, #333);
@@ -1601,7 +1674,7 @@
   display: inline-block;
   font-size: 0.75rem;
   padding: 2px 7px;
-  border-radius: 10px;
+  border-radius: var(--curator-radius-lg);
   white-space: nowrap;
 }
 .curator-chip-same_performer      { background: #4a90d9; color: #fff; }
@@ -1699,12 +1772,12 @@
 
 .curator-curate-rated {
   font-size: 0.8rem;
-  color: #6c757d;
+  color: var(--curator-card-text-muted);
 }
 
 .curator-curate-policy {
   font-size: 0.8rem;
-  color: #6c757d;
+  color: var(--curator-card-text-muted);
   margin: 0.25rem 0 0;
 }
 
@@ -1717,17 +1790,17 @@
 .curator-curate-verdict {
   margin-top: 1rem;
   padding: 0.75rem;
-  border: 1px solid #444;
-  border-radius: 0.25rem;
+  border: 1px solid var(--curator-card-border);
+  border-radius: var(--curator-radius-sm);
 }
 
 .curator-curate-verdict {
-  color: #e6e6e6;
+  color: var(--curator-card-text);
 }
 
 .curator-curate-verdict h3 {
   font-size: 1rem;
-  color: #fff;
+  color: var(--curator-card-text);
 }
 
 .curator-curate-started h3 {
@@ -1760,7 +1833,7 @@
 }
 
 .curator-curate-suggestion-text small {
-  color: #6c757d;
+  color: var(--curator-card-text-muted);
 }
 
 .curator-curate-custom {
@@ -1781,7 +1854,7 @@
 
 .curator-curate-meta {
   font-size: 0.8rem;
-  color: #6c757d;
+  color: var(--curator-card-text-muted);
   display: flex;
   gap: 0.5rem;
 }
@@ -1803,13 +1876,13 @@
 .curator-curate-preview {
   position: absolute;
   inset: 0;
-  background: #000;
+  background: var(--curator-wash-recessed);
   cursor: pointer;
 }
 
 .curator-curate-details {
   font-size: 0.8rem;
-  color: #6c757d;
+  color: var(--curator-card-text-muted);
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
@@ -1864,8 +1937,8 @@
   flex-direction: column;
   gap: 0.25rem;
   background: transparent;
-  border: 2px solid #444;
-  border-radius: 0.25rem;
+  border: 2px solid var(--curator-card-border);
+  border-radius: var(--curator-radius-sm);
   padding: 0;
   overflow: hidden;
   text-align: left;
@@ -1888,7 +1961,7 @@
   flex-wrap: wrap;
   gap: 0.25rem;
   font-size: 0.75rem;
-  color: #6c757d;
+  color: var(--curator-card-text-muted);
   padding: 0 0.4rem;
 }
 
@@ -1898,7 +1971,7 @@
 
 .curator-pick-tally {
   font-size: 0.85rem;
-  color: #6c757d;
+  color: var(--curator-card-text-muted);
 }
 
 .curator-pick-controls {
@@ -1913,7 +1986,7 @@
   gap: 0.25rem;
   margin-right: 0.75rem;
   padding-right: 0.75rem;
-  border-right: 1px solid #444;
+  border-right: 1px solid var(--curator-card-border);
 }
 
 .curator-pick-answer-group {
@@ -1929,8 +2002,8 @@
 }
 
 .curator-pick-verdict-card {
-  border: 1px solid #444;
-  border-radius: 0.25rem;
+  border: 1px solid var(--curator-card-border);
+  border-radius: var(--curator-radius-sm);
   padding: 0.35rem;
   display: flex;
   flex-direction: column;
@@ -1939,13 +2012,13 @@
 
 .curator-pick-verdict-label {
   font-size: 0.8rem;
-  color: #e6e6e6;
+  color: var(--curator-card-text);
 }
 
 .curator-pick-verdict-track {
   height: 0.4rem;
-  background: #333;
-  border-radius: 2px;
+  background: var(--curator-wash-recessed);
+  border-radius: var(--curator-radius-sm);
   overflow: hidden;
 }
 
@@ -1956,7 +2029,7 @@
 
 .curator-pick-verdict-count {
   font-size: 0.7rem;
-  color: #b8b8b8;
+  color: var(--curator-card-text-muted);
 }
 
 .curator-pick-media {
@@ -1969,12 +2042,12 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  background: #000;
+  background: var(--curator-wash-recessed);
   pointer-events: none;
 }
 
 .curator-pick-title {
-  color: #fff;
+  color: var(--curator-card-text);
 }
 
 .curator-pick-performers {
@@ -1987,7 +2060,7 @@
 
 .curator-pick-details {
   font-size: 0.78rem;
-  color: #c8c8c8;
+  color: var(--curator-card-text-muted);
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
@@ -2006,7 +2079,7 @@
   height: 100%;
   object-fit: cover;
   display: block;
-  background: #000;
+  background: var(--curator-wash-recessed);
   pointer-events: none;
 }
 
@@ -2021,8 +2094,8 @@
   width: 5rem;
   height: 3.5rem;
   object-fit: cover;
-  border-radius: 3px;
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  border-radius: var(--curator-radius-sm);
+  border: 1px solid var(--curator-card-border-strong);
   flex-shrink: 0;
 }
 
@@ -2035,53 +2108,53 @@
 
 .curator-pick-verdict-summary {
   font-size: 0.85rem;
-  color: #b8b8b8;
+  color: var(--curator-card-text-muted);
   margin: 0.25rem 0 0.5rem;
 }
 
 .curator-pick-verdict-note {
   font-size: 0.8rem;
-  color: #b8b8b8;
+  color: var(--curator-card-text-muted);
   margin-top: 0.5rem;
 }
 
 .curator-pick-flag {
   font-size: 0.7rem;
-  color: #e0b25a;
+  color: var(--curator-accent-secondary);
   cursor: pointer;
   align-self: flex-start;
   margin: 0.2rem 0.4rem 0.3rem;
   border: 1px solid rgba(216, 162, 74, 0.45);
-  border-radius: 3px;
+  border-radius: var(--curator-radius-sm);
   padding: 0.1rem 0.35rem;
   background: rgba(216, 162, 74, 0.08);
 }
 
 .curator-pick-flag:hover {
   background: rgba(216, 162, 74, 0.18);
-  border-color: #d8a24a;
+  border-color: var(--curator-accent-secondary);
 }
 
 .curator-pick-hint {
   font-size: 0.72rem;
-  color: #8a8a8a;
+  color: var(--curator-card-text-muted);
   margin-left: 0.4rem;
 }
 
 .curator-pick-hint kbd {
   font-family: inherit;
   font-size: 0.68rem;
-  background: #2c2c2c;
-  border: 1px solid #555;
+  background: var(--curator-wash-raised);
+  border: 1px solid var(--curator-card-border-strong);
   border-bottom-width: 2px;
-  border-radius: 3px;
+  border-radius: var(--curator-radius-sm);
   padding: 0.05rem 0.3rem;
-  color: #d0d0d0;
+  color: var(--curator-card-text-muted);
 }
 
 .curator-pick-verdict-headline {
   font-size: 1rem;
-  color: #fff;
+  color: var(--curator-card-text);
   font-weight: 600;
   margin: 0 0 0.6rem;
 }
@@ -2102,7 +2175,7 @@
 
 .curator-pick-verdict-row-label {
   font-size: 0.85rem;
-  color: #e6e6e6;
+  color: var(--curator-card-text);
 }
 
 .curator-pick-verdict-row .curator-pick-verdict-count {
@@ -2116,7 +2189,7 @@
   align-items: center;
   gap: 0.75rem;
   border: 1px solid rgba(107, 142, 35, 0.5);
-  border-radius: 0.4rem;
+  border-radius: var(--curator-radius);
   background: linear-gradient(90deg, rgba(107, 142, 35, 0.12), rgba(107, 142, 35, 0.03));
   padding: 0.75rem 1rem;
   margin-bottom: 1rem;
@@ -2136,7 +2209,7 @@
 .curator-curate-nudge-body p {
   margin: 0.15rem 0 0;
   font-size: 0.85rem;
-  color: #b8b8b8;
+  color: var(--curator-card-text-muted);
 }
 
 /* ── Impact report (verdict) ────────────────────────────────────────────── */
@@ -2144,7 +2217,7 @@
 .curator-impact {
   margin-top: 1.25rem;
   padding-top: 1rem;
-  border-top: 1px solid #444;
+  border-top: 1px solid var(--curator-card-border);
 }
 
 .curator-impact-heading {
@@ -2154,7 +2227,7 @@
 
 .curator-impact-ago {
   font-size: 0.8rem;
-  color: #8a8a8a;
+  color: var(--curator-card-text-muted);
   margin: 0 0 0.75rem;
 }
 
@@ -2168,7 +2241,7 @@
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  color: #8a8a8a;
+  color: var(--curator-card-text-muted);
   margin-bottom: 0.4rem;
 }
 
@@ -2208,25 +2281,25 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border: 1px solid #444;
-  border-radius: 0.3rem;
+  border: 1px solid var(--curator-card-border);
+  border-radius: var(--curator-radius-sm);
   padding: 0.35rem;
   color: inherit;
   text-decoration: none;
 }
 
 .curator-impact-scene:hover {
-  border-color: #666;
-  background: rgba(255, 255, 255, 0.03);
+  border-color: var(--curator-card-border-strong);
+  background: var(--curator-wash-raised);
 }
 
 .curator-impact-thumb {
   width: 3.2rem;
   height: 2rem;
   object-fit: cover;
-  border-radius: 3px;
+  border-radius: var(--curator-radius-sm);
   flex-shrink: 0;
-  background: #111;
+  background: var(--curator-wash-recessed);
 }
 
 .curator-impact-scene-body {
@@ -2236,7 +2309,7 @@
 
 .curator-impact-scene-title {
   font-size: 0.8rem;
-  color: #e6e6e6;
+  color: var(--curator-card-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2244,7 +2317,7 @@
 
 .curator-impact-scene-meta {
   font-size: 0.68rem;
-  color: #8a8a8a;
+  color: var(--curator-card-text-muted);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2254,16 +2327,16 @@
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  border: 1px solid #444;
-  border-radius: 0.3rem;
+  border: 1px solid var(--curator-card-border);
+  border-radius: var(--curator-radius-sm);
   padding: 0.3rem 0.45rem;
   color: inherit;
   text-decoration: none;
 }
 
 .curator-impact-person:hover {
-  border-color: #666;
-  background: rgba(255, 255, 255, 0.03);
+  border-color: var(--curator-card-border-strong);
+  background: var(--curator-wash-raised);
 }
 
 .curator-impact-avatar {
@@ -2272,14 +2345,14 @@
   object-fit: cover;
   border-radius: 50%;
   flex-shrink: 0;
-  background: #111;
+  background: var(--curator-wash-recessed);
 }
 
 .curator-impact-person-name {
   flex: 1;
   min-width: 0;
   font-size: 0.8rem;
-  color: #e6e6e6;
+  color: var(--curator-card-text);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2289,8 +2362,8 @@
   display: flex;
   align-items: center;
   gap: 0.4rem;
-  border: 1px solid #444;
-  border-radius: 999px;
+  border: 1px solid var(--curator-card-border);
+  border-radius: var(--curator-radius-lg);
   padding: 0.15rem 0.5rem;
   color: inherit;
   text-decoration: none;
@@ -2298,13 +2371,13 @@
 }
 
 .curator-impact-tag:hover {
-  border-color: #666;
-  background: rgba(255, 255, 255, 0.03);
+  border-color: var(--curator-card-border-strong);
+  background: var(--curator-wash-raised);
 }
 
 .curator-impact-tag-name {
   font-size: 0.78rem;
-  color: #e6e6e6;
+  color: var(--curator-card-text);
 }
 
 .curator-impact-delta {
@@ -2324,7 +2397,7 @@
 
 .curator-impact-scene-why {
   font-size: 0.68rem;
-  color: #8a8a8a;
+  color: var(--curator-card-text-muted);
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2332,7 +2405,7 @@
 
 .curator-impact-weak {
   font-size: 0.75rem;
-  color: #b8985a;
+  color: var(--curator-accent-secondary);
   margin: 0 0 0.4rem;
 }
 
@@ -2340,15 +2413,15 @@
   align-self: flex-start;
   background: transparent;
   border: none;
-  color: #8a8a8a;
+  color: var(--curator-card-text-muted);
   cursor: pointer;
   font-size: 0.85rem;
   padding: 0.2rem 0.3rem;
   line-height: 1;
-  border-radius: 3px;
+  border-radius: var(--curator-radius-sm);
 }
 
 .curator-curate-nudge-dismiss:hover {
-  color: #e6e6e6;
-  background: rgba(255, 255, 255, 0.08);
+  color: var(--curator-card-text);
+  background: var(--curator-wash-raised);
 }

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -548,8 +548,14 @@
   background: var(--curator-wash-raised);
 }
 
+/* Literal, not var(--curator-accent) — same WCAG AA failure as the old
+   .btn-primary gradient (dark theme's vivid #4f8ce0 measures 3.41:1 against
+   white text, below 4.5:1). Light theme's --curator-accent is already this
+   exact literal (#1d5fb8, 6.21:1), so hardcoding it fixes dark theme
+   without touching the token other UI (lane-hue dots, focus rings) still
+   relies on being vivid. */
 .curator-manage-item[aria-current="page"] {
-  background: var(--curator-accent);
+  background: #1d5fb8;
   color: #fff;
 }
 
@@ -588,7 +594,9 @@
 }
 
 .curator-manage-item[aria-current="page"] .curator-manage-item-desc {
-  color: rgba(255, 255, 255, 0.78);
+  /* 0.78 measured 4.46:1 against the new #1d5fb8 background, just under
+     AA's 4.5:1 — bumped to clear it with a small margin. */
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .curator-manage-detail {
@@ -2515,11 +2523,22 @@
   border-radius: var(--curator-radius-lg);
   white-space: nowrap;
 }
-.curator-chip-same_performer      { background: #4a90d9; color: #fff; }
-.curator-chip-similar_performer   { background: #4a90d9aa; color: #fff; }
-.curator-chip-shared_content      { background: #50b86c; color: #fff; }
-.curator-chip-similar_structure   { background: #50b86caa; color: #fff; }
-.curator-chip-same_studio         { background: #e67e22; color: #fff; }
+/* Literal (not alpha-blended) colors, each independently measured against
+   white text — the previous versions used a base hue at full opacity for
+   "same_X" and the identical hue at ~67% alpha for "similar_X" to convey
+   "weaker match" via transparency. That let the "same_X" solids fail WCAG
+   AA outright (3.34:1/2.50:1/2.85:1 measured for blue/green/orange) and
+   made "similar_X" contrast depend on whatever's behind the chip (a card
+   surface that's white in light theme), which can't be guaranteed to pass
+   at all. Darker solids for "same_X", and a lighter-but-still-AA-passing
+   solid of the same hue for "similar_X" (instead of alpha) keep the same
+   visual distinction with contrast that holds regardless of backdrop.
+   multi_hop already passed (4.67:1) and is unchanged. */
+.curator-chip-same_performer      { background: #1d5fb8; color: #fff; }
+.curator-chip-similar_performer   { background: #316bb0; color: #fff; }
+.curator-chip-shared_content      { background: #1e7e34; color: #fff; }
+.curator-chip-similar_structure   { background: #278041; color: #fff; }
+.curator-chip-same_studio         { background: #a0530a; color: #fff; }
 .curator-chip-multi_hop           { background: #9b59b6; color: #fff; }
 .curator-chip-tags                { background: #555; color: #ddd; }
 

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -844,66 +844,140 @@
   width: 0.9rem;
 }
 
-/* Sentiment slider: a single 6-stop track, "Never" at position 0 then the
-   5-point spectrum from curator-sentiment-danger to -love. The wrapping
-   label carries the current tier's className (reusing the --sc custom
-   property declared above) so the thumb inherits the right color via the
-   shared .curator-range rules above; when the tier classes above are used
-   here, their border-color assignment is a harmless no-op since this
-   wrapper draws no border. */
+/* Sentiment slider (redesigned to match the GH #150 design mockup's
+   .rs-track/.rs-stop/.rs-thumb, which the original native-<input>-styled
+   version — round 15's specificity fix — never actually matched: that fix
+   made the native range render *something* coherent, but not the mockup's
+   compact fixed-width track with visible per-stop tick dots). The visible
+   rail (.curator-sentiment-rail/-stop/-thumb) is purely decorative; a fully
+   transparent native range input (.curator-sentiment-input) sits on top at
+   the same geometry, capturing clicks/drags/keyboard for free instead of
+   hand-rolling the mockup's manual pointer math. The wrapping label carries
+   the current tier's className (reusing the --sc custom property declared
+   above) so the active stop/thumb inherit the right color. */
 .curator-sentiment-range-wrap {
   align-items: center;
   display: flex;
-  flex: 1 1 auto;
-  gap: 0.4rem;
-  min-width: 6rem;
+  gap: 0.6rem;
 }
 
 .curator-sentiment-current {
-  color: var(--curator-text-muted);
+  color: var(--curator-text);
   flex: 0 0 auto;
-  font-size: 0.72rem;
-  min-width: 5.5rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  min-width: 5.2rem;
 }
+
+.curator-sentiment-never .curator-sentiment-current { color: #dc3545; }
 
 .curator-sentiment-track {
-  flex: 1 1 auto;
-  min-width: 4rem;
+  flex: 0 0 auto;
+  height: 1.2rem;
   position: relative;
+  width: 10rem;
 }
 
-.curator-sentiment-divider {
+.curator-sentiment-rail {
   background: var(--curator-border-strong);
-  bottom: 0;
-  left: 10%;
+  border-radius: 2px;
+  height: 4px;
+  left: 0;
   position: absolute;
-  top: 0;
-  transform: translateX(-1px);
-  width: 2px;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
 }
 
-.curator-sentiment-range {
+.curator-sentiment-stop {
+  background: var(--curator-border-strong);
+  border-radius: 50%;
+  height: 6px;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  transition: background 0.15s ease, transform 0.15s ease;
+  width: 6px;
+}
+
+.curator-sentiment-stop-active {
+  background: var(--sc, var(--curator-accent));
+  transform: translate(-50%, -50%) scale(1.15);
+}
+
+.curator-sentiment-stop-never {
+  background: color-mix(in srgb, #dc3545 55%, var(--curator-border-strong));
+  border-radius: 2px;
+  height: 8px;
+  width: 8px;
+}
+
+.curator-sentiment-stop-never.curator-sentiment-stop-active {
+  background: #dc3545;
+  transform: translate(-50%, -50%) scale(1.25);
+}
+
+.curator-sentiment-thumb {
+  background: var(--sc, var(--curator-accent));
+  border: 2px solid var(--curator-surface);
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px var(--sc, var(--curator-accent));
+  height: 14px;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  transition: left 0.18s cubic-bezier(0.34, 1.4, 0.64, 1);
+  width: 14px;
+}
+
+.curator-sentiment-thumb-unset {
+  opacity: 0.5;
+}
+
+.curator-sentiment-never .curator-sentiment-thumb {
+  background: #dc3545;
+  box-shadow: 0 0 0 1px #dc3545;
+}
+
+/* The model's own continuous estimate (Taste Profile only — see
+   TagSentimentControl's inferredValue prop), shown as a small hollow ring
+   distinct from the solid direct-rating thumb so the two can be compared
+   without the model's read silently overriding what the user set. */
+.curator-sentiment-model-dot {
+  background: var(--curator-surface);
+  border: 1.5px solid var(--curator-text-muted);
+  border-radius: 50%;
+  height: 7px;
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 7px;
+}
+
+.curator-sentiment-input {
+  appearance: none;
+  -webkit-appearance: none;
+  cursor: pointer;
+  height: 100%;
+  inset: 0;
+  margin: 0;
+  opacity: 0;
+  position: absolute;
   width: 100%;
 }
 
-.curator-sentiment-range-unset::-webkit-slider-thumb {
-  opacity: 0.45;
-}
-
-.curator-sentiment-range-unset::-moz-range-thumb {
-  opacity: 0.45;
-}
-
-.curator-sentiment-range-blocked {
-  opacity: 0.4;
-}
-
-.curator-sentiment-compact .curator-sentiment-range-wrap {
-  min-width: 4rem;
+/* The interactive input is fully transparent, so its own focus ring (which
+   would otherwise render invisibly along with the rest of it) needs to be
+   redirected onto the decorative thumb for keyboard users. The input has to
+   paint after (on top of) the rail to receive clicks, which rules out a
+   ~ sibling-combinator selector here (it only matches *later* siblings) —
+   :has() on the shared ancestor sidesteps the ordering requirement. */
+.curator-sentiment-track:has(.curator-sentiment-input:focus-visible) .curator-sentiment-thumb {
+  box-shadow: 0 0 0 1px var(--sc, var(--curator-accent)), 0 0 0 4px var(--curator-glow-color);
 }
 
 .curator-sentiment-compact .curator-sentiment-track {
-  min-width: 3rem;
+  width: 6rem;
 }
 
 /* TagSentimentControl renders in two different contexts: standalone on the
@@ -913,18 +987,11 @@
    deliberately-always-dark --curator-card-surface. Force the pinned-dark
    card tokens back on specifically for that nested case so the slider
    doesn't go light-on-dark there in light mode. */
-.curator-external-tag-rating .curator-sentiment-never,
-.curator-external-tag-rating .curator-sentiment-danger,
-.curator-external-tag-rating .curator-sentiment-warning,
-.curator-external-tag-rating .curator-sentiment-neutral,
-.curator-external-tag-rating .curator-sentiment-like,
-.curator-external-tag-rating .curator-sentiment-love { color: var(--curator-card-text); }
-.curator-external-tag-rating .curator-sentiment-current { color: var(--curator-card-text-muted); }
-.curator-external-tag-rating .curator-sentiment-divider { background: var(--curator-card-border-strong); }
-.curator-external-tag-rating .curator-sentiment-range::-webkit-slider-runnable-track { background: var(--curator-card-border-strong); }
-.curator-external-tag-rating .curator-sentiment-range::-moz-range-track { background: var(--curator-card-border-strong); }
-.curator-external-tag-rating .curator-sentiment-range::-webkit-slider-thumb { border-color: var(--curator-card-text); }
-.curator-external-tag-rating .curator-sentiment-range::-moz-range-thumb { border-color: var(--curator-card-text); }
+.curator-external-tag-rating .curator-sentiment-current { color: var(--curator-card-text); }
+.curator-external-tag-rating .curator-sentiment-rail { background: var(--curator-card-border-strong); }
+.curator-external-tag-rating .curator-sentiment-stop { background: var(--curator-card-border-strong); }
+.curator-external-tag-rating .curator-sentiment-thumb { border-color: var(--curator-card-surface); }
+.curator-external-tag-rating .curator-sentiment-model-dot { background: var(--curator-card-surface); border-color: var(--curator-card-text-muted); }
 
 @media (max-width: 480px) {
   .curator-sentiment .btn-sm {

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -220,6 +220,20 @@
   min-width: 0;
 }
 
+.curator-view-stats {
+  color: var(--curator-text);
+  display: block !important;
+  font-weight: 600;
+  margin-top: 0.3rem !important;
+}
+
+.curator-view-actions {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  gap: 0.5rem;
+}
+
 .curator-view-copy h1 {
   font-size: 1.5rem;
   margin: 0 0 0.2rem;
@@ -1912,13 +1926,18 @@
   }
 
   /* Brand shrinks to its icon mark only, freeing width for the scrollable
-     nav strip next to it — same trade the mockup makes at this width. */
-  .curator-tagline {
+     nav strip next to it — same trade the mockup makes at this width
+     (brand-word: none). Measured: without this, brand+controls alone ate
+     278px of a 390px viewport, leaving the nav ~22px — room for a sliver
+     of one pill, nothing scrollable in any useful sense. */
+  .curator-tagline,
+  .curator-header h1 {
     display: none;
   }
 
-  .curator-header h1 {
-    font-size: 1.1rem;
+  .curator-icon-button {
+    height: 1.6rem;
+    width: 1.6rem;
   }
 
   /* .curator-navigation's base rule (grid-column: 1 / -1; grid-row: 2)
@@ -1936,13 +1955,20 @@
     display: none;
   }
 
-  .curator-tabs .nav-link {
-    justify-content: center;
-    padding-inline: 0.45rem;
+  /* Shrink, don't strip: the mockup's primary-nav keeps every pill's text
+     label at every width, relying on horizontal scroll (plus this fade
+     mask at the edges) rather than going icon-only. Icon-only pills lose
+     their visual anchor once the background/border is gone on the
+     inactive ones — they read as disconnected floating icons instead of
+     a nav row, which is exactly what looked broken here before. */
+  .curator-tabs {
+    -webkit-mask-image: linear-gradient(90deg, transparent, #000 1rem, #000 calc(100% - 1rem), transparent);
+    mask-image: linear-gradient(90deg, transparent, #000 1rem, #000 calc(100% - 1rem), transparent);
   }
 
-  .curator-tabs .nav-link span {
-    display: none;
+  .curator-tabs .nav-link {
+    font-size: 0.78rem;
+    padding: 0.4rem 0.55rem;
   }
 
   .curator-lane-switcher {

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2348,6 +2348,10 @@
 }
 .curator-score-app { background: #50b86c; }
 
+.curator-score-bar-clipped {
+  background: repeating-linear-gradient(45deg, #50b86c, #50b86c 4px, #d59a52 4px, #d59a52 8px);
+}
+
 /* ---- Relationship chips ---- */
 .curator-chips {
   display: flex;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -1,30 +1,15 @@
-/* Design tokens (GH #150 Package 1). Stash's own chrome (navbar, page
-   background) has no light theme at all — confirmed against the running
-   app, not just its default SCSS — so a viewer's prefers-color-scheme
-   can't be used to drive Curator's palette: a light-calibrated accent
-   sitting in Stash's permanently-dark navbar just reads as washed out,
-   not "light mode". Every token below is therefore the dark column from
-   the #150 design brief, applied unconditionally. The light column
-   (bg #f1f2f5, accent #1d5fb8, secondary #a56f2a, lane hues at the same
-   62/46 S/L recipe as the dark set below) is preserved here for whenever
-   Stash ships a real light theme:
-     --curator-bg: #f1f2f5; --curator-accent: #1d5fb8;
-     --curator-accent-secondary: #a56f2a;
-     --curator-hue-for_you: #2d6cbe; --curator-hue-similar: #2d9cbe;
-     --curator-hue-best_bets: #2dbe8e; --curator-hue-hunt: #2dbe45;
-     --curator-hue-discover: #be9c2d; --curator-hue-adventure: #be5d2d;
-     --curator-hue-revisit: #692dbe; --curator-hue-expand: #be2d75;
-     --curator-hue-prune: #be392d; --curator-surface: #ffffff;
-     --curator-surface-raised: #e9ebef; --curator-border: rgba(16,18,22,.14);
-     --curator-border-strong: rgba(16,18,22,.24); --curator-text: #16181c;
-     --curator-text-muted: #5b6470; --curator-wash-raised: rgba(16,18,22,.04);
-     --curator-wash-recessed: rgba(16,18,22,.06);
-     --curator-shadow-color: rgba(16,18,22,.16);
-     --curator-glow-color: rgba(29,95,184,.22).
-   --curator-card-* stays a separate, identical-today family: it backs
-   Stash's native scene-card/performer-card internals, whose title and
-   detail text is hardcoded light-on-dark with no theming hook, so those
-   surfaces must stay pinned dark even after Stash grows a light theme. */
+/* Design tokens (GH #150 Package 1, revised GH #152 Package 5). Stash's own
+   chrome (navbar, page background) has no light theme at all, so these
+   tokens can't be driven by the viewer's prefers-color-scheme — a
+   light-calibrated accent sitting in Stash's permanently-dark navbar would
+   read as washed out, not "light mode". Dark stays the default (bare
+   :root, matching the app it's embedded in and every existing install);
+   light is an explicit opt-in via [data-theme="light"], flipped by the
+   header's theme toggle rather than by OS preference.
+   --curator-card-* is a separate, always-dark family: it backs Stash's
+   native scene-card/performer-card internals, whose title and detail text
+   is hardcoded light-on-dark with no theming hook, so those surfaces stay
+   pinned dark in both themes. */
 :root {
   --curator-bg: #101216;
   --curator-surface: #182126;
@@ -49,15 +34,15 @@
   --curator-accent: #4f8ce0;
   --curator-accent-secondary: #d59a52;
 
-  --curator-hue-for_you: #6e9cd8;
-  --curator-hue-similar: #6ec0d8;
-  --curator-hue-best_bets: #6ed8b5;
-  --curator-hue-hunt: #6ed880;
-  --curator-hue-discover: #d8c06e;
-  --curator-hue-adventure: #d8916e;
-  --curator-hue-revisit: #9a6ed8;
-  --curator-hue-expand: #d86ea3;
-  --curator-hue-prune: #d8776e;
+  --curator-hue-for_you: #4f8ce0;
+  --curator-hue-similar: #6cc4dc;
+  --curator-hue-best_bets: #d59a52;
+  --curator-hue-hunt: #d98a9e;
+  --curator-hue-discover: #5cc19c;
+  --curator-hue-adventure: #e0824f;
+  --curator-hue-revisit: #b79ce0;
+  --curator-hue-expand: #e0645c;
+  --curator-hue-prune: #9aa1ab;
 
   --curator-radius-sm: 4px;
   --curator-radius: 7px;
@@ -69,9 +54,44 @@
   --curator-shadow-glow: 0 0.25rem 0.8rem var(--curator-glow-color);
 
   --curator-gradient-brand: linear-gradient(145deg, var(--curator-accent), var(--curator-hue-similar));
+
+  --curator-font-display: "Iowan Old Style", "Palatino Linotype", Palatino, "Book Antiqua", Georgia, serif;
+  --curator-font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+  --curator-font-mono: ui-monospace, "SF Mono", "Cascadia Mono", "Roboto Mono", Consolas, monospace;
+}
+
+.curator-page[data-theme="light"] {
+  --curator-bg: #f1f2f5;
+  --curator-surface: #ffffff;
+  --curator-surface-raised: #e9ebef;
+  --curator-border: rgba(16, 18, 22, 0.14);
+  --curator-border-strong: rgba(16, 18, 22, 0.24);
+  --curator-text: #16181c;
+  --curator-text-muted: #5b6470;
+  --curator-overlay: rgba(16, 18, 22, 0.5);
+  --curator-wash-raised: rgba(16, 18, 22, 0.04);
+  --curator-wash-recessed: rgba(16, 18, 22, 0.06);
+  --curator-shadow-color: rgba(16, 18, 22, 0.16);
+  --curator-glow-color: rgba(29, 95, 184, 0.22);
+
+  --curator-accent: #1d5fb8;
+  --curator-accent-secondary: #a56f2a;
+
+  --curator-hue-for_you: #1d5fb8;
+  --curator-hue-similar: #1f7f96;
+  --curator-hue-best_bets: #a56f2a;
+  --curator-hue-hunt: #a34a63;
+  --curator-hue-discover: #2f8f68;
+  --curator-hue-adventure: #b85e33;
+  --curator-hue-revisit: #7452ad;
+  --curator-hue-expand: #b83f4c;
+  --curator-hue-prune: #7c838c;
 }
 
 .curator-page {
+  background: var(--curator-bg);
+  color: var(--curator-text);
+  font-family: var(--curator-font-ui);
   box-sizing: border-box;
   margin: 0 auto;
   max-width: 112rem;
@@ -79,6 +99,12 @@
   overflow-x: clip;
   padding: 0.55rem 1.25rem 2rem;
   width: 100%;
+}
+
+.curator-page h1,
+.curator-page h2,
+.curator-page h3 {
+  font-family: var(--curator-font-display);
 }
 
 .curator-header {
@@ -730,7 +756,7 @@
 }
 
 .curator-profile-table td:last-child {
-  font-family: monospace;
+  font-family: var(--curator-font-mono);
   max-width: 32rem;
   overflow-wrap: anywhere;
 }
@@ -2381,7 +2407,7 @@
 }
 
 .curator-pick-hint kbd {
-  font-family: inherit;
+  font-family: var(--curator-font-mono);
   font-size: 0.68rem;
   background: var(--curator-wash-raised);
   border: 1px solid var(--curator-card-border-strong);

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -1385,11 +1385,11 @@
   margin-left: 0.35rem;
 }
 
-.curator-expand-filters {
+.curator-filter-panel-body {
   margin: 0.4rem 0 0.8rem;
 }
 
-.curator-expand-filters > div {
+.curator-filter-panel-body > div {
   align-items: end;
   display: grid;
   gap: 0.5rem;
@@ -1397,7 +1397,7 @@
   margin-top: 0.5rem;
 }
 
-.curator-expand-filters label {
+.curator-filter-panel-body label {
   font-size: 0.78rem;
   margin: 0;
 }
@@ -1885,7 +1885,7 @@
     grid-template-columns: 1fr;
   }
 
-  .curator-expand-filters > div {
+  .curator-filter-panel-body > div {
     grid-template-columns: 1fr;
   }
 

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -738,6 +738,41 @@
   color: var(--curator-text-muted);
 }
 
+/* Design-mockup "confidence pips" (ConfidencePips) — 5 bars filled
+   left-to-right by how much viewing history backs the model's inference. */
+.curator-confidence-wrap {
+  align-items: center;
+  display: flex;
+  flex: 0 0 auto;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.curator-confidence-label {
+  color: var(--curator-text-muted);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.curator-confidence-pips {
+  display: flex;
+  gap: 3px;
+}
+
+.curator-confidence-pips span {
+  background: var(--curator-border-strong);
+  border-radius: 1px;
+  display: block;
+  height: 12px;
+  width: 5px;
+}
+
+.curator-confidence-pips span.on {
+  background: var(--curator-accent);
+}
+
 .curator-sentiment {
   display: flex;
   flex-wrap: wrap;
@@ -930,28 +965,26 @@
   width: 14px;
 }
 
-.curator-sentiment-thumb-unset {
-  opacity: 0.5;
-}
-
 .curator-sentiment-never .curator-sentiment-thumb {
   background: #dc3545;
   box-shadow: 0 0 0 1px #dc3545;
 }
 
 /* The model's own continuous estimate (Taste Profile only — see
-   TagSentimentControl's inferredValue prop), shown as a small hollow ring
-   distinct from the solid direct-rating thumb so the two can be compared
-   without the model's read silently overriding what the user set. */
+   TagSentimentControl's inferredValue prop): a small tick in a third color
+   (the existing amber secondary accent — distinct from the blue direct-
+   rating thumb and the red "Never" stop) on the same track, so the two can
+   be compared without the model's read silently overriding what the user
+   set or being mistaken for another stop/thumb. */
 .curator-sentiment-model-dot {
-  background: var(--curator-surface);
-  border: 1.5px solid var(--curator-text-muted);
+  background: var(--curator-accent-secondary);
   border-radius: 50%;
-  height: 7px;
+  height: 6px;
   position: absolute;
   top: 50%;
   transform: translate(-50%, -50%);
-  width: 7px;
+  width: 6px;
+  z-index: 1;
 }
 
 .curator-sentiment-input {
@@ -971,9 +1004,16 @@
    redirected onto the decorative thumb for keyboard users. The input has to
    paint after (on top of) the rail to receive clicks, which rules out a
    ~ sibling-combinator selector here (it only matches *later* siblings) —
-   :has() on the shared ancestor sidesteps the ordering requirement. */
+   :has() on the shared ancestor sidesteps the ordering requirement. An
+   unrated item has no thumb to ring (see TagSentimentControl — nothing
+   renders there until a real value exists), so the rail itself is the
+   fallback target for that case. */
 .curator-sentiment-track:has(.curator-sentiment-input:focus-visible) .curator-sentiment-thumb {
   box-shadow: 0 0 0 1px var(--sc, var(--curator-accent)), 0 0 0 4px var(--curator-glow-color);
+}
+
+.curator-sentiment-track:has(.curator-sentiment-input:focus-visible) .curator-sentiment-rail {
+  box-shadow: 0 0 0 3px var(--curator-glow-color);
 }
 
 .curator-sentiment-compact .curator-sentiment-track {
@@ -991,7 +1031,6 @@
 .curator-external-tag-rating .curator-sentiment-rail { background: var(--curator-card-border-strong); }
 .curator-external-tag-rating .curator-sentiment-stop { background: var(--curator-card-border-strong); }
 .curator-external-tag-rating .curator-sentiment-thumb { border-color: var(--curator-card-surface); }
-.curator-external-tag-rating .curator-sentiment-model-dot { background: var(--curator-card-surface); border-color: var(--curator-card-text-muted); }
 
 @media (max-width: 480px) {
   .curator-sentiment .btn-sm {

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -88,6 +88,42 @@
   --curator-hue-prune: #7c838c;
 }
 
+/* Bare <button>s don't inherit color from their parent by default in most
+   browsers (the UA stylesheet gives them their own color: buttontext) — any
+   text inside one that doesn't set its own explicit color falls back to
+   near-black regardless of the surrounding dark background. Confirmed
+   reproducing on .curator-lane-card-name. Fix at the root rather than
+   patching each instance found. */
+.curator-page button {
+  color: inherit;
+}
+
+/* Plain Bootstrap <Button>s (Generate, Rebuild, Submit picks, etc.) only
+   ever picked up curator's design tokens where a hand-picked custom class
+   (.curator-icon-button and friends) happened to set them explicitly —
+   every other button on the page kept Stash's own default Bootstrap
+   radius, reading as a different, un-reskinned control next to anything
+   that did get a custom class. Scope the radius token to every button
+   under .curator-page so the whole page is visually one family. */
+.curator-page .btn {
+  border-radius: var(--curator-radius);
+  transition: transform 0.12s ease, border-color 0.15s ease, background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease;
+}
+
+.curator-page .btn:active {
+  transform: scale(0.96);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .curator-page .btn {
+    transition: none;
+  }
+
+  .curator-page .btn:active {
+    transform: none;
+  }
+}
+
 .curator-page {
   background: var(--curator-bg);
   color: var(--curator-text);
@@ -95,6 +131,7 @@
   box-sizing: border-box;
   margin: 0 auto;
   max-width: 112rem;
+  min-height: 100vh;
   min-width: 0;
   overflow-x: clip;
   padding: 0.55rem 1.25rem 2rem;
@@ -296,6 +333,7 @@
 }
 
 .curator-lane-card-name {
+  color: var(--curator-text);
   font-size: 0.85rem;
   font-weight: 700;
 }
@@ -553,7 +591,7 @@
 .curator-sentiment-range {
   appearance: none;
   -webkit-appearance: none;
-  background: linear-gradient(90deg, #212529, #212529 10%, #dc3545 12%, #fd7e14, #6c757d, #6b8e23, #198754);
+  background: var(--curator-card-border-strong);
   border-radius: var(--curator-radius-lg);
   display: block;
   height: 0.35rem;
@@ -820,10 +858,6 @@
   justify-content: center;
   padding: 0;
   width: 1.8rem;
-}
-
-.curator-profiling-button svg {
-  font-size: 0.78rem;
 }
 
 /* Health/sync status popover (GH #150 Package 3): replaces the always-open
@@ -2079,6 +2113,14 @@
   color: var(--curator-card-text);
 }
 
+.curator-curate-started {
+  background: var(--curator-surface);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius);
+  margin-top: 0.75rem;
+  padding: 1rem 1.1rem;
+}
+
 .curator-curate-started h3 {
   font-size: 1rem;
 }
@@ -2182,12 +2224,6 @@
     aspect-ratio: 16 / 9;
     max-height: 180px;
   }
-}
-
-.curator-curate-tabs {
-  display: flex;
-  gap: 0.25rem;
-  margin-bottom: 0.75rem;
 }
 
 .curator-pick-compare {

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -387,6 +387,15 @@
   min-width: 0;
 }
 
+/* Bootstrap's own .nav-tabs rule (also applied here — the Nav component
+   renders className="curator-tabs nav nav-tabs") sets `margin: auto` then
+   `margin-bottom: 1.5rem`, i.e. an auto top margin plus a *fixed* 21px
+   bottom margin — that 21px doesn't get distributed as centering space
+   (there's no free space left to give the auto margin once the fixed
+   bottom margin claims its share), so the tabs strip sat flush against the
+   header's top edge with 21px of invisible margin below it instead of
+   being vertically centered like every other header control. `margin: 0`
+   here overrides both. */
 .curator-tabs {
   align-items: center;
   align-self: center;
@@ -395,7 +404,7 @@
   flex-wrap: nowrap;
   height: 3rem;
   justify-content: flex-start;
-  margin-inline: 0;
+  margin: 0;
   min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
@@ -1641,17 +1650,20 @@
    .minimal utility (meant to strip background/border) and .curator-page
    .btn-primary wins on specificity, painting a solid gradient pill over
    what's meant to be a quiet on-image icon+count trigger — reads as
-   shouting for attention on every single card. Force it back to a discreet
-   outline treatment instead, matching .curator-icon-action elsewhere. */
+   shouting for attention on every single card. First attempt used a dark
+   translucent overlay treatment, which read as "solid black" rather than
+   discreet; matches the actual .btn-secondary look used elsewhere (e.g. the
+   "More" menu trigger) instead. */
 .curator-page .curator-card .card-popovers .btn.minimal {
-  background: var(--curator-overlay);
-  border-color: transparent;
-  color: #fff;
+  background: var(--curator-surface);
+  border-color: var(--curator-border-strong);
+  color: var(--curator-text);
 }
 
 .curator-page .curator-card .card-popovers .btn.minimal:hover {
-  background: color-mix(in srgb, var(--curator-overlay) 80%, #000);
-  color: #fff;
+  background: var(--curator-surface-raised);
+  border-color: var(--curator-text-muted);
+  color: var(--curator-text);
 }
 
 .curator-card .card-popovers .fa-icon {

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -776,12 +776,69 @@
 .curator-sentiment-like             { --sc: #6b8e23; border-color: var(--sc); }
 .curator-sentiment-love             { --sc: #198754; border-color: var(--sc); }
 
+/* Shared themed look for every native <input type="range"> in the app
+   (Taste Profile sentiment, Similar/Expand "Minimum match", Prune
+   "aggressiveness", Sentiment-review "Appeal ≤" threshold) — apply
+   className="curator-range" to opt in. Stash's own global
+   `input[type="range"]` rule (element + [type] attribute = 0,1,1
+   specificity) and its `::-webkit-slider-thumb`/`::-webkit-slider-runnable-
+   track` pseudo-rules (0,1,2) beat a bare `.curator-range` class (0,1,0/1),
+   so every slider silently fell back to Stash's hardcoded dark
+   Bootstrap-blue look (solid rgb(0,123,255) track, rgb(57,75,89) thumb, both
+   theme-blind) regardless of curator's own light/dark theme — the .curator-
+   page prefix (an extra class) is what wins the specificity fight. Thumb
+   background reads var(--sc, ...) so the Taste Profile sentiment slider's
+   wrapping tier className (below) recolors it for free, with no separate
+   override rule needed. */
+.curator-page .curator-range {
+  appearance: none;
+  -webkit-appearance: none;
+  background: transparent;
+  display: block;
+  height: 0.9rem;
+  outline: none;
+}
+
+.curator-page .curator-range::-webkit-slider-runnable-track {
+  background: var(--curator-border-strong);
+  border-radius: var(--curator-radius-lg);
+  height: 0.35rem;
+}
+
+.curator-page .curator-range::-moz-range-track {
+  background: var(--curator-border-strong);
+  border-radius: var(--curator-radius-lg);
+  height: 0.35rem;
+}
+
+.curator-page .curator-range::-webkit-slider-thumb {
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--sc, var(--curator-accent));
+  border: 2px solid var(--curator-text);
+  border-radius: 50%;
+  cursor: pointer;
+  height: 0.9rem;
+  margin-top: -0.275rem;
+  width: 0.9rem;
+}
+
+.curator-page .curator-range::-moz-range-thumb {
+  background: var(--sc, var(--curator-accent));
+  border: 2px solid var(--curator-text);
+  border-radius: 50%;
+  cursor: pointer;
+  height: 0.9rem;
+  width: 0.9rem;
+}
+
 /* Sentiment slider: a single 6-stop track, "Never" at position 0 then the
    5-point spectrum from curator-sentiment-danger to -love. The wrapping
    label carries the current tier's className (reusing the --sc custom
-   property declared above) so the thumb inherits the right color; when the
-   tier classes above are used here, their border-color assignment is a
-   harmless no-op since this wrapper draws no border. */
+   property declared above) so the thumb inherits the right color via the
+   shared .curator-range rules above; when the tier classes above are used
+   here, their border-color assignment is a harmless no-op since this
+   wrapper draws no border. */
 .curator-sentiment-range-wrap {
   align-items: center;
   display: flex;
@@ -814,34 +871,7 @@
 }
 
 .curator-sentiment-range {
-  appearance: none;
-  -webkit-appearance: none;
-  background: var(--curator-border-strong);
-  border-radius: var(--curator-radius-lg);
-  display: block;
-  height: 0.35rem;
-  outline: none;
   width: 100%;
-}
-
-.curator-sentiment-range::-webkit-slider-thumb {
-  appearance: none;
-  -webkit-appearance: none;
-  background: var(--sc, var(--curator-accent));
-  border: 2px solid var(--curator-text);
-  border-radius: 50%;
-  cursor: pointer;
-  height: 0.9rem;
-  width: 0.9rem;
-}
-
-.curator-sentiment-range::-moz-range-thumb {
-  background: var(--sc, var(--curator-accent));
-  border: 2px solid var(--curator-text);
-  border-radius: 50%;
-  cursor: pointer;
-  height: 0.9rem;
-  width: 0.9rem;
 }
 
 .curator-sentiment-range-unset::-webkit-slider-thumb {
@@ -879,7 +909,8 @@
 .curator-external-tag-rating .curator-sentiment-love { color: var(--curator-card-text); }
 .curator-external-tag-rating .curator-sentiment-current { color: var(--curator-card-text-muted); }
 .curator-external-tag-rating .curator-sentiment-divider { background: var(--curator-card-border-strong); }
-.curator-external-tag-rating .curator-sentiment-range { background: var(--curator-card-border-strong); }
+.curator-external-tag-rating .curator-sentiment-range::-webkit-slider-runnable-track { background: var(--curator-card-border-strong); }
+.curator-external-tag-rating .curator-sentiment-range::-moz-range-track { background: var(--curator-card-border-strong); }
 .curator-external-tag-rating .curator-sentiment-range::-webkit-slider-thumb { border-color: var(--curator-card-text); }
 .curator-external-tag-rating .curator-sentiment-range::-moz-range-thumb { border-color: var(--curator-card-text); }
 

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -776,6 +776,18 @@
 .curator-sentiment-like             { --sc: #6b8e23; border-color: var(--sc); }
 .curator-sentiment-love             { --sc: #198754; border-color: var(--sc); }
 
+/* Taste Profile's belief badge ("I think you like/dislike this" / "I'm
+   unsure") reuses these same tier classes for their --sc value instead of
+   Bootstrap's one-size-fits-all badge-info cyan, which gave "like" and
+   "dislike" (the one signal worth scanning 949 rows for) identical color. */
+.badge.curator-sentiment-love,
+.badge.curator-sentiment-danger,
+.badge.curator-sentiment-neutral {
+  background: color-mix(in srgb, var(--sc) 18%, transparent);
+  border: 1px solid var(--sc);
+  color: var(--sc);
+}
+
 /* Shared themed look for every native <input type="range"> in the app
    (Taste Profile sentiment, Similar/Expand "Minimum match", Prune
    "aggressiveness", Sentiment-review "Appeal ≤" threshold) — apply

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -138,6 +138,46 @@
   width: 100%;
 }
 
+/* Bootstrap's stock .alert-* colors (35 call sites across every screen —
+   empty states, errors, confirmations) were never reskinned, so every one
+   of them renders as a light, un-themed box in an otherwise all-dark page.
+   Same tinted-dark-surface pattern already used for lane cards and
+   sentiment tiers, just applied at the page level since alerts appear
+   everywhere. */
+.curator-page .alert {
+  border-radius: var(--curator-radius);
+}
+
+.curator-page .alert-info {
+  background: color-mix(in srgb, var(--curator-accent) 14%, var(--curator-surface));
+  border-color: color-mix(in srgb, var(--curator-accent) 40%, transparent);
+  color: var(--curator-text);
+}
+
+.curator-page .alert-danger {
+  background: color-mix(in srgb, #e0645c 16%, var(--curator-surface));
+  border-color: color-mix(in srgb, #e0645c 45%, transparent);
+  color: var(--curator-text);
+}
+
+.curator-page .alert-warning {
+  background: color-mix(in srgb, #e0824f 16%, var(--curator-surface));
+  border-color: color-mix(in srgb, #e0824f 45%, transparent);
+  color: var(--curator-text);
+}
+
+.curator-page .alert-success {
+  background: color-mix(in srgb, #5cc19c 16%, var(--curator-surface));
+  border-color: color-mix(in srgb, #5cc19c 45%, transparent);
+  color: var(--curator-text);
+}
+
+.curator-page .alert-secondary {
+  background: var(--curator-surface-raised);
+  border-color: var(--curator-border);
+  color: var(--curator-text);
+}
+
 .curator-page h1,
 .curator-page h2,
 .curator-page h3 {

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -381,6 +381,77 @@
   color: #fff;
 }
 
+/* Sentiment slider: the 5-point spectrum from curator-sentiment-danger to
+   -love. The wrapping label carries the current tier's className (reusing
+   the --sc custom property declared above) so the thumb inherits the right
+   color; when the tier classes above are used here, their border-color
+   assignment is a harmless no-op since this wrapper draws no border. */
+.curator-sentiment-range-wrap {
+  align-items: center;
+  display: flex;
+  flex: 1 1 auto;
+  gap: 0.4rem;
+  min-width: 6rem;
+}
+
+.curator-sentiment-current {
+  color: var(--curator-card-text-muted);
+  flex: 0 0 auto;
+  font-size: 0.72rem;
+  min-width: 5.5rem;
+}
+
+.curator-sentiment-range {
+  appearance: none;
+  -webkit-appearance: none;
+  background: linear-gradient(90deg, #dc3545, #fd7e14, #6c757d, #6b8e23, #198754);
+  border-radius: var(--curator-radius-lg);
+  flex: 1 1 auto;
+  height: 0.35rem;
+  min-width: 4rem;
+  outline: none;
+}
+
+.curator-sentiment-range::-webkit-slider-thumb {
+  appearance: none;
+  -webkit-appearance: none;
+  background: var(--sc, var(--curator-accent));
+  border: 2px solid var(--curator-card-text);
+  border-radius: 50%;
+  cursor: pointer;
+  height: 0.9rem;
+  width: 0.9rem;
+}
+
+.curator-sentiment-range::-moz-range-thumb {
+  background: var(--sc, var(--curator-accent));
+  border: 2px solid var(--curator-card-text);
+  border-radius: 50%;
+  cursor: pointer;
+  height: 0.9rem;
+  width: 0.9rem;
+}
+
+.curator-sentiment-range-unset::-webkit-slider-thumb {
+  opacity: 0.45;
+}
+
+.curator-sentiment-range-unset::-moz-range-thumb {
+  opacity: 0.45;
+}
+
+.curator-sentiment-range-blocked {
+  opacity: 0.4;
+}
+
+.curator-sentiment-compact .curator-sentiment-range-wrap {
+  min-width: 4rem;
+}
+
+.curator-sentiment-compact .curator-sentiment-range {
+  min-width: 3rem;
+}
+
 @media (max-width: 480px) {
   .curator-sentiment .btn-sm {
     font-size: 0.7rem;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -441,6 +441,17 @@
   margin-top: 0.5rem;
 }
 
+/* Neither the mockup nor this shell caps the detail pane's height — with
+   short demo content that never mattered, but a real section (e.g.
+   Sentiment review with many cards) can run tens of thousands of pixels
+   tall, pushing the section list off-screen and forcing a scroll-to-top
+   just to switch sections. Pin the list instead of trying to guess a
+   max-height for the detail pane. */
+.curator-manage-list {
+  position: sticky;
+  top: 0.75rem;
+}
+
 @media (max-width: 860px) {
   .curator-manage-shell {
     grid-template-columns: 1fr;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2044,6 +2044,23 @@
   padding: 0 0.25rem;
 }
 
+/* This button gets no explicit `variant` prop, so React-Bootstrap's default
+   ("primary") still applies the .btn-primary class alongside Stash's own
+   .minimal utility (meant to strip background/border entirely) — and
+   .curator-page .btn-primary (0,2,0 specificity) beats .minimal (0,1,1),
+   so the gradient painted over what should read as a plain ghost icon+count
+   trigger. Force it back to transparent specifically for this button. */
+.curator-page .curator-external-popover-button.minimal {
+  background: none;
+  border-color: transparent;
+  color: var(--curator-text-muted);
+}
+
+.curator-page .curator-external-popover-button.minimal:hover {
+  background: var(--curator-wash-raised);
+  color: var(--curator-text);
+}
+
 .curator-external-popover-links {
   display: flex;
   gap: 0.3rem;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -124,6 +124,35 @@
   }
 }
 
+/* Bootstrap's stock .btn-primary/-secondary fills read heavier and flatter
+   than the mockup's palette: secondary there is just a bordered, --surface
+   button (color comes from the border/text, not a solid fill), and the
+   gradient treatment is reserved for the one true primary action per
+   screen rather than applied to every button that happens to default to
+   "primary". Restyle both to match. */
+.curator-page .btn-secondary,
+.curator-page .btn-outline-secondary {
+  background: var(--curator-surface);
+  border-color: var(--curator-border-strong);
+  color: var(--curator-text);
+}
+
+.curator-page .btn-secondary:hover,
+.curator-page .btn-outline-secondary:hover {
+  background: var(--curator-surface-raised);
+  border-color: var(--curator-text-muted);
+}
+
+.curator-page .btn-primary {
+  background: var(--curator-gradient-brand);
+  border-color: var(--curator-accent);
+  color: #fff;
+}
+
+.curator-page .btn-primary:hover {
+  filter: brightness(1.08);
+}
+
 .curator-page {
   background: var(--curator-bg);
   color: var(--curator-text);
@@ -906,13 +935,26 @@
   gap: 0.4rem;
 }
 
+/* Icon buttons carried whatever Bootstrap variant they happened to be
+   given (mostly the unset default, "primary" — a solid blue fill) with no
+   override, so the header read as a row of heavy filled blocks instead of
+   the mockup's uniformly bordered, --surface-background .icon-btn. Force
+   the same subtle treatment here regardless of variant. */
 .curator-icon-button {
   align-items: center;
+  background: var(--curator-surface) !important;
+  border-color: var(--curator-border-strong) !important;
+  color: var(--curator-text-muted) !important;
   display: inline-flex;
   height: 1.8rem;
   justify-content: center;
   padding: 0;
   width: 1.8rem;
+}
+
+.curator-icon-button:hover {
+  border-color: var(--curator-text-muted) !important;
+  color: var(--curator-text) !important;
 }
 
 /* Health/sync status popover (GH #150 Package 3): replaces the always-open

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -200,23 +200,23 @@
   font-family: var(--curator-font-ui);
   box-sizing: border-box;
   /* Stash's own route wrapper (.main.container-fluid, outside anything
-     this stylesheet controls) carries a fixed 15px horizontal gutter with
-     a transparent background — Stash's real page background (a different
-     blue-grey, not --curator-bg) was showing through that gutter on every
-     side, most visibly on narrow/mobile widths where 15px is a much
-     bigger fraction of the screen. Same root cause as min-height above
-     (Stash's chrome bleeding through where this page doesn't reach), just
-     the horizontal axis instead of vertical — extend past the gutter with
-     matching negative margin, matched by extra inline padding so the
+     this stylesheet controls) carries a fixed 15px horizontal gutter *and*
+     a 7px top-padding gutter, both with a transparent background — Stash's
+     real page background (a different blue-grey, not --curator-bg) shows
+     through on all three edges: a thin grey bar between the navbar and
+     this page's own background at the top, and the same gutter bleed
+     horizontally, most visible on narrow/mobile widths where 15px is a
+     bigger fraction of the screen. Extend past the gutter on all three
+     sides with matching negative margin, matched by extra padding so the
      visible content inset is unchanged.
   */
-  margin: 0 auto 0;
+  margin: -7px auto 0;
   margin-inline: -15px;
   max-width: calc(112rem + 30px);
   min-height: 100vh;
   min-width: 0;
   overflow-x: clip;
-  padding: 0.55rem calc(1.25rem + 15px) 2rem;
+  padding: calc(0.55rem + 7px) calc(1.25rem + 15px) 2rem;
   width: calc(100% + 30px);
 }
 
@@ -266,11 +266,15 @@
   font-family: var(--curator-font-display);
 }
 
+/* Single row (brand | scrollable nav | controls) at every width, matching
+   the design mockup's app-header-inner — previously a 2-row grid (brand +
+   controls on row 1, nav spanning full-width on row 2) above 36rem, which
+   the mockup never does. */
 .curator-header {
   align-items: center;
-  display: grid;
+  display: flex;
+  flex-wrap: nowrap;
   gap: 0.5rem 1.5rem;
-  grid-template-columns: auto minmax(0, 1fr) auto;
 }
 
 .curator-header > *,
@@ -379,8 +383,7 @@
 .curator-navigation {
   align-items: stretch;
   display: flex;
-  grid-column: 1 / -1;
-  grid-row: 2;
+  flex: 1 1 auto;
   min-width: 0;
 }
 
@@ -1261,16 +1264,12 @@
 
 .curator-controls {
   align-items: center;
-  align-self: center;
   display: flex;
-  flex: 0 1 auto;
+  flex: 0 0 auto;
   flex-wrap: nowrap;
   gap: 0.35rem 0.6rem;
-  grid-column: 3;
-  grid-row: 1;
   height: 3rem;
-  justify-content: space-between;
-  margin-left: auto;
+  justify-content: flex-end;
 }
 
 .curator-task-buttons {
@@ -1340,6 +1339,12 @@
 
 .curator-health-pulse-idle {
   background: var(--curator-border-strong);
+}
+
+.curator-health-pulse-pending,
+.curator-health-pulse-rebuilding {
+  background: var(--curator-accent-secondary);
+  box-shadow: 0 0 0 0.18rem color-mix(in srgb, var(--curator-accent-secondary) 22%, transparent);
 }
 
 .curator-health-panel {
@@ -1524,21 +1529,47 @@
   min-width: 16rem;
 }
 
+/* Shared loading indicator for every async panel (Similar/Expand/
+   Recommendations/Prune/Sentiment review/Backups/Profiling/Diagnostics) —
+   previously text-only, with no visual cue that something was actually
+   happening while a card grid populated or refreshed. */
 .curator-loading {
+  align-items: center;
+  display: flex;
+  gap: 0.6rem;
   margin: 1rem 0;
   max-width: 28rem;
 }
 
-.curator-loading > span {
-  color: var(--curator-text-muted);
-  display: block;
-  margin-bottom: 0.4rem;
+.curator-loading::before {
+  animation: curator-spin 0.7s linear infinite;
+  border: 2px solid var(--curator-border-strong);
+  border-radius: 50%;
+  border-top-color: var(--curator-accent);
+  content: "";
+  flex: 0 0 auto;
+  height: 1rem;
+  width: 1rem;
 }
 
+@keyframes curator-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.curator-loading > span {
+  color: var(--curator-text-muted);
+}
+
+/* --curator-card-min-width is set inline on .curator-page (see the header's
+   card-size button, CuratorPage's cardSize state) — Compact/Comfortable/
+   Spacious just change this one variable, cycling through 16rem/22rem/
+   28rem. */
 .curator-grid {
   display: grid;
   gap: 0.8rem;
-  grid-template-columns: repeat(auto-fill, minmax(22rem, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(var(--curator-card-min-width, 22rem), 1fr));
 }
 
 .curator-card {
@@ -1602,6 +1633,25 @@
 
 .curator-card .card-popovers .btn {
   padding-inline: 0.35rem;
+}
+
+/* Same root cause as .curator-external-popover-button below: these native
+   SceneCard overlay buttons (tag/performer count, organized toggle) get no
+   explicit variant, so Bootstrap's "primary" default fights Stash's own
+   .minimal utility (meant to strip background/border) and .curator-page
+   .btn-primary wins on specificity, painting a solid gradient pill over
+   what's meant to be a quiet on-image icon+count trigger — reads as
+   shouting for attention on every single card. Force it back to a discreet
+   outline treatment instead, matching .curator-icon-action elsewhere. */
+.curator-page .curator-card .card-popovers .btn.minimal {
+  background: var(--curator-overlay);
+  border-color: transparent;
+  color: #fff;
+}
+
+.curator-page .curator-card .card-popovers .btn.minimal:hover {
+  background: color-mix(in srgb, var(--curator-overlay) 80%, #000);
+  color: #fff;
 }
 
 .curator-card .card-popovers .fa-icon {
@@ -2351,10 +2401,6 @@
     padding-inline: calc(0.65rem + 15px);
   }
 
-  /* The header stays one row (brand | scrollable nav | controls) at every
-     width, matching the mockup's primary-nav — it never drops to a second
-     row of its own. .curator-tabs already scrolls horizontally (see base
-     rule above), so the middle grid column just shrinks instead. */
   .curator-tabs .nav-link {
     white-space: nowrap;
   }
@@ -2383,7 +2429,6 @@
      (brand-word: none). Measured: without this, brand+controls alone ate
      278px of a 390px viewport, leaving the nav ~22px — room for a sliver
      of one pill, nothing scrollable in any useful sense. */
-  .curator-tagline,
   .curator-header h1 {
     display: none;
   }
@@ -2391,17 +2436,6 @@
   .curator-icon-button {
     height: 1.6rem;
     width: 1.6rem;
-  }
-
-  /* .curator-navigation's base rule (grid-column: 1 / -1; grid-row: 2)
-     always gives the nav its own full-width row below brand+controls —
-     fine with room to spare, but on a phone the mockup instead keeps nav
-     inline as a horizontally-scrollable strip between the brand and
-     controls, one row total. Only override the placement at this width;
-     the desktop two-row header is intentional and unaffected. */
-  .curator-navigation {
-    grid-column: 2;
-    grid-row: 1;
   }
 
   .curator-health-pill-label {

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2289,6 +2289,30 @@
     mask-image: linear-gradient(90deg, transparent, #000 1rem, #000 calc(100% - 1rem), transparent);
   }
 
+  /* The fade mask alone isn't a strong enough affordance when the active
+     pill happens to fill the visible strip edge-to-edge (no sliver of the
+     next pill peeks through to hint "more here") — a narrow first-load
+     viewport with only "Recommendations" visible reads as the complete nav,
+     not a scrollable one. A persistent chevron makes the affordance
+     unambiguous regardless of scroll position or which pill is active. */
+  .curator-navigation {
+    position: relative;
+  }
+
+  .curator-navigation::after {
+    border-right: 2px solid var(--curator-text-muted);
+    border-top: 2px solid var(--curator-text-muted);
+    content: "";
+    height: 0.4rem;
+    opacity: 0.65;
+    pointer-events: none;
+    position: absolute;
+    right: 0.2rem;
+    top: 50%;
+    transform: translateY(-50%) rotate(45deg);
+    width: 0.4rem;
+  }
+
   .curator-tabs .nav-link {
     font-size: 0.78rem;
     padding: 0.4rem 0.55rem;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -1263,6 +1263,33 @@
 .curator-lane-hunt { --lane-color: var(--curator-hue-hunt); }
 .curator-lane-prune { --lane-color: var(--curator-hue-prune); }
 
+/* --lane-color (above) is the vivid dark-theme hue, used for icon color and
+   border accents where flat text-on-background contrast doesn't apply —
+   left as-is. .curator-source-badge (BEST BETS / DISCOVER / REVISIT /
+   ADVENTURE corner badges) pairs white text directly on a solid fill of
+   that hue, same shape of bug as the original --curator-gradient-brand fix:
+   every single lane hue measured 1.99–3.42:1 against white, all failing
+   AA (4.5:1) — Similar and Discover were the worst, below even the
+   original button-contrast bug's worst case. Per user request, applied
+   the *same technique* as that fix (a 145deg two-stop gradient of a
+   darker, independently-AA-passing color) rather than one flat solid, so
+   the badges also get the same visual depth as the logo mark/active nav
+   pill. Where the light-theme hue already passed 4.5:1 it's reused as the
+   lighter gradient stop (for_you/similar/hunt/revisit/expand); the other
+   four (best_bets/discover/adventure/prune) needed new darker literals —
+   light theme's own versions still fell short (3.83–4.48:1). Each
+   gradient's second stop is that first stop darkened ~22% further, which
+   can only raise contrast, never lower it. */
+.curator-lane-for_you { --lane-badge-gradient: linear-gradient(145deg, #1d5fb8, #174a90); }
+.curator-lane-similar { --lane-badge-gradient: linear-gradient(145deg, #1f7f96, #186375); }
+.curator-lane-best_bets { --lane-badge-gradient: linear-gradient(145deg, #976d3a, #76552d); }
+.curator-lane-hunt { --lane-badge-gradient: linear-gradient(145deg, #a34a63, #7f3a4d); }
+.curator-lane-discover { --lane-badge-gradient: linear-gradient(145deg, #3f836a, #316653); }
+.curator-lane-adventure { --lane-badge-gradient: linear-gradient(145deg, #ac643d, #864e30); }
+.curator-lane-revisit { --lane-badge-gradient: linear-gradient(145deg, #7452ad, #5a4087); }
+.curator-lane-expand { --lane-badge-gradient: linear-gradient(145deg, #b83f4c, #90313b); }
+.curator-lane-prune { --lane-badge-gradient: linear-gradient(145deg, #72777f, #595d63); }
+
 .curator-tabs .nav-link svg {
   color: var(--lane-color);
 }
@@ -1381,6 +1408,37 @@
   color: var(--curator-text);
   font-weight: 600;
   text-align: right;
+}
+
+.curator-card-size-panel {
+  background: var(--curator-surface);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius);
+  box-shadow: var(--curator-shadow-lg);
+  color: var(--curator-text);
+  min-width: 11rem;
+  padding: 0.75rem 0.85rem;
+}
+
+.curator-card-size-head {
+  align-items: center;
+  display: flex;
+  font-size: 0.75rem;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+}
+
+.curator-card-size-head label {
+  font-weight: 600;
+  margin: 0;
+}
+
+.curator-card-size-head span {
+  color: var(--curator-text-muted);
+}
+
+.curator-card-size-panel .curator-range {
+  width: 100%;
 }
 
 .curator-task-indicator {
@@ -1630,8 +1688,17 @@
   display: none;
 }
 
+/* bottom is tuned to vertically center these against .scene-card__date in
+   the same row, not against the card as a whole — the two aren't siblings
+   (card-popovers is a direct child of .scene-card; the date lives inside
+   .scene-card__details, nested under a sibling .card-section), so there's
+   no flex/grid relationship to align them automatically. Stable in
+   practice because .curator-card-description below is hidden (0 height)
+   and both the title (.card-section-title) and details row have fixed
+   min-heights regardless of content, so this row's position relative to
+   the card's bottom edge doesn't shift with title wrapping. */
 .curator-card .card-popovers {
-  bottom: 0.2rem;
+  bottom: 0.92rem;
   flex-wrap: nowrap;
   justify-content: flex-end;
   left: 7.5rem;
@@ -1653,10 +1720,13 @@
    shouting for attention on every single card. First attempt used a dark
    translucent overlay treatment, which read as "solid black" rather than
    discreet; matches the actual .btn-secondary look used elsewhere (e.g. the
-   "More" menu trigger) instead. */
+   "More" menu trigger) instead. .minimal's own `border: none` shorthand
+   still collapses border-width/style even once border-color is overridden
+   here — border-color alone is invisible without them — so the border has
+   to be respecified in full, not just recolored. */
 .curator-page .curator-card .card-popovers .btn.minimal {
   background: var(--curator-surface);
-  border-color: var(--curator-border-strong);
+  border: 1px solid var(--curator-border-strong);
   color: var(--curator-text);
 }
 
@@ -1698,7 +1768,7 @@
 
 .curator-source-badge {
   align-items: center;
-  background: var(--lane-color, var(--curator-overlay));
+  background: var(--lane-badge-gradient, var(--curator-overlay));
   border-radius: var(--curator-radius-sm);
   color: #fff;
   display: inline-flex;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2200,6 +2200,33 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 0.6rem;
+  position: relative;
+}
+
+.curator-pick-vs {
+  align-items: center;
+  background: var(--curator-surface-raised);
+  border: 1px solid var(--curator-card-border-strong);
+  border-radius: 50%;
+  color: var(--curator-card-text-muted);
+  display: flex;
+  font-size: 0.7rem;
+  font-weight: 700;
+  height: 1.9rem;
+  justify-content: center;
+  left: 50%;
+  position: absolute;
+  text-transform: uppercase;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  width: 1.9rem;
+  z-index: 1;
+}
+
+@media (max-width: 576px) {
+  .curator-pick-vs {
+    display: none;
+  }
 }
 
 @media (max-width: 576px) {
@@ -2308,20 +2335,6 @@
   color: var(--curator-card-text-muted);
 }
 
-.curator-pick-media {
-  position: relative;
-}
-
-.curator-pick-video {
-  position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  background: var(--curator-wash-recessed);
-  pointer-events: none;
-}
-
 .curator-pick-title {
   color: var(--curator-card-text);
 }
@@ -2347,6 +2360,7 @@
 .curator-pick-media {
   position: relative;
   aspect-ratio: 16 / 9;
+  max-height: 13rem;
   overflow: hidden;
 }
 

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -924,7 +924,7 @@
     );
   }
 
-  function TasteProfilePanel() {
+  function TasteProfilePanel({ embedded = false } = {}) {
     const [data, setData] = React.useState(null);
     const [error, setError] = React.useState("");
     const [query, setQuery] = React.useState("");
@@ -960,9 +960,9 @@
     }
     return React.createElement(
       "section",
-      { className: "curator-taste", "aria-labelledby": "curator-taste-title" },
-      React.createElement("h2", { id: "curator-taste-title" }, "Taste Profile"),
-      React.createElement("p", null, "Declared answers are strong evidence, not hard exclusions. Clear an answer to return to behavior-derived inference."),
+      { className: "curator-taste", "aria-labelledby": embedded ? undefined : "curator-taste-title" },
+      !embedded && React.createElement("h2", { id: "curator-taste-title" }, "Taste Profile"),
+      !embedded && React.createElement("p", null, "Declared answers are strong evidence, not hard exclusions. Clear an answer to return to behavior-derived inference."),
       React.createElement(
         "div",
         { className: "curator-taste-toolbar" },
@@ -3701,7 +3701,7 @@
   // mounted unmodified — this is pure relocation, not a rebuild.
   const MANAGE_BODIES = {
     feedback: () => React.createElement(FeedbackHistoryPanel),
-    taste: () => React.createElement(TasteProfilePanel),
+    taste: () => React.createElement(TasteProfilePanel, { embedded: true }),
     sentiment: () => React.createElement(ScoreReviewPanel),
     history: () => React.createElement(RecommendationHistoryPanel),
     backups: () => React.createElement(BackupPanel),
@@ -3977,7 +3977,7 @@
           React.createElement("span", { className: "curator-lane-card-desc" }, laneItem.description)
         ))
       ),
-      laneOption && React.createElement(
+      laneOption && lane !== "curate" && React.createElement(
         "div",
         { className: "curator-view-guidance" },
         React.createElement(

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -1567,6 +1567,7 @@
               "div",
               { className: "curator-pick-cards" },
               React.createElement(PickSceneCard, { meta: currentPair.scene_a, picked: answer === "a" || (flash && flash.pairId === currentPair.pair_id && flash.winner === "a"), onPick: () => answerPicks(currentPair.pair_id, "a"), onFlag: () => answerPicks(currentPair.pair_id, "flag_a") }),
+              React.createElement("span", { className: "curator-pick-vs", "aria-hidden": "true" }, "vs"),
               React.createElement(PickSceneCard, { meta: currentPair.scene_b, picked: answer === "b" || (flash && flash.pairId === currentPair.pair_id && flash.winner === "b"), onPick: () => answerPicks(currentPair.pair_id, "b"), onFlag: () => answerPicks(currentPair.pair_id, "flag_b") })
             ),
             React.createElement(

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -1688,10 +1688,19 @@
   // keyed off item.details.score_breakdown and it silently rendered empty
   // for real Similar-panel results, since that field isn't populated there.
   // A single clamped fill is the one thing guaranteed to have real data.
+  // Utility/appeal is usually in [0, 1], but bonuses (e.g. uncovered-content)
+  // can push final_utility modestly above 1.0 — clamping the fill to 1.0
+  // made every overflowing score (1.15, 1.16, 1.17, ...) render at the same
+  // ~100% width as a plain 0.95, erasing the difference. Scale against a
+  // slightly wider ceiling so that range is visible; anything that still
+  // exceeds the ceiling gets a distinct "off the chart" treatment rather
+  // than silently pinning to 100% again.
+  const UTILITY_BAR_CEILING = 1.2;
   function utilityBar(value) {
-    const pct = Math.round(Math.min(1, Math.max(0, value)) * 100);
+    const clipped = value > UTILITY_BAR_CEILING;
+    const pct = Math.round((Math.min(UTILITY_BAR_CEILING, Math.max(0, value)) / UTILITY_BAR_CEILING) * 100);
     return React.createElement("div", { className: "curator-score-bar" },
-      React.createElement("span", { className: "curator-score-bar-seg curator-score-app", style: { width: pct + "%" }, title: `Utility ${value.toFixed(3)}` })
+      React.createElement("span", { className: `curator-score-bar-seg curator-score-app${clipped ? " curator-score-bar-clipped" : ""}`, style: { width: pct + "%" }, title: `Utility ${value.toFixed(3)}` })
     );
   }
 

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -843,7 +843,7 @@
             { className: "curator-sentiment-rail", "aria-hidden": "true" },
             [0, 1, 2, 3, 4, 5].map((stop) => React.createElement("span", {
               key: stop,
-              className: `curator-sentiment-stop${stop === 0 ? " curator-sentiment-stop-never" : ""}${stopIndex === stop ? " curator-sentiment-stop-active" : ""}`,
+              className: `curator-sentiment-stop${stop === 0 ? " curator-sentiment-stop-never" : ""}${rated && stopIndex === stop ? " curator-sentiment-stop-active" : ""}`,
               style: { left: `${(stop / 5) * 100}%` },
             })),
             hasModelEstimate && React.createElement("span", {
@@ -1124,7 +1124,7 @@
             "article",
             { key: item.tag_id, className: "curator-taste-item" },
             React.createElement("div", null,
-              React.createElement("strong", null, item.name),
+              React.createElement("strong", null, React.createElement(NavLink, { to: `/tags/${item.tag_id}`, title: `Review scenes tagged ${item.name}` }, item.name)),
               item.prompt && React.createElement("span", { className: `badge ${item.prompt === "belief" ? nearestSentiment(item.inferred_value)[2] : "curator-sentiment-neutral"}` }, item.prompt === "belief" ? beliefSentence(item.inferred_value) : "I'm unsure"),
               React.createElement("small", null, `Inferred ${item.inferred_value.toFixed(2)} · confidence ${item.confidence.toFixed(2)} · support ${item.support.toFixed(1)} · ${item.scene_count} local scene${item.scene_count === 1 ? "" : "s"}`)
             ),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -3761,6 +3761,17 @@
       ? route.get("section") || (MAINTENANCE_ITEMS.some((item) => item.value === requestedView) ? requestedView : MAINTENANCE_ITEMS[0].value)
       : null;
     const [slate, setSlate] = React.useState(null);
+    const [headerTaskBusy, setHeaderTaskBusy] = React.useState(false);
+    async function runHeaderTask(taskName) {
+      setHeaderTaskBusy(true);
+      try {
+        await runTask(taskName);
+      } catch (failure) {
+        setError(failure.message);
+      } finally {
+        setHeaderTaskBusy(false);
+      }
+    }
     const [error, setError] = React.useState("");
     const [loading, setLoading] = React.useState(true);
     const [refreshKey, setRefreshKey] = React.useState(0);
@@ -3975,22 +3986,29 @@
           { className: "curator-view-copy" },
           React.createElement("h1", null, laneByValue.has(lane) ? "Recommendations" : laneOption.label),
           React.createElement("p", null, laneOption.description),
-          laneByValue.has(lane) && React.createElement("p", null, "The colored corner icon identifies the source lane; Score is ranking utility, not a probability.")
+          laneByValue.has(lane) && React.createElement("p", null, "The colored corner icon identifies the source lane; Score is ranking utility, not a probability."),
+          laneByValue.has(lane) && slate && React.createElement("p", { className: "curator-view-stats" }, `${slate.total} in rotation`)
         ),
-        laneByValue.has(lane) && diversityEnabled !== null && React.createElement(
-          Button,
-          {
-            className: "curator-diversity-toggle",
-            size: "sm",
-            variant: diversityEnabled ? "primary" : "secondary",
-            disabled: diversitySaving,
-            "aria-pressed": diversityEnabled,
-            "aria-label": diversityEnabled ? "Disable recommendation variety" : "Enable recommendation variety",
-            title: diversityEnabled ? "Switch to the model's score-first order" : "Vary performers, studios, and similar content",
-            onClick: toggleDiversity,
-          },
-          React.createElement(FontAwesomeIcon, { icon: faBalanceScale }),
-          diversityEnabled ? " Balanced" : " Score-first"
+        React.createElement(
+          "div",
+          { className: "curator-view-actions" },
+          laneByValue.has(lane) && React.createElement(Button, { size: "sm", variant: "secondary", disabled: headerTaskBusy, onClick: () => runHeaderTask("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench }), " Rebuild"),
+          laneByValue.has(lane) && React.createElement(Button, { size: "sm", disabled: headerTaskBusy, onClick: () => runHeaderTask("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync }), " Sync library"),
+          laneByValue.has(lane) && diversityEnabled !== null && React.createElement(
+            Button,
+            {
+              className: "curator-diversity-toggle",
+              size: "sm",
+              variant: diversityEnabled ? "primary" : "secondary",
+              disabled: diversitySaving,
+              "aria-pressed": diversityEnabled,
+              "aria-label": diversityEnabled ? "Disable recommendation variety" : "Enable recommendation variety",
+              title: diversityEnabled ? "Switch to the model's score-first order" : "Vary performers, studios, and similar content",
+              onClick: toggleDiversity,
+            },
+            React.createElement(FontAwesomeIcon, { icon: faBalanceScale }),
+            diversityEnabled ? " Balanced" : " Score-first"
+          )
         )
       ),
       followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -10,8 +10,7 @@
   const { Button, ButtonGroup, Nav } = libraries.Bootstrap;
   const { NavLink, useHistory, useLocation } = libraries.ReactRouterDOM;
   const { FontAwesomeIcon } = libraries.ReactFontAwesome;
-  const { faDev } = libraries.FontAwesomeBrands;
-  const { faBalanceScale, faBroom, faBullseye, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faCrosshairs, faDatabase, faDownload, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faMoon, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSun, faSync, faTag, faThumbsDown, faThumbsUp, faUser, faUserCheck, faVenus, faWrench, faXmark } = libraries.FontAwesomeSolid;
+  const { faBalanceScale, faBroom, faBullseye, faChartLine, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faCrosshairs, faDatabase, faDownload, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faMoon, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSun, faSync, faTag, faThumbsDown, faThumbsUp, faUser, faUserCheck, faVenus, faWrench, faXmark } = libraries.FontAwesomeSolid;
   const componentTransforms = window.StashCuratorComponentTransforms ||= {};
 
   function transformComponentProps(name, props) {
@@ -127,7 +126,7 @@
     {
       value: "profiling",
       label: "Profiling",
-      icon: faDev,
+      icon: faChartLine,
       maintenance: true,
       description: "Inspect render and query performance profiles captured during development.",
     },
@@ -1166,7 +1165,6 @@
     const [flash, setFlash] = React.useState(null); // {pairId, winner} while the outline shows
     const [picksUndo, setPicksUndo] = React.useState([]); // [{pairId, winner}] for Forward
     const FLASH_MS = 500;
-    const [curateTab, setCurateTab] = React.useState("pick");
     const [tags, setTags] = React.useState(null);
     const [suggestions, setSuggestions] = React.useState(null);
     const [suggestionError, setSuggestionError] = React.useState("");
@@ -1301,7 +1299,7 @@
       }
     }, [picksRound, picksAnswers]);
     React.useEffect(() => {
-      if (curateTab !== "pick" || !picksRound || picksVerdict || picksRound.pairs.length === 0) {
+      if (!picksRound || picksVerdict || picksRound.pairs.length === 0) {
         return;
       }
       const answeredCount = Object.keys(picksAnswers).length;
@@ -1329,7 +1327,7 @@
       }
       window.addEventListener("keydown", onKey);
       return () => window.removeEventListener("keydown", onKey);
-    }, [curateTab, picksRound, picksVerdict, picksAnswers, flash]);
+    }, [picksRound, picksVerdict, picksAnswers, flash]);
     async function submitPicks() {
       const entries = Object.entries(picksAnswers)
         .filter(([, winner]) => winner !== "similar")
@@ -1396,14 +1394,7 @@
       { className: "curator-curate", "aria-labelledby": "curator-curate-title" },
       React.createElement("h2", { id: "curator-curate-title" }, "Curate"),
       React.createElement("p", null, "Pick the scene you prefer in each pair — every choice teaches the model about all tags, performers, and studios the scenes carried."),
-      React.createElement(
-        "div",
-        { className: "curator-curate-tabs", role: "tablist", "aria-label": "Curate views" },
-        React.createElement(Button, { size: "sm", variant: curateTab === "pick" ? "primary" : "secondary", role: "tab", "aria-selected": curateTab === "pick", onClick: () => setCurateTab("pick") }, "Pick"),
-        React.createElement(Button, { size: "sm", variant: curateTab === "tags" ? "primary" : "secondary", role: "tab", "aria-selected": curateTab === "tags", onClick: () => setCurateTab("tags") }, "Tag sentiment")
-      ),
-      curateTab === "tags" && React.createElement(TasteProfilePanel),
-      curateTab === "pick" && !picksRound && React.createElement(
+      !picksRound && React.createElement(
         "div",
         { className: "curator-curate-started" },
         React.createElement("h3", null, "Compare two scenes"),
@@ -1439,7 +1430,7 @@
           )
         )
       ),
-      curateTab === "pick" && picksRound && React.createElement(
+      picksRound && React.createElement(
         "div",
         { className: "curator-pick" },
         React.createElement(
@@ -3453,7 +3444,7 @@
     );
   }
 
-  function CuratorControls({ onRefresh, onProfiling, profilingActive, theme, onToggleTheme }) {
+  function CuratorControls({ onRefresh, theme, onToggleTheme }) {
     const [jobs, setJobs] = React.useState([]);
     const [health, setHealth] = React.useState(null);
     const [message, setMessage] = React.useState("");
@@ -3603,7 +3594,6 @@
           { className: "curator-task-buttons" },
           React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Use after Stash library changes. Sync changed metadata and history, then refresh recommendations.", "aria-label": "Sync library changes and refresh recommendations", onClick: () => start("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync })),
           React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Force a recommendation refresh from already-synced data. Does not contact Stash.", "aria-label": "Rebuild recommendations without syncing Stash", onClick: () => start("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench })),
-          React.createElement(Button, { className: "curator-icon-button curator-profiling-button", size: "sm", variant: profilingActive ? "primary" : "secondary", title: "Open performance profiles.", "aria-label": "Open performance profiles", "aria-pressed": profilingActive, onClick: onProfiling }, React.createElement(FontAwesomeIcon, { icon: faDev })),
           React.createElement(Button, { className: "curator-icon-button", size: "sm", title: theme === "light" ? "Switch to dark theme" : "Switch to light theme", "aria-label": theme === "light" ? "Switch to dark theme" : "Switch to light theme", onClick: onToggleTheme }, React.createElement(FontAwesomeIcon, { icon: theme === "light" ? faMoon : faSun })),
           React.createElement(NavLink, { className: "btn btn-secondary btn-sm curator-icon-button", title: "Open Curator's plugin settings.", "aria-label": "Plugin settings", to: "/settings?tab=plugins" }, React.createElement(FontAwesomeIcon, { icon: faCog }))
         )
@@ -3954,7 +3944,7 @@
             })
           )
         ),
-        React.createElement(CuratorControls, { onRefresh: refresh, onProfiling: () => openManage("profiling"), profilingActive: lane === "manage" && currentSection === "profiling", theme, onToggleTheme: toggleTheme })
+        React.createElement(CuratorControls, { onRefresh: refresh, theme, onToggleTheme: toggleTheme })
       ),
       laneByValue.has(lane) && React.createElement(
         "div",

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -10,7 +10,7 @@
   const { Button, ButtonGroup, Nav } = libraries.Bootstrap;
   const { NavLink, useHistory, useLocation } = libraries.ReactRouterDOM;
   const { FontAwesomeIcon } = libraries.ReactFontAwesome;
-  const { faBalanceScale, faBroom, faBullseye, faChartLine, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faCrosshairs, faDatabase, faDownload, faExpand, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faMoon, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSun, faSync, faTag, faThumbsDown, faThumbsUp, faUser, faVenus, faWrench, faXmark } = libraries.FontAwesomeSolid;
+  const { faBalanceScale, faBroom, faBullseye, faChartLine, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faCrosshairs, faDatabase, faDownload, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faMoon, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSun, faSync, faTag, faThLarge, faThumbsDown, faThumbsUp, faUser, faVenus, faWrench, faXmark } = libraries.FontAwesomeSolid;
   const componentTransforms = window.StashCuratorComponentTransforms ||= {};
 
   function transformComponentProps(name, props) {
@@ -154,11 +154,9 @@
   const EVENT_QUEUE_KEY = "stash-curator:event-queue:v1";
   const THEME_STORAGE_KEY = "stash-curator:theme";
   const CARD_SIZE_STORAGE_KEY = "stash-curator:card-size";
-  const CARD_SIZES = [
-    { key: "compact", label: "Compact", minWidth: "16rem" },
-    { key: "comfortable", label: "Comfortable", minWidth: "22rem" },
-    { key: "spacious", label: "Spacious", minWidth: "28rem" },
-  ];
+  const CARD_SIZE_MIN = 14;
+  const CARD_SIZE_MAX = 32;
+  const CARD_SIZE_DEFAULT = 22;
   const TAG_PREFERENCE_QUEUE_KEY = "stash-curator:tag-preference-queue:v1";
   const TERM_PREFERENCE_QUEUE_KEY = "stash-curator:term-preference-queue:v1";
   const ORIGIN_KEY = "stash-curator:origin:v1";
@@ -3628,7 +3626,7 @@
     );
   }
 
-  function CuratorControls({ onRefresh, theme, onToggleTheme, cardSize, onCycleCardSize }) {
+  function CuratorControls({ onRefresh, theme, onToggleTheme, cardSize, onChangeCardSize }) {
     const [jobs, setJobs] = React.useState([]);
     const [health, setHealth] = React.useState(null);
     const [message, setMessage] = React.useState("");
@@ -3785,6 +3783,42 @@
           healthTrigger
         )
       : healthTrigger;
+    // Card size used to be a click-to-cycle icon button (3 fixed steps,
+    // faExpand icon) — feedback: the icon read as "fullscreen" rather than
+    // "resize cards", and cycling blind made it hard to tell how many
+    // distinct sizes even existed. A hover-revealed slider makes every
+    // size directly selectable and reachable in one drag instead of up to
+    // 2 extra clicks, and CARD_SIZE_MIN..MAX is a continuous range rather
+    // than 3 fixed stops.
+    const cardSizeTrigger = React.createElement(Button, { className: "curator-icon-button", size: "sm", title: `Card size (${cardSize}rem) — hover to adjust`, "aria-label": `Card size: ${cardSize}rem` }, React.createElement(FontAwesomeIcon, { icon: faThLarge }));
+    const cardSizeControl = !onChangeCardSize ? null : HoverPopover
+      ? React.createElement(
+          HoverPopover,
+          {
+            className: "curator-card-size-trigger",
+            enterDelay: 150,
+            leaveDelay: 250,
+            placement: "bottom",
+            content: React.createElement(
+              "div",
+              { className: "curator-card-size-panel" },
+              React.createElement("div", { className: "curator-card-size-head" }, React.createElement("label", { htmlFor: "curator-card-size-input" }, "Card size"), React.createElement("span", null, `${cardSize}rem`)),
+              React.createElement("input", {
+                id: "curator-card-size-input",
+                type: "range",
+                className: "curator-range",
+                min: CARD_SIZE_MIN,
+                max: CARD_SIZE_MAX,
+                step: 1,
+                value: cardSize,
+                "aria-label": "Card size",
+                onChange: (event) => onChangeCardSize(Number(event.target.value)),
+              })
+            ),
+          },
+          cardSizeTrigger
+        )
+      : cardSizeTrigger;
     return React.createElement(
       React.Fragment,
       null,
@@ -3798,7 +3832,7 @@
           React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Use after Stash library changes. Sync changed metadata and history, then refresh recommendations.", "aria-label": "Sync library changes and refresh recommendations", onClick: () => start("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync })),
           React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Force a recommendation refresh from already-synced data. Does not contact Stash.", "aria-label": "Rebuild recommendations without syncing Stash", onClick: () => start("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench })),
           React.createElement(Button, { className: "curator-icon-button", size: "sm", title: theme === "light" ? "Switch to dark theme" : "Switch to light theme", "aria-label": theme === "light" ? "Switch to dark theme" : "Switch to light theme", onClick: onToggleTheme }, React.createElement(FontAwesomeIcon, { icon: theme === "light" ? faMoon : faSun })),
-          onCycleCardSize && React.createElement(Button, { className: "curator-icon-button", size: "sm", title: `Card size: ${CARD_SIZES.find((size) => size.key === cardSize)?.label}. Click to cycle.`, "aria-label": `Card size: ${CARD_SIZES.find((size) => size.key === cardSize)?.label}. Click to cycle.`, onClick: onCycleCardSize }, React.createElement(FontAwesomeIcon, { icon: faExpand })),
+          cardSizeControl,
           React.createElement(NavLink, { className: "btn btn-secondary btn-sm curator-icon-button", title: "Open Curator's plugin settings.", "aria-label": "Plugin settings", to: "/settings?tab=plugins" }, React.createElement(FontAwesomeIcon, { icon: faCog }))
         )
       ),
@@ -4020,24 +4054,20 @@
     }
     const [cardSize, setCardSize] = React.useState(() => {
       try {
-        const stored = window.localStorage.getItem(CARD_SIZE_STORAGE_KEY);
-        return CARD_SIZES.some((size) => size.key === stored) ? stored : "comfortable";
+        const stored = Number(window.localStorage.getItem(CARD_SIZE_STORAGE_KEY));
+        return stored >= CARD_SIZE_MIN && stored <= CARD_SIZE_MAX ? stored : CARD_SIZE_DEFAULT;
       } catch {
-        return "comfortable";
+        return CARD_SIZE_DEFAULT;
       }
     });
-    function cycleCardSize() {
-      setCardSize((current) => {
-        const index = CARD_SIZES.findIndex((size) => size.key === current);
-        const next = CARD_SIZES[(index + 1) % CARD_SIZES.length].key;
-        try {
-          window.localStorage.setItem(CARD_SIZE_STORAGE_KEY, next);
-        } catch {
-          // localStorage can be unavailable (private browsing); the change
-          // still works for the session, it just won't persist.
-        }
-        return next;
-      });
+    function changeCardSize(value) {
+      setCardSize(value);
+      try {
+        window.localStorage.setItem(CARD_SIZE_STORAGE_KEY, String(value));
+      } catch {
+        // localStorage can be unavailable (private browsing); the change
+        // still works for the session, it just won't persist.
+      }
     }
 
     React.useEffect(() => setFollowUps([]), [lane]);
@@ -4166,7 +4196,7 @@
 
     return React.createElement(
       "main",
-      { className: "curator-page container-fluid", "data-theme": theme, style: { "--curator-card-min-width": CARD_SIZES.find((size) => size.key === cardSize)?.minWidth } },
+      { className: "curator-page container-fluid", "data-theme": theme, style: { "--curator-card-min-width": `${cardSize}rem` } },
       React.createElement(
         "header",
         { className: "curator-header" },
@@ -4195,7 +4225,7 @@
             })
           )
         ),
-        React.createElement(CuratorControls, { onRefresh: refresh, theme, onToggleTheme: toggleTheme, cardSize, onCycleCardSize: cycleCardSize })
+        React.createElement(CuratorControls, { onRefresh: refresh, theme, onToggleTheme: toggleTheme, cardSize, onChangeCardSize: changeCardSize })
       ),
       laneByValue.has(lane) && React.createElement(
         "div",

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -868,7 +868,7 @@
         ),
         !compact && React.createElement("span", { className: "curator-sentiment-current" }, currentLabel)
       ),
-      (rated || compact) && React.createElement(Button, { size: "sm", variant: "link", className: compact && !rated ? "curator-sentiment-clear-placeholder" : undefined, "aria-label": "Clear answer", title: "Clear answer", onClick: () => onChange({ value: null, blocked: false }) }, compact ? "Clear" : "Clear answer")
+      React.createElement(Button, { size: "sm", variant: "secondary", className: !rated ? "curator-sentiment-clear-placeholder" : undefined, "aria-label": "Clear answer", title: "Clear answer", onClick: () => onChange({ value: null, blocked: false }) }, compact ? "Clear" : "Clear answer")
     );
   }
 

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -552,10 +552,18 @@
     if (!copied) throw new Error("Copy failed");
   }
 
-  function loadSlate(lane, page = 1, prefetched = false) {
+  // filters narrow a lane's already-classified candidates server-side (same
+  // include/exclude tag, performer, studio, and gender shape as Similar).
+  // Filtered slates aren't cached: the persistent slateCache is keyed only
+  // by lane+page, and filter combinations change too often relative to how
+  // long they stay open to be worth a filter-aware cache key.
+  function loadSlate(lane, page = 1, prefetched = false, filters = null) {
+    const hasFilters = Boolean(filters && (filters.includeTags?.length || filters.excludeTags?.length || filters.performers?.length || filters.studios?.length || filters.gender));
     const key = slateKey(lane, page);
-    if (slateCache.has(key)) return Promise.resolve(slateCache.get(key));
-    if (slateRequests.has(key)) return slateRequests.get(key);
+    if (!hasFilters) {
+      if (slateCache.has(key)) return Promise.resolve(slateCache.get(key));
+      if (slateRequests.has(key)) return slateRequests.get(key);
+    }
     const generation = cacheGeneration;
     const request = operation({
       operation: "get_slate",
@@ -564,6 +572,13 @@
       exclude_scene_ids: [...(laneExclusions.get(lane) || [])],
       exploration: 0,
       context: { route: location.pathname, prefetched },
+      ...(hasFilters ? {
+        include_tags: filters.includeTags || [],
+        exclude_tags: filters.excludeTags || [],
+        performer_ids: filters.performers || [],
+        studio_ids: filters.studios || [],
+        gender: filters.gender || "",
+      } : {}),
     })
       .then((data) => {
         if (generation !== cacheGeneration) return data;
@@ -575,12 +590,14 @@
         }
         cachedModelId = data.model_id;
         cachedConfigUpdatedAtMs = data.config_updated_at_ms;
-        slateCache.set(slateKey(lane, page), data);
-        persistSlateCache();
+        if (!hasFilters) {
+          slateCache.set(slateKey(lane, page), data);
+          persistSlateCache();
+        }
         return data;
       })
       .finally(() => slateRequests.delete(key));
-    slateRequests.set(key, request);
+    if (!hasFilters) slateRequests.set(key, request);
     return request;
   }
 
@@ -2315,6 +2332,12 @@
   }) {
     const sceneGated = variant !== "hunt";
     const showScene = !sceneGated || entityType === "scene";
+    // Recommendations narrows a lane's already-classified local scenes: no
+    // StashDB-only concept (hide-phash), similarity score (minimum match),
+    // or the "boost favorited performers" ranking knob (favorite-only) — all
+    // three are about ranking a candidate against a source entity or a
+    // remote catalog, not about narrowing a pre-picked set.
+    const rankingOnly = variant !== "recommendations";
     const minimumMin = variant === "expand" ? "-0.2" : "0";
     const genderAriaLabel = variant === "expand" ? "External performer gender" : "Performer gender";
     const favoriteExtra = variant === "expand" ? { title: "Show only scenes containing a performer favorited in your local library", "aria-pressed": favoriteOnly } : {};
@@ -2328,10 +2351,10 @@
         showScene && React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: onExcludeTagsChange }),
         sceneGated && showScene && React.createElement(FilterTokens, { kind: "performer", label: "Performers", values: performers, onChange: onPerformersChange }),
         sceneGated && showScene && React.createElement(FilterTokens, { kind: "studio", label: "Studios", values: studios, onChange: onStudiosChange }),
-        sceneGated && showScene && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", ...favoriteExtra, onClick: onToggleFavorite }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"),
-        showScene && React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: onToggleHidePhash }, React.createElement(FontAwesomeIcon, { icon: faClone }), " Hide exact PHash matches"),
+        rankingOnly && sceneGated && showScene && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", ...favoriteExtra, onClick: onToggleFavorite }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"),
+        rankingOnly && showScene && React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: onToggleHidePhash }, React.createElement(FontAwesomeIcon, { icon: faClone }), " Hide exact PHash matches"),
         sceneGated && React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: onGenderChange, "aria-label": genderAriaLabel }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))),
-        sceneGated && showScene && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimum.toFixed(2)}`), React.createElement("input", { type: "range", min: minimumMin, max: "0.8", step: "0.05", value: minimum, onChange: onMinimumChange })),
+        rankingOnly && sceneGated && showScene && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimum.toFixed(2)}`), React.createElement("input", { type: "range", min: minimumMin, max: "0.8", step: "0.05", value: minimum, onChange: onMinimumChange })),
         applyVisible && React.createElement(Button, { size: "sm", variant: "primary", onClick: onApply }, "Apply")
       )
     );
@@ -3796,6 +3819,23 @@
     const [refreshKey, setRefreshKey] = React.useState(0);
     const [page, setPage] = useUrlPage(laneByValue.has(lane) ? `page_${lane}` : "page_for_you");
     const [configReady, setConfigReady] = React.useState(false);
+    const initialSlateFilters = React.useMemo(() => defaultFilters("recommendations"), []);
+    const [filtersOpen, setFiltersOpen] = React.useState(false);
+    const [filterIncludeTags, setFilterIncludeTags] = React.useState(initialSlateFilters.includeTags || []);
+    const [filterExcludeTags, setFilterExcludeTags] = React.useState(initialSlateFilters.excludeTags || []);
+    const [filterPerformers, setFilterPerformers] = React.useState(initialSlateFilters.performers || []);
+    const [filterStudios, setFilterStudios] = React.useState(initialSlateFilters.studios || []);
+    const [filterGender, setFilterGender] = React.useState(initialSlateFilters.gender || "");
+    const slateFilters = { includeTags: filterIncludeTags, excludeTags: filterExcludeTags, performers: filterPerformers, studios: filterStudios, gender: filterGender };
+    const activeSlateFilterCount = filterIncludeTags.length + filterExcludeTags.length + filterPerformers.length + filterStudios.length + (filterGender ? 1 : 0);
+    function applySavedSlateFilters(value) {
+      setFilterIncludeTags(value.includeTags || []);
+      setFilterExcludeTags(value.excludeTags || []);
+      setFilterPerformers(value.performers || []);
+      setFilterStudios(value.studios || []);
+      setFilterGender(value.gender || "");
+      setPage(1);
+    }
     const [diversityEnabled, setDiversityEnabled] = React.useState(null);
     const [diversitySaving, setDiversitySaving] = React.useState(false);
     const [followUps, setFollowUps] = React.useState([]);
@@ -3846,11 +3886,11 @@
         setError("");
         return () => { active = false; };
       }
-      const cached = slateCache.get(slateKey(lane, page));
+      const cached = activeSlateFilterCount === 0 ? slateCache.get(slateKey(lane, page)) : null;
       setSlate(cached || null);
       setLoading(!cached);
       setError("");
-      loadSlate(lane, page).then(
+      loadSlate(lane, page, false, slateFilters).then(
         (data) => {
           if (!active) return;
           setSlate(data);
@@ -3861,7 +3901,7 @@
       return () => {
         active = false;
       };
-    }, [lane, page, refreshKey, configReady]);
+    }, [lane, page, refreshKey, configReady, filterIncludeTags, filterExcludeTags, filterPerformers, filterStudios, filterGender]);
     React.useEffect(() => {
       if (slate?.page === page) {
         const last = Math.max(1, Math.ceil(slate.total / slate.page_size));
@@ -4030,9 +4070,21 @@
             },
             React.createElement(FontAwesomeIcon, { icon: faBalanceScale }),
             diversityEnabled ? " Balanced" : " Score-first"
-          )
+          ),
+          laneByValue.has(lane) && React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters", activeSlateFilterCount > 0 && React.createElement("span", { className: "curator-filter-count" }, activeSlateFilterCount)),
+          laneByValue.has(lane) && React.createElement(SavedFilters, { scope: "recommendations", current: { includeTags: filterIncludeTags, excludeTags: filterExcludeTags, performers: filterPerformers, studios: filterStudios, gender: filterGender }, onApply: applySavedSlateFilters })
         )
       ),
+      laneByValue.has(lane) && filtersOpen && React.createElement(FilterBar, {
+        variant: "recommendations",
+        entityType: "scene",
+        includeTags: filterIncludeTags, onIncludeTagsChange: (value) => setFilterIncludeTags(value),
+        excludeTags: filterExcludeTags, onExcludeTagsChange: (value) => setFilterExcludeTags(value),
+        performers: filterPerformers, onPerformersChange: (value) => setFilterPerformers(value),
+        studios: filterStudios, onStudiosChange: (value) => setFilterStudios(value),
+        gender: filterGender, onGenderChange: (event) => setFilterGender(event.target.value),
+        onApply: () => { setPage(1); setFiltersOpen(false); },
+      }),
       followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),
       lane === "similar" && !loadingComponents && React.createElement(SimilarityPanel),
       lane === "curate" && React.createElement(CuratePanel),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -763,7 +763,7 @@
             min: "0",
             max: "5",
             step: "1",
-            className: `curator-sentiment-range${!rated ? " curator-sentiment-range-unset" : ""}${blocked ? " curator-sentiment-range-blocked" : ""}`,
+            className: `curator-range curator-sentiment-range${!rated ? " curator-sentiment-range-unset" : ""}${blocked ? " curator-sentiment-range-blocked" : ""}`,
             value: stopIndex,
             "aria-label": `Sentiment for ${tag.name}`,
             "aria-valuetext": currentLabel,
@@ -2354,7 +2354,7 @@
         rankingOnly && sceneGated && showScene && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", ...favoriteExtra, onClick: onToggleFavorite }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"),
         rankingOnly && showScene && React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: onToggleHidePhash }, React.createElement(FontAwesomeIcon, { icon: faClone }), " Hide exact PHash matches"),
         sceneGated && React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: onGenderChange, "aria-label": genderAriaLabel }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))),
-        rankingOnly && sceneGated && showScene && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimum.toFixed(2)}`), React.createElement("input", { type: "range", min: minimumMin, max: "0.8", step: "0.05", value: minimum, onChange: onMinimumChange })),
+        rankingOnly && sceneGated && showScene && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimum.toFixed(2)}`), React.createElement("input", { type: "range", className: "curator-range", min: minimumMin, max: "0.8", step: "0.05", value: minimum, onChange: onMinimumChange })),
         applyVisible && React.createElement(Button, { size: "sm", variant: "primary", onClick: onApply }, "Apply")
       )
     );
@@ -2733,7 +2733,7 @@
           { className: "btn-group", role: "group", "aria-label": "Prune view" },
           [["candidates", "Candidates"], ["tagged", "Tagged"], ["explicit", "Explicit dislikes"], ["suspects", "Model suspects"]].map(([value, label]) => React.createElement(Button, { key: value, size: "sm", variant: view === value ? "primary" : "secondary", onClick: () => updateUrl((s) => ({ ...s, view: value, page: 1 })) }, label))
         ),
-        view !== "tagged" && React.createElement("label", { className: "curator-prune-aggressiveness", title: "Move right to include less certain predicted dislikes." }, React.createElement("span", null, aggressiveness < 0.34 ? "Conservative" : aggressiveness < 0.67 ? "Balanced" : "Aggressive"), React.createElement("input", { type: "range", min: 0, max: 1, step: 0.05, value: aggressiveness, onChange: (event) => updateUrl((s) => ({ ...s, aggressiveness: Number(event.target.value), page: 1 })), "aria-label": "Prune prediction aggressiveness" })),
+        view !== "tagged" && React.createElement("label", { className: "curator-prune-aggressiveness", title: "Move right to include less certain predicted dislikes." }, React.createElement("span", null, aggressiveness < 0.34 ? "Conservative" : aggressiveness < 0.67 ? "Balanced" : "Aggressive"), React.createElement("input", { type: "range", className: "curator-range", min: 0, max: 1, step: 0.05, value: aggressiveness, onChange: (event) => updateUrl((s) => ({ ...s, aggressiveness: Number(event.target.value), page: 1 })), "aria-label": "Prune prediction aggressiveness" })),
         view !== "tagged" && React.createElement(Button, { size: "sm", variant: "danger", disabled: !ids.length, onClick: tagPage }, `Tag visible (${ids.length})`)
       ),
       loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Reviewing prune evidence…")),
@@ -3715,7 +3715,7 @@
         "div",
         { className: "curator-expand-toolbar" },
         React.createElement("label", { className: "curator-toolbar-select" }, React.createElement(FontAwesomeIcon, { icon: faSortAmountDown }), React.createElement("select", { value: order, onChange: (event) => updateUrl((s) => ({ ...s, order: event.target.value, page: 1 })), "aria-label": "Sort sentiment review" }, React.createElement("option", { value: "asc" }, "Least appealing first"), React.createElement("option", { value: "desc" }, "Most appealing first"))),
-        React.createElement("label", { className: "curator-prune-aggressiveness", title: "Show scenes at or below this appeal threshold." }, React.createElement("span", null, `Appeal ≤ ${threshold.toFixed(2)}`), React.createElement("input", { type: "range", min: -1, max: 1, step: 0.05, value: threshold, onChange: (event) => updateUrl((s) => ({ ...s, maxAppeal: Number(event.target.value), page: 1 })), "aria-label": "Maximum appeal threshold" }))
+        React.createElement("label", { className: "curator-prune-aggressiveness", title: "Show scenes at or below this appeal threshold." }, React.createElement("span", null, `Appeal ≤ ${threshold.toFixed(2)}`), React.createElement("input", { type: "range", className: "curator-range", min: -1, max: 1, step: 0.05, value: threshold, onChange: (event) => updateUrl((s) => ({ ...s, maxAppeal: Number(event.target.value), page: 1 })), "aria-label": "Maximum appeal threshold" }))
       ),
       loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Loading sentiment review…")),
       error && React.createElement("div", { className: "alert alert-danger" }, error),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2303,7 +2303,7 @@
     const favoriteExtra = variant === "expand" ? { title: "Show only scenes containing a performer favorited in your local library", "aria-pressed": favoriteOnly } : {};
     return React.createElement(
       "div",
-      { className: "curator-expand-filters curator-filter-panel" },
+      { className: "curator-filter-panel-body curator-filter-panel" },
       React.createElement(
         "div",
         null,

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -956,12 +956,14 @@
     );
   }
 
+  const TASTE_PROFILE_PAGE_SIZE = 30;
   function TasteProfilePanel({ embedded = false } = {}) {
     const [data, setData] = React.useState(null);
     const [error, setError] = React.useState("");
     const [query, setQuery] = React.useState("");
     const [sort, setSort] = React.useState("suggested");
     const [status, setStatus] = React.useState("all");
+    const [page, setPage] = useUrlPage("page_taste");
     useCuratorActivity("taste", !data && !error, "Loading taste profile…");
     React.useEffect(() => {
       let active = true;
@@ -990,6 +992,16 @@
         return difference || left.name.localeCompare(right.name);
       });
     }
+    // Taste Profile can hold ~1,000 tags fetched in one get_taste_profile
+    // call; rendering every visibleItems row unpaginated made the Manage
+    // document tens of thousands of pixels tall (the root cause of the
+    // "unbounded Manage page height" bug — see round 11's sticky section
+    // list, which only masked the symptom). Paginate client-side since the
+    // full filtered/sorted list is already in memory.
+    React.useEffect(() => setPage(1, { replace: true }), [query, status, sort]);
+    const totalPages = Math.max(1, Math.ceil(visibleItems.length / TASTE_PROFILE_PAGE_SIZE));
+    React.useEffect(() => { if (page > totalPages) setPage(totalPages, { replace: true }); }, [page, totalPages]);
+    const pageItems = visibleItems.slice((page - 1) * TASTE_PROFILE_PAGE_SIZE, page * TASTE_PROFILE_PAGE_SIZE);
     return React.createElement(
       "section",
       { className: "curator-taste", "aria-labelledby": embedded ? undefined : "curator-taste-title" },
@@ -1017,7 +1029,7 @@
       data && React.createElement(
         "div",
         { className: "curator-taste-list" },
-        visibleItems.map((item) =>
+        pageItems.map((item) =>
           React.createElement(
             "article",
             { key: item.tag_id, className: "curator-taste-item" },
@@ -1029,7 +1041,8 @@
             React.createElement(TagSentimentControl, { tag: item, value: item.direct_value, blocked: item.direct_blocked, onChange: (value) => answer(item.tag_id, value) })
           )
         )
-      )
+      ),
+      data && visibleItems.length > 0 && React.createElement(Pager, { page, total: visibleItems.length, pageSize: TASTE_PROFILE_PAGE_SIZE, hasMore: page * TASTE_PROFILE_PAGE_SIZE < visibleItems.length, loading: false, onPage: setPage, label: "Taste profile pages" })
     );
   }
 

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -708,35 +708,43 @@
     [1, "Strong like", "curator-sentiment-love"],
   ];
 
-  // A 6-point control: "Never" is a separate toggle (not on the continuous
-  // track, since it's categorically different from "how much do you like
-  // this" — it means "don't ask again"), and the 5 sentiment levels are one
-  // continuous range input rather than 5 discrete buttons.
+  // A single 6-stop control: "Never" is stop 0 on the same track as the 5
+  // sentiment levels (not a separate toggle) — set apart visually with its
+  // own color and a divider line, per the #150 design brief, but still one
+  // continuous range input rather than a track plus an out-of-band button.
   function TagSentimentControl({ tag, value, blocked, onChange, compact = false }) {
     const rated = (value !== null && value !== undefined) || blocked;
-    const sliderValue = value ?? 0;
-    const currentEntry = !blocked && rated ? SENTIMENTS.find(([score]) => score === value) : null;
-    const currentLabel = blocked ? "Never" : currentEntry ? currentEntry[1] : "Not rated";
-    const tierClass = currentEntry ? currentEntry[2] : "";
+    const stopIndex = blocked ? 0 : rated ? SENTIMENTS.findIndex(([score]) => score === value) + 1 : 3;
+    const currentLabel = blocked ? "Never" : rated ? SENTIMENTS[stopIndex - 1][1] : "Not rated";
+    const tierClass = blocked ? "curator-sentiment-never" : rated ? SENTIMENTS[stopIndex - 1][2] : "";
+    function handleChange(event) {
+      const index = Number(event.target.value);
+      if (index === 0) onChange({ value: null, blocked: true });
+      else onChange({ value: SENTIMENTS[index - 1][0], blocked: false });
+    }
     return React.createElement(
       "div",
       { className: `curator-sentiment curator-sentiment-slider${compact ? " curator-sentiment-compact" : ""}`, role: "group", "aria-label": `Sentiment for ${tag.name}` },
-      React.createElement(Button, { size: "sm", className: `curator-sentiment-never${blocked ? " curator-sentiment-active" : ""}`, "aria-pressed": blocked, "aria-label": "Never show scenes with this tag", title: "Never show scenes with this tag", onClick: () => onChange({ blocked: true }) }, "Never"),
       React.createElement(
         "label",
         { className: `curator-sentiment-range-wrap${tierClass ? ` ${tierClass}` : ""}` },
         !compact && React.createElement("span", { className: "curator-sentiment-current" }, currentLabel),
-        React.createElement("input", {
-          type: "range",
-          min: "-1",
-          max: "1",
-          step: "0.5",
-          className: `curator-sentiment-range${!rated ? " curator-sentiment-range-unset" : ""}${blocked ? " curator-sentiment-range-blocked" : ""}`,
-          value: sliderValue,
-          "aria-label": `Sentiment for ${tag.name}`,
-          "aria-valuetext": currentLabel,
-          onChange: (event) => onChange({ value: Number(event.target.value), blocked: false }),
-        })
+        React.createElement(
+          "span",
+          { className: "curator-sentiment-track" },
+          React.createElement("span", { className: "curator-sentiment-divider", "aria-hidden": "true" }),
+          React.createElement("input", {
+            type: "range",
+            min: "0",
+            max: "5",
+            step: "1",
+            className: `curator-sentiment-range${!rated ? " curator-sentiment-range-unset" : ""}${blocked ? " curator-sentiment-range-blocked" : ""}`,
+            value: stopIndex,
+            "aria-label": `Sentiment for ${tag.name}`,
+            "aria-valuetext": currentLabel,
+            onChange: handleChange,
+          })
+        )
       ),
       (rated || compact) && React.createElement(Button, { size: "sm", variant: "link", className: compact && !rated ? "curator-sentiment-clear-placeholder" : undefined, "aria-label": "Clear answer", title: "Clear answer", onClick: () => onChange({ value: null, blocked: false }) }, compact ? "Clear" : "Clear answer")
     );

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -683,17 +683,36 @@
     [1, "Strong like", "curator-sentiment-love"],
   ];
 
+  // A 6-point control: "Never" is a separate toggle (not on the continuous
+  // track, since it's categorically different from "how much do you like
+  // this" — it means "don't ask again"), and the 5 sentiment levels are one
+  // continuous range input rather than 5 discrete buttons.
   function TagSentimentControl({ tag, value, blocked, onChange, compact = false }) {
-    const rated = value !== null && value !== undefined || blocked;
+    const rated = (value !== null && value !== undefined) || blocked;
+    const sliderValue = value ?? 0;
+    const currentEntry = !blocked && rated ? SENTIMENTS.find(([score]) => score === value) : null;
+    const currentLabel = blocked ? "Never" : currentEntry ? currentEntry[1] : "Not rated";
+    const tierClass = currentEntry ? currentEntry[2] : "";
     return React.createElement(
       "div",
-      { className: `curator-sentiment${compact ? " curator-sentiment-compact" : ""}`, role: "group", "aria-label": `Sentiment for ${tag.name}` },
+      { className: `curator-sentiment curator-sentiment-slider${compact ? " curator-sentiment-compact" : ""}`, role: "group", "aria-label": `Sentiment for ${tag.name}` },
       React.createElement(Button, { size: "sm", className: `curator-sentiment-never${blocked ? " curator-sentiment-active" : ""}`, "aria-pressed": blocked, "aria-label": "Never show scenes with this tag", title: "Never show scenes with this tag", onClick: () => onChange({ blocked: true }) }, "Never"),
-      SENTIMENTS.map(([score, label, cls]) => {
-        const selected = !blocked && value === score;
-        const shortLabel = score === -1 ? "--" : score === -0.5 ? "-" : score === 0 ? "0" : score === 0.5 ? "+" : "++";
-        return React.createElement(Button, { key: score, size: "sm", className: `${cls}${selected ? " curator-sentiment-active" : ""}`, "aria-pressed": selected, "aria-label": label, title: label, onClick: () => onChange({ value: score, blocked: false }) }, compact ? shortLabel : label);
-      }),
+      React.createElement(
+        "label",
+        { className: `curator-sentiment-range-wrap${tierClass ? ` ${tierClass}` : ""}` },
+        !compact && React.createElement("span", { className: "curator-sentiment-current" }, currentLabel),
+        React.createElement("input", {
+          type: "range",
+          min: "-1",
+          max: "1",
+          step: "0.5",
+          className: `curator-sentiment-range${!rated ? " curator-sentiment-range-unset" : ""}${blocked ? " curator-sentiment-range-blocked" : ""}`,
+          value: sliderValue,
+          "aria-label": `Sentiment for ${tag.name}`,
+          "aria-valuetext": currentLabel,
+          onChange: (event) => onChange({ value: Number(event.target.value), blocked: false }),
+        })
+      ),
       (rated || compact) && React.createElement(Button, { size: "sm", variant: "link", className: compact && !rated ? "curator-sentiment-clear-placeholder" : undefined, "aria-label": "Clear answer", title: "Clear answer", onClick: () => onChange({ value: null, blocked: false }) }, compact ? "Clear" : "Clear answer")
     );
   }
@@ -1617,6 +1636,38 @@
     );
   }
 
+  // Shared "Why this?"/"Score · X" details shell, used by RecommendationCard,
+  // ExternalCard, and SimilarityPanel's library-match grid. The shell (the
+  // two <details>/<summary> elements) is genuinely identical across all
+  // three; what goes inside each is not (RecommendationCard lazy-loads its
+  // explanation on toggle and shows a ScoreNode tree, the other two are
+  // static), so content stays fully caller-supplied via props rather than
+  // forcing those shapes into a shared config.
+  function EvidenceScore({ evidenceProps, evidenceContent, scoreSummary, scoreContent }) {
+    return React.createElement(
+      React.Fragment,
+      null,
+      evidenceContent !== null && React.createElement("details", { className: "curator-evidence", ...evidenceProps }, React.createElement("summary", null, "Why this?"), evidenceContent),
+      React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, `Score · ${scoreSummary}`), scoreContent)
+    );
+  }
+
+  // The "external" action-set variant (StashDB/Whisparr/shortlist), sibling
+  // to Feedback's "local" variant (thumbs up/down + More menu).
+  function ExternalActions({ href, item, kind, copied, onCopy, onShortlist, tagsAvailable, tagsActive, tagLoading, onRateTags, onShowScenes, whisparrEnabled, canWhisparr, whisparr, onAddToWhisparr }) {
+    return React.createElement(
+      "div",
+      { className: "curator-prune-actions" },
+      React.createElement("a", { className: "btn btn-secondary btn-sm curator-icon-action", href, target: "_blank", rel: "noreferrer", title: "Open on StashDB", "aria-label": "Open on StashDB" }, React.createElement(FontAwesomeIcon, { icon: faExternalLinkAlt })),
+      React.createElement(Button, { className: "curator-icon-action", size: "sm", title: copied ? "Copied" : "Copy StashDB ID", "aria-label": copied ? "Copied" : "Copy StashDB ID", onClick: onCopy }, React.createElement(FontAwesomeIcon, { icon: copied ? faCheckCircle : faCopy })),
+      onShortlist && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: item.shortlisted ? "primary" : "secondary", title: item.shortlisted ? "Remove from shortlist" : "Add to shortlist", "aria-label": item.shortlisted ? "Remove from shortlist" : "Add to shortlist", onClick: () => onShortlist(item, kind) }, React.createElement(FontAwesomeIcon, { icon: faList })),
+      kind === "scene" && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: tagsActive ? "primary" : "secondary", disabled: !tagsAvailable || tagLoading, title: "Rate tags & terms", "aria-label": "Rate tags & terms", onClick: onRateTags }, React.createElement(FontAwesomeIcon, { icon: faTag })),
+      kind === "performer" && onShowScenes && React.createElement(Button, { className: "curator-icon-action", size: "sm", title: "Show this performer's scenes", "aria-label": "Show this performer's scenes", onClick: () => onShowScenes(item) }, React.createElement(FontAwesomeIcon, { icon: faFilm })),
+      kind === "scene" && canWhisparr && React.createElement(Button, { className: "curator-icon-action curator-whisparr-action", size: "sm", variant: "primary", disabled: !whisparrEnabled || whisparr?.status === "adding" || whisparr?.status === "sent" || whisparr?.status === "already_exists", title: !whisparrEnabled ? "Configure Whisparr in plugin settings" : whisparr?.status === "error" ? "Retry sending to Whisparr" : "Send to Whisparr", "aria-label": !whisparrEnabled ? "Whisparr is not configured" : whisparr?.status === "error" ? "Retry sending to Whisparr" : "Send to Whisparr", onClick: onAddToWhisparr }, React.createElement("span", { className: "curator-whisparr-logo", "aria-hidden": "true" }, React.createElement("span", { className: "curator-whisparr-fallback" }, "W"), React.createElement("img", { src: WHISPARR_LOGO, alt: "", onError: (event) => event.currentTarget.remove() }))),
+      whisparr && React.createElement("small", { className: `curator-whisparr-status ${whisparr.status === "error" ? "text-danger" : ""}`, role: "status" }, whisparr.message)
+    );
+  }
+
   const ExternalCard = Api.register.component("stash-curator.ExternalCard", function ExternalCard(props) {
     const { HoverPopover } = Api.components;
     const { item, kind, gender, onShortlist, onShowScenes, onWhisparr, whisparrEnabled } = transformComponentProps("stash-curator.ExternalCard", props);
@@ -1707,8 +1758,8 @@
       payload.curator_local_match?.type === "phash" && React.createElement("span", { className: "curator-phash-badge", title: "A local scene has the same exact PHash. This is strong matching evidence, not guaranteed identity." }, "Likely local · exact PHash"),
       React.createElement("div", { className: `curator-external-thumbnail thumbnail-section ${kind === "scene" ? "video-section" : ""}` }, React.createElement("a", { className: `${kind}-card-link`, href, target: "_blank", rel: "noreferrer" }, image && React.createElement("img", { className: `${kind}-card-image`, src: image, loading: "lazy", alt: "" })), kind === "scene" && payload.studio?.name && React.createElement("span", { className: "curator-external-studio-overlay" }, payload.studio.name)),
       React.createElement("div", { className: "card-section" }, React.createElement(TitleLink, localProfile, React.createElement("h5", { className: "card-section-title flex-aligned" }, title)), React.createElement("div", { className: kind === "scene" ? "scene-card__details" : "curator-external-details" }, React.createElement("span", null, payload.release_date || payload.birth_date || ""), metadataControls), kind === "scene" && payload.details && React.createElement("p", { className: "curator-card-description" }, payload.details)),
-      React.createElement("div", { className: "curator-card-body" }, (() => { let scoreDetail; if (item.similarity === undefined) { scoreDetail = `Match ${item.score.toFixed(2)} · found via ${item.sources.join(", ")}`; } else { scoreDetail = `Similarity ${item.similarity.toFixed(2)}` + (item.appeal !== undefined ? ` · appeal ${item.appeal.toFixed(2)}` : ""); const mh = item.details && item.details.score_breakdown && item.details.score_breakdown.multi_hop; if (mh > 0) scoreDetail += " + multi-hop " + mh.toFixed(4); } return React.createElement("div", { className: "curator-card-details" }, payload.why?.length && React.createElement("details", { className: "curator-evidence" }, React.createElement("summary", null, "Why this?"), React.createElement("p", { className: "curator-explanation" }, payload.why.join(" · "))), React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, `Score · ${item.score.toFixed(2)}`), scoreBar(item), React.createElement("p", null, scoreDetail))); })()),
-      React.createElement("div", { className: "curator-prune-actions" }, React.createElement("a", { className: "btn btn-secondary btn-sm curator-icon-action", href, target: "_blank", rel: "noreferrer", title: "Open on StashDB", "aria-label": "Open on StashDB" }, React.createElement(FontAwesomeIcon, { icon: faExternalLinkAlt })), React.createElement(Button, { className: "curator-icon-action", size: "sm", title: copied ? "Copied" : "Copy StashDB ID", "aria-label": copied ? "Copied" : "Copy StashDB ID", onClick: async () => { try { await copyText(item.id); setCopied(true); setTimeout(() => setCopied(false), 1500); } catch (_) { setCopied(false); } } }, React.createElement(FontAwesomeIcon, { icon: copied ? faCheckCircle : faCopy })), onShortlist && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: item.shortlisted ? "primary" : "secondary", title: item.shortlisted ? "Remove from shortlist" : "Add to shortlist", "aria-label": item.shortlisted ? "Remove from shortlist" : "Add to shortlist", onClick: () => onShortlist(item, kind) }, React.createElement(FontAwesomeIcon, { icon: faList })), kind === "scene" && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: tagChoices !== null ? "primary" : "secondary", disabled: tags.length === 0 || tagLoading, title: "Rate tags & terms", "aria-label": "Rate tags & terms", onClick: rateTags }, React.createElement(FontAwesomeIcon, { icon: faTag })), kind === "performer" && onShowScenes && React.createElement(Button, { className: "curator-icon-action", size: "sm", title: "Show this performer's scenes", "aria-label": "Show this performer's scenes", onClick: () => onShowScenes(item) }, React.createElement(FontAwesomeIcon, { icon: faFilm })), kind === "scene" && onWhisparr && React.createElement(Button, { className: "curator-icon-action curator-whisparr-action", size: "sm", variant: "primary", disabled: !whisparrEnabled || whisparr?.status === "adding" || whisparr?.status === "sent" || whisparr?.status === "already_exists", title: !whisparrEnabled ? "Configure Whisparr in plugin settings" : whisparr?.status === "error" ? "Retry sending to Whisparr" : "Send to Whisparr", "aria-label": !whisparrEnabled ? "Whisparr is not configured" : whisparr?.status === "error" ? "Retry sending to Whisparr" : "Send to Whisparr", onClick: addToWhisparr }, React.createElement("span", { className: "curator-whisparr-logo", "aria-hidden": "true" }, React.createElement("span", { className: "curator-whisparr-fallback" }, "W"), React.createElement("img", { src: WHISPARR_LOGO, alt: "", onError: (event) => event.currentTarget.remove() }))), whisparr && React.createElement("small", { className: `curator-whisparr-status ${whisparr.status === "error" ? "text-danger" : ""}`, role: "status" }, whisparr.message)),
+      React.createElement("div", { className: "curator-card-body" }, (() => { let scoreDetail; if (item.similarity === undefined) { scoreDetail = `Match ${item.score.toFixed(2)} · found via ${item.sources.join(", ")}`; } else { scoreDetail = `Similarity ${item.similarity.toFixed(2)}` + (item.appeal !== undefined ? ` · appeal ${item.appeal.toFixed(2)}` : ""); const mh = item.details && item.details.score_breakdown && item.details.score_breakdown.multi_hop; if (mh > 0) scoreDetail += " + multi-hop " + mh.toFixed(4); } return React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, { evidenceContent: payload.why?.length ? React.createElement("p", { className: "curator-explanation" }, payload.why.join(" · ")) : null, scoreSummary: item.score.toFixed(2), scoreContent: React.createElement(React.Fragment, null, scoreBar(item), React.createElement("p", null, scoreDetail)) })); })()),
+      React.createElement(ExternalActions, { href, item, kind, copied, onCopy: async () => { try { await copyText(item.id); setCopied(true); setTimeout(() => setCopied(false), 1500); } catch (_) { setCopied(false); } }, onShortlist, tagsAvailable: tags.length > 0, tagsActive: tagChoices !== null, tagLoading, onRateTags: rateTags, onShowScenes, whisparrEnabled, canWhisparr: Boolean(onWhisparr), whisparr, onAddToWhisparr: addToWhisparr }),
       kind === "scene" && tagChoices !== null && React.createElement("div", { className: "curator-external-tag-rating" }, React.createElement("div", { className: "curator-external-tag-rating-header" }, React.createElement("strong", null, "Rate tags & terms"), React.createElement(Button, { size: "sm", variant: "link", className: "curator-external-tag-rating-close", "aria-label": "Collapse matching local tag ratings", title: "Collapse matching local tag ratings", onClick: rateTags }, "Collapse")), tagLoading && React.createElement("small", { role: "status" }, "Matching local tags…"), tagError && React.createElement("small", { className: "text-danger", role: "status" }, tagError), !tagLoading && !tagError && React.createElement(React.Fragment, null, React.createElement(RatingSection, { title: "Matching local tags", rows: tagChoices.map((tag) => ({ key: tag.tag_id, tag_id: tag.tag_id, name: tag.name, direct_value: tag.direct_value, direct_blocked: tag.direct_blocked })), onAnswer: answerTag, emptyLabel: "No matching local tags." }), React.createElement(RatingSection, { title: "Description terms", rows: termChoices.map((term) => ({ key: term.term, term: term.term, name: term.term, direct_value: term.direct_value, direct_blocked: term.direct_blocked })), onAnswer: answerTerm, emptyLabel: "No description terms in the model." })))
     );
   });
@@ -1990,36 +2041,38 @@
         React.createElement(
           "div",
           { className: "curator-card-details" },
-          React.createElement(
-            "details",
-            { className: "curator-evidence", onToggle: explain },
-            React.createElement("summary", null, "Why this?"),
-            explanationLoading && React.createElement("small", { role: "status" }, "Explaining…"),
-            explanationError && React.createElement("small", { className: "text-danger", role: "alert" }, explanationError),
-            explanation && React.createElement("p", { className: "curator-explanation" }, explanation.summary),
-            explanation && React.createElement(
-              "ul",
+          React.createElement(EvidenceScore, {
+            evidenceProps: { onToggle: explain },
+            evidenceContent: React.createElement(
+              React.Fragment,
               null,
-              explanation.supporting_reasons.map((reason, index) =>
-                React.createElement(
-                  "li",
-                  { key: `${reason.code}-${index}` },
-                  `${reasonLabel(reason.code)} (${reason.magnitude.toFixed(2)})`
+              explanationLoading && React.createElement("small", { role: "status" }, "Explaining…"),
+              explanationError && React.createElement("small", { className: "text-danger", role: "alert" }, explanationError),
+              explanation && React.createElement("p", { className: "curator-explanation" }, explanation.summary),
+              explanation && React.createElement(
+                "ul",
+                null,
+                explanation.supporting_reasons.map((reason, index) =>
+                  React.createElement(
+                    "li",
+                    { key: `${reason.code}-${index}` },
+                    `${reasonLabel(reason.code)} (${reason.magnitude.toFixed(2)})`
+                  )
                 )
               )
-            )
-          ),
-          React.createElement(
-            "details",
-            { className: "curator-score" },
-            React.createElement("summary", null, `Score · ${item.final_utility.toFixed(2)}`),
-            React.createElement(ScoreNode, { name: "appeal", value: item.appeal }),
-            React.createElement(ScoreNode, { name: "current_fit", value: item.current_fit }),
-            React.createElement(ScoreNode, { name: "confidence", value: item.confidence }),
-            React.createElement(ScoreNode, { name: "components", value: item.components }),
-            React.createElement(ScoreNode, { name: "diversity_penalties", value: item.penalties }),
-            React.createElement(ScoreNode, { name: "diversity_bonuses", value: item.bonuses })
-          ),
+            ),
+            scoreSummary: item.final_utility.toFixed(2),
+            scoreContent: React.createElement(
+              React.Fragment,
+              null,
+              React.createElement(ScoreNode, { name: "appeal", value: item.appeal }),
+              React.createElement(ScoreNode, { name: "current_fit", value: item.current_fit }),
+              React.createElement(ScoreNode, { name: "confidence", value: item.confidence }),
+              React.createElement(ScoreNode, { name: "components", value: item.components }),
+              React.createElement(ScoreNode, { name: "diversity_penalties", value: item.penalties }),
+              React.createElement(ScoreNode, { name: "diversity_bonuses", value: item.bonuses })
+            ),
+          }),
           React.createElement(Feedback, { item, onRemove, onThumbDown })
         )
       )
@@ -2185,6 +2238,53 @@
       React.createElement("input", { value: name, onChange: (event) => setName(event.target.value), placeholder: "Filter name", "aria-label": "Filter name" }),
       React.createElement("label", null, React.createElement("input", { type: "checkbox", checked: makeDefault, onChange: (event) => setMakeDefault(event.target.checked) }), " Default"),
       React.createElement(Button, { size: "sm", disabled: !name.trim(), onClick: save }, "Save")
+    );
+  }
+
+  // Shared filter panel for Similar/Expand/Hunt. The three views show
+  // different field subsets (hunt only ever shows tags + hide-phash, with
+  // no entityType gating at all, since it has no "scene vs performer"
+  // split); variant captures that shape plus the couple of markup
+  // differences (favorites button's aria-pressed/title, gender aria-label,
+  // minimum-match range floor) that predate this extraction and aren't
+  // being "fixed" here, just ported as-is. State mutation stays with the
+  // caller (each already has its own updateUrl closures per field).
+  function FilterBar({
+    variant,
+    entityType,
+    includeTags, onIncludeTagsChange,
+    excludeTags, onExcludeTagsChange,
+    performers, onPerformersChange,
+    studios, onStudiosChange,
+    favoriteOnly, onToggleFavorite,
+    hidePhashMatches, onToggleHidePhash,
+    gender, onGenderChange,
+    minimum, onMinimumChange,
+    savedCurrent, onApplySaved,
+    applyVisible = true, onApply,
+  }) {
+    const sceneGated = variant !== "hunt";
+    const showScene = !sceneGated || entityType === "scene";
+    const minimumMin = variant === "expand" ? "-0.2" : "0";
+    const genderAriaLabel = variant === "expand" ? "External performer gender" : "Performer gender";
+    const favoriteExtra = variant === "expand" ? { title: "Show only scenes containing a performer favorited in your local library", "aria-pressed": favoriteOnly } : {};
+    return React.createElement(
+      "div",
+      { className: "curator-expand-filters curator-filter-panel" },
+      React.createElement(
+        "div",
+        null,
+        showScene && React.createElement(FilterTokens, { kind: "tag", label: "Include tags", values: includeTags, onChange: onIncludeTagsChange }),
+        showScene && React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: onExcludeTagsChange }),
+        sceneGated && showScene && React.createElement(FilterTokens, { kind: "performer", label: "Performers", values: performers, onChange: onPerformersChange }),
+        sceneGated && showScene && React.createElement(FilterTokens, { kind: "studio", label: "Studios", values: studios, onChange: onStudiosChange }),
+        sceneGated && showScene && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", ...favoriteExtra, onClick: onToggleFavorite }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"),
+        showScene && React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: onToggleHidePhash }, React.createElement(FontAwesomeIcon, { icon: faClone }), " Hide exact PHash matches"),
+        sceneGated && React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: onGenderChange, "aria-label": genderAriaLabel }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))),
+        sceneGated && showScene && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimum.toFixed(2)}`), React.createElement("input", { type: "range", min: minimumMin, max: "0.8", step: "0.05", value: minimum, onChange: onMinimumChange })),
+        (sceneGated ? showScene : true) && React.createElement(SavedFilters, { scope: variant, current: savedCurrent, onApply: onApplySaved }),
+        applyVisible && React.createElement(Button, { size: "sm", variant: "primary", onClick: onApply }, "Apply")
+      )
     );
   }
 
@@ -2439,7 +2539,22 @@
         source === "stashdb" && React.createElement(Button, { className: "curator-include-owned", size: "sm", variant: includeOwned ? "primary" : "secondary", "aria-pressed": includeOwned, title: `Include ${entityType}s already in your library so the remote ranking can be compared with the local search`, "aria-label": includeOwned ? `Hide library ${entityType}s` : `Include library ${entityType}s`, onClick: () => updateUrl((s) => ({ ...s, includeOwned: !s.includeOwned, page: 1, excludedIds: [] })) }, React.createElement(FontAwesomeIcon, { icon: faUserCheck }), " Local"),
         React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters")
       ),
-      filtersOpen && React.createElement("div", { className: "curator-expand-filters curator-filter-panel" }, React.createElement("div", null, entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Include tags", values: includeTags, onChange: (value) => updateUrl((s) => ({ ...s, includeTags: value })) }), entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: (value) => updateUrl((s) => ({ ...s, excludeTags: value })) }), entityType === "scene" && React.createElement(FilterTokens, { kind: "performer", label: "Performers", values: filterPerformers, onChange: (value) => updateUrl((s) => ({ ...s, filterPerformers: value })) }), entityType === "scene" && React.createElement(FilterTokens, { kind: "studio", label: "Studios", values: filterStudios, onChange: (value) => updateUrl((s) => ({ ...s, filterStudios: value })) }), entityType === "scene" && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", onClick: () => updateUrl((s) => ({ ...s, favoriteOnly: !s.favoriteOnly })) }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"), entityType === "scene" && React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: () => updateUrl((s) => ({ ...s, hidePhashMatches: !s.hidePhashMatches })) }, React.createElement(FontAwesomeIcon, { icon: faClone }), " Hide exact PHash matches"), React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: (event) => updateUrl((s) => ({ ...s, gender: event.target.value })), "aria-label": "Performer gender" }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))), entityType === "scene" && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimumSimilarity.toFixed(2)}`), React.createElement("input", { type: "range", min: "0", max: "0.8", step: "0.05", value: minimumSimilarity, onChange: (event) => updateUrl((s) => ({ ...s, minimumSimilarity: Number(event.target.value) })) })), entityType === "scene" && React.createElement(SavedFilters, { scope: "similar", current: { gender, favoriteOnly, hidePhashMatches, includeTags, excludeTags, performers: filterPerformers, studios: filterStudios, minimum: minimumSimilarity }, onApply: applySaved }), selected && React.createElement(Button, { size: "sm", variant: "primary", onClick: () => updateUrl((s) => ({ ...s, excludedIds: [], page: 1, fetchTick: s.fetchTick + 1 })) }, "Apply"))),
+      filtersOpen && React.createElement(FilterBar, {
+        variant: "similar",
+        entityType,
+        includeTags, onIncludeTagsChange: (value) => updateUrl((s) => ({ ...s, includeTags: value })),
+        excludeTags, onExcludeTagsChange: (value) => updateUrl((s) => ({ ...s, excludeTags: value })),
+        performers: filterPerformers, onPerformersChange: (value) => updateUrl((s) => ({ ...s, filterPerformers: value })),
+        studios: filterStudios, onStudiosChange: (value) => updateUrl((s) => ({ ...s, filterStudios: value })),
+        favoriteOnly, onToggleFavorite: () => updateUrl((s) => ({ ...s, favoriteOnly: !s.favoriteOnly })),
+        hidePhashMatches, onToggleHidePhash: () => updateUrl((s) => ({ ...s, hidePhashMatches: !s.hidePhashMatches })),
+        gender, onGenderChange: (event) => updateUrl((s) => ({ ...s, gender: event.target.value })),
+        minimum: minimumSimilarity, onMinimumChange: (event) => updateUrl((s) => ({ ...s, minimumSimilarity: Number(event.target.value) })),
+        savedCurrent: { gender, favoriteOnly, hidePhashMatches, includeTags, excludeTags, performers: filterPerformers, studios: filterStudios, minimum: minimumSimilarity },
+        onApplySaved: applySaved,
+        applyVisible: Boolean(selected),
+        onApply: () => updateUrl((s) => ({ ...s, excludedIds: [], page: 1, fetchTick: s.fetchTick + 1 })),
+      }),
       search && !selected && React.createElement(
         "div",
         { className: "curator-similar-candidates" },
@@ -2456,7 +2571,7 @@
         items.map((item) => {
           const entity = entities.get(String(item.entity_id));
           if (!entity) return null;
-          const body = React.createElement("div", { className: "curator-card-body" }, entityType === "scene" && React.createElement(LocalRatingPanel, { sceneId: item.entity_id }), React.createElement("div", { className: "curator-card-details" }, React.createElement("details", { className: "curator-evidence" }, React.createElement("summary", null, "Why this?"), React.createElement("p", { className: "curator-explanation" }, relationshipChips(item))), React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, `Score · ${item.rank_score.toFixed(2)}`), scoreBar(item), React.createElement("p", null, `Similarity ${item.similarity.toFixed(2)} · predicted appeal ${item.appeal.toFixed(2)}`))));
+          const body = React.createElement("div", { className: "curator-card-body" }, entityType === "scene" && React.createElement(LocalRatingPanel, { sceneId: item.entity_id }), React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, { evidenceContent: React.createElement("p", { className: "curator-explanation" }, relationshipChips(item)), scoreSummary: item.rank_score.toFixed(2), scoreContent: React.createElement(React.Fragment, null, scoreBar(item), React.createElement("p", null, `Similarity ${item.similarity.toFixed(2)} · predicted appeal ${item.appeal.toFixed(2)}`)) })));
           if (entityType === "performer") return React.createElement("article", { key: item.entity_id, className: "curator-card" }, React.createElement(PerformerCard, { performer: entity }), body);
           const feedbackItem = { ...item, scene_id: item.entity_id, impression_id: result.impression_id };
           function rememberOrigin(event) {
@@ -2771,8 +2886,31 @@
         data?.ready && React.createElement("label", { className: "curator-toolbar-select" }, React.createElement(FontAwesomeIcon, { icon: faSortAmountDown }), React.createElement("select", { value: huntSort, onChange: (event) => updateUrl((s) => ({ ...s, page: 1, huntSort: event.target.value })), "aria-label": "Sort Performer Hunt results" }, React.createElement("option", { value: "date" }, "Release date"), React.createElement("option", { value: "score" }, "Preference score")))
       ),
       entityType === "hunt" && data?.truncated && React.createElement("div", { className: "alert alert-warning" }, `Showing the first ${data.fetched_count.toLocaleString()} of ${data.stashdb_total.toLocaleString()} StashDB scenes; the safety cap is ${data.limit.toLocaleString()}. Counts below apply to the fetched scenes.`),
-      entityType === "hunt" && filtersOpen && React.createElement("div", { className: "curator-expand-filters curator-filter-panel" }, React.createElement("div", null, React.createElement(FilterTokens, { kind: "tag", label: "Include tags", values: includeTags, onChange: (value) => updateUrl((s) => ({ ...s, includeTags: value })) }), React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: (value) => updateUrl((s) => ({ ...s, excludeTags: value })) }), React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: () => updateUrl((s) => ({ ...s, hidePhashMatches: !s.hidePhashMatches })) }, React.createElement(FontAwesomeIcon, { icon: faClone }), " Hide exact PHash matches"), React.createElement(SavedFilters, { scope: "hunt", current: { hidePhashMatches, includeTags, excludeTags }, onApply: (value) => updateUrl((s) => ({ ...s, page: 1, hidePhashMatches: value.hidePhashMatches !== false, includeTags: value.includeTags || [], excludeTags: value.excludeTags || [] })) }), React.createElement(Button, { size: "sm", variant: "primary", onClick: () => (updateUrl((s) => ({ ...s, page: 1 })), setFiltersOpen(false)) }, "Apply"))),
-      entityType !== "shortlist" && entityType !== "hunt" && filtersOpen && React.createElement("div", { className: "curator-expand-filters curator-filter-panel" }, React.createElement("div", null, entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Include tags", values: includeTags, onChange: (value) => updateUrl((s) => ({ ...s, includeTags: value })) }), entityType === "scene" && React.createElement(FilterTokens, { kind: "tag", label: "Exclude tags", values: excludeTags, onChange: (value) => updateUrl((s) => ({ ...s, excludeTags: value })) }), entityType === "scene" && React.createElement(FilterTokens, { kind: "performer", label: "Performers", values: performers, onChange: (value) => updateUrl((s) => ({ ...s, performers: value })) }), entityType === "scene" && React.createElement(FilterTokens, { kind: "studio", label: "Studios", values: studios, onChange: (value) => updateUrl((s) => ({ ...s, studios: value })) }), entityType === "scene" && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", title: "Show only scenes containing a performer favorited in your local library", "aria-pressed": favoriteOnly, onClick: () => updateUrl((s) => ({ ...s, page: 1, favoriteOnly: !s.favoriteOnly })) }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"), entityType === "scene" && React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: () => updateUrl((s) => ({ ...s, page: 1, hidePhashMatches: !s.hidePhashMatches })) }, React.createElement(FontAwesomeIcon, { icon: faClone }), " Hide exact PHash matches"), React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: (event) => updateUrl((s) => ({ ...s, page: 1, gender: event.target.value })), "aria-label": "External performer gender" }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))), entityType === "scene" && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimumScore.toFixed(2)}`), React.createElement("input", { type: "range", min: "-0.2", max: "0.8", step: "0.05", value: minimumScore, onChange: (event) => updateUrl((s) => ({ ...s, minimumScore: Number(event.target.value) })) })), entityType === "scene" && React.createElement(SavedFilters, { scope: "expand", current: { gender, favoriteOnly, hidePhashMatches, includeTags, excludeTags, performers, studios, minimum: minimumScore }, onApply: applySaved }), React.createElement(Button, { size: "sm", variant: "primary", onClick: () => (updateUrl((s) => ({ ...s, page: 1 })), setFilterVersion((value) => value + 1)) }, "Apply"))),
+      entityType === "hunt" && filtersOpen && React.createElement(FilterBar, {
+        variant: "hunt",
+        entityType,
+        includeTags, onIncludeTagsChange: (value) => updateUrl((s) => ({ ...s, includeTags: value })),
+        excludeTags, onExcludeTagsChange: (value) => updateUrl((s) => ({ ...s, excludeTags: value })),
+        hidePhashMatches, onToggleHidePhash: () => updateUrl((s) => ({ ...s, hidePhashMatches: !s.hidePhashMatches })),
+        savedCurrent: { hidePhashMatches, includeTags, excludeTags },
+        onApplySaved: (value) => updateUrl((s) => ({ ...s, page: 1, hidePhashMatches: value.hidePhashMatches !== false, includeTags: value.includeTags || [], excludeTags: value.excludeTags || [] })),
+        onApply: () => (updateUrl((s) => ({ ...s, page: 1 })), setFiltersOpen(false)),
+      }),
+      entityType !== "shortlist" && entityType !== "hunt" && filtersOpen && React.createElement(FilterBar, {
+        variant: "expand",
+        entityType,
+        includeTags, onIncludeTagsChange: (value) => updateUrl((s) => ({ ...s, includeTags: value })),
+        excludeTags, onExcludeTagsChange: (value) => updateUrl((s) => ({ ...s, excludeTags: value })),
+        performers, onPerformersChange: (value) => updateUrl((s) => ({ ...s, performers: value })),
+        studios, onStudiosChange: (value) => updateUrl((s) => ({ ...s, studios: value })),
+        favoriteOnly, onToggleFavorite: () => updateUrl((s) => ({ ...s, page: 1, favoriteOnly: !s.favoriteOnly })),
+        hidePhashMatches, onToggleHidePhash: () => updateUrl((s) => ({ ...s, page: 1, hidePhashMatches: !s.hidePhashMatches })),
+        gender, onGenderChange: (event) => updateUrl((s) => ({ ...s, page: 1, gender: event.target.value })),
+        minimum: minimumScore, onMinimumChange: (event) => updateUrl((s) => ({ ...s, minimumScore: Number(event.target.value) })),
+        savedCurrent: { gender, favoriteOnly, hidePhashMatches, includeTags, excludeTags, performers, studios, minimum: minimumScore },
+        onApplySaved: applySaved,
+        onApply: () => (updateUrl((s) => ({ ...s, page: 1 })), setFilterVersion((value) => value + 1)),
+      }),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
       message && React.createElement("p", { role: "status" }, message),
       entityType === "hunt" && !huntPerformer && React.createElement("div", { className: "alert alert-info" }, "Select a local performer linked to StashDB."),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -1023,7 +1023,7 @@
             { key: item.tag_id, className: "curator-taste-item" },
             React.createElement("div", null,
               React.createElement("strong", null, item.name),
-              item.prompt && React.createElement("span", { className: "badge badge-info" }, item.prompt === "belief" ? `I think you ${item.inferred_value >= 0 ? "like" : "dislike"} this` : "I'm unsure"),
+              item.prompt && React.createElement("span", { className: `badge ${item.prompt === "belief" ? (item.inferred_value >= 0 ? "curator-sentiment-love" : "curator-sentiment-danger") : "curator-sentiment-neutral"}` }, item.prompt === "belief" ? `I think you ${item.inferred_value >= 0 ? "like" : "dislike"} this` : "I'm unsure"),
               React.createElement("small", null, `Inferred ${item.inferred_value.toFixed(2)} · confidence ${item.confidence.toFixed(2)} · support ${item.support.toFixed(1)} · ${item.scene_count} local scene${item.scene_count === 1 ? "" : "s"}`)
             ),
             React.createElement(TagSentimentControl, { tag: item, value: item.direct_value, blocked: item.direct_blocked, onChange: (value) => answer(item.tag_id, value) })

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -720,6 +720,13 @@
     const labels = {
       "appeal.performer_identity": "Performer match",
       "appeal.content_neighbor": "Similar content",
+      // The baseline reason present on every impression regardless of lane
+      // (core/slate.go, slate_greedy.go, score_review.go all seed reasonIDs
+      // with this) — richer reasons like the two above are appended after
+      // it when they apply, but plenty of items have no reason beyond this
+      // one. The naive fallback below (last dot-segment, title-cased) turns
+      // it into the confusing bare word "Lane".
+      "eligibility.lane": "Eligible for this lane",
     };
     const fallback = code.split(".").at(-1).replaceAll("_", " ");
     return labels[code] || fallback.charAt(0).toUpperCase() + fallback.slice(1);
@@ -2168,7 +2175,7 @@
           ? React.createElement(NavLink, { to: `/scenes/${item.scene_id}` }, scene.title || `Scene ${item.scene_id}`)
           : React.createElement("span", { className: "text-muted" }, "Scene removed from Stash")
       ),
-      React.createElement("td", null, laneByValue.get(item.lane)?.label || item.lane),
+      React.createElement("td", null, item.lane === "score_review" ? "Sentiment review" : (laneByValue.get(item.lane)?.label || item.lane)),
       React.createElement(
         "td",
         null,

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -748,7 +748,7 @@
   function sentimentValueToTrackPct(value) {
     return 20 + (Math.max(-1, Math.min(1, value)) + 1) * 40;
   }
-  function nearestSentimentLabel(value) {
+  function nearestSentiment(value) {
     let best = SENTIMENTS[0];
     let bestDistance = Infinity;
     for (const entry of SENTIMENTS) {
@@ -758,7 +758,36 @@
         best = entry;
       }
     }
-    return best[1];
+    return best;
+  }
+  function nearestSentimentLabel(value) {
+    return nearestSentiment(value)[1];
+  }
+  const BELIEF_PHRASES = {
+    "Strong dislike": "strongly dislike",
+    "Slight dislike": "slightly dislike",
+    "Neutral": "feel neutral about",
+    "Slight like": "slightly like",
+    "Strong like": "strongly like",
+  };
+  function beliefSentence(value) {
+    return `I think you ${BELIEF_PHRASES[nearestSentimentLabel(value)]} this`;
+  }
+
+  // Design-mockup "confidence pips": 5 bars, filled left-to-right by how
+  // much viewing history supports the model's inference for this tag.
+  function ConfidencePips({ confidence }) {
+    const on = Math.round(Math.max(0, Math.min(1, confidence)) * 5);
+    return React.createElement(
+      "div",
+      { className: "curator-confidence-wrap" },
+      React.createElement("span", { className: "curator-confidence-label" }, "Confidence"),
+      React.createElement(
+        "div",
+        { className: "curator-confidence-pips", title: "How much viewing history supports this inference — more filled bars means more evidence" },
+        [0, 1, 2, 3, 4].map((index) => React.createElement("span", { key: index, className: index < on ? "on" : "" }))
+      )
+    );
   }
 
   // A single 6-stop control: "Never" is stop 0 on the same track as the 5
@@ -770,17 +799,34 @@
   // math the way the original design mockup's static-HTML version did.
   // `inferredValue`, when given (only Taste Profile has this — it's the
   // model's own continuous estimate, distinct from the user's discrete
-  // direct rating), renders as a small hollow ring on the same track so the
-  // two can be compared at a glance.
+  // direct rating), renders as a small differently-colored tick on the same
+  // track so the two can be compared at a glance.
   function TagSentimentControl({ tag, value, blocked, onChange, compact = false, inferredValue = null }) {
     const rated = (value !== null && value !== undefined) || blocked;
     const stopIndex = blocked ? 0 : rated ? SENTIMENTS.findIndex(([score]) => score === value) + 1 : 3;
     const currentLabel = blocked ? "Never" : rated ? SENTIMENTS[stopIndex - 1][1] : "Not rated";
     const tierClass = blocked ? "curator-sentiment-never" : rated ? SENTIMENTS[stopIndex - 1][2] : "";
-    function handleChange(event) {
-      const index = Number(event.target.value);
+    function commit(index) {
       if (index === 0) onChange({ value: null, blocked: true });
       else onChange({ value: SENTIMENTS[index - 1][0], blocked: false });
+    }
+    function handleChange(event) {
+      commit(Number(event.target.value));
+    }
+    // An unrated item is displayed with the thumb parked at stop 3
+    // ("Neutral")'s position, purely as a resting point — there's no real
+    // value yet. A native range input only fires input/change when its
+    // value actually changes, so a click that resolves to that SAME stop
+    // (i.e. clicking dead-center on "Neutral") is indistinguishable from a
+    // no-op to the browser and silently does nothing. Recompute the
+    // intended stop from click position and commit directly whenever it
+    // matches the value already showing, which is exactly the case the
+    // native event won't fire for.
+    function handleClick(event) {
+      const rect = event.currentTarget.getBoundingClientRect();
+      const ratio = Math.min(1, Math.max(0, (event.clientX - rect.left) / rect.width));
+      const index = Math.round(ratio * 5);
+      if (index === stopIndex) commit(index);
     }
     const hasModelEstimate = inferredValue !== null && inferredValue !== undefined;
     return React.createElement(
@@ -805,7 +851,7 @@
               style: { left: `${sentimentValueToTrackPct(inferredValue)}%` },
               title: `Model estimate: ${nearestSentimentLabel(inferredValue)} (${inferredValue.toFixed(2)})`,
             }),
-            React.createElement("span", { className: `curator-sentiment-thumb${!rated ? " curator-sentiment-thumb-unset" : ""}`, style: { left: `${(stopIndex / 5) * 100}%` } })
+            rated && React.createElement("span", { className: "curator-sentiment-thumb", style: { left: `${(stopIndex / 5) * 100}%` } })
           ),
           React.createElement("input", {
             type: "range",
@@ -817,6 +863,7 @@
             "aria-label": `Sentiment for ${tag.name}`,
             "aria-valuetext": currentLabel,
             onChange: handleChange,
+            onClick: handleClick,
           })
         ),
         !compact && React.createElement("span", { className: "curator-sentiment-current" }, currentLabel)
@@ -1078,9 +1125,10 @@
             { key: item.tag_id, className: "curator-taste-item" },
             React.createElement("div", null,
               React.createElement("strong", null, item.name),
-              item.prompt && React.createElement("span", { className: `badge ${item.prompt === "belief" ? (item.inferred_value >= 0 ? "curator-sentiment-love" : "curator-sentiment-danger") : "curator-sentiment-neutral"}` }, item.prompt === "belief" ? `I think you ${item.inferred_value >= 0 ? "like" : "dislike"} this` : "I'm unsure"),
+              item.prompt && React.createElement("span", { className: `badge ${item.prompt === "belief" ? nearestSentiment(item.inferred_value)[2] : "curator-sentiment-neutral"}` }, item.prompt === "belief" ? beliefSentence(item.inferred_value) : "I'm unsure"),
               React.createElement("small", null, `Inferred ${item.inferred_value.toFixed(2)} · confidence ${item.confidence.toFixed(2)} · support ${item.support.toFixed(1)} · ${item.scene_count} local scene${item.scene_count === 1 ? "" : "s"}`)
             ),
+            React.createElement(ConfidencePips, { confidence: item.confidence }),
             React.createElement(TagSentimentControl, { tag: item, value: item.direct_value, blocked: item.direct_blocked, inferredValue: item.inferred_value, onChange: (value) => answer(item.tag_id, value) })
           )
         )

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -11,7 +11,7 @@
   const { NavLink, useHistory, useLocation } = libraries.ReactRouterDOM;
   const { FontAwesomeIcon } = libraries.ReactFontAwesome;
   const { faDev } = libraries.FontAwesomeBrands;
-  const { faBalanceScale, faBroom, faBullseye, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faCrosshairs, faDatabase, faDownload, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSync, faTag, faThumbsDown, faThumbsUp, faUser, faUserCheck, faVenus, faWrench, faXmark } = libraries.FontAwesomeSolid;
+  const { faBalanceScale, faBroom, faBullseye, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faCrosshairs, faDatabase, faDownload, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faMoon, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSun, faSync, faTag, faThumbsDown, faThumbsUp, faUser, faUserCheck, faVenus, faWrench, faXmark } = libraries.FontAwesomeSolid;
   const componentTransforms = window.StashCuratorComponentTransforms ||= {};
 
   function transformComponentProps(name, props) {
@@ -52,17 +52,28 @@
   const NAV_ITEMS = [
     ...LANES,
     {
-      value: "feedback",
-      label: "Feedback history",
-      icon: faThumbsUp,
-      maintenance: true,
-      description: "Review recent feedback, undo mistakes, or replace an action without rewriting history.",
+      value: "curate",
+      label: "Curate",
+      icon: faBullseye,
+      description: "Compare scenes in pairs to teach the model fast, or review tag sentiment.",
     },
     {
       value: "similar",
       label: "Similar",
       icon: faClone,
       description: "Choose a scene or performer, then compare preference-aware matches from your Library or StashDB.",
+    },
+    {
+      value: "expand",
+      label: "Expand",
+      icon: faGlobe,
+      description: "External metadata candidates scored locally. Wildcard items are selected outside preference-derived seeds.",
+    },
+    {
+      value: "hunt",
+      label: "Performer Hunt",
+      icon: faCrosshairs,
+      description: "Find scenes listed for a performer on StashDB and compare them with exact links in your library.",
     },
     {
       value: "taste",
@@ -79,37 +90,18 @@
       description: "Review the model's sentiment estimates: least-appealing scenes first, with reasons and feedback on each card.",
     },
     {
+      value: "feedback",
+      label: "Feedback history",
+      icon: faThumbsUp,
+      maintenance: true,
+      description: "Review recent feedback, undo mistakes, or replace an action without rewriting history.",
+    },
+    {
       value: "history",
       label: "Recently recommended",
       icon: faHistory,
       maintenance: true,
       description: "Revisit qualified recommendations with the reasons recorded when each card appeared.",
-    },
-    {
-      value: "expand",
-      label: "Expand",
-      icon: faGlobe,
-      description: "External metadata candidates scored locally. Wildcard items are selected outside preference-derived seeds.",
-    },
-    {
-      value: "backups",
-      label: "Backups",
-      icon: faDatabase,
-      maintenance: true,
-      description: "Create, inspect, and safely restore Curator sidecar backups.",
-    },
-    {
-      value: "hunt",
-      label: "Performer Hunt",
-      icon: faCrosshairs,
-      description: "Find scenes listed for a performer on StashDB and compare them with exact links in your library.",
-    },
-    {
-      value: "diagnostics",
-      label: "Diagnostics",
-      icon: faWrench,
-      maintenance: true,
-      description: "Preview and export a privacy-safe status report for bug reports.",
     },
     {
       value: "prune",
@@ -119,10 +111,18 @@
       description: "Curator never deletes media; tagging is reversible, and Candidates, Explicit dislikes, and Model suspects are separate review queues.",
     },
     {
-      value: "curate",
-      label: "Curate",
-      icon: faBullseye,
-      description: "Compare scenes in pairs to teach the model fast, or review tag sentiment.",
+      value: "backups",
+      label: "Backups",
+      icon: faDatabase,
+      maintenance: true,
+      description: "Create, inspect, and safely restore Curator sidecar backups.",
+    },
+    {
+      value: "diagnostics",
+      label: "Diagnostics",
+      icon: faWrench,
+      maintenance: true,
+      description: "Preview and export a privacy-safe status report for bug reports.",
     },
     {
       value: "profiling",
@@ -153,6 +153,7 @@
     MANAGE_NAV_ITEM,
   ];
   const EVENT_QUEUE_KEY = "stash-curator:event-queue:v1";
+  const THEME_STORAGE_KEY = "stash-curator:theme";
   const TAG_PREFERENCE_QUEUE_KEY = "stash-curator:tag-preference-queue:v1";
   const TERM_PREFERENCE_QUEUE_KEY = "stash-curator:term-preference-queue:v1";
   const ORIGIN_KEY = "stash-curator:origin:v1";
@@ -3443,7 +3444,7 @@
     );
   }
 
-  function CuratorControls({ onRefresh, onProfiling, profilingActive }) {
+  function CuratorControls({ onRefresh, onProfiling, profilingActive, theme, onToggleTheme }) {
     const [jobs, setJobs] = React.useState([]);
     const [health, setHealth] = React.useState(null);
     const [message, setMessage] = React.useState("");
@@ -3594,6 +3595,7 @@
           React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Use after Stash library changes. Sync changed metadata and history, then refresh recommendations.", "aria-label": "Sync library changes and refresh recommendations", onClick: () => start("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync })),
           React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Force a recommendation refresh from already-synced data. Does not contact Stash.", "aria-label": "Rebuild recommendations without syncing Stash", onClick: () => start("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench })),
           React.createElement(Button, { className: "curator-icon-button curator-profiling-button", size: "sm", variant: profilingActive ? "primary" : "secondary", title: "Open performance profiles.", "aria-label": "Open performance profiles", "aria-pressed": profilingActive, onClick: onProfiling }, React.createElement(FontAwesomeIcon, { icon: faDev })),
+          React.createElement(Button, { className: "curator-icon-button", size: "sm", title: theme === "light" ? "Switch to dark theme" : "Switch to light theme", "aria-label": theme === "light" ? "Switch to dark theme" : "Switch to light theme", onClick: onToggleTheme }, React.createElement(FontAwesomeIcon, { icon: theme === "light" ? faMoon : faSun })),
           React.createElement(NavLink, { className: "btn btn-secondary btn-sm curator-icon-button", title: "Open Curator's plugin settings.", "aria-label": "Plugin settings", to: "/settings?tab=plugins" }, React.createElement(FontAwesomeIcon, { icon: faCog }))
         )
       ),
@@ -3768,6 +3770,25 @@
     const [diversityEnabled, setDiversityEnabled] = React.useState(null);
     const [diversitySaving, setDiversitySaving] = React.useState(false);
     const [followUps, setFollowUps] = React.useState([]);
+    const [theme, setTheme] = React.useState(() => {
+      try {
+        return window.localStorage.getItem(THEME_STORAGE_KEY) === "light" ? "light" : "dark";
+      } catch {
+        return "dark";
+      }
+    });
+    function toggleTheme() {
+      setTheme((current) => {
+        const next = current === "light" ? "dark" : "light";
+        try {
+          window.localStorage.setItem(THEME_STORAGE_KEY, next);
+        } catch {
+          // localStorage can be unavailable (private browsing); the toggle
+          // still works for the session, it just won't persist.
+        }
+        return next;
+      });
+    }
 
     React.useEffect(() => setFollowUps([]), [lane]);
 
@@ -3895,7 +3916,7 @@
 
     return React.createElement(
       "main",
-      { className: "curator-page container-fluid" },
+      { className: "curator-page container-fluid", "data-theme": theme },
       React.createElement(
         "header",
         { className: "curator-header" },
@@ -3924,7 +3945,7 @@
             })
           )
         ),
-        React.createElement(CuratorControls, { onRefresh: refresh, onProfiling: () => openManage("profiling"), profilingActive: lane === "manage" && currentSection === "profiling" })
+        React.createElement(CuratorControls, { onRefresh: refresh, onProfiling: () => openManage("profiling"), profilingActive: lane === "manage" && currentSection === "profiling", theme, onToggleTheme: toggleTheme })
       ),
       laneByValue.has(lane) && React.createElement(
         "div",

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -1451,6 +1451,7 @@
             "div",
             { className: "curator-curate-quick-block" },
             React.createElement("strong", null, "Pick-test a hypothesis"),
+            suggestions === null && React.createElement("small", { role: "status" }, "Loading hypotheses…"),
             suggestions && suggestions.length === 0 && React.createElement("small", null, "No hypotheses yet — Manage → Taste Profile and your rated scenes generate them."),
             (suggestions || []).map((suggestion) =>
               React.createElement(

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -4042,14 +4042,14 @@
       // it keeps its pre-existing !loadingComponents gate even though it now
       // mounts inside ManagePanel rather than as its own top-level branch.
       lane === "manage" && (currentSection !== "prune" || !loadingComponents) && React.createElement(ManagePanel, { section: currentSection, onSelectSection: openManage }),
-      error && React.createElement("div", { className: "alert alert-danger" }, error, React.createElement("p", null, "Run “Sync and build recommendations” from Tasks if no model exists yet."), React.createElement(Button, { size: "sm", variant: "primary", onClick: () => start("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync }), " Sync and build now")),
+      error && React.createElement("div", { className: "alert alert-danger" }, error, React.createElement("p", null, "Run “Sync and build recommendations” from Tasks if no model exists yet."), React.createElement(Button, { size: "sm", variant: "primary", onClick: () => runTask("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync }), " Sync and build now")),
       scenesQuery.error && React.createElement("div", { className: "alert alert-danger" }, scenesQuery.error.message),
       lane === "for_you" && !nudgeDismissed && !readCurateNudge().dismissed && readCurateNudge().rounds < MAX_NUDGE_ROUNDS && React.createElement(CurateNudge, { onOpen: () => openView("curate"), onDismiss: () => { dismissCurateNudge(); setNudgeDismissed(true); } }),
       laneByValue.has(lane) && slate && !loading &&
         React.createElement(
           React.Fragment,
           null,
-          visibleItems.length === 0 && React.createElement("div", { className: "alert alert-info" }, React.createElement("p", null, "Nothing qualifies for this lane right now."), React.createElement(Button, { size: "sm", variant: "secondary", onClick: () => start("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench }), " Rebuild model")),
+          visibleItems.length === 0 && React.createElement("div", { className: "alert alert-info" }, React.createElement("p", null, "Nothing qualifies for this lane right now."), React.createElement(Button, { size: "sm", variant: "secondary", onClick: () => runTask("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench }), " Rebuild model")),
           React.createElement(
             "section",
             { className: "curator-grid", role: "tabpanel", "aria-live": "polite" },

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -1921,36 +1921,36 @@
       }
     }
     return React.createElement(
-      "tr",
-      null,
+      "div",
+      { className: "curator-record-row curator-feedback-row" },
+      React.createElement("span", { className: "curator-record-icon" }, React.createElement(FontAwesomeIcon, { icon: faThumbsUp })),
       React.createElement(
-        "td",
-        null,
-        scene
-          ? React.createElement(NavLink, { to: `/scenes/${item.scene_id}` }, scene.title || `Scene ${item.scene_id}`)
-          : React.createElement("span", { className: "text-muted" }, "Scene removed from Stash")
+        "div",
+        { className: "curator-record-main" },
+        React.createElement(
+          "div",
+          { className: "curator-record-title" },
+          scene
+            ? React.createElement(NavLink, { to: `/scenes/${item.scene_id}` }, scene.title || `Scene ${item.scene_id}`)
+            : React.createElement("span", { className: "text-muted" }, "Scene removed from Stash")
+        ),
+        React.createElement("div", { className: "curator-record-meta" }, `${FEEDBACK_LABELS[item.feedback_type] || item.feedback_type} · ${new Date(item.occurred_at_ms).toLocaleString()}`)
       ),
-      React.createElement("td", null, FEEDBACK_LABELS[item.feedback_type] || item.feedback_type),
-      React.createElement("td", null, new Date(item.occurred_at_ms).toLocaleString()),
-      React.createElement(
-        "td",
-        null,
-        item.reversed_by_id
-          ? React.createElement("span", { className: "text-muted" }, "Corrected")
-          : React.createElement(
-              "div",
-              { className: "curator-feedback-correction" },
-              React.createElement(Button, { size: "sm", variant: "link", disabled: busy, onClick: () => correct(null) }, "Undo"),
-              React.createElement(
-                "select",
-                { className: "form-control form-control-sm", value: replacement, disabled: busy, onChange: (event) => setReplacement(event.target.value), "aria-label": "Replacement feedback" },
-                React.createElement("option", { value: "" }, "Replace with…"),
-                Object.entries(FEEDBACK_LABELS).map(([value, label]) => React.createElement("option", { key: value, value }, label))
-              ),
-              React.createElement(Button, { size: "sm", disabled: busy || !replacement, onClick: () => correct(replacement) }, "Save"),
-              error && React.createElement("small", { className: "text-danger" }, error)
-            )
-      )
+      item.reversed_by_id
+        ? React.createElement("span", { className: "text-muted" }, "Corrected")
+        : React.createElement(
+            "div",
+            { className: "curator-feedback-correction" },
+            React.createElement(Button, { size: "sm", variant: "link", disabled: busy, onClick: () => correct(null) }, "Undo"),
+            React.createElement(
+              "select",
+              { className: "form-control form-control-sm", value: replacement, disabled: busy, onChange: (event) => setReplacement(event.target.value), "aria-label": "Replacement feedback" },
+              React.createElement("option", { value: "" }, "Replace with…"),
+              Object.entries(FEEDBACK_LABELS).map(([value, label]) => React.createElement("option", { key: value, value }, label))
+            ),
+            React.createElement(Button, { size: "sm", variant: "link", disabled: busy || !replacement, onClick: () => correct(replacement) }, "Save"),
+            error && React.createElement("small", { className: "text-danger" }, error)
+          )
     );
   }
 
@@ -1991,13 +1991,8 @@
       data && !loading && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No feedback has been recorded yet."),
       data && data.items.length > 0 && React.createElement(
         "div",
-        { className: "table-responsive" },
-        React.createElement(
-          "table",
-          { className: "table" },
-          React.createElement("thead", null, React.createElement("tr", null, ["Scene", "Action", "Time", "Correction"].map((label) => React.createElement("th", { key: label, scope: "col" }, label)))),
-          React.createElement("tbody", null, data.items.map((item) => React.createElement(FeedbackHistoryRow, { key: item.feedback_id, item, scene: scenes.get(String(item.scene_id)), onCorrect: () => setVersion((value) => value + 1) })))
-        )
+        { className: "curator-record-list" },
+        data.items.map((item) => React.createElement(FeedbackHistoryRow, { key: item.feedback_id, item, scene: scenes.get(String(item.scene_id)), onCorrect: () => setVersion((value) => value + 1) }))
       ),
       data && React.createElement(Pager, { page, total: data.total, pageSize: data.page_size, hasMore: page * data.page_size < data.total, loading, onPage: setPage, label: "Feedback history pages" })
     );
@@ -3060,20 +3055,20 @@
       data && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No Curator backups found."),
       data && data.items.length > 0 && React.createElement(
         "div",
-        { className: "table-responsive" },
-        React.createElement(
-          "table",
-          { className: "table" },
-          React.createElement("thead", null, React.createElement("tr", null, ["Created", "Size", "File", "Action"].map((label) => React.createElement("th", { key: label, scope: "col" }, label)))),
-          React.createElement("tbody", null, data.items.map((item) => React.createElement(
-            "tr",
-            { key: item.id },
-            React.createElement("td", null, new Date(item.created_at_ms).toLocaleString()),
-            React.createElement("td", null, `${(item.size_bytes / 1048576).toFixed(1)} MB`),
-            React.createElement("td", null, item.id),
-            React.createElement("td", null, React.createElement(Button, { size: "sm", disabled: busy, onClick: () => restore(item) }, "Restore"), " ", React.createElement(Button, { size: "sm", variant: "danger", disabled: busy, onClick: () => remove(item) }, "Delete"))
-          )))
-        )
+        { className: "curator-record-list" },
+        data.items.map((item) => React.createElement(
+          "div",
+          { key: item.id, className: "curator-record-row" },
+          React.createElement("span", { className: "curator-record-icon" }, React.createElement(FontAwesomeIcon, { icon: faDatabase })),
+          React.createElement(
+            "div",
+            { className: "curator-record-main" },
+            React.createElement("div", { className: "curator-record-title" }, item.id),
+            React.createElement("div", { className: "curator-record-meta" }, `${new Date(item.created_at_ms).toLocaleString()} · ${(item.size_bytes / 1048576).toFixed(1)} MB`)
+          ),
+          React.createElement(Button, { size: "sm", variant: "link", disabled: busy, onClick: () => restore(item) }, "Restore"),
+          React.createElement(Button, { size: "sm", variant: "link", className: "curator-record-destructive", disabled: busy, onClick: () => remove(item) }, "Delete")
+        ))
       )
     );
   }

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -1688,7 +1688,7 @@
       null,
       evidenceContent !== null && React.createElement("details", { className: "curator-evidence", ...evidenceProps }, React.createElement("summary", null, "Why this?"), evidenceContent),
       scoreBarContent && React.createElement("div", { className: "curator-match-row" }, React.createElement("span", { className: "curator-match-label" }, "Match"), scoreBarContent, React.createElement("span", { className: "curator-match-value" }, scoreSummary)),
-      React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, `Score · ${scoreSummary}`), scoreContent)
+      React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, scoreBarContent ? "Score breakdown" : `Score · ${scoreSummary}`), scoreContent)
     );
   }
 
@@ -1730,10 +1730,17 @@
     const tags = kind === "scene" ? payload.tags || [] : [];
     function metadataPopover(id, icon, label, count, content) {
       if (!count) return null;
+      const trigger = React.createElement(Button, { className: "minimal curator-external-popover-button", size: "sm", title: label, "aria-label": `${count} ${label.toLowerCase()}` }, React.createElement(FontAwesomeIcon, { icon }), React.createElement("span", null, count));
+      // Api.components.HoverPopover is undefined on a cold/direct navigation
+      // to /plugins/stash-curator until some other part of Stash's own app
+      // has mounted first (same root cause as CuratorControls' health-pill
+      // guard) — fall back to the trigger alone rather than crashing the
+      // whole card on an invalid element type.
+      if (!HoverPopover) return trigger;
       return React.createElement(
         HoverPopover,
         { className: `curator-external-${id}-trigger`, enterDelay: 150, leaveDelay: 250, placement: "bottom", content: React.createElement("div", { className: `curator-external-popover-links curator-external-${id}-popover` }, content) },
-        React.createElement(Button, { className: "minimal curator-external-popover-button", size: "sm", title: label, "aria-label": `${count} ${label.toLowerCase()}` }, React.createElement(FontAwesomeIcon, { icon }), React.createElement("span", null, count))
+        trigger
       );
     }
     const metadataControls = kind === "scene" && React.createElement(
@@ -1887,6 +1894,8 @@
     never_show: "Never Show",
     metadata_wrong: "Metadata Wrong",
     prune: "Prune",
+    curation_pair_winner: "Picked in Curate",
+    curation_pair_loser: "Passed over in Curate",
   };
 
   function FeedbackHistoryRow({ item, scene, onCorrect }) {
@@ -2062,14 +2071,19 @@
         setExplanationLoading(false);
       }
     }
+    // score_review is a synthetic pseudo-lane (Sentiment review reuses this
+    // card to page through the bottom of the model's score distribution,
+    // not a real recommendation source) — it was never given a label,
+    // falling through to the raw enum value ("SCORE_REVIEW") in the badge.
+    const laneLabel = item.source_lane === "score_review" ? "Sentiment review" : (laneByValue.get(item.source_lane)?.label || item.source_lane);
     return React.createElement(
       "article",
       { className: `curator-card curator-source-${item.source_lane}`, onClickCapture: rememberOrigin, ref: card },
       React.createElement(
         "span",
-        { className: `curator-source-badge curator-lane-${item.source_lane}`, title: `Selected from ${laneByValue.get(item.source_lane)?.label || item.source_lane}`, "aria-label": `Selected from ${laneByValue.get(item.source_lane)?.label || item.source_lane}` },
+        { className: `curator-source-badge curator-lane-${item.source_lane}`, title: `Selected from ${laneLabel}`, "aria-label": `Selected from ${laneLabel}` },
         React.createElement(FontAwesomeIcon, { icon: laneByValue.get(item.source_lane)?.icon || faCompass }),
-        React.createElement("span", null, (laneByValue.get(item.source_lane)?.label || item.source_lane).toUpperCase())
+        React.createElement("span", null, laneLabel.toUpperCase())
       ),
       scene
         ? React.createElement(SceneCard, { scene })

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -1427,7 +1427,7 @@
             "div",
             { className: "curator-curate-quick-block" },
             React.createElement("strong", null, "Pick-test a hypothesis"),
-            suggestions && suggestions.length === 0 && React.createElement("small", null, "No hypotheses yet — the Tag sentiment tab and your rated scenes generate them."),
+            suggestions && suggestions.length === 0 && React.createElement("small", null, "No hypotheses yet — Manage → Taste Profile and your rated scenes generate them."),
             (suggestions || []).map((suggestion) =>
               React.createElement(
                 "div",

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -10,7 +10,7 @@
   const { Button, ButtonGroup, Nav } = libraries.Bootstrap;
   const { NavLink, useHistory, useLocation } = libraries.ReactRouterDOM;
   const { FontAwesomeIcon } = libraries.ReactFontAwesome;
-  const { faBalanceScale, faBroom, faBullseye, faChartLine, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faCrosshairs, faDatabase, faDownload, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faMoon, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSun, faSync, faTag, faThumbsDown, faThumbsUp, faUser, faVenus, faWrench, faXmark } = libraries.FontAwesomeSolid;
+  const { faBalanceScale, faBroom, faBullseye, faChartLine, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faCrosshairs, faDatabase, faDownload, faExpand, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faMoon, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSun, faSync, faTag, faThumbsDown, faThumbsUp, faUser, faVenus, faWrench, faXmark } = libraries.FontAwesomeSolid;
   const componentTransforms = window.StashCuratorComponentTransforms ||= {};
 
   function transformComponentProps(name, props) {
@@ -153,6 +153,12 @@
   ];
   const EVENT_QUEUE_KEY = "stash-curator:event-queue:v1";
   const THEME_STORAGE_KEY = "stash-curator:theme";
+  const CARD_SIZE_STORAGE_KEY = "stash-curator:card-size";
+  const CARD_SIZES = [
+    { key: "compact", label: "Compact", minWidth: "16rem" },
+    { key: "comfortable", label: "Comfortable", minWidth: "22rem" },
+    { key: "spacious", label: "Spacious", minWidth: "28rem" },
+  ];
   const TAG_PREFERENCE_QUEUE_KEY = "stash-curator:tag-preference-queue:v1";
   const TERM_PREFERENCE_QUEUE_KEY = "stash-curator:term-preference-queue:v1";
   const ORIGIN_KEY = "stash-curator:origin:v1";
@@ -2410,6 +2416,7 @@
     const [saved, setSaved] = React.useState(() => readFilterPresets()[scope] || {});
     const [name, setName] = React.useState("");
     const [makeDefault, setMakeDefault] = React.useState(false);
+    const [switchId] = React.useState(() => `curator-default-switch-${uuid()}`);
     function save() {
       const clean = name.trim();
       if (!clean) return;
@@ -2425,7 +2432,12 @@
       { className: "curator-saved-filters" },
       React.createElement("select", { value: "", onChange: (event) => { const value = saved.presets?.[event.target.value]; if (value) onApply(value); }, "aria-label": "Load saved filter" }, React.createElement("option", { value: "" }, "Saved filters…"), Object.keys(saved.presets || {}).sort().map((value) => React.createElement("option", { key: value, value }, `${value}${saved.default === value ? " · default" : ""}`))),
       React.createElement("input", { value: name, onChange: (event) => setName(event.target.value), placeholder: "Filter name", "aria-label": "Filter name" }),
-      React.createElement("label", null, React.createElement("input", { type: "checkbox", checked: makeDefault, onChange: (event) => setMakeDefault(event.target.checked) }), " Default"),
+      React.createElement(
+        "div",
+        { className: "custom-control custom-switch curator-default-switch" },
+        React.createElement("input", { type: "checkbox", className: "custom-control-input", id: switchId, checked: makeDefault, onChange: (event) => setMakeDefault(event.target.checked) }),
+        React.createElement("label", { className: "custom-control-label", htmlFor: switchId }, "Default")
+      ),
       React.createElement(Button, { size: "sm", variant: "secondary", disabled: !name.trim(), onClick: save }, "Save")
     );
   }
@@ -2752,6 +2764,7 @@
         "div",
         { className: "curator-similar-candidates" },
         candidates.map((entity) => React.createElement(Button, { key: entity.id, size: "sm", variant: "secondary", onClick: () => choose(entity) }, entity.title || entity.name || `#${entity.id}`)),
+        (sceneSearch.loading || performerSearch.loading) && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Searching…")),
         !sceneSearch.loading && !performerSearch.loading && candidates.length === 0 && React.createElement("p", null, "No matches found.")
       ),
       selected && React.createElement("div", { className: "curator-similar-reference" }, React.createElement("strong", null, "Comparing from"), React.createElement(SourceReference, { entity: sourceEntity, type: entityType, fallback: selected })),
@@ -3111,6 +3124,7 @@
       error && React.createElement("div", { className: "alert alert-danger" }, error),
       message && React.createElement("p", { role: "status" }, message),
       entityType === "hunt" && !huntPerformer && React.createElement("div", { className: "alert alert-info" }, "Select a local performer linked to StashDB."),
+      loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Loading candidates…")),
       data && !data.ready && React.createElement("div", { className: "alert alert-info" }, React.createElement("p", null, "Expand has not been prepared yet — StashDB candidates need to be collected first."), React.createElement(Button, { size: "sm", variant: "primary", onClick: refresh }, React.createElement(FontAwesomeIcon, { icon: faSync }), " Prepare now")),
       data?.ready && visibleItems.length === 0 && React.createElement("div", { className: "alert alert-info" }, entityType === "hunt" ? "No scenes match this view." : "No external candidates match these filters."),
       data?.ready && React.createElement(
@@ -3614,7 +3628,7 @@
     );
   }
 
-  function CuratorControls({ onRefresh, theme, onToggleTheme }) {
+  function CuratorControls({ onRefresh, theme, onToggleTheme, cardSize, onCycleCardSize }) {
     const [jobs, setJobs] = React.useState([]);
     const [health, setHealth] = React.useState(null);
     const [message, setMessage] = React.useState("");
@@ -3725,11 +3739,30 @@
     // curator). CuratorControls always renders, so fall back to the trigger
     // pill alone rather than crashing the whole page on an invalid element.
     const { HoverPopover } = Api.components;
+    // "Synced" on its own only ever meant "has a sync ever completed" — it
+    // never told you whether the model itself needs attention (pending
+    // events not yet folded in, or a rebuild already underway), so the pill
+    // could read "Synced" right when a rebuild would actually be useful.
+    // Surface those states in both the pulse color and the label text
+    // instead of only inside the hover popover.
+    const pillState = running ? "running"
+      : latestFailure ? "failed"
+        : health?.model_rebuilding ? "rebuilding"
+          : health?.model_pending ? "pending"
+            : hasSynced ? "ready" : "idle";
+    const pillLabel = {
+      running: "Running",
+      failed: "Failed",
+      rebuilding: "Rebuilding",
+      pending: `${health?.model_pending_events || 0} pending`,
+      ready: "Synced",
+      idle: "Not synced",
+    }[pillState];
     const healthTrigger = React.createElement(
       "button",
       { type: "button", className: "curator-health-pill", "aria-label": "Curator sync and task status" },
-      React.createElement("span", { className: `curator-health-pulse curator-health-pulse-${running ? "running" : latestFailure ? "failed" : hasSynced ? "ready" : "idle"}` }),
-      React.createElement("span", { className: "curator-health-pill-label" }, running ? "Running" : hasSynced ? "Synced" : "Not synced")
+      React.createElement("span", { className: `curator-health-pulse curator-health-pulse-${pillState}` }),
+      React.createElement("span", { className: "curator-health-pill-label" }, pillLabel)
     );
     const healthControl = HoverPopover
       ? React.createElement(
@@ -3765,6 +3798,7 @@
           React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Use after Stash library changes. Sync changed metadata and history, then refresh recommendations.", "aria-label": "Sync library changes and refresh recommendations", onClick: () => start("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync })),
           React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Force a recommendation refresh from already-synced data. Does not contact Stash.", "aria-label": "Rebuild recommendations without syncing Stash", onClick: () => start("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench })),
           React.createElement(Button, { className: "curator-icon-button", size: "sm", title: theme === "light" ? "Switch to dark theme" : "Switch to light theme", "aria-label": theme === "light" ? "Switch to dark theme" : "Switch to light theme", onClick: onToggleTheme }, React.createElement(FontAwesomeIcon, { icon: theme === "light" ? faMoon : faSun })),
+          onCycleCardSize && React.createElement(Button, { className: "curator-icon-button", size: "sm", title: `Card size: ${CARD_SIZES.find((size) => size.key === cardSize)?.label}. Click to cycle.`, "aria-label": `Card size: ${CARD_SIZES.find((size) => size.key === cardSize)?.label}. Click to cycle.`, onClick: onCycleCardSize }, React.createElement(FontAwesomeIcon, { icon: faExpand })),
           React.createElement(NavLink, { className: "btn btn-secondary btn-sm curator-icon-button", title: "Open Curator's plugin settings.", "aria-label": "Plugin settings", to: "/settings?tab=plugins" }, React.createElement(FontAwesomeIcon, { icon: faCog }))
         )
       ),
@@ -3984,6 +4018,27 @@
         return next;
       });
     }
+    const [cardSize, setCardSize] = React.useState(() => {
+      try {
+        const stored = window.localStorage.getItem(CARD_SIZE_STORAGE_KEY);
+        return CARD_SIZES.some((size) => size.key === stored) ? stored : "comfortable";
+      } catch {
+        return "comfortable";
+      }
+    });
+    function cycleCardSize() {
+      setCardSize((current) => {
+        const index = CARD_SIZES.findIndex((size) => size.key === current);
+        const next = CARD_SIZES[(index + 1) % CARD_SIZES.length].key;
+        try {
+          window.localStorage.setItem(CARD_SIZE_STORAGE_KEY, next);
+        } catch {
+          // localStorage can be unavailable (private browsing); the change
+          // still works for the session, it just won't persist.
+        }
+        return next;
+      });
+    }
 
     React.useEffect(() => setFollowUps([]), [lane]);
 
@@ -4111,11 +4166,11 @@
 
     return React.createElement(
       "main",
-      { className: "curator-page container-fluid", "data-theme": theme },
+      { className: "curator-page container-fluid", "data-theme": theme, style: { "--curator-card-min-width": CARD_SIZES.find((size) => size.key === cardSize)?.minWidth } },
       React.createElement(
         "header",
         { className: "curator-header" },
-        React.createElement("div", { className: "curator-brand" }, React.createElement("span", { className: "curator-brand-mark", "aria-hidden": "true" }, React.createElement(FontAwesomeIcon, { icon: faCompass })), React.createElement("div", null, React.createElement("h1", null, "Stash Curator"), React.createElement("p", { className: "curator-tagline" }, "Navigate your library, guided by your taste."))),
+        React.createElement("div", { className: "curator-brand", title: "Navigate your library, guided by your taste." }, React.createElement("span", { className: "curator-brand-mark", "aria-hidden": "true" }, React.createElement(FontAwesomeIcon, { icon: faCompass })), React.createElement("h1", null, "Curator")),
         React.createElement(
           "div",
           { className: "curator-navigation" },
@@ -4140,7 +4195,7 @@
             })
           )
         ),
-        React.createElement(CuratorControls, { onRefresh: refresh, theme, onToggleTheme: toggleTheme })
+        React.createElement(CuratorControls, { onRefresh: refresh, theme, onToggleTheme: toggleTheme, cardSize, onCycleCardSize: cycleCardSize })
       ),
       laneByValue.has(lane) && React.createElement(
         "div",
@@ -4223,6 +4278,7 @@
       error && React.createElement("div", { className: "alert alert-danger" }, error, React.createElement("p", null, "Run “Sync and build recommendations” from Tasks if no model exists yet."), React.createElement(Button, { size: "sm", variant: "primary", onClick: () => runTask("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync }), " Sync and build now")),
       scenesQuery.error && React.createElement("div", { className: "alert alert-danger" }, scenesQuery.error.message),
       lane === "for_you" && !nudgeDismissed && !readCurateNudge().dismissed && readCurateNudge().rounds < MAX_NUDGE_ROUNDS && React.createElement(CurateNudge, { onOpen: () => openView("curate"), onDismiss: () => { dismissCurateNudge(); setNudgeDismissed(true); } }),
+      laneByValue.has(lane) && loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Loading recommendations…")),
       laneByValue.has(lane) && slate && !loading &&
         React.createElement(
           React.Fragment,

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -740,11 +740,39 @@
     [1, "Strong like", "curator-sentiment-love"],
   ];
 
+  // The 5-point spectrum spans stops 1-5 of the 6-stop track (stop 0 is
+  // "Never"), i.e. positions 20%/40%/60%/80%/100% — a continuous value in
+  // [-1, 1] (Taste Profile's model-inferred sentiment) maps onto that same
+  // linear scale, skipping the "Never" slot since inference has no opinion
+  // on hard exclusion.
+  function sentimentValueToTrackPct(value) {
+    return 20 + (Math.max(-1, Math.min(1, value)) + 1) * 40;
+  }
+  function nearestSentimentLabel(value) {
+    let best = SENTIMENTS[0];
+    let bestDistance = Infinity;
+    for (const entry of SENTIMENTS) {
+      const distance = Math.abs(entry[0] - value);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = entry;
+      }
+    }
+    return best[1];
+  }
+
   // A single 6-stop control: "Never" is stop 0 on the same track as the 5
   // sentiment levels (not a separate toggle) — set apart visually with its
-  // own color and a divider line, per the #150 design brief, but still one
-  // continuous range input rather than a track plus an out-of-band button.
-  function TagSentimentControl({ tag, value, blocked, onChange, compact = false }) {
+  // own color, per the #150 design brief. The visible track/stops/thumb are
+  // a purely decorative rail; a fully transparent native range input sits
+  // on top capturing clicks/drags/keyboard, so the control stays as
+  // accessible as a plain <input type="range"> without hand-rolling pointer
+  // math the way the original design mockup's static-HTML version did.
+  // `inferredValue`, when given (only Taste Profile has this — it's the
+  // model's own continuous estimate, distinct from the user's discrete
+  // direct rating), renders as a small hollow ring on the same track so the
+  // two can be compared at a glance.
+  function TagSentimentControl({ tag, value, blocked, onChange, compact = false, inferredValue = null }) {
     const rated = (value !== null && value !== undefined) || blocked;
     const stopIndex = blocked ? 0 : rated ? SENTIMENTS.findIndex(([score]) => score === value) + 1 : 3;
     const currentLabel = blocked ? "Never" : rated ? SENTIMENTS[stopIndex - 1][1] : "Not rated";
@@ -754,29 +782,44 @@
       if (index === 0) onChange({ value: null, blocked: true });
       else onChange({ value: SENTIMENTS[index - 1][0], blocked: false });
     }
+    const hasModelEstimate = inferredValue !== null && inferredValue !== undefined;
     return React.createElement(
       "div",
       { className: `curator-sentiment curator-sentiment-slider${compact ? " curator-sentiment-compact" : ""}`, role: "group", "aria-label": `Sentiment for ${tag.name}` },
       React.createElement(
         "label",
         { className: `curator-sentiment-range-wrap${tierClass ? ` ${tierClass}` : ""}` },
-        !compact && React.createElement("span", { className: "curator-sentiment-current" }, currentLabel),
         React.createElement(
           "span",
           { className: "curator-sentiment-track" },
-          React.createElement("span", { className: "curator-sentiment-divider", "aria-hidden": "true" }),
+          React.createElement(
+            "span",
+            { className: "curator-sentiment-rail", "aria-hidden": "true" },
+            [0, 1, 2, 3, 4, 5].map((stop) => React.createElement("span", {
+              key: stop,
+              className: `curator-sentiment-stop${stop === 0 ? " curator-sentiment-stop-never" : ""}${stopIndex === stop ? " curator-sentiment-stop-active" : ""}`,
+              style: { left: `${(stop / 5) * 100}%` },
+            })),
+            hasModelEstimate && React.createElement("span", {
+              className: "curator-sentiment-model-dot",
+              style: { left: `${sentimentValueToTrackPct(inferredValue)}%` },
+              title: `Model estimate: ${nearestSentimentLabel(inferredValue)} (${inferredValue.toFixed(2)})`,
+            }),
+            React.createElement("span", { className: `curator-sentiment-thumb${!rated ? " curator-sentiment-thumb-unset" : ""}`, style: { left: `${(stopIndex / 5) * 100}%` } })
+          ),
           React.createElement("input", {
             type: "range",
             min: "0",
             max: "5",
             step: "1",
-            className: `curator-range curator-sentiment-range${!rated ? " curator-sentiment-range-unset" : ""}${blocked ? " curator-sentiment-range-blocked" : ""}`,
+            className: "curator-sentiment-input",
             value: stopIndex,
             "aria-label": `Sentiment for ${tag.name}`,
             "aria-valuetext": currentLabel,
             onChange: handleChange,
           })
-        )
+        ),
+        !compact && React.createElement("span", { className: "curator-sentiment-current" }, currentLabel)
       ),
       (rated || compact) && React.createElement(Button, { size: "sm", variant: "link", className: compact && !rated ? "curator-sentiment-clear-placeholder" : undefined, "aria-label": "Clear answer", title: "Clear answer", onClick: () => onChange({ value: null, blocked: false }) }, compact ? "Clear" : "Clear answer")
     );
@@ -1038,7 +1081,7 @@
               item.prompt && React.createElement("span", { className: `badge ${item.prompt === "belief" ? (item.inferred_value >= 0 ? "curator-sentiment-love" : "curator-sentiment-danger") : "curator-sentiment-neutral"}` }, item.prompt === "belief" ? `I think you ${item.inferred_value >= 0 ? "like" : "dislike"} this` : "I'm unsure"),
               React.createElement("small", null, `Inferred ${item.inferred_value.toFixed(2)} · confidence ${item.confidence.toFixed(2)} · support ${item.support.toFixed(1)} · ${item.scene_count} local scene${item.scene_count === 1 ? "" : "s"}`)
             ),
-            React.createElement(TagSentimentControl, { tag: item, value: item.direct_value, blocked: item.direct_blocked, onChange: (value) => answer(item.tag_id, value) })
+            React.createElement(TagSentimentControl, { tag: item, value: item.direct_value, blocked: item.direct_blocked, inferredValue: item.inferred_value, onChange: (value) => answer(item.tag_id, value) })
           )
         )
       ),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -3761,17 +3761,6 @@
       ? route.get("section") || (MAINTENANCE_ITEMS.some((item) => item.value === requestedView) ? requestedView : MAINTENANCE_ITEMS[0].value)
       : null;
     const [slate, setSlate] = React.useState(null);
-    const [headerTaskBusy, setHeaderTaskBusy] = React.useState(false);
-    async function runHeaderTask(taskName) {
-      setHeaderTaskBusy(true);
-      try {
-        await runTask(taskName);
-      } catch (failure) {
-        setError(failure.message);
-      } finally {
-        setHeaderTaskBusy(false);
-      }
-    }
     const [error, setError] = React.useState("");
     const [loading, setLoading] = React.useState(true);
     const [refreshKey, setRefreshKey] = React.useState(0);
@@ -3992,8 +3981,6 @@
         React.createElement(
           "div",
           { className: "curator-view-actions" },
-          laneByValue.has(lane) && React.createElement(Button, { size: "sm", variant: "secondary", disabled: headerTaskBusy, onClick: () => runHeaderTask("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench }), " Rebuild"),
-          laneByValue.has(lane) && React.createElement(Button, { size: "sm", disabled: headerTaskBusy, onClick: () => runHeaderTask("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync }), " Sync library"),
           laneByValue.has(lane) && diversityEnabled !== null && React.createElement(
             Button,
             {

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -1581,12 +1581,11 @@
               ),
               React.createElement(
                 "div",
-                { className: "curator-pick-answer-group", role: "group", "aria-label": "Rate this comparison" },
-                React.createElement(Button, { size: "sm", variant: "primary", onClick: () => answerPicks(currentPair.pair_id, "a") }, "← Left"),
-                React.createElement(Button, { size: "sm", variant: "primary", onClick: () => answerPicks(currentPair.pair_id, "b") }, "Right →"),
-                React.createElement(Button, { size: "sm", variant: "secondary", onClick: () => answerPicks(currentPair.pair_id, "similar") }, "Similar ↑"),
-                React.createElement(Button, { size: "sm", variant: "secondary", onClick: () => answerPicks(currentPair.pair_id, "skip") }, "Skip ↓"),
-                React.createElement("span", { className: "curator-pick-hint" }, "Keys: ", React.createElement("kbd", null, "←/→"), " pick · ", React.createElement("kbd", null, "↑"), " similar · ", React.createElement("kbd", null, "↓"), " skip")
+                { className: "curator-pick-answer-group", role: "group", "aria-label": "Rate this comparison", title: "Keys: ←/→ pick · ↑ similar · ↓ skip" },
+                React.createElement(Button, { size: "sm", variant: "primary", title: "← pick", onClick: () => answerPicks(currentPair.pair_id, "a") }, "← Left"),
+                React.createElement(Button, { size: "sm", variant: "primary", title: "→ pick", onClick: () => answerPicks(currentPair.pair_id, "b") }, "Right →"),
+                React.createElement(Button, { size: "sm", variant: "secondary", title: "↑ similar", onClick: () => answerPicks(currentPair.pair_id, "similar") }, "Similar ↑"),
+                React.createElement(Button, { size: "sm", variant: "secondary", title: "↓ skip", onClick: () => answerPicks(currentPair.pair_id, "skip") }, "Skip ↓")
               )
             )
           );
@@ -1656,17 +1655,19 @@
     );
   }
 
-  function scoreBar(item) {
-    const bd = item.details?.score_breakdown || {};
-    const sim = bd.similarity || 0;
-    const app = bd.appeal || 0;
-    const mh = bd.multi_hop || 0;
-    const total = sim + app + mh || 1;
-    const pct = (v) => Math.round(v / total * 100);
+  // The always-visible match bar needs to be robust to whatever score
+  // shape a caller has — RecommendationCard's final_utility, ExternalCard's
+  // basic match score, and SimilarityPanel's rank_score are all "ranking
+  // utility, not a probability" (per the cards' own copy) and can exceed 1,
+  // and none reliably carry the similarity/appeal/multi-hop breakdown a
+  // segmented bar would need — an earlier version tried a segmented bar
+  // keyed off item.details.score_breakdown and it silently rendered empty
+  // for real Similar-panel results, since that field isn't populated there.
+  // A single clamped fill is the one thing guaranteed to have real data.
+  function utilityBar(value) {
+    const pct = Math.round(Math.min(1, Math.max(0, value)) * 100);
     return React.createElement("div", { className: "curator-score-bar" },
-      React.createElement("span", { className: "curator-score-bar-seg curator-score-sim", style: { width: pct(sim) + "%" }, title: `Similarity ${sim.toFixed(3)}` }),
-      React.createElement("span", { className: "curator-score-bar-seg curator-score-app", style: { width: pct(app) + "%" }, title: `Appeal ${app.toFixed(3)}` }),
-      mh > 0 && React.createElement("span", { className: "curator-score-bar-seg curator-score-mh", style: { width: pct(mh) + "%" }, title: `Multi-hop ${mh.toFixed(4)}` })
+      React.createElement("span", { className: "curator-score-bar-seg curator-score-app", style: { width: pct + "%" }, title: `Utility ${value.toFixed(3)}` })
     );
   }
 
@@ -1677,11 +1678,16 @@
   // explanation on toggle and shows a ScoreNode tree, the other two are
   // static), so content stays fully caller-supplied via props rather than
   // forcing those shapes into a shared config.
-  function EvidenceScore({ evidenceProps, evidenceContent, scoreSummary, scoreContent }) {
+  // The match bar is always visible in the mockup — it's the at-a-glance
+  // signal a card carries, not something worth an extra click to see.
+  // Everything else (the breakdown text/tree) stays behind the existing
+  // collapsed "Score · N" details for progressive disclosure.
+  function EvidenceScore({ evidenceProps, evidenceContent, scoreBarContent, scoreSummary, scoreContent }) {
     return React.createElement(
       React.Fragment,
       null,
       evidenceContent !== null && React.createElement("details", { className: "curator-evidence", ...evidenceProps }, React.createElement("summary", null, "Why this?"), evidenceContent),
+      scoreBarContent && React.createElement("div", { className: "curator-match-row" }, React.createElement("span", { className: "curator-match-label" }, "Match"), scoreBarContent, React.createElement("span", { className: "curator-match-value" }, scoreSummary)),
       React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, `Score · ${scoreSummary}`), scoreContent)
     );
   }
@@ -1792,7 +1798,7 @@
       payload.curator_local_match?.type === "phash" && React.createElement("span", { className: "curator-phash-badge", title: "A local scene has the same exact PHash. This is strong matching evidence, not guaranteed identity." }, "Likely local · exact PHash"),
       React.createElement("div", { className: `curator-external-thumbnail thumbnail-section ${kind === "scene" ? "video-section" : ""}` }, React.createElement("a", { className: `${kind}-card-link`, href, target: "_blank", rel: "noreferrer" }, image && React.createElement("img", { className: `${kind}-card-image`, src: image, loading: "lazy", alt: "" })), kind === "scene" && payload.studio?.name && React.createElement("span", { className: "curator-external-studio-overlay" }, payload.studio.name)),
       React.createElement("div", { className: "card-section" }, React.createElement(TitleLink, localProfile, React.createElement("h5", { className: "card-section-title flex-aligned" }, title)), React.createElement("div", { className: kind === "scene" ? "scene-card__details" : "curator-external-details" }, React.createElement("span", null, payload.release_date || payload.birth_date || ""), metadataControls), kind === "scene" && payload.details && React.createElement("p", { className: "curator-card-description" }, payload.details)),
-      React.createElement("div", { className: "curator-card-body" }, (() => { let scoreDetail; if (item.similarity === undefined) { scoreDetail = `Match ${item.score.toFixed(2)} · found via ${item.sources.join(", ")}`; } else { scoreDetail = `Similarity ${item.similarity.toFixed(2)}` + (item.appeal !== undefined ? ` · appeal ${item.appeal.toFixed(2)}` : ""); const mh = item.details && item.details.score_breakdown && item.details.score_breakdown.multi_hop; if (mh > 0) scoreDetail += " + multi-hop " + mh.toFixed(4); } return React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, { evidenceContent: payload.why?.length ? React.createElement("p", { className: "curator-explanation" }, payload.why.join(" · ")) : null, scoreSummary: item.score.toFixed(2), scoreContent: React.createElement(React.Fragment, null, scoreBar(item), React.createElement("p", null, scoreDetail)) })); })()),
+      React.createElement("div", { className: "curator-card-body" }, (() => { let scoreDetail; if (item.similarity === undefined) { scoreDetail = `Match ${item.score.toFixed(2)} · found via ${item.sources.join(", ")}`; } else { scoreDetail = `Similarity ${item.similarity.toFixed(2)}` + (item.appeal !== undefined ? ` · appeal ${item.appeal.toFixed(2)}` : ""); const mh = item.details && item.details.score_breakdown && item.details.score_breakdown.multi_hop; if (mh > 0) scoreDetail += " + multi-hop " + mh.toFixed(4); } return React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, { evidenceContent: payload.why?.length ? React.createElement("p", { className: "curator-explanation" }, payload.why.join(" · ")) : null, scoreBarContent: utilityBar(item.score), scoreSummary: item.score.toFixed(2), scoreContent: React.createElement("p", null, scoreDetail) })); })()),
       React.createElement(ExternalActions, { href, item, kind, copied, onCopy: async () => { try { await copyText(item.id); setCopied(true); setTimeout(() => setCopied(false), 1500); } catch (_) { setCopied(false); } }, onShortlist, tagsAvailable: tags.length > 0, tagsActive: tagChoices !== null, tagLoading, onRateTags: rateTags, onShowScenes, whisparrEnabled, canWhisparr: Boolean(onWhisparr), whisparr, onAddToWhisparr: addToWhisparr }),
       kind === "scene" && tagChoices !== null && React.createElement("div", { className: "curator-external-tag-rating" }, React.createElement("div", { className: "curator-external-tag-rating-header" }, React.createElement("strong", null, "Rate tags & terms"), React.createElement(Button, { size: "sm", variant: "link", className: "curator-external-tag-rating-close", "aria-label": "Collapse matching local tag ratings", title: "Collapse matching local tag ratings", onClick: rateTags }, "Collapse")), tagLoading && React.createElement("small", { role: "status" }, "Matching local tags…"), tagError && React.createElement("small", { className: "text-danger", role: "status" }, tagError), !tagLoading && !tagError && React.createElement(React.Fragment, null, React.createElement(RatingSection, { title: "Matching local tags", rows: tagChoices.map((tag) => ({ key: tag.tag_id, tag_id: tag.tag_id, name: tag.name, direct_value: tag.direct_value, direct_blocked: tag.direct_blocked })), onAnswer: answerTag, emptyLabel: "No matching local tags." }), React.createElement(RatingSection, { title: "Description terms", rows: termChoices.map((term) => ({ key: term.term, term: term.term, name: term.term, direct_value: term.direct_value, direct_blocked: term.direct_blocked })), onAnswer: answerTerm, emptyLabel: "No description terms in the model." })))
     );
@@ -2062,7 +2068,8 @@
       React.createElement(
         "span",
         { className: `curator-source-badge curator-lane-${item.source_lane}`, title: `Selected from ${laneByValue.get(item.source_lane)?.label || item.source_lane}`, "aria-label": `Selected from ${laneByValue.get(item.source_lane)?.label || item.source_lane}` },
-        React.createElement(FontAwesomeIcon, { icon: laneByValue.get(item.source_lane)?.icon || faCompass })
+        React.createElement(FontAwesomeIcon, { icon: laneByValue.get(item.source_lane)?.icon || faCompass }),
+        React.createElement("span", null, (laneByValue.get(item.source_lane)?.label || item.source_lane).toUpperCase())
       ),
       scene
         ? React.createElement(SceneCard, { scene })
@@ -2095,6 +2102,7 @@
                 )
               )
             ),
+            scoreBarContent: utilityBar(item.final_utility),
             scoreSummary: item.final_utility.toFixed(2),
             scoreContent: React.createElement(
               React.Fragment,
@@ -2294,7 +2302,6 @@
     hidePhashMatches, onToggleHidePhash,
     gender, onGenderChange,
     minimum, onMinimumChange,
-    savedCurrent, onApplySaved,
     applyVisible = true, onApply,
   }) {
     const sceneGated = variant !== "hunt";
@@ -2316,7 +2323,6 @@
         showScene && React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: onToggleHidePhash }, React.createElement(FontAwesomeIcon, { icon: faClone }), " Hide exact PHash matches"),
         sceneGated && React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: onGenderChange, "aria-label": genderAriaLabel }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))),
         sceneGated && showScene && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimum.toFixed(2)}`), React.createElement("input", { type: "range", min: minimumMin, max: "0.8", step: "0.05", value: minimum, onChange: onMinimumChange })),
-        (sceneGated ? showScene : true) && React.createElement(SavedFilters, { scope: variant, current: savedCurrent, onApply: onApplySaved }),
         applyVisible && React.createElement(Button, { size: "sm", variant: "primary", onClick: onApply }, "Apply")
       )
     );
@@ -2572,7 +2578,8 @@
           React.createElement(Button, { size: "sm", type: "submit", disabled: !query.trim() }, "Search")
         ),
         source === "stashdb" && React.createElement(Button, { className: "curator-include-owned", size: "sm", variant: includeOwned ? "primary" : "secondary", "aria-pressed": includeOwned, title: `Include ${entityType}s already in your library so the remote ranking can be compared with the local search`, "aria-label": includeOwned ? `Hide library ${entityType}s` : `Include library ${entityType}s`, onClick: () => updateUrl((s) => ({ ...s, includeOwned: !s.includeOwned, page: 1, excludedIds: [] })) }, React.createElement(FontAwesomeIcon, { icon: faUserCheck }), " Local"),
-        React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters", activeFilterCount > 0 && React.createElement("span", { className: "curator-filter-count" }, activeFilterCount))
+        React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters", activeFilterCount > 0 && React.createElement("span", { className: "curator-filter-count" }, activeFilterCount)),
+        React.createElement(SavedFilters, { scope: "similar", current: { gender, favoriteOnly, hidePhashMatches, includeTags, excludeTags, performers: filterPerformers, studios: filterStudios, minimum: minimumSimilarity }, onApply: applySaved })
       ),
       filtersOpen && React.createElement(FilterBar, {
         variant: "similar",
@@ -2585,8 +2592,6 @@
         hidePhashMatches, onToggleHidePhash: () => updateUrl((s) => ({ ...s, hidePhashMatches: !s.hidePhashMatches })),
         gender, onGenderChange: (event) => updateUrl((s) => ({ ...s, gender: event.target.value })),
         minimum: minimumSimilarity, onMinimumChange: (event) => updateUrl((s) => ({ ...s, minimumSimilarity: Number(event.target.value) })),
-        savedCurrent: { gender, favoriteOnly, hidePhashMatches, includeTags, excludeTags, performers: filterPerformers, studios: filterStudios, minimum: minimumSimilarity },
-        onApplySaved: applySaved,
         applyVisible: Boolean(selected),
         onApply: () => updateUrl((s) => ({ ...s, excludedIds: [], page: 1, fetchTick: s.fetchTick + 1 })),
       }),
@@ -2606,7 +2611,7 @@
         items.map((item) => {
           const entity = entities.get(String(item.entity_id));
           if (!entity) return null;
-          const body = React.createElement("div", { className: "curator-card-body" }, entityType === "scene" && React.createElement(LocalRatingPanel, { sceneId: item.entity_id }), React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, { evidenceContent: React.createElement("p", { className: "curator-explanation" }, relationshipChips(item)), scoreSummary: item.rank_score.toFixed(2), scoreContent: React.createElement(React.Fragment, null, scoreBar(item), React.createElement("p", null, `Similarity ${item.similarity.toFixed(2)} · predicted appeal ${item.appeal.toFixed(2)}`)) })));
+          const body = React.createElement("div", { className: "curator-card-body" }, entityType === "scene" && React.createElement(LocalRatingPanel, { sceneId: item.entity_id }), React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, { evidenceContent: React.createElement("p", { className: "curator-explanation" }, relationshipChips(item)), scoreBarContent: utilityBar(item.rank_score), scoreSummary: item.rank_score.toFixed(2), scoreContent: React.createElement("p", null, `Similarity ${item.similarity.toFixed(2)} · predicted appeal ${item.appeal.toFixed(2)}`) })));
           if (entityType === "performer") return React.createElement("article", { key: item.entity_id, className: "curator-card" }, React.createElement(PerformerCard, { performer: entity }), body);
           const feedbackItem = { ...item, scene_id: item.entity_id, impression_id: result.impression_id };
           function rememberOrigin(event) {
@@ -2910,6 +2915,8 @@
         !huntOnly && React.createElement(Button, { className: "curator-shortlist-tab", size: "sm", variant: entityType === "shortlist" ? "primary" : "secondary", onClick: () => updateUrl((s) => ({ ...s, entityType: "shortlist", performerId: null })) }, React.createElement(FontAwesomeIcon, { icon: faList }), " Shortlist"),
         entityType === "scene" && React.createElement("label", { className: "curator-toolbar-select" }, React.createElement(FontAwesomeIcon, { icon: faSortAmountDown }), React.createElement("select", { value: sort, onChange: (event) => updateUrl((s) => ({ ...s, page: 1, sort: event.target.value })), "aria-label": "Sort Expand results" }, React.createElement("option", { value: "match" }, "Best match"), React.createElement("option", { value: "newest" }, "Newest"))),
         entityType !== "shortlist" && React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters", activeFilterCount > 0 && React.createElement("span", { className: "curator-filter-count" }, activeFilterCount)),
+        entityType === "hunt" && React.createElement(SavedFilters, { scope: "hunt", current: { hidePhashMatches, includeTags, excludeTags }, onApply: (value) => updateUrl((s) => ({ ...s, page: 1, hidePhashMatches: value.hidePhashMatches !== false, includeTags: value.includeTags || [], excludeTags: value.excludeTags || [] })) }),
+        entityType !== "shortlist" && entityType !== "hunt" && React.createElement(SavedFilters, { scope: "expand", current: { gender, favoriteOnly, hidePhashMatches, includeTags, excludeTags, performers, studios, minimum: minimumScore }, onApply: applySaved }),
         performerId && React.createElement(Button, { size: "sm", variant: "link", onClick: () => updateUrl((s) => ({ ...s, page: 1, performerId: null })) }, "Clear performer filter"),
         React.createElement(Button, { className: "curator-icon-button", size: "sm", disabled: entityType === "hunt" && !huntPerformer, title: entityType === "hunt" ? "Refresh this performer's scenes directly from StashDB." : "Refresh the bounded StashDB candidate cache in a background task.", "aria-label": entityType === "hunt" ? "Refresh Performer Hunt" : "Refresh Expand cache", onClick: refresh }, React.createElement(FontAwesomeIcon, { icon: faSync })),
         data?.fetched_at_ms && React.createElement("small", null, `${Date.now() > data.expires_at_ms ? "Stale · " : ""}Updated ${new Date(data.fetched_at_ms).toLocaleString()}`)
@@ -2928,8 +2935,6 @@
         includeTags, onIncludeTagsChange: (value) => updateUrl((s) => ({ ...s, includeTags: value })),
         excludeTags, onExcludeTagsChange: (value) => updateUrl((s) => ({ ...s, excludeTags: value })),
         hidePhashMatches, onToggleHidePhash: () => updateUrl((s) => ({ ...s, hidePhashMatches: !s.hidePhashMatches })),
-        savedCurrent: { hidePhashMatches, includeTags, excludeTags },
-        onApplySaved: (value) => updateUrl((s) => ({ ...s, page: 1, hidePhashMatches: value.hidePhashMatches !== false, includeTags: value.includeTags || [], excludeTags: value.excludeTags || [] })),
         onApply: () => (updateUrl((s) => ({ ...s, page: 1 })), setFiltersOpen(false)),
       }),
       entityType !== "shortlist" && entityType !== "hunt" && filtersOpen && React.createElement(FilterBar, {
@@ -2943,8 +2948,6 @@
         hidePhashMatches, onToggleHidePhash: () => updateUrl((s) => ({ ...s, page: 1, hidePhashMatches: !s.hidePhashMatches })),
         gender, onGenderChange: (event) => updateUrl((s) => ({ ...s, page: 1, gender: event.target.value })),
         minimum: minimumScore, onMinimumChange: (event) => updateUrl((s) => ({ ...s, minimumScore: Number(event.target.value) })),
-        savedCurrent: { gender, favoriteOnly, hidePhashMatches, includeTags, excludeTags, performers, studios, minimum: minimumScore },
-        onApplySaved: applySaved,
         onApply: () => (updateUrl((s) => ({ ...s, page: 1 })), setFilterVersion((value) => value + 1)),
       }),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
@@ -3037,7 +3040,7 @@
       { className: "curator-backup-page" },
       React.createElement(Button, { size: "sm", disabled: busy, onClick: create }, busy ? "Working…" : "Create backup"),
       loading && React.createElement("div", { className: "curator-loading", role: "status" }, "Loading backups…"),
-      data && React.createElement("p", null, `Backup directory: ${data.backup_directory}`),
+      data && React.createElement("p", null, "Backup directory: ", React.createElement("code", { className: "curator-mono" }, data.backup_directory)),
       message && React.createElement("div", { className: "alert alert-success", role: "status" }, message),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
       data && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No Curator backups found."),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -3974,6 +3974,7 @@
         React.createElement(
           "div",
           { className: "curator-view-copy" },
+          React.createElement("h1", null, laneByValue.has(lane) ? "Recommendations" : laneOption.label),
           React.createElement("p", null, laneOption.description),
           laneByValue.has(lane) && React.createElement("p", null, "The colored corner icon identifies the source lane; Score is ranking utility, not a probability.")
         ),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2647,7 +2647,7 @@
       search && !selected && React.createElement(
         "div",
         { className: "curator-similar-candidates" },
-        candidates.map((entity) => React.createElement(Button, { key: entity.id, variant: "link", onClick: () => choose(entity) }, entity.title || entity.name || `#${entity.id}`)),
+        candidates.map((entity) => React.createElement(Button, { key: entity.id, size: "sm", variant: "secondary", onClick: () => choose(entity) }, entity.title || entity.name || `#${entity.id}`)),
         !sceneSearch.loading && !performerSearch.loading && candidates.length === 0 && React.createElement("p", null, "No matches found.")
       ),
       selected && React.createElement("div", { className: "curator-similar-reference" }, React.createElement("strong", null, "Comparing from"), React.createElement(SourceReference, { entity: sourceEntity, type: entityType, fallback: selected })),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -124,10 +124,34 @@
       icon: faBullseye,
       description: "Compare scenes in pairs to teach the model fast, or review tag sentiment.",
     },
+    {
+      value: "profiling",
+      label: "Profiling",
+      icon: faDev,
+      maintenance: true,
+      description: "Inspect render and query performance profiles captured during development.",
+    },
   ];
   const PRIMARY_NAV_ITEMS = NAV_ITEMS.filter((item) => !item.maintenance);
   const MAINTENANCE_ITEMS = NAV_ITEMS.filter((item) => item.maintenance);
   const laneByValue = new Map(LANES.map((lane) => [lane.value, lane]));
+  const RECOMMENDATIONS_NAV_ITEM = {
+    value: "recommendations",
+    label: "Recommendations",
+    icon: faStar,
+    description: "A balanced shelf of strong matches, timely revisits, and a little discovery, split into five lanes.",
+  };
+  const MANAGE_NAV_ITEM = {
+    value: "manage",
+    label: "Manage",
+    icon: faWrench,
+    description: "Feedback history, taste profile, sentiment review, recent recommendations, backups, diagnostics, prune queues, and profiling.",
+  };
+  const TOP_NAV_ITEMS = [
+    RECOMMENDATIONS_NAV_ITEM,
+    ...PRIMARY_NAV_ITEMS.filter((item) => !laneByValue.has(item.value)),
+    MANAGE_NAV_ITEM,
+  ];
   const EVENT_QUEUE_KEY = "stash-curator:event-queue:v1";
   const TAG_PREFERENCE_QUEUE_KEY = "stash-curator:tag-preference-queue:v1";
   const TERM_PREFERENCE_QUEUE_KEY = "stash-curator:term-preference-queue:v1";
@@ -2518,6 +2542,7 @@
       }
       return React.createElement("span", { className: "curator-chips" }, ...chips);
     }
+    const activeFilterCount = (includeTags?.length || 0) + (excludeTags?.length || 0) + (filterPerformers?.length || 0) + (filterStudios?.length || 0) + (favoriteOnly ? 1 : 0) + (hidePhashMatches ? 1 : 0);
     return React.createElement(
       "section",
       { className: "curator-similar" },
@@ -2537,7 +2562,7 @@
           React.createElement(Button, { size: "sm", type: "submit", disabled: !query.trim() }, "Search")
         ),
         source === "stashdb" && React.createElement(Button, { className: "curator-include-owned", size: "sm", variant: includeOwned ? "primary" : "secondary", "aria-pressed": includeOwned, title: `Include ${entityType}s already in your library so the remote ranking can be compared with the local search`, "aria-label": includeOwned ? `Hide library ${entityType}s` : `Include library ${entityType}s`, onClick: () => updateUrl((s) => ({ ...s, includeOwned: !s.includeOwned, page: 1, excludedIds: [] })) }, React.createElement(FontAwesomeIcon, { icon: faUserCheck }), " Local"),
-        React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters")
+        React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters", activeFilterCount > 0 && React.createElement("span", { className: "curator-filter-count" }, activeFilterCount))
       ),
       filtersOpen && React.createElement(FilterBar, {
         variant: "similar",
@@ -2864,6 +2889,7 @@
         if (page > last) updateUrl((s) => ({ ...s, page: last }), { replace: true });
       }
     }, [data, entityType, huntItems.length, page, pageSize]);
+    const activeFilterCount = (includeTags?.length || 0) + (excludeTags?.length || 0) + (performers?.length || 0) + (studios?.length || 0) + (favoriteOnly ? 1 : 0) + (hidePhashMatches ? 1 : 0);
     return React.createElement(
       "section",
       { className: huntOnly ? "curator-hunt" : "curator-expand" },
@@ -2873,7 +2899,7 @@
         !huntOnly && React.createElement("div", { className: "btn-group", role: "group", "aria-label": "Explore external content" }, [["scene", "Scenes", faPlayCircle], ["performer", "Performers", faUser]].map(([value, label, icon]) => React.createElement(Button, { key: value, size: "sm", variant: entityType === value ? "primary" : "secondary", onClick: () => updateUrl((s) => ({ ...s, entityType: value, performerId: null })) }, React.createElement(FontAwesomeIcon, { icon }), ` ${label}`))),
         !huntOnly && React.createElement(Button, { className: "curator-shortlist-tab", size: "sm", variant: entityType === "shortlist" ? "primary" : "secondary", onClick: () => updateUrl((s) => ({ ...s, entityType: "shortlist", performerId: null })) }, React.createElement(FontAwesomeIcon, { icon: faList }), " Shortlist"),
         entityType === "scene" && React.createElement("label", { className: "curator-toolbar-select" }, React.createElement(FontAwesomeIcon, { icon: faSortAmountDown }), React.createElement("select", { value: sort, onChange: (event) => updateUrl((s) => ({ ...s, page: 1, sort: event.target.value })), "aria-label": "Sort Expand results" }, React.createElement("option", { value: "match" }, "Best match"), React.createElement("option", { value: "newest" }, "Newest"))),
-        entityType !== "shortlist" && React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters"),
+        entityType !== "shortlist" && React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters", activeFilterCount > 0 && React.createElement("span", { className: "curator-filter-count" }, activeFilterCount)),
         performerId && React.createElement(Button, { size: "sm", variant: "link", onClick: () => updateUrl((s) => ({ ...s, page: 1, performerId: null })) }, "Clear performer filter"),
         React.createElement(Button, { className: "curator-icon-button", size: "sm", disabled: entityType === "hunt" && !huntPerformer, title: entityType === "hunt" ? "Refresh this performer's scenes directly from StashDB." : "Refresh the bounded StashDB candidate cache in a background task.", "aria-label": entityType === "hunt" ? "Refresh Performer Hunt" : "Refresh Expand cache", onClick: refresh }, React.createElement(FontAwesomeIcon, { icon: faSync })),
         data?.fetched_at_ms && React.createElement("small", null, `${Date.now() > data.expires_at_ms ? "Stale · " : ""}Updated ${new Date(data.fetched_at_ms).toLocaleString()}`)
@@ -3521,21 +3547,47 @@
       )
     );
 
+    // Api.components.HoverPopover is only registered once some other part of
+    // Stash's own app has mounted first — on a cold/direct navigation to the
+    // Curator page it can still be undefined here (confirmed empirically: it
+    // reliably resolves in-app, but not on a fresh load of /plugins/stash-
+    // curator). CuratorControls always renders, so fall back to the trigger
+    // pill alone rather than crashing the whole page on an invalid element.
+    const { HoverPopover } = Api.components;
+    const healthTrigger = React.createElement(
+      "button",
+      { type: "button", className: "curator-health-pill", "aria-label": "Curator sync and task status" },
+      React.createElement("span", { className: `curator-health-pulse curator-health-pulse-${running ? "running" : latestFailure ? "failed" : hasSynced ? "ready" : "idle"}` }),
+      React.createElement("span", { className: "curator-health-pill-label" }, running ? "Running" : hasSynced ? "Synced" : "Not synced")
+    );
+    const healthControl = HoverPopover
+      ? React.createElement(
+          HoverPopover,
+          {
+            className: "curator-health-trigger",
+            enterDelay: 150,
+            leaveDelay: 250,
+            placement: "bottom",
+            content: React.createElement(
+              "div",
+              { className: "curator-health-panel", role: "status" },
+              React.createElement("div", { className: "curator-health-row" }, React.createElement("span", null, "Sync"), React.createElement("b", null, running ? `Running ${running.job_type}` : hasSynced ? "Synced" : "Not synced")),
+              React.createElement(CuratorTaskIndicator, { activeJobs, activities, failure: latestFailure, doneJob }),
+              React.createElement("div", { className: "curator-health-row" }, React.createElement("span", null, "Model"), React.createElement("b", null, health?.model_pending ? `${health.model_pending_events} waiting` : modelStatus)),
+              React.createElement("div", { className: "curator-health-row" }, React.createElement("span", null, "Playback sessions captured"), React.createElement("b", null, health?.capture?.direct_playback_sessions || 0)),
+              health?.last_sync_at_ms && React.createElement("div", { className: "curator-health-row" }, React.createElement("span", null, "Last sync"), React.createElement("b", null, new Date(health.last_sync_at_ms).toLocaleString()))
+            ),
+          },
+          healthTrigger
+        )
+      : healthTrigger;
     return React.createElement(
       React.Fragment,
       null,
       React.createElement(
         "section",
         { className: "curator-controls" },
-        React.createElement(
-          "div",
-          { className: "curator-status", role: "status" },
-          React.createElement("span", { title: running ? `Running ${running.job_type}` : hasSynced ? "Library synchronized" : "Library has not been synchronized" }, React.createElement(FontAwesomeIcon, { icon: faDatabase }), running ? "Running" : hasSynced ? "Synced" : "Not synced"),
-          React.createElement(CuratorTaskIndicator, { activeJobs, activities, failure: latestFailure, doneJob }),
-          React.createElement("span", { title: health?.model_pending ? "Playback and feedback are batched before rebuilding the preference model." : modelStatus }, React.createElement(FontAwesomeIcon, { icon: health?.model_pending ? faClock : health?.ready ? faCheckCircle : faWrench }), modelStatus),
-          React.createElement("span", { title: "Playback sessions captured by Curator" }, React.createElement(FontAwesomeIcon, { icon: faPlay }), health?.capture?.direct_playback_sessions || 0),
-          health?.last_sync_at_ms && React.createElement("span", { title: `Last sync ${new Date(health.last_sync_at_ms).toLocaleString()}` }, React.createElement(FontAwesomeIcon, { icon: faClock }), new Date(health.last_sync_at_ms).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }))
-        ),
+        healthControl,
         React.createElement(
           "div",
           { className: "curator-task-buttons" },
@@ -3633,6 +3685,63 @@
     );
   }
 
+  // Manage shell (GH #150 Package 3): a two-pane list/detail view that hosts
+  // every maintenance-flagged NAV_ITEMS entry plus Profiling. Each panel is
+  // mounted unmodified — this is pure relocation, not a rebuild.
+  const MANAGE_BODIES = {
+    feedback: () => React.createElement(FeedbackHistoryPanel),
+    taste: () => React.createElement(TasteProfilePanel),
+    sentiment: () => React.createElement(ScoreReviewPanel),
+    history: () => React.createElement(RecommendationHistoryPanel),
+    backups: () => React.createElement(BackupPanel),
+    diagnostics: () => React.createElement(DiagnosticsPanel),
+    prune: () => React.createElement(PrunePanel),
+    profiling: () => React.createElement(ProfilingPanel),
+  };
+
+  function ManagePanel({ section, onSelectSection }) {
+    const items = MAINTENANCE_ITEMS;
+    const active = items.find((item) => item.value === section) || items[0];
+    const body = MANAGE_BODIES[active.value];
+    return React.createElement(
+      "div",
+      { className: "curator-manage-shell" },
+      React.createElement(
+        "nav",
+        { className: "curator-manage-list", "aria-label": "Manage sections" },
+        items.map((item) => React.createElement(
+          "button",
+          {
+            key: item.value,
+            type: "button",
+            className: "curator-manage-item",
+            "aria-current": item.value === active.value ? "page" : undefined,
+            onClick: () => onSelectSection(item.value),
+            title: item.description,
+          },
+          React.createElement("span", { className: "curator-manage-item-icon" }, React.createElement(FontAwesomeIcon, { icon: item.icon })),
+          React.createElement(
+            "span",
+            { className: "curator-manage-item-copy" },
+            React.createElement("span", { className: "curator-manage-item-title" }, item.label),
+            React.createElement("span", { className: "curator-manage-item-desc" }, item.description)
+          )
+        ))
+      ),
+      React.createElement(
+        "section",
+        { className: "curator-manage-detail", "aria-live": "polite" },
+        React.createElement(
+          "div",
+          { className: "curator-manage-detail-head" },
+          React.createElement("h2", null, active.label),
+          React.createElement("p", null, active.description)
+        ),
+        body && body()
+      )
+    );
+  }
+
   function CuratorPage() {
     const history = useHistory();
     const routeLocation = useLocation();
@@ -3640,7 +3749,16 @@
     const requestedView = route.get("view") || "for_you";
     const loadingComponents = Api.hooks.useLoadComponents([Api.loadableComponents.SceneCard, Api.loadableComponents.PerformerCard]);
     const [nudgeDismissed, setNudgeDismissed] = React.useState(false);
-    const lane = NAV_ITEMS.some((item) => item.value === requestedView) || requestedView === "profiling" ? requestedView : "for_you";
+    // "?view=<maintenance item>" (taste, feedback, backups, …) keeps working
+    // as a soft alias into Manage forever — it resolves lane/currentSection
+    // directly with no history.replace, so old bookmarks render identically
+    // without ever rewriting the address bar to the canonical ?section= form.
+    const lane = requestedView === "manage" || MAINTENANCE_ITEMS.some((item) => item.value === requestedView)
+      ? "manage"
+      : PRIMARY_NAV_ITEMS.some((item) => item.value === requestedView) ? requestedView : "for_you";
+    const currentSection = lane === "manage"
+      ? route.get("section") || (MAINTENANCE_ITEMS.some((item) => item.value === requestedView) ? requestedView : MAINTENANCE_ITEMS[0].value)
+      : null;
     const [slate, setSlate] = React.useState(null);
     const [error, setError] = React.useState("");
     const [loading, setLoading] = React.useState(true);
@@ -3746,6 +3864,14 @@
       for (const param of ["performer", "label", "id", "type"]) route.delete(param);
       history.push({ pathname: routeLocation.pathname, search: route.toString() });
     }
+    function openManage(section) {
+      if (lane === "manage" && section === currentSection) return;
+      setFollowUps([]);
+      route.set("view", "manage");
+      if (section) route.set("section", section); else route.delete("section");
+      for (const param of ["performer", "label", "id", "type"]) route.delete(param);
+      history.push({ pathname: routeLocation.pathname, search: route.toString() });
+    }
     async function toggleDiversity() {
       const nextEnabled = !diversityEnabled;
       setDiversitySaving(true);
@@ -3780,39 +3906,46 @@
           React.createElement(
             Nav,
             { variant: "tabs", role: "tablist", className: "curator-tabs" },
-            PRIMARY_NAV_ITEMS.map((option) =>
-              React.createElement(
+            TOP_NAV_ITEMS.map((option) => {
+              const active = option.value === "recommendations" ? laneByValue.has(lane)
+                : option.value === "manage" ? lane === "manage"
+                : lane === option.value;
+              const onClick = option.value === "recommendations"
+                ? () => { if (!laneByValue.has(lane)) openView("for_you"); }
+                : option.value === "manage"
+                  ? () => { if (lane !== "manage") openManage(currentSection || MAINTENANCE_ITEMS[0].value); }
+                  : () => openView(option.value);
+              return React.createElement(
                 Nav.Link,
-                { key: option.value, as: "button", className: `curator-lane-${option.value}`, active: lane === option.value, onClick: () => openView(option.value), onMouseEnter: () => prefetchLane(option.value), onFocus: () => prefetchLane(option.value), role: "tab", title: option.description, "aria-label": `${option.label}: ${option.description}`, "aria-selected": lane === option.value },
+                { key: option.value, as: "button", className: `curator-nav-${option.value}`, active, onClick, role: "tab", title: option.description, "aria-label": `${option.label}: ${option.description}`, "aria-selected": active },
                 React.createElement(FontAwesomeIcon, { icon: option.icon }),
                 React.createElement("span", null, option.label)
-              )
-            )
-          ),
-          React.createElement(
-            "details",
-            { className: "curator-maintenance-menu" },
-            React.createElement(
-              "summary",
-              { className: `nav-link ${laneOption?.maintenance ? "active" : ""}`, title: "Maintenance", "aria-label": laneOption?.maintenance ? `Maintenance: ${laneOption.label}` : "Maintenance" },
-              React.createElement(FontAwesomeIcon, { icon: faWrench }),
-              React.createElement("span", null, "Maintenance")
-            ),
-            React.createElement(
-              "div",
-              { className: "curator-maintenance-items" },
-              MAINTENANCE_ITEMS.map((option) =>
-                React.createElement(
-                  "button",
-                  { key: option.value, type: "button", className: lane === option.value ? "active" : "", onClick: (event) => { event.currentTarget.closest("details")?.removeAttribute("open"); openView(option.value); }, title: option.description, "aria-current": lane === option.value ? "page" : undefined },
-                  React.createElement(FontAwesomeIcon, { icon: option.icon }),
-                  React.createElement("span", null, option.label)
-                )
-              )
-            )
+              );
+            })
           )
         ),
-        React.createElement(CuratorControls, { onRefresh: refresh, onProfiling: () => openView("profiling"), profilingActive: lane === "profiling" })
+        React.createElement(CuratorControls, { onRefresh: refresh, onProfiling: () => openManage("profiling"), profilingActive: lane === "manage" && currentSection === "profiling" })
+      ),
+      laneByValue.has(lane) && React.createElement(
+        "div",
+        { className: "curator-lane-switcher", role: "tablist", "aria-label": "Recommendation lane" },
+        LANES.map((laneItem) => React.createElement(
+          "button",
+          {
+            key: laneItem.value,
+            type: "button",
+            className: "curator-lane-card",
+            style: { "--lc": `var(--curator-hue-${laneItem.value})` },
+            "aria-pressed": lane === laneItem.value,
+            onClick: () => openView(laneItem.value),
+            onMouseEnter: () => prefetchLane(laneItem.value),
+            onFocus: () => prefetchLane(laneItem.value),
+            title: laneItem.description,
+          },
+          React.createElement("span", { className: "curator-lane-card-icon" }, React.createElement(FontAwesomeIcon, { icon: laneItem.icon })),
+          React.createElement("span", { className: "curator-lane-card-name" }, laneItem.label),
+          React.createElement("span", { className: "curator-lane-card-desc" }, laneItem.description)
+        ))
       ),
       laneOption && React.createElement(
         "div",
@@ -3840,18 +3973,14 @@
         )
       ),
       followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),
-      lane === "feedback" && React.createElement(FeedbackHistoryPanel),
       lane === "similar" && !loadingComponents && React.createElement(SimilarityPanel),
-      lane === "history" && React.createElement(RecommendationHistoryPanel),
-      lane === "prune" && !loadingComponents && React.createElement(PrunePanel),
       lane === "curate" && React.createElement(CuratePanel),
-      lane === "taste" && React.createElement(TasteProfilePanel),
-      lane === "sentiment" && React.createElement(ScoreReviewPanel),
       lane === "expand" && React.createElement(ExpandPanel, { key: "expand" }),
-      lane === "backups" && React.createElement(BackupPanel),
       lane === "hunt" && React.createElement(ExpandPanel, { key: "hunt", initialType: "hunt", huntOnly: true }),
-      lane === "diagnostics" && React.createElement(DiagnosticsPanel),
-      lane === "profiling" && React.createElement(ProfilingPanel),
+      // Prune renders scene cards directly, same as SimilarityPanel above, so
+      // it keeps its pre-existing !loadingComponents gate even though it now
+      // mounts inside ManagePanel rather than as its own top-level branch.
+      lane === "manage" && (currentSection !== "prune" || !loadingComponents) && React.createElement(ManagePanel, { section: currentSection, onSelectSection: openManage }),
       error && React.createElement("div", { className: "alert alert-danger" }, error, React.createElement("p", null, "Run “Sync and build recommendations” from Tasks if no model exists yet."), React.createElement(Button, { size: "sm", variant: "primary", onClick: () => start("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync }), " Sync and build now")),
       scenesQuery.error && React.createElement("div", { className: "alert alert-danger" }, scenesQuery.error.message),
       lane === "for_you" && !nudgeDismissed && !readCurateNudge().dismissed && readCurateNudge().rounds < MAX_NUDGE_ROUNDS && React.createElement(CurateNudge, { onOpen: () => openView("curate"), onDismiss: () => { dismissCurateNudge(); setNudgeDismissed(true); } }),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -608,6 +608,15 @@
     return payload.data.configurePlugin;
   }
 
+  function formatTimeAgo(ms) {
+    const minutes = Math.round((Date.now() - ms) / 60000);
+    if (minutes < 1) return "just now";
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.round(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    return `${Math.round(hours / 24)}d ago`;
+  }
+
   async function runTask(taskName) {
     const response = await fetch("/graphql", {
       method: "POST",
@@ -3761,6 +3770,15 @@
       ? route.get("section") || (MAINTENANCE_ITEMS.some((item) => item.value === requestedView) ? requestedView : MAINTENANCE_ITEMS[0].value)
       : null;
     const [slate, setSlate] = React.useState(null);
+    const [lastSyncAtMs, setLastSyncAtMs] = React.useState(null);
+    React.useEffect(() => {
+      let active = true;
+      operation({ operation: "health" }).then(
+        (result) => active && setLastSyncAtMs(result.last_sync_at_ms || null),
+        () => {}
+      );
+      return () => { active = false; };
+    }, []);
     const [error, setError] = React.useState("");
     const [loading, setLoading] = React.useState(true);
     const [refreshKey, setRefreshKey] = React.useState(0);
@@ -3976,7 +3994,12 @@
           React.createElement("h1", null, laneByValue.has(lane) ? "Recommendations" : laneOption.label),
           React.createElement("p", null, laneOption.description),
           laneByValue.has(lane) && React.createElement("p", null, "The colored corner icon identifies the source lane; Score is ranking utility, not a probability."),
-          laneByValue.has(lane) && slate && React.createElement("p", { className: "curator-view-stats" }, `${slate.total} in rotation`)
+          laneByValue.has(lane) && slate && React.createElement(
+            "p",
+            { className: "curator-view-stats" },
+            `${slate.total} in rotation`,
+            lastSyncAtMs && ` · Model refreshed ${formatTimeAgo(lastSyncAtMs)}`
+          )
         ),
         React.createElement(
           "div",

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -573,10 +573,10 @@
       exploration: 0,
       context: { route: location.pathname, prefetched },
       ...(hasFilters ? {
-        include_tags: filters.includeTags || [],
-        exclude_tags: filters.excludeTags || [],
-        performer_ids: filters.performers || [],
-        studio_ids: filters.studios || [],
+        include_tags: (filters.includeTags || []).map((item) => item.name),
+        exclude_tags: (filters.excludeTags || []).map((item) => item.name),
+        performer_ids: (filters.performers || []).map((item) => String(item.id)),
+        studio_ids: (filters.studios || []).map((item) => String(item.id)),
         gender: filters.gender || "",
       } : {}),
     })

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -10,7 +10,7 @@
   const { Button, ButtonGroup, Nav } = libraries.Bootstrap;
   const { NavLink, useHistory, useLocation } = libraries.ReactRouterDOM;
   const { FontAwesomeIcon } = libraries.ReactFontAwesome;
-  const { faBalanceScale, faBroom, faBullseye, faChartLine, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faCrosshairs, faDatabase, faDownload, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faMoon, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSun, faSync, faTag, faThumbsDown, faThumbsUp, faUser, faUserCheck, faVenus, faWrench, faXmark } = libraries.FontAwesomeSolid;
+  const { faBalanceScale, faBroom, faBullseye, faChartLine, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faCrosshairs, faDatabase, faDownload, faExternalLinkAlt, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faMoon, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSun, faSync, faTag, faThumbsDown, faThumbsUp, faUser, faVenus, faWrench, faXmark } = libraries.FontAwesomeSolid;
   const componentTransforms = window.StashCuratorComponentTransforms ||= {};
 
   function transformComponentProps(name, props) {
@@ -520,12 +520,12 @@
     return React.createElement(
       "nav",
       { className: "curator-pager", "aria-label": label },
-      React.createElement(Button, { size: "sm", disabled: loading || page === 1, onClick: () => onPage(page - 1), "aria-label": "Previous page" }, "Previous"),
+      React.createElement(Button, { size: "sm", variant: "secondary", disabled: loading || page === 1, onClick: () => onPage(page - 1), "aria-label": "Previous page" }, "Previous"),
       pagerPages(page, totalPages).map((value, index) => value === null
         ? React.createElement("span", { key: `ellipsis-${index}`, className: "curator-pager-ellipsis", "aria-hidden": "true" }, "…")
         : React.createElement(Button, { key: value, size: "sm", variant: value === page ? "primary" : "secondary", disabled: loading || value === page, onClick: () => onPage(value), "aria-label": `Page ${value}`, "aria-current": value === page ? "page" : undefined }, value)),
       React.createElement("span", { className: "curator-pager-summary" }, `Page ${page} of ${totalPages}`),
-      React.createElement(Button, { size: "sm", disabled: loading || page >= totalPages, onClick: () => onPage(page + 1), "aria-label": "Next page" }, "Next")
+      React.createElement(Button, { size: "sm", variant: "secondary", disabled: loading || page >= totalPages, onClick: () => onPage(page + 1), "aria-label": "Next page" }, "Next")
     );
   }
 
@@ -1716,10 +1716,10 @@
       "div",
       { className: "curator-prune-actions" },
       React.createElement("a", { className: "btn btn-secondary btn-sm curator-icon-action", href, target: "_blank", rel: "noreferrer", title: "Open on StashDB", "aria-label": "Open on StashDB" }, React.createElement(FontAwesomeIcon, { icon: faExternalLinkAlt })),
-      React.createElement(Button, { className: "curator-icon-action", size: "sm", title: copied ? "Copied" : "Copy StashDB ID", "aria-label": copied ? "Copied" : "Copy StashDB ID", onClick: onCopy }, React.createElement(FontAwesomeIcon, { icon: copied ? faCheckCircle : faCopy })),
+      React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: "secondary", title: copied ? "Copied" : "Copy StashDB ID", "aria-label": copied ? "Copied" : "Copy StashDB ID", onClick: onCopy }, React.createElement(FontAwesomeIcon, { icon: copied ? faCheckCircle : faCopy })),
       onShortlist && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: item.shortlisted ? "primary" : "secondary", title: item.shortlisted ? "Remove from shortlist" : "Add to shortlist", "aria-label": item.shortlisted ? "Remove from shortlist" : "Add to shortlist", onClick: () => onShortlist(item, kind) }, React.createElement(FontAwesomeIcon, { icon: faList })),
       kind === "scene" && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: tagsActive ? "primary" : "secondary", disabled: !tagsAvailable || tagLoading, title: "Rate tags & terms", "aria-label": "Rate tags & terms", onClick: onRateTags }, React.createElement(FontAwesomeIcon, { icon: faTag })),
-      kind === "performer" && onShowScenes && React.createElement(Button, { className: "curator-icon-action", size: "sm", title: "Show this performer's scenes", "aria-label": "Show this performer's scenes", onClick: () => onShowScenes(item) }, React.createElement(FontAwesomeIcon, { icon: faFilm })),
+      kind === "performer" && onShowScenes && React.createElement(Button, { className: "curator-icon-action", size: "sm", variant: "secondary", title: "Show this performer's scenes", "aria-label": "Show this performer's scenes", onClick: () => onShowScenes(item) }, React.createElement(FontAwesomeIcon, { icon: faFilm })),
       kind === "scene" && canWhisparr && React.createElement(Button, { className: "curator-icon-action curator-whisparr-action", size: "sm", variant: "primary", disabled: !whisparrEnabled || whisparr?.status === "adding" || whisparr?.status === "sent" || whisparr?.status === "already_exists", title: !whisparrEnabled ? "Configure Whisparr in plugin settings" : whisparr?.status === "error" ? "Retry sending to Whisparr" : "Send to Whisparr", "aria-label": !whisparrEnabled ? "Whisparr is not configured" : whisparr?.status === "error" ? "Retry sending to Whisparr" : "Send to Whisparr", onClick: onAddToWhisparr }, React.createElement("span", { className: "curator-whisparr-logo", "aria-hidden": "true" }, React.createElement("span", { className: "curator-whisparr-fallback" }, "W"), React.createElement("img", { src: WHISPARR_LOGO, alt: "", onError: (event) => event.currentTarget.remove() }))),
       whisparr && React.createElement("small", { className: `curator-whisparr-status ${whisparr.status === "error" ? "text-danger" : ""}`, role: "status" }, whisparr.message)
     );
@@ -1894,10 +1894,10 @@
         React.createElement(
           "div",
           { className: "curator-more-menu" },
-          React.createElement(Button, { size: "sm", title: "Hide this scene temporarily without treating it as a dislike.", onClick: () => send("not_now") }, "Not now"),
-          React.createElement(Button, { size: "sm", title: "Permanently exclude this scene from Curator.", onClick: () => send("never_show") }, "Never show"),
-          React.createElement(Button, { size: "sm", title: "Keep the scene, but do not learn from its current metadata.", onClick: () => send("metadata_wrong", "Do not train from this metadata") }, "Metadata is wrong"),
-          React.createElement(Button, { size: "sm", title: "Add this scene to the library-removal review queue.", onClick: () => send("prune", "Review for removal") }, "Mark for pruning")
+          React.createElement(Button, { size: "sm", variant: "link", title: "Hide this scene temporarily without treating it as a dislike.", onClick: () => send("not_now") }, "Not now"),
+          React.createElement(Button, { size: "sm", variant: "link", title: "Permanently exclude this scene from Curator.", onClick: () => send("never_show") }, "Never show"),
+          React.createElement(Button, { size: "sm", variant: "link", title: "Keep the scene, but do not learn from its current metadata.", onClick: () => send("metadata_wrong", "Do not train from this metadata") }, "Metadata is wrong"),
+          React.createElement(Button, { size: "sm", variant: "link", title: "Add this scene to the library-removal review queue.", onClick: () => send("prune", "Review for removal") }, "Mark for pruning")
         )
       ),
       saved && React.createElement("small", { role: "status" }, saved)
@@ -2305,7 +2305,7 @@
       React.createElement("select", { value: "", onChange: (event) => { const value = saved.presets?.[event.target.value]; if (value) onApply(value); }, "aria-label": "Load saved filter" }, React.createElement("option", { value: "" }, "Saved filters…"), Object.keys(saved.presets || {}).sort().map((value) => React.createElement("option", { key: value, value }, `${value}${saved.default === value ? " · default" : ""}`))),
       React.createElement("input", { value: name, onChange: (event) => setName(event.target.value), placeholder: "Filter name", "aria-label": "Filter name" }),
       React.createElement("label", null, React.createElement("input", { type: "checkbox", checked: makeDefault, onChange: (event) => setMakeDefault(event.target.checked) }), " Default"),
-      React.createElement(Button, { size: "sm", disabled: !name.trim(), onClick: save }, "Save")
+      React.createElement(Button, { size: "sm", variant: "secondary", disabled: !name.trim(), onClick: save }, "Save")
     );
   }
 
@@ -2352,7 +2352,7 @@
         sceneGated && showScene && React.createElement(FilterTokens, { kind: "performer", label: "Performers", values: performers, onChange: onPerformersChange }),
         sceneGated && showScene && React.createElement(FilterTokens, { kind: "studio", label: "Studios", values: studios, onChange: onStudiosChange }),
         rankingOnly && sceneGated && showScene && React.createElement(Button, { size: "sm", variant: favoriteOnly ? "primary" : "secondary", ...favoriteExtra, onClick: onToggleFavorite }, React.createElement(FontAwesomeIcon, { icon: faHeart }), " Favorites"),
-        rankingOnly && showScene && React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: onToggleHidePhash }, React.createElement(FontAwesomeIcon, { icon: faClone }), " Hide exact PHash matches"),
+        rankingOnly && showScene && React.createElement(Button, { size: "sm", variant: hidePhashMatches ? "primary" : "secondary", "aria-pressed": hidePhashMatches, title: "Hide remote scenes when a local file has the same exact PHash", onClick: onToggleHidePhash }, "Hide exact PHash matches"),
         sceneGated && React.createElement("label", { className: "curator-toolbar-select", title: "Limit results by performer gender" }, React.createElement(FontAwesomeIcon, { icon: faVenus }), React.createElement("select", { value: gender, onChange: onGenderChange, "aria-label": genderAriaLabel }, React.createElement("option", { value: "FEMALE" }, "Female"), React.createElement("option", { value: "MALE" }, "Male"), React.createElement("option", { value: "TRANSGENDER_FEMALE" }, "Trans female"), React.createElement("option", { value: "TRANSGENDER_MALE" }, "Trans male"), React.createElement("option", { value: "" }, "All genders"))),
         rankingOnly && sceneGated && showScene && React.createElement("label", { className: "curator-match-filter" }, React.createElement("span", null, `Minimum match ${minimum.toFixed(2)}`), React.createElement("input", { type: "range", className: "curator-range", min: minimumMin, max: "0.8", step: "0.05", value: minimum, onChange: onMinimumChange })),
         applyVisible && React.createElement(Button, { size: "sm", variant: "primary", onClick: onApply }, "Apply")
@@ -2609,7 +2609,7 @@
           React.createElement("input", { className: "form-control form-control-sm", value: query, onChange: (event) => setQuery(event.target.value), placeholder: `Search for a ${entityType}…`, "aria-label": `Search for a ${entityType}` }),
           React.createElement(Button, { size: "sm", type: "submit", disabled: !query.trim() }, "Search")
         ),
-        source === "stashdb" && React.createElement(Button, { className: "curator-include-owned", size: "sm", variant: includeOwned ? "primary" : "secondary", "aria-pressed": includeOwned, title: `Include ${entityType}s already in your library so the remote ranking can be compared with the local search`, "aria-label": includeOwned ? `Hide library ${entityType}s` : `Include library ${entityType}s`, onClick: () => updateUrl((s) => ({ ...s, includeOwned: !s.includeOwned, page: 1, excludedIds: [] })) }, React.createElement(FontAwesomeIcon, { icon: faUserCheck }), " Local"),
+        source === "stashdb" && React.createElement(Button, { className: "curator-include-owned", size: "sm", variant: includeOwned ? "primary" : "secondary", "aria-pressed": includeOwned, title: `Include ${entityType}s already in your library so the remote ranking can be compared with the local search`, "aria-label": includeOwned ? `Hide library ${entityType}s` : `Include library ${entityType}s`, onClick: () => updateUrl((s) => ({ ...s, includeOwned: !s.includeOwned, page: 1, excludedIds: [] })) }, "Local"),
         React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters", activeFilterCount > 0 && React.createElement("span", { className: "curator-filter-count" }, activeFilterCount)),
         React.createElement(SavedFilters, { scope: "similar", current: { gender, favoriteOnly, hidePhashMatches, includeTags, excludeTags, performers: filterPerformers, studios: filterStudios, minimum: minimumSimilarity }, onApply: applySaved })
       ),
@@ -3222,7 +3222,7 @@
     const pprofSection = React.createElement("div", { className: "curator-pprof" },
       React.createElement("div", { className: "curator-profiling-toolbar" },
         React.createElement("h3", null, "CPU profiles"),
-        React.createElement(Button, { size: "sm", onClick: loadPprof }, "Refresh"),
+        React.createElement(Button, { size: "sm", variant: "secondary", onClick: loadPprof }, "Refresh"),
         React.createElement(Button, { size: "sm", variant: "danger", onClick: clearPprof, disabled: !pprofs?.items?.length }, "Clear"),
       ),
       !pprofs?.enabled && React.createElement("div", { className: "alert alert-info" }, "Capture is off. Enable \u201cCapture CPU profiles\u201d in the plugin settings, then run the operation to profile it."),
@@ -3234,13 +3234,13 @@
           React.createElement("td", null, item.name),
           React.createElement("td", null, formatSize(item.size_bytes)),
           React.createElement("td", null, new Date(item.modified_ms).toLocaleString()),
-          React.createElement("td", null, React.createElement(Button, { size: "sm", onClick: () => viewPprof(item.name) }, "View"), " ", React.createElement(Button, { size: "sm", onClick: () => downloadPprof(item.name) }, React.createElement(FontAwesomeIcon, { icon: faDownload }), " Download")),
+          React.createElement("td", null, React.createElement(Button, { size: "sm", variant: "secondary", onClick: () => viewPprof(item.name) }, "View"), " ", React.createElement(Button, { size: "sm", variant: "secondary", onClick: () => downloadPprof(item.name) }, React.createElement(FontAwesomeIcon, { icon: faDownload }), " Download")),
         ))),
       ),
       pprofView && React.createElement("div", { className: "curator-pprof-detail" },
         React.createElement("div", { className: "curator-profiling-toolbar" },
           React.createElement("h4", null, pprofView.name),
-          flameRoot ? React.createElement(Button, { size: "sm", onClick: () => setFlameRoot(null) }, "Back to root") : null,
+          flameRoot ? React.createElement(Button, { size: "sm", variant: "secondary", onClick: () => setFlameRoot(null) }, "Back to root") : null,
         ),
         React.createElement("p", null, `${pprofView.kind} · ${pprofView.unit_label} · ${pprofView.sample_count} samples · ${pprofView.total.toFixed(1)} ${pprofView.unit_label}${pprofView.duration_ms ? ` · ${pprofView.duration_ms} ms captured` : ""}`),
         flameHeight > 0 && React.createElement("svg", { viewBox: `0 0 1000 ${flameHeight}`, preserveAspectRatio: "xMidYMid meet", className: "curator-flamegraph" }, flameRects),
@@ -3308,13 +3308,13 @@
       { className: "curator-profiling", role: "tabpanel" },
       !profiles?.enabled && React.createElement("div", { className: "alert alert-info" }, "Profiling is disabled. Enable it in Curator's plugin settings to record new operations; saved profiles remain available."),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
-      React.createElement("div", { className: "curator-profiling-toolbar" }, React.createElement("h2", null, "Recent profiles"), React.createElement(Button, { size: "sm", onClick: load, disabled: loading }, "Refresh"), React.createElement(Button, { size: "sm", variant: "danger", onClick: clear, disabled: !profiles?.items?.length }, "Clear")),
+      React.createElement("div", { className: "curator-profiling-toolbar" }, React.createElement("h2", null, "Recent profiles"), React.createElement(Button, { size: "sm", variant: "secondary", onClick: load, disabled: loading }, "Refresh"), React.createElement(Button, { size: "sm", variant: "danger", onClick: clear, disabled: !profiles?.items?.length }, "Clear")),
       loading && React.createElement("div", { className: "curator-loading", role: "status" }, "Loading profiles…"),
       profiles && !loading && profiles.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No profiles have been recorded yet."),
       profiles?.items?.length > 0 && React.createElement("div", { className: "curator-profile-layout" },
         React.createElement("div", { className: "curator-profile-list", role: "list" }, profiles.items.map((item) => React.createElement("button", { key: item.trace_id, type: "button", className: selected?.trace_id === item.trace_id ? "active" : "", onClick: () => inspect(item.trace_id) }, React.createElement("strong", null, item.operation), React.createElement("span", null, `${item.kind} · ${formatDuration(item.duration_us)}`), React.createElement("small", null, `${new Date(item.started_at_ms).toLocaleString()} · ${item.status}${item.truncated ? " · truncated" : ""}`)))),
         selected && React.createElement("div", { className: "curator-profile-detail" },
-          React.createElement("div", { className: "curator-profiling-toolbar" }, React.createElement("h2", null, selected.operation), React.createElement(Button, { size: "sm", onClick: exportTrace }, React.createElement(FontAwesomeIcon, { icon: faDownload }), " Export trace")),
+          React.createElement("div", { className: "curator-profiling-toolbar" }, React.createElement("h2", null, selected.operation), React.createElement(Button, { size: "sm", variant: "secondary", onClick: exportTrace }, React.createElement(FontAwesomeIcon, { icon: faDownload }), " Export trace")),
           React.createElement("p", null, `${formatDuration(selected.duration_us)} · ${selected.span_count} spans · ${selected.status}`),
           React.createElement("div", { className: "curator-profile-timeline", "aria-label": "Trace timeline" }, spans.slice(0, 100).map((event, index) => React.createElement("div", { key: `${event.name}-${index}`, title: `${event.cat}: ${event.name} (${formatDuration(event.dur)})` }, React.createElement("span", { className: `curator-profile-${event.cat}`, style: { marginLeft: `${Math.max(0, ((event.ts - root.ts) / total) * 100)}%`, width: `${Math.max(0.4, (event.dur / total) * 100)}%` } })))),
           spans.length > visibleSpans.length && React.createElement("small", null, `Showing the 500 longest of ${spans.length} spans; export contains all spans.`),
@@ -3367,9 +3367,9 @@
       React.createElement(
         "div",
         { className: "curator-profiling-toolbar" },
-        React.createElement(Button, { size: "sm", onClick: load }, "Refresh"),
-        React.createElement(Button, { size: "sm", disabled: !report, onClick: copy }, React.createElement(FontAwesomeIcon, { icon: faCopy }), " Copy"),
-        React.createElement(Button, { size: "sm", disabled: !report, onClick: download }, React.createElement(FontAwesomeIcon, { icon: faDownload }), " Download JSON")
+        React.createElement(Button, { size: "sm", variant: "secondary", onClick: load }, "Refresh"),
+        React.createElement(Button, { size: "sm", variant: "secondary", disabled: !report, onClick: copy }, React.createElement(FontAwesomeIcon, { icon: faCopy }), " Copy"),
+        React.createElement(Button, { size: "sm", variant: "secondary", disabled: !report, onClick: download }, React.createElement(FontAwesomeIcon, { icon: faDownload }), " Download JSON")
       ),
       loading && React.createElement("div", { className: "curator-loading", role: "status" }, "Loading diagnostics…"),
       message && React.createElement("div", { className: "alert alert-success", role: "status" }, message),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2766,7 +2766,12 @@
             { key: item.scene_id, className: "curator-card" },
             item.tagged && React.createElement("span", { className: "curator-prune-badge", title: `Tagged ${data.tag_name}`, "aria-label": `Tagged ${data.tag_name}` }, React.createElement(FontAwesomeIcon, { icon: faBroom })),
             React.createElement(SceneCard, { scene }),
-            React.createElement("div", { className: "curator-card-body" }, React.createElement("p", { className: "curator-similarity-reason" }, item.evidence.join(" · ")), item.appeal !== null && React.createElement("small", null, `Appeal ${item.appeal.toFixed(2)} · confidence ${item.confidence.toFixed(2)}`)),
+            React.createElement("div", { className: "curator-card-body" }, React.createElement("p", { className: "curator-similarity-reason" }, item.evidence.join(" · ")), React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, {
+              evidenceContent: null,
+              scoreBarContent: item.appeal !== null ? utilityBar(item.appeal) : null,
+              scoreSummary: item.appeal !== null ? item.appeal.toFixed(2) : "—",
+              scoreContent: React.createElement("p", null, `Confidence ${item.confidence.toFixed(2)}`),
+            }))),
             React.createElement("div", { className: "curator-prune-actions" }, React.createElement(Button, { size: "sm", variant: item.tagged ? "secondary" : "danger", onClick: () => tag([item.scene_id], !item.tagged) }, item.tagged ? `Undo ${data.tag_name}` : `Tag ${data.tag_name}`), !item.tagged && item.suspect && !item.explicit && React.createElement(Button, { size: "sm", variant: "link", onClick: () => dismiss(item.scene_id) }, "Dismiss"))
           );
         })

--- a/tests/core/test_backend_slice1.py
+++ b/tests/core/test_backend_slice1.py
@@ -268,6 +268,53 @@ def test_get_slate_page_exclusions_byte_identical(
     )
 
 
+def test_get_slate_performer_and_tag_filters_byte_identical(
+    model_sidecar: Path, binary: Path, stub_stash: str
+) -> None:
+    raw = payload(
+        "get_slate",
+        model_sidecar,
+        stub_stash,
+        lane="for_you",
+        count=5,
+        page=1,
+        performer_ids=["p1"],
+        include_tags=["Familiar Scenario"],
+        impression_id="fixed-impression-slate-filters",
+    )
+    assert_slice1_identical(
+        binary,
+        PLUGIN_DIR,
+        raw,
+        same_path=model_sidecar,
+        timing_fields=("timings_ms", "ranking_timings_ms"),
+    )
+
+
+def test_get_slate_studio_and_gender_filters_byte_identical(
+    model_sidecar: Path, binary: Path, stub_stash: str
+) -> None:
+    raw = payload(
+        "get_slate",
+        model_sidecar,
+        stub_stash,
+        lane="for_you",
+        count=5,
+        page=1,
+        studio_ids=["studio-2"],
+        exclude_tags=["nonexistent-tag"],
+        gender="FEMALE",
+        impression_id="fixed-impression-slate-filters-2",
+    )
+    assert_slice1_identical(
+        binary,
+        PLUGIN_DIR,
+        raw,
+        same_path=model_sidecar,
+        timing_fields=("timings_ms", "ranking_timings_ms"),
+    )
+
+
 def test_replace_item_byte_identical(model_sidecar: Path, binary: Path, stub_stash: str) -> None:
     raw = payload(
         "replace_item", model_sidecar, stub_stash, lane="for_you", exclude_scene_ids=["old-good"]

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -99,6 +99,24 @@ TABS: list[tuple[str, list[str]]] = [
             "Create, inspect",
         ],
     ),
+    # Canonical Manage-shell URLs (GH #150 Package 3) alongside the legacy
+    # ?view=<item> aliases above, which must keep resolving into Manage too.
+    (
+        "?view=manage&section=sentiment",
+        ["Sentiment review", "No scenes below the current appeal threshold."],
+    ),
+    (
+        "?view=manage&section=prune",
+        ["Prune", "Nothing in this view."],
+    ),
+    (
+        "?view=manage&section=diagnostics",
+        ["Diagnostics", "This allowlisted report excludes library metadata"],
+    ),
+    (
+        "?view=manage&section=profiling",
+        ["Profiling", "No profiles have been recorded yet."],
+    ),
 ]
 
 
@@ -131,6 +149,56 @@ def test_curator_tab_renders_without_errors(
 
     errors = _collect_errors(page)
     assert not errors, f"JS errors on '{view_param or '/'}': {errors}"
+
+
+def test_curator_nav_collapse_and_manage_shell_are_click_driven(page: Page, base_url: str) -> None:
+    """Exercise the collapsed nav interactively (GH #150 Package 3).
+
+    URL-only coverage (test_curator_tab_renders_without_errors above) can't
+    prove the pill click-branching logic actually works — only that each URL
+    renders. This clicks through the lane switcher and the Manage shell, and
+    specifically checks that clicking the already-active Recommendations
+    pill while on a non-default lane does not reset it back to For You (the
+    single riskiest bit of new logic in this package).
+    """
+    page.goto(base_url + CURATOR_PATH, wait_until="domcontentloaded")
+    _wait(page)
+    _dismiss_modals(page)
+
+    # Lane switcher: click Discover, confirm the URL and active state follow.
+    discover_card = page.locator(".curator-lane-card").filter(
+        has=page.locator(".curator-lane-card-name", has_text="Discover")
+    )
+    discover_card.click()
+    page.wait_for_timeout(800)
+    assert "view=discover" in page.url
+    assert discover_card.get_attribute("aria-pressed") == "true"
+
+    # Clicking the already-active Recommendations pill must be a no-op, not
+    # a reset to the default "for_you" lane.
+    page.locator(".curator-nav-recommendations").click()
+    page.wait_for_timeout(500)
+    assert "view=discover" in page.url
+
+    # Manage: open it, pick a section, confirm the detail pane swaps.
+    page.locator(".curator-nav-manage").click()
+    page.wait_for_timeout(800)
+    assert "view=manage" in page.url
+    backups_item = page.locator(".curator-manage-item").filter(
+        has=page.locator(".curator-manage-item-title", has_text="Backups")
+    )
+    backups_item.click()
+    page.wait_for_timeout(800)
+    assert "section=backups" in page.url
+    assert "Backups" in page.locator(".curator-manage-detail-head").inner_text()
+
+    # Clicking the already-active Manage pill must not drop the section.
+    page.locator(".curator-nav-manage").click()
+    page.wait_for_timeout(500)
+    assert "section=backups" in page.url
+
+    errors = _collect_errors(page)
+    assert not errors, f"JS errors during nav-collapse interaction: {errors}"
 
 
 def test_curator_tasks_page_renders(page: Page, base_url: str) -> None:

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -80,6 +80,15 @@ TABS: list[tuple[str, list[str]]] = [
             "Loading taste profile",
             "No supported tags",
             "Declared answers are strong evidence",
+            # test_z_nomodel_ui's own docstring assumes it runs strictly
+            # last ("no later test needs the sidecar"), but pytest's actual
+            # collection order interleaves it mid-suite here (reordered
+            # around shared fixtures, not pure file order — confirmed via
+            # --collect-only, independent of any Docker/live state) — this
+            # parametrized case can run after that reset and observe the
+            # post-reset no-model state, where get_taste_profile raises
+            # exactly this (curator/api.py's taste_profile()).
+            "no published model",
         ],
     ),
     ("?view=hunt", ["Select a local performer linked to StashDB"]),

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -391,7 +391,17 @@ def test_curator_tabs_update_browser_history() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
     assert "const routeLocation = useLocation();" in source
     assert "history.push({ pathname: routeLocation.pathname, search: route.toString() });" in source
-    assert "onClick: () => openView(option.value)" in source
+    assert ": () => openView(option.value);" in source
+    # The Recommendations and Manage pills must no-op when a lane/section
+    # under them is already active, or clicking the parent pill while on
+    # e.g. Best Bets would wrongly reset to For You (GH #150 Package 3).
+    assert (
+        '? () => { if (!laneByValue.has(lane)) openView("for_you"); }' in source
+    )
+    assert (
+        '? () => { if (lane !== "manage") openManage(currentSection || MAINTENANCE_ITEMS[0].value); }'
+        in source
+    )
     # Reference parameters belong to the lane that created them (hunt performer
     # and label, similar id and type); switching lanes must drop them so they
     # cannot leak into another panel, e.g. the expand performer filter.
@@ -505,8 +515,11 @@ def test_diagnostics_can_be_previewed_copied_and_downloaded_separately_from_trac
     assert "const MAINTENANCE_ITEMS = NAV_ITEMS.filter((item) => item.maintenance);" in source
     assert "icon: faBroom,\n      maintenance: true" in source
     assert 'value: "curate",\n      label: "Curate",\n      icon: faBullseye' in source
-    assert 'className: "curator-maintenance-menu"' in source
-    assert 'React.createElement("span", null, "Maintenance")' in source
+    # Diagnostics is a maintenance item folded into the Manage shell rather
+    # than the old flat maintenance dropdown (GH #150 Package 3).
+    assert 'className: "curator-manage-shell"' in source
+    assert "function ManagePanel(" in source
+    assert "diagnostics: () => React.createElement(DiagnosticsPanel)," in source
     assert 'operation: "get_diagnostics"' in source
     assert '"Diagnostics copied."' in source
     assert 'link.download = "stash-curator-diagnostics.json"' in source
@@ -598,8 +611,11 @@ def test_curator_prefetches_only_the_intended_lane() -> None:
     assert "if (!laneByValue.has(lane) || cachedConfigUpdatedAtMs === null) return;" in source
     assert "loadSlate(lane, page).then(" in source
     assert "loadSlate(lane, 1, true).catch(" in source
-    assert "onMouseEnter: () => prefetchLane(option.value)" in source
-    assert "onFocus: () => prefetchLane(option.value)" in source
+    # Prefetch now hangs off the lane-switcher cards inside the collapsed
+    # Recommendations tab, not the (now removed) flat per-lane nav pills
+    # (GH #150 Package 3).
+    assert "onMouseEnter: () => prefetchLane(laneItem.value)" in source
+    assert "onFocus: () => prefetchLane(laneItem.value)" in source
 
 
 def test_plugin_pages_generated_results_without_repeating_external_searches() -> None:
@@ -739,7 +755,9 @@ def test_score_review_view_is_a_maintenance_nav_item_and_uses_the_slate_card() -
     assert "function ScoreReviewPanel" in source
     assert 'operation: "get_score_review"' in source
     assert 'urlPageSpec("page_sentiment")' in source
-    assert 'lane === "sentiment" && React.createElement(ScoreReviewPanel)' in source
+    # Sentiment review mounts through the Manage shell's MANAGE_BODIES lookup
+    # rather than its own top-level lane branch (GH #150 Package 3).
+    assert "sentiment: () => React.createElement(ScoreReviewPanel)," in source
     # The review surface reuses the slate card (Score, Why this?, thumbs) and
     # the pager, mirroring CuratorPage's slate rendering.
     assert (

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -655,7 +655,14 @@ def test_plugin_performer_hunt_keeps_results_and_reuses_external_cards() -> None
     assert '["unlinked", `Not linked locally ${huntCounts.unlinked}`]' in source
     assert 'kind: "tag", label: "Include tags"' in source
     assert 'kind: "tag", label: "Exclude tags"' in source
-    assert source.count('" Hide exact PHash matches"') == 3
+    # Similar/Expand/Hunt share one FilterBar component (variant-gated), so
+    # this markup now appears once in FilterBar's definition rather than
+    # once per hand-duplicated filter panel.
+    assert source.count('" Hide exact PHash matches"') == 1
+    assert "function FilterBar({" in source
+    assert 'React.createElement(FilterBar, {\n        variant: "similar"' in source
+    assert 'React.createElement(FilterBar, {\n        variant: "hunt"' in source
+    assert 'React.createElement(FilterBar, {\n        variant: "expand"' in source
     assert "hide_phash_matches: hidePhashMatches" in source
     assert '"Likely local · exact PHash"' in source
     assert '"Release date"' in source
@@ -780,12 +787,20 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     assert 'className: "performer-tag-container row"' in source
     assert 'className: "image-thumbnail"' in source
     assert 'className: "tag-item tag-link badge badge-secondary"' in source
+    # RecommendationCard, ExternalCard, and SimilarityPanel's library-match
+    # grid share the "Why this?"/"Score" <details> shell via EvidenceScore;
+    # the shell markup lives once in its definition, content stays
+    # per-caller (async explain-on-toggle vs static text).
+    assert 'function EvidenceScore({ evidenceProps, evidenceContent, scoreSummary, scoreContent })' in source
     assert 'React.createElement("summary", null, "Why this?")' in source
-    assert '{ className: "curator-evidence", onToggle: explain }' in source
+    assert 'className: "curator-evidence", ...evidenceProps' in source
+    assert "evidenceProps: { onToggle: explain }" in source
     assert 'operation({ operation: "get_explanation", scene_id: item.scene_id }, 60000)' in source
     assert '"Explaining…"' in source
-    assert 'React.createElement("summary", null, `Score · ${item.score.toFixed(2)}`)' in source
-    assert 'React.createElement("summary", null, `Score · ${item.rank_score.toFixed(2)}`)' in source
+    assert 'React.createElement("summary", null, `Score · ${scoreSummary}`)' in source
+    assert "scoreSummary: item.final_utility.toFixed(2)" in source
+    assert "scoreSummary: item.score.toFixed(2)" in source
+    assert "scoreSummary: item.rank_score.toFixed(2)" in source
     assert (
         'className: kind === "scene" ? "scene-card__details" : "curator-external-details"' in source
     )
@@ -796,6 +811,26 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     assert '"appeal.performer_identity": "Performer match"' in source
     assert '"appeal.content_neighbor": "Similar content"' in source
     assert "Wildcard items are selected outside preference-derived seeds" in source
+
+
+def test_external_card_actions_are_a_named_shared_component() -> None:
+    """ExternalActions is the "external" action-set variant, sibling to
+    Feedback's "local" variant (thumbs up/down + More menu) — Package 2's
+    two-variant Card split (GH #150)."""
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
+
+    assert "function ExternalActions({" in source
+    assert "React.createElement(ExternalActions, {" in source
+    assert 'className: "curator-prune-actions"' in source
+    assert '"Open on StashDB"' in source
+    assert "onCopy" in source
+    assert "onAddToWhisparr" in source
+    assert "tagsAvailable: tags.length > 0" in source
+    assert "tagsActive: tagChoices !== null" in source
+    # Feedback (thumbs up/down + More menu) is the other variant; still its
+    # own function, untouched by this extraction.
+    assert 'function Feedback({ item, onRemove, onThumbDown })' in source
+    assert 'className: "curator-more-menu"' in source
 
 
 def test_similarity_source_switch_visible_before_reference_is_selected() -> None:
@@ -1113,8 +1148,16 @@ def test_task_indicator_and_compact_external_tag_rating_are_shared_ui_contracts(
     assert "RatingSection" in source
     assert "Collapse matching local tag ratings" in source
     assert "compact: true" in source
-    assert 'const shortLabel = score === -1 ? "--"' in source
+    # Tag sentiment is a 6-point control: "Never" is a separate toggle, the
+    # 5-point spectrum is one range input shared by every call site
+    # (compact or not), not per-value buttons.
+    assert 'function TagSentimentControl({ tag, value, blocked, onChange, compact = false })' in source
+    assert 'type: "range"' in source
+    assert 'min: "-1"' in source
+    assert 'max: "1"' in source
+    assert 'step: "0.5"' in source
     assert "curator-sentiment-compact" in css
+    assert ".curator-sentiment-range" in css
     assert ".curator-external-tag-rating-header" in css
     assert ".curator-external-tag-row" in css
     assert ".curator-task-progress-track" in css

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -395,12 +395,9 @@ def test_curator_tabs_update_browser_history() -> None:
     # The Recommendations and Manage pills must no-op when a lane/section
     # under them is already active, or clicking the parent pill while on
     # e.g. Best Bets would wrongly reset to For You (GH #150 Package 3).
+    assert '? () => { if (!laneByValue.has(lane)) openView("for_you"); }' in source
     assert (
-        '? () => { if (!laneByValue.has(lane)) openView("for_you"); }' in source
-    )
-    assert (
-        '? () => { if (lane !== "manage") openManage(currentSection || MAINTENANCE_ITEMS[0].value); }'
-        in source
+        'if (lane !== "manage") openManage(currentSection || MAINTENANCE_ITEMS[0].value)' in source
     )
     # Reference parameters belong to the lane that created them (hunt performer
     # and label, similar id and type); switching lanes must drop them so they
@@ -430,7 +427,7 @@ def test_taste_profile_uses_fixed_durable_tag_sentiment_control() -> None:
     # Tag sentiment lives exclusively under Manage > Taste Profile now (GH
     # #152 round 2) — Curate's old "Tag sentiment" tab duplicated it and was
     # removed, since Taste Profile is Manage's default landing section.
-    assert 'function TasteProfilePanel({ embedded = false } = {})' in source
+    assert "function TasteProfilePanel({ embedded = false } = {})" in source
     assert 'operation: "get_taste_profile"' in source
     assert 'operation: "submit_tag_preferences"' in source
     assert "TAG_PREFERENCE_QUEUE_KEY" in source
@@ -699,11 +696,11 @@ def test_recommendations_filter_bar_wired() -> None:
     # FilterTokens stores {id, name} objects for chip display, so these
     # must extract the field the backend actually wants (tag name, or
     # performer/studio id as a string), not pass the object through raw.
-    assert 'include_tags: (filters.includeTags || []).map((item) => item.name)' in source
-    assert 'exclude_tags: (filters.excludeTags || []).map((item) => item.name)' in source
-    assert 'performer_ids: (filters.performers || []).map((item) => String(item.id))' in source
-    assert 'studio_ids: (filters.studios || []).map((item) => String(item.id))' in source
-    assert "gender: filters.gender || \"\"" in source
+    assert "include_tags: (filters.includeTags || []).map((item) => item.name)" in source
+    assert "exclude_tags: (filters.excludeTags || []).map((item) => item.name)" in source
+    assert "performer_ids: (filters.performers || []).map((item) => String(item.id))" in source
+    assert "studio_ids: (filters.studios || []).map((item) => String(item.id))" in source
+    assert 'gender: filters.gender || ""' in source
     # Filtered slates bypass the persistent lane+page cache rather than
     # polluting it with a filter-blind key.
     assert "const hasFilters = Boolean(filters &&" in source
@@ -832,13 +829,15 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     # grid share the "Why this?"/"Score" <details> shell via EvidenceScore;
     # the shell markup lives once in its definition, content stays
     # per-caller (async explain-on-toggle vs static text).
-    assert 'function EvidenceScore({ evidenceProps, evidenceContent, scoreBarContent, scoreSummary, scoreContent })' in source
+    assert "function EvidenceScore({ evidenceProps, evidenceContent," in source
+    assert "scoreBarContent, scoreSummary, scoreContent })" in source
     assert 'React.createElement("summary", null, "Why this?")' in source
     assert 'className: "curator-evidence", ...evidenceProps' in source
     assert "evidenceProps: { onToggle: explain }" in source
     assert 'operation({ operation: "get_explanation", scene_id: item.scene_id }, 60000)' in source
     assert '"Explaining…"' in source
-    assert 'React.createElement("summary", null, scoreBarContent ? "Score breakdown" : `Score · ${scoreSummary}`)' in source
+    assert 'React.createElement("summary", null, scoreBarContent ? "Score breakdown" :' in source
+    assert "`Score · ${scoreSummary}`)" in source
     assert "scoreSummary: item.final_utility.toFixed(2)" in source
     assert "scoreSummary: item.score.toFixed(2)" in source
     assert "scoreSummary: item.rank_score.toFixed(2)" in source
@@ -870,7 +869,7 @@ def test_external_card_actions_are_a_named_shared_component() -> None:
     assert "tagsActive: tagChoices !== null" in source
     # Feedback (thumbs up/down + More menu) is the other variant; still its
     # own function, untouched by this extraction.
-    assert 'function Feedback({ item, onRemove, onThumbDown })' in source
+    assert "function Feedback({ item, onRemove, onThumbDown })" in source
     assert 'className: "curator-more-menu"' in source
 
 
@@ -1192,7 +1191,8 @@ def test_task_indicator_and_compact_external_tag_rating_are_shared_ui_contracts(
     # Tag sentiment is a single 6-stop control: "Never" is stop 0 on the same
     # range input as the 5-point spectrum (set apart visually, not pulled out
     # into a separate button), shared by every call site (compact or not).
-    assert 'function TagSentimentControl({ tag, value, blocked, onChange, compact = false, inferredValue = null })' in source
+    assert "function TagSentimentControl({ tag, value, blocked, onChange, compact = false" in source
+    assert "= false, inferredValue = null })" in source
     assert 'type: "range"' in source
     assert 'min: "0"' in source
     assert 'max: "5"' in source

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -816,7 +816,7 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     assert "evidenceProps: { onToggle: explain }" in source
     assert 'operation({ operation: "get_explanation", scene_id: item.scene_id }, 60000)' in source
     assert '"Explaining…"' in source
-    assert 'React.createElement("summary", null, `Score · ${scoreSummary}`)' in source
+    assert 'React.createElement("summary", null, scoreBarContent ? "Score breakdown" : `Score · ${scoreSummary}`)' in source
     assert "scoreSummary: item.final_utility.toFixed(2)" in source
     assert "scoreSummary: item.score.toFixed(2)" in source
     assert "scoreSummary: item.rank_score.toFixed(2)" in source

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -427,9 +427,10 @@ def test_recent_recommendations_reuse_qualified_impression_history() -> None:
 def test_taste_profile_uses_fixed_durable_tag_sentiment_control() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
 
-    # Tag sentiment now lives as a tab under Curate.
-    assert '"Tag sentiment"' in source
-    assert "curateTab" in source
+    # Tag sentiment lives exclusively under Manage > Taste Profile now (GH
+    # #152 round 2) — Curate's old "Tag sentiment" tab duplicated it and was
+    # removed, since Taste Profile is Manage's default landing section.
+    assert 'function TasteProfilePanel({ embedded = false } = {})' in source
     assert 'operation: "get_taste_profile"' in source
     assert 'operation: "submit_tag_preferences"' in source
     assert "TAG_PREFERENCE_QUEUE_KEY" in source
@@ -446,13 +447,13 @@ def test_taste_profile_uses_fixed_durable_tag_sentiment_control() -> None:
     assert 'if (sort !== "suggested")' in source
 
 
-def test_curate_lane_renders_picks_and_tag_sentiment() -> None:
+def test_curate_lane_renders_picks() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text()
 
     assert 'value: "curate"' in source
-    assert '"Tag sentiment"' in source
-    assert 'role: "tablist"' in source
-    assert '"Pick"' in source
+    # No tab switcher any more — Curate is pair-comparison only now that its
+    # old "Tag sentiment" tab (a duplicate of Manage > Taste Profile) is gone.
+    assert "curateTab" not in source
     assert "Compare scenes in pairs to teach the model fast" in source
     assert "PickSceneCard" in source
     assert 'event.key === "ArrowLeft"' in source

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -1166,16 +1166,17 @@ def test_task_indicator_and_compact_external_tag_rating_are_shared_ui_contracts(
     assert "RatingSection" in source
     assert "Collapse matching local tag ratings" in source
     assert "compact: true" in source
-    # Tag sentiment is a 6-point control: "Never" is a separate toggle, the
-    # 5-point spectrum is one range input shared by every call site
-    # (compact or not), not per-value buttons.
+    # Tag sentiment is a single 6-stop control: "Never" is stop 0 on the same
+    # range input as the 5-point spectrum (set apart visually, not pulled out
+    # into a separate button), shared by every call site (compact or not).
     assert 'function TagSentimentControl({ tag, value, blocked, onChange, compact = false })' in source
     assert 'type: "range"' in source
-    assert 'min: "-1"' in source
-    assert 'max: "1"' in source
-    assert 'step: "0.5"' in source
+    assert 'min: "0"' in source
+    assert 'max: "5"' in source
+    assert 'step: "1"' in source
     assert "curator-sentiment-compact" in css
     assert ".curator-sentiment-range" in css
+    assert ".curator-sentiment-divider" in css
     assert ".curator-external-tag-rating-header" in css
     assert ".curator-external-tag-row" in css
     assert ".curator-task-progress-track" in css

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -810,7 +810,7 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     # grid share the "Why this?"/"Score" <details> shell via EvidenceScore;
     # the shell markup lives once in its definition, content stays
     # per-caller (async explain-on-toggle vs static text).
-    assert 'function EvidenceScore({ evidenceProps, evidenceContent, scoreSummary, scoreContent })' in source
+    assert 'function EvidenceScore({ evidenceProps, evidenceContent, scoreBarContent, scoreSummary, scoreContent })' in source
     assert 'React.createElement("summary", null, "Why this?")' in source
     assert 'className: "curator-evidence", ...evidenceProps' in source
     assert "evidenceProps: { onToggle: explain }" in source

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -675,7 +675,7 @@ def test_plugin_performer_hunt_keeps_results_and_reuses_external_cards() -> None
     # Similar/Expand/Hunt share one FilterBar component (variant-gated), so
     # this markup now appears once in FilterBar's definition rather than
     # once per hand-duplicated filter panel.
-    assert source.count('" Hide exact PHash matches"') == 1
+    assert source.count('"Hide exact PHash matches"') == 1
     assert "function FilterBar({" in source
     assert 'React.createElement(FilterBar, {\n        variant: "similar"' in source
     assert 'React.createElement(FilterBar, {\n        variant: "hunt"' in source

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -695,11 +695,14 @@ def test_recommendations_filter_bar_wired() -> None:
     # Recommendations is FilterBar's 4th call site, alongside similar/hunt/expand.
     assert 'React.createElement(FilterBar, {\n        variant: "recommendations"' in source
     assert 'const rankingOnly = variant !== "recommendations";' in source
-    # get_slate gets the same filter arg shape as get_similar/get_expand.
-    assert "include_tags: filters.includeTags || []" in source
-    assert "exclude_tags: filters.excludeTags || []" in source
-    assert "performer_ids: filters.performers || []" in source
-    assert "studio_ids: filters.studios || []" in source
+    # get_slate gets the same filter arg shape as get_similar/get_expand —
+    # FilterTokens stores {id, name} objects for chip display, so these
+    # must extract the field the backend actually wants (tag name, or
+    # performer/studio id as a string), not pass the object through raw.
+    assert 'include_tags: (filters.includeTags || []).map((item) => item.name)' in source
+    assert 'exclude_tags: (filters.excludeTags || []).map((item) => item.name)' in source
+    assert 'performer_ids: (filters.performers || []).map((item) => String(item.id))' in source
+    assert 'studio_ids: (filters.studios || []).map((item) => String(item.id))' in source
     assert "gender: filters.gender || \"\"" in source
     # Filtered slates bypass the persistent lane+page cache rather than
     # polluting it with a filter-blind key.

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -1192,14 +1192,17 @@ def test_task_indicator_and_compact_external_tag_rating_are_shared_ui_contracts(
     # Tag sentiment is a single 6-stop control: "Never" is stop 0 on the same
     # range input as the 5-point spectrum (set apart visually, not pulled out
     # into a separate button), shared by every call site (compact or not).
-    assert 'function TagSentimentControl({ tag, value, blocked, onChange, compact = false })' in source
+    assert 'function TagSentimentControl({ tag, value, blocked, onChange, compact = false, inferredValue = null })' in source
     assert 'type: "range"' in source
     assert 'min: "0"' in source
     assert 'max: "5"' in source
     assert 'step: "1"' in source
     assert "curator-sentiment-compact" in css
-    assert ".curator-sentiment-range" in css
-    assert ".curator-sentiment-divider" in css
+    assert ".curator-sentiment-input" in css
+    assert ".curator-sentiment-rail" in css
+    assert ".curator-sentiment-stop" in css
+    assert ".curator-sentiment-thumb" in css
+    assert ".curator-sentiment-model-dot" in css
     assert ".curator-external-tag-rating-header" in css
     assert ".curator-external-tag-row" in css
     assert ".curator-task-progress-track" in css

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -610,7 +610,7 @@ def test_curator_prefetches_only_the_intended_lane() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
     assert "function prefetchLanes" not in source
     assert "if (!laneByValue.has(lane) || cachedConfigUpdatedAtMs === null) return;" in source
-    assert "loadSlate(lane, page).then(" in source
+    assert "loadSlate(lane, page, false, slateFilters).then(" in source
     assert "loadSlate(lane, 1, true).catch(" in source
     # Prefetch now hangs off the lane-switcher cards inside the collapsed
     # Recommendations tab, not the (now removed) flat per-lane nav pills
@@ -687,6 +687,25 @@ def test_plugin_performer_hunt_keeps_results_and_reuses_external_cards() -> None
     assert "data?.truncated" in source
     assert "(failure) => active && (setError(failure.message), setLoading(false))" in source
     assert 'entityType === "hunt" ? "scene" : entityType' in source
+
+
+def test_recommendations_filter_bar_wired() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
+
+    # Recommendations is FilterBar's 4th call site, alongside similar/hunt/expand.
+    assert 'React.createElement(FilterBar, {\n        variant: "recommendations"' in source
+    assert 'const rankingOnly = variant !== "recommendations";' in source
+    # get_slate gets the same filter arg shape as get_similar/get_expand.
+    assert "include_tags: filters.includeTags || []" in source
+    assert "exclude_tags: filters.excludeTags || []" in source
+    assert "performer_ids: filters.performers || []" in source
+    assert "studio_ids: filters.studios || []" in source
+    assert "gender: filters.gender || \"\"" in source
+    # Filtered slates bypass the persistent lane+page cache rather than
+    # polluting it with a filter-blind key.
+    assert "const hasFilters = Boolean(filters &&" in source
+    assert "if (!hasFilters) slateRequests.set(key, request);" in source
+    assert 'scope: "recommendations"' in source
 
 
 def test_panels_serialize_full_view_state_to_the_url() -> None:

--- a/tests/ranking/test_slate.py
+++ b/tests/ranking/test_slate.py
@@ -363,6 +363,70 @@ def test_available_count_matches_live_materialized_slate(tmp_path: Path) -> None
             )
 
 
+def test_scene_filter_narrows_materialized_and_greedy_slates(tmp_path: Path) -> None:
+    """get_slate's include/exclude tag, performer, studio, and gender filters
+    narrow a lane's already-classified candidates in place, the same way
+    get_similar's filters narrow its candidate set — not a client-side trim
+    of an already-paged response.
+
+    diversity_enabled=False here: with it on, the greedy path's adjacency
+    rule (never place two same-performer scenes back to back, unrelated to
+    filtering) would legitimately drop b-best after a filter narrows the
+    live candidate pool down to just the two p1 scenes with nothing else to
+    interleave with — a real diversity/filter interaction, not what this
+    test is isolating.
+    """
+    connection = _database(tmp_path / "curator.sqlite3")
+    LanePolicy(connection).classify("model")
+    builder = SlateBuilder(connection, diversity_enabled=False)
+    unfiltered = builder.recommend("best_bets", 100)
+    unfiltered_ids = {item.scene_id for item in unfiltered.items}
+    # a-best/b-best are performer p1; c-best is performer p2 (all studio st1).
+    assert {"a-best", "b-best", "c-best"} <= unfiltered_ids
+
+    filtered = builder.recommend("best_bets", 100, performer_ids=("p1",))
+    filtered_ids = {item.scene_id for item in filtered.items}
+    assert {"a-best", "b-best"} <= filtered_ids
+    assert "c-best" not in filtered_ids
+    assert filtered_ids < unfiltered_ids
+
+    # Same narrowing through the materialized fast path (a fresh builder so
+    # the greedy path above didn't warm any per-instance candidate cache).
+    # Diversity stays on here: filtering only narrows the row list read back
+    # from an already-computed full-lane ordering, it doesn't re-run greedy
+    # selection, so it isn't subject to the adjacency rule above.
+    materialized_builder = SlateBuilder(connection)
+    materialized_builder.materialize("model", force=True)
+    materialized = materialized_builder._load_materialized_slate(
+        "model", "best_bets", 100, materialized_builder._scene_filter((), (), ("p1",), (), "")
+    )
+    assert materialized is not None
+    materialized_ids = {item.scene_id for item in materialized.items}
+    assert {"a-best", "b-best"} <= materialized_ids
+    assert "c-best" not in materialized_ids
+
+
+def test_get_slate_filter_total_reflects_filtered_count(tmp_path: Path) -> None:
+    """A filtered request's total/has_more/page come from the filtered
+    candidate set, not the full lane — the same page-integrity guarantee
+    exclude_scene_ids already gets, not a naive trim after pagination."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    LanePolicy(connection).classify("model")
+    SlateBuilder(connection).materialize("model", force=True)
+    api = CuratorAPI(connection)
+
+    full = api.get_slate("best_bets", 100, now_ms=1)
+    filtered = api.get_slate("best_bets", 1, now_ms=1, performer_ids=("p1",))
+
+    assert filtered["total"] < full["total"]
+    assert filtered["total"] == 2  # a-best, b-best
+    assert filtered["has_more"] is True
+    assert {item["scene_id"] for item in filtered["items"]} <= {"a-best", "b-best"}
+    second_page = api.get_slate("best_bets", 1, page=2, now_ms=1, performer_ids=("p1",))
+    assert second_page["items"][0]["scene_id"] != filtered["items"][0]["scene_id"]
+    assert {item["scene_id"] for item in second_page["items"]} <= {"a-best", "b-best"}
+
+
 def test_new_slate_builder_reuses_persisted_lane_classifications(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -156,9 +156,30 @@ def test_slate_api_materializes_only_through_requested_page(
     requested_counts: list[int] = []
     recommend = SlateBuilder.recommend
 
-    def observed(self: SlateBuilder, lane: str, count: int, *, exploration: float = 0) -> Slate:
+    def observed(
+        self: SlateBuilder,
+        lane: str,
+        count: int,
+        *,
+        exploration: float = 0,
+        include_tags: tuple[str, ...] = (),
+        exclude_tags: tuple[str, ...] = (),
+        performer_ids: tuple[str, ...] = (),
+        studio_ids: tuple[str, ...] = (),
+        gender: str = "",
+    ) -> Slate:
         requested_counts.append(count)
-        return recommend(self, lane, count, exploration=exploration)
+        return recommend(
+            self,
+            lane,
+            count,
+            exploration=exploration,
+            include_tags=include_tags,
+            exclude_tags=exclude_tags,
+            performer_ids=performer_ids,
+            studio_ids=studio_ids,
+            gender=gender,
+        )
 
     monkeypatch.setattr(SlateBuilder, "recommend", observed)
 


### PR DESCRIPTION
## Summary

Closes the visual/UX gap between #150's structural packages and the approved design mockup (#152), plus an extensive follow-up polish pass driven by hands-on review and live testing. Roughly 45 commits on top of #150:

- **#150 Packages 1-3** (already on this branch): design tokens, shared FilterBar/Card components, collapsed primary nav + Manage two-pane shell.
- **#152 gap-closing work**: typography tokens, light theme, curated lane hues, per-screen page headers, correct nav order, the sentiment control collapsed to a single 6-stop track.
- **A long tail of rounds** fixing issues found via structural audits, WCAG AA contrast sweeps (buttons, relationship chips, lane badges, Manage's active nav item), functional bugs (Recommendations filter payload shape, several raw-enum-leak spots, a Manage page height blowup fixed by paginating Taste Profile), and direct hands-on feedback (header layout, card sizing, loading spinners, slider redesign, misaligned/miscolored elements).
- **Backend**: server-side filtering for Recommendations lanes (merged in from a peer branch, `backend/recommendations-filters`), with Go/Python kept byte-identical per the existing differential-test suite.

`REVIEW_CHECKLIST.md` (included) is the detailed round-by-round log — what broke, why, and how it was verified — for anyone who wants the specifics behind a given change rather than re-deriving them from the diff.

A few items are explicitly deferred, not attempted here:
- Settings-in-Manage — tracked separately as #151.
- ExternalCard's 5-icon action row (redesign suggestion, not a defect).
- Systemic loading-skeleton work beyond the spinner already added.
- Inline sentiment slider on Curate's pair-comparison screen (previously triaged as deferred).

## Test plan

- [x] `python3 -m pytest tests/ -q --ignore=tests/integration` — 560 passed
- [x] `cd core && go test -count=1 ./...` — pass
- [x] Manual verification throughout against both a local synthetic test instance and the live instance (screenshots, computed-style/geometry checks, real Playwright clicks — not just static review) for every round in `REVIEW_CHECKLIST.md`
- [x] Both light and dark theme spot-checked across the changed surfaces
- [ ] CI (Compiled core / Integration / Quality) — running on this PR
