### PR TITLE
fix(plugin): let Enter add the top match in tag/performer/studio filter inputs

### DIFF
--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2405,7 +2405,7 @@
       "label",
       { className: "curator-token-filter" },
       React.createElement("span", null, label),
-      React.createElement("div", { className: "curator-token-input" }, values.map((item) => React.createElement("button", { key: item.id, type: "button", title: `Remove ${item.name}`, onClick: () => onChange(values.filter((value) => value.id !== item.id)) }, item.name, " ×")), disabled ? null : React.createElement("input", { value: query, onChange: (event) => setQuery(event.target.value), placeholder: values.length ? "Add…" : `Search ${label.toLowerCase()}…` })),
+      React.createElement("div", { className: "curator-token-input" }, values.map((item) => React.createElement("button", { key: item.id, type: "button", title: `Remove ${item.name}`, onClick: () => onChange(values.filter((value) => value.id !== item.id)) }, item.name, " ×")), disabled ? null : React.createElement("input", { value: query, onChange: (event) => setQuery(event.target.value), onKeyDown: (event) => { if (event.key === "Enter" && options.length > 0) { event.preventDefault(); add(options[0]); } }, placeholder: values.length ? "Add…" : `Search ${label.toLowerCase()}…` })),
       query && options.length > 0 && React.createElement("div", { className: "curator-token-options" }, options.map((item) => React.createElement("button", { key: item.id, type: "button", onClick: () => add(item) }, item.name)))
     );
   }


### PR DESCRIPTION
## Summary

Fixes a UX bug in `FilterTokens` (the tag/performer/studio "Add…" filter box used on Recommendations, Similar, Expand, and Hunt): typing a name and pressing Enter did nothing — the filter only ever picked up a value when a suggestion from the dropdown was explicitly clicked. There was no keyboard path at all. From the user's side this presents as "I typed a filter and saved it, but no filter is ever applied," since nothing was actually added to the filter set.

Fix: pressing Enter now adds the top currently-visible suggestion, same as the value clicking it would add.

## Test plan

- [x] `uv run --frozen pytest tests/ -q --ignore=tests/integration` — 560 passed
- [x] `scripts/verify full` — ruff, mypy, plugin packaging, full pytest (583 passed), perf gate all clean
- [x] Manually verified against a live instance: typing a tag name and pressing Enter now adds it as a chip, clears the input, and triggers a refetch with the new filter applied; confirmed for both a tag filter and a performer filter
