### PR TITLE
feat(plugin): in-plugin Settings panel under Manage

### DIFF
--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -691,6 +691,34 @@
   color: #e0645c;
 }
 
+.curator-settings-group + .curator-settings-group {
+  margin-top: 1.4rem;
+}
+
+.curator-settings-group h3 {
+  font-size: 0.95rem;
+  margin: 0 0 0.2rem;
+}
+
+.curator-settings-field {
+  align-items: flex-start;
+}
+
+.curator-settings-control {
+  flex: none;
+  width: 12rem;
+}
+
+.curator-settings-saving {
+  color: var(--curator-text-muted);
+  flex: none;
+  font-size: 0.72rem;
+}
+
+.curator-settings-field-error {
+  color: #e0645c;
+}
+
 .curator-feedback-row {
   align-items: flex-start;
 }

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -3859,8 +3859,7 @@
           React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Use after Stash library changes. Sync changed metadata and history, then refresh recommendations.", "aria-label": "Sync library changes and refresh recommendations", onClick: () => start("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync })),
           React.createElement(Button, { className: "curator-icon-button", size: "sm", title: "Force a recommendation refresh from already-synced data. Does not contact Stash.", "aria-label": "Rebuild recommendations without syncing Stash", onClick: () => start("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench })),
           React.createElement(Button, { className: "curator-icon-button", size: "sm", title: theme === "light" ? "Switch to dark theme" : "Switch to light theme", "aria-label": theme === "light" ? "Switch to dark theme" : "Switch to light theme", onClick: onToggleTheme }, React.createElement(FontAwesomeIcon, { icon: theme === "light" ? faMoon : faSun })),
-          cardSizeControl,
-          React.createElement(NavLink, { className: "btn btn-secondary btn-sm curator-icon-button", title: "Open Curator's plugin settings.", "aria-label": "Plugin settings", to: "/settings?tab=plugins" }, React.createElement(FontAwesomeIcon, { icon: faCog }))
+          cardSizeControl
         )
       ),
       setupChecklist,

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -130,6 +130,13 @@
       maintenance: true,
       description: "Inspect render and query performance profiles captured during development.",
     },
+    {
+      value: "settings",
+      label: "Settings",
+      icon: faCog,
+      maintenance: true,
+      description: "Sync, discovery, prune, and Whisparr integration settings, without leaving Curator.",
+    },
   ];
   const PRIMARY_NAV_ITEMS = NAV_ITEMS.filter((item) => !item.maintenance);
   const MAINTENANCE_ITEMS = NAV_ITEMS.filter((item) => item.maintenance);
@@ -144,7 +151,7 @@
     value: "manage",
     label: "Manage",
     icon: faWrench,
-    description: "Feedback history, taste profile, sentiment review, recent recommendations, backups, diagnostics, prune queues, and profiling.",
+    description: "Feedback history, taste profile, sentiment review, recent recommendations, backups, diagnostics, prune queues, profiling, and settings.",
   };
   const TOP_NAV_ITEMS = [
     RECOMMENDATIONS_NAV_ITEM,
@@ -627,6 +634,26 @@
       throw new Error(payload.errors?.[0]?.message || `HTTP ${response.status}`);
     }
     return payload.data.configurePlugin;
+  }
+
+  // Curator's own get_config operation only echoes curator_config (the
+  // subset of settings synced into the sidecar DB); raw plugin settings
+  // like whisparrApiKey never pass through it. Query Stash directly for
+  // those, mirroring plugin/backend.py's SETTINGS_QUERY.
+  async function getPluginSettings() {
+    const response = await fetch("/graphql", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: 'query CuratorPluginSettings { configuration { plugins(include: ["stash-curator"]) } }',
+      }),
+    });
+    const payload = await response.json();
+    if (!response.ok || payload.errors) {
+      throw new Error(payload.errors?.[0]?.message || `HTTP ${response.status}`);
+    }
+    return payload.data.configuration.plugins["stash-curator"] || {};
   }
 
   function formatTimeAgo(ms) {
@@ -3924,6 +3951,212 @@
     );
   }
 
+  // GH #151: settings a first version needs, grouped for the panel below.
+  // Each entry's `key` is the camelCase name configurePlugin/stash-curator.yml
+  // use; `configKey` (when present) is the snake_case name the same setting
+  // is echoed back under from get_config's curator_config-backed `config`
+  // object. Fields without a `configKey` aren't mirrored into curator_config
+  // (see plugin/backend.py's _apply_plugin_settings) and are read back via
+  // getPluginSettings() instead.
+  const SETTINGS_GENDER_OPTIONS = [
+    { value: "FEMALE", label: "Female" },
+    { value: "MALE", label: "Male" },
+    { value: "TRANSGENDER_FEMALE", label: "Trans female" },
+    { value: "TRANSGENDER_MALE", label: "Trans male" },
+    { value: "", label: "All genders" },
+  ];
+  const SETTINGS_FIELD_GROUPS = [
+    {
+      title: "Sync & model timing",
+      fields: [
+        { key: "pageSize", configKey: "page_size", type: "NUMBER", label: "Results per page", description: "Number of results shown on Curator recommendation, Similar, and Expand pages. Default 20." },
+        { key: "syncPageSize", configKey: "sync_page_size", type: "NUMBER", label: "Sync page size", description: "Number of Stash records fetched per synchronization request. Default 250." },
+        { key: "modelUpdateEventThreshold", configKey: "model_update_event_threshold", type: "NUMBER", label: "Actions before model update", description: "Rebuild after this many new playback or feedback actions. Default 5." },
+        { key: "modelUpdateMaxWaitMinutes", configKey: "model_update_max_wait_minutes", type: "NUMBER", label: "Maximum model update delay (minutes)", description: "Rebuild pending preference changes after this delay. Default 30." },
+        { key: "modelUpdateMinIntervalMinutes", configKey: "model_update_min_interval_minutes", type: "NUMBER", label: "Minimum model update interval (minutes)", description: "Minimum time between automatic preference-model rebuilds. Default 60." },
+      ],
+    },
+    {
+      title: "Discovery",
+      fields: [
+        { key: "expandWildcard", configKey: "expand_wildcard", type: "BOOLEAN", label: "Expand popularity wildcard", description: "Include a small trending/popular sample outside preference-derived seeds." },
+        { key: "expandGender", configKey: "expand_gender", type: "SELECT", options: SETTINGS_GENDER_OPTIONS, label: "External performer gender", description: "Default StashDB gender filter for Expand and Similar. Default Female; choose All genders for no filter." },
+        { key: "expandHorizonDays", configKey: "expand_horizon_days", type: "NUMBER", label: "Expand recent-release horizon (days)", description: "Recent-release window used by Expand. Default 90." },
+      ],
+    },
+    {
+      title: "Prune",
+      fields: [
+        { key: "pruneTagName", configKey: "prune_tag_name", type: "STRING", label: "Prune tag", description: "Tag applied by the Prune page. Default [Prune]." },
+      ],
+    },
+    {
+      title: "Whisparr integration",
+      fields: [
+        { key: "whisparrUrl", type: "STRING", label: "Whisparr v3 URL", description: "Optional Whisparr base URL used by Expand scene actions." },
+        { key: "whisparrApiKey", type: "PASSWORD", label: "Whisparr API key", description: "Optional Whisparr API key. It is used only by the plugin backend." },
+        { key: "whisparrRootFolder", type: "STRING", label: "Whisparr root folder override", description: "Optional. Leave empty to use Whisparr's first configured root folder." },
+        { key: "whisparrQualityProfileId", type: "NUMBER", optional: true, label: "Whisparr quality profile ID override", description: "Optional. Leave empty to use Whisparr's fallback (or first) quality profile." },
+        { key: "whisparrSearchImmediately", type: "BOOLEAN", default: true, label: "Search Whisparr immediately", description: "Start a release search after adding a scene. Enabled by default." },
+      ],
+    },
+  ];
+
+  function SettingsField({ field, value, saving, error, onSave }) {
+    const [draft, setDraft] = React.useState(value ?? "");
+    React.useEffect(() => { setDraft(value ?? ""); }, [value]);
+    const inputId = `curator-setting-${field.key}`;
+    function commitText() {
+      const trimmed = String(draft).trim();
+      const current = String(value ?? "");
+      if (trimmed === current) return;
+      if (field.type === "NUMBER") {
+        if (trimmed === "") {
+          if (field.optional) onSave("");
+          else setDraft(current);
+          return;
+        }
+        const num = Number(trimmed);
+        if (Number.isNaN(num)) { setDraft(current); return; }
+        onSave(num);
+        return;
+      }
+      onSave(trimmed);
+    }
+    let control;
+    if (field.type === "BOOLEAN") {
+      control = React.createElement(
+        "div",
+        { className: "custom-control custom-switch" },
+        React.createElement("input", { type: "checkbox", className: "custom-control-input", id: inputId, checked: Boolean(value), disabled: saving, onChange: (event) => onSave(event.target.checked) }),
+        React.createElement("label", { className: "custom-control-label", htmlFor: inputId }, value ? "On" : "Off")
+      );
+    } else if (field.type === "SELECT") {
+      control = React.createElement(
+        "select",
+        { id: inputId, className: "form-control form-control-sm curator-settings-control", value: value ?? "", disabled: saving, onChange: (event) => onSave(event.target.value) },
+        field.options.map((option) => React.createElement("option", { key: option.value, value: option.value }, option.label))
+      );
+    } else {
+      control = React.createElement("input", {
+        id: inputId,
+        type: field.type === "PASSWORD" ? "password" : field.type === "NUMBER" ? "number" : "text",
+        className: "form-control form-control-sm curator-settings-control",
+        value: draft,
+        disabled: saving,
+        onChange: (event) => setDraft(event.target.value),
+        onBlur: commitText,
+        onKeyDown: (event) => { if (event.key === "Enter") event.target.blur(); },
+      });
+    }
+    return React.createElement(
+      "div",
+      { className: "curator-record-row curator-settings-field" },
+      React.createElement(
+        "div",
+        { className: "curator-record-main" },
+        React.createElement("label", { className: "curator-record-title", htmlFor: inputId }, field.label),
+        React.createElement("p", { className: "curator-record-meta" }, field.description),
+        error && React.createElement("p", { className: "curator-record-meta curator-settings-field-error" }, error)
+      ),
+      control,
+      saving && React.createElement("span", { className: "curator-settings-saving" }, "Saving…")
+    );
+  }
+
+  function SettingsPanel({ diversityEnabled, diversitySaving, onToggleDiversity }) {
+    const [config, setConfig] = React.useState(null);
+    const [raw, setRaw] = React.useState(null);
+    const [loading, setLoading] = React.useState(true);
+    const [error, setError] = React.useState("");
+    const [savingKeys, setSavingKeys] = React.useState(() => new Set());
+    const [fieldErrors, setFieldErrors] = React.useState({});
+    useCuratorActivity("settings", loading, "Loading settings…");
+    React.useEffect(() => {
+      let cancelled = false;
+      Promise.all([operation({ operation: "get_config" }), getPluginSettings()])
+        .then(([configData, settingsData]) => {
+          if (cancelled) return;
+          setConfig(configData.config);
+          setRaw(settingsData);
+        })
+        .catch((failure) => { if (!cancelled) setError(failure.message); })
+        .finally(() => { if (!cancelled) setLoading(false); });
+      return () => { cancelled = true; };
+    }, []);
+    async function saveField(field, value) {
+      setSavingKeys((current) => new Set(current).add(field.key));
+      setFieldErrors((current) => ({ ...current, [field.key]: "" }));
+      try {
+        await configurePlugin({ [field.key]: value });
+        if (field.configKey) {
+          const data = await operation({ operation: "get_config" });
+          cachedConfigUpdatedAtMs = data.updated_at_ms;
+          setConfig(data.config);
+        } else {
+          setRaw(await getPluginSettings());
+        }
+      } catch (failure) {
+        setFieldErrors((current) => ({ ...current, [field.key]: failure.message }));
+      } finally {
+        setSavingKeys((current) => { const next = new Set(current); next.delete(field.key); return next; });
+      }
+    }
+    if (loading) return React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Loading settings…"));
+    if (!config || !raw) return React.createElement("div", { className: "alert alert-danger" }, error || "Unable to load settings.");
+    return React.createElement(
+      "section",
+      { className: "curator-settings-panel" },
+      error && React.createElement("div", { className: "alert alert-danger" }, error),
+      onToggleDiversity && diversityEnabled !== null && React.createElement(
+        "div",
+        { className: "curator-settings-group" },
+        React.createElement("h3", null, "Recommendations"),
+        React.createElement(
+          "div",
+          { className: "curator-record-row curator-settings-field" },
+          React.createElement(
+            "div",
+            { className: "curator-record-main" },
+            React.createElement("span", { className: "curator-record-title" }, "Recommendation variety"),
+            React.createElement("p", { className: "curator-record-meta" }, "Vary performers, studios, and similar content instead of pure score-first ordering.")
+          ),
+          React.createElement(
+            Button,
+            {
+              size: "sm",
+              variant: diversityEnabled ? "primary" : "secondary",
+              disabled: diversitySaving,
+              "aria-pressed": diversityEnabled,
+              onClick: onToggleDiversity,
+            },
+            React.createElement(FontAwesomeIcon, { icon: faBalanceScale }),
+            diversityEnabled ? " Balanced" : " Score-first"
+          )
+        )
+      ),
+      SETTINGS_FIELD_GROUPS.map((group) => React.createElement(
+        "div",
+        { key: group.title, className: "curator-settings-group" },
+        React.createElement("h3", null, group.title),
+        group.fields.map((field) => {
+          const rawValue = raw ? raw[field.key] : undefined;
+          const value = field.configKey
+            ? config[field.configKey]
+            : (rawValue === undefined || rawValue === null || rawValue === "") && field.default !== undefined ? field.default : rawValue;
+          return React.createElement(SettingsField, {
+            key: field.key,
+            field,
+            value,
+            saving: savingKeys.has(field.key),
+            error: fieldErrors[field.key],
+            onSave: (next) => saveField(field, next),
+          });
+        })
+      ))
+    );
+  }
+
   // Manage shell (GH #150 Package 3): a two-pane list/detail view that hosts
   // every maintenance-flagged NAV_ITEMS entry plus Profiling. Each panel is
   // mounted unmodified — this is pure relocation, not a rebuild.
@@ -3936,9 +4169,10 @@
     diagnostics: () => React.createElement(DiagnosticsPanel),
     prune: () => React.createElement(PrunePanel),
     profiling: () => React.createElement(ProfilingPanel),
+    settings: (extra) => React.createElement(SettingsPanel, extra),
   };
 
-  function ManagePanel({ section, onSelectSection }) {
+  function ManagePanel({ section, onSelectSection, diversityEnabled, diversitySaving, onToggleDiversity }) {
     const items = MAINTENANCE_ITEMS;
     const active = items.find((item) => item.value === section) || items[0];
     const body = MANAGE_BODIES[active.value];
@@ -3976,7 +4210,7 @@
           React.createElement("h2", null, active.label),
           React.createElement("p", null, active.description)
         ),
-        body && body()
+        body && body({ diversityEnabled, diversitySaving, onToggleDiversity })
       )
     );
   }
@@ -4304,7 +4538,7 @@
       // Prune renders scene cards directly, same as SimilarityPanel above, so
       // it keeps its pre-existing !loadingComponents gate even though it now
       // mounts inside ManagePanel rather than as its own top-level branch.
-      lane === "manage" && (currentSection !== "prune" || !loadingComponents) && React.createElement(ManagePanel, { section: currentSection, onSelectSection: openManage }),
+      lane === "manage" && (currentSection !== "prune" || !loadingComponents) && React.createElement(ManagePanel, { section: currentSection, onSelectSection: openManage, diversityEnabled, diversitySaving, onToggleDiversity: toggleDiversity }),
       error && React.createElement("div", { className: "alert alert-danger" }, error, React.createElement("p", null, "Run “Sync and build recommendations” from Tasks if no model exists yet."), React.createElement(Button, { size: "sm", variant: "primary", onClick: () => runTask("Sync and build recommendations") }, React.createElement(FontAwesomeIcon, { icon: faSync }), " Sync and build now")),
       scenesQuery.error && React.createElement("div", { className: "alert alert-danger" }, scenesQuery.error.message),
       lane === "for_you" && !nudgeDismissed && !readCurateNudge().dismissed && readCurateNudge().rounds < MAX_NUDGE_ROUNDS && React.createElement(CurateNudge, { onOpen: () => openView("curate"), onDismiss: () => { dismissCurateNudge(); setNudgeDismissed(true); } }),

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -666,13 +666,22 @@ def test_settings_panel_reads_and_saves_every_configured_field() -> None:
     assert 'value: "settings"' in source
     assert "icon: faCog,\n      maintenance: true" in source
     assert "settings: (extra) => React.createElement(SettingsPanel, extra)," in source
-    assert "function SettingsPanel({ diversityEnabled, diversitySaving, onToggleDiversity })" in source
+    assert (
+        "function SettingsPanel({ diversityEnabled, diversitySaving, onToggleDiversity })" in source
+    )
     assert "body && body({ diversityEnabled, diversitySaving, onToggleDiversity })" in source
-    assert "React.createElement(ManagePanel, { section: currentSection, onSelectSection: openManage, diversityEnabled, diversitySaving, onToggleDiversity: toggleDiversity })" in source
+    assert (
+        "React.createElement(ManagePanel, { section: currentSection, "
+        "onSelectSection: openManage, diversityEnabled, diversitySaving, "
+        "onToggleDiversity: toggleDiversity })" in source
+    )
 
     # Raw plugin settings (Whisparr fields) aren't in curator_config, so the
     # panel reads them straight from Stash rather than through get_config.
-    assert 'query CuratorPluginSettings { configuration { plugins(include: ["stash-curator"]) } }' in source
+    assert (
+        'query CuratorPluginSettings { configuration { plugins(include: ["stash-curator"]) } }'
+        in source
+    )
     assert 'payload.data.configuration.plugins["stash-curator"] || {}' in source
 
     # One configurePlugin call per field, on change, matching the

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -657,6 +657,60 @@ def test_recommendation_variety_toggle_updates_native_setting_and_cache() -> Non
     assert 'diversityEnabled ? " Balanced" : " Score-first"' in source
 
 
+def test_settings_panel_reads_and_saves_every_configured_field() -> None:
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
+
+    # Manage-shell wiring (GH #151): a maintenance nav entry plus a
+    # MANAGE_BODIES factory, following the same three-touch-point pattern
+    # as every other maintenance panel.
+    assert 'value: "settings"' in source
+    assert "icon: faCog,\n      maintenance: true" in source
+    assert "settings: (extra) => React.createElement(SettingsPanel, extra)," in source
+    assert "function SettingsPanel({ diversityEnabled, diversitySaving, onToggleDiversity })" in source
+    assert "body && body({ diversityEnabled, diversitySaving, onToggleDiversity })" in source
+    assert "React.createElement(ManagePanel, { section: currentSection, onSelectSection: openManage, diversityEnabled, diversitySaving, onToggleDiversity: toggleDiversity })" in source
+
+    # Raw plugin settings (Whisparr fields) aren't in curator_config, so the
+    # panel reads them straight from Stash rather than through get_config.
+    assert 'query CuratorPluginSettings { configuration { plugins(include: ["stash-curator"]) } }' in source
+    assert 'payload.data.configuration.plugins["stash-curator"] || {}' in source
+
+    # One configurePlugin call per field, on change, matching the
+    # toggleDiversity precedent this panel reuses for the diversity toggle
+    # instead of re-implementing its cache-busting side effects.
+    assert "await configurePlugin({ [field.key]: value });" in source
+
+    # Every setting the issue calls out as in scope for v1 is represented,
+    # with the config-backed ones mapped to their curator_config key and the
+    # Whisparr-only ones left to read back via getPluginSettings().
+    expected_fields = {
+        "pageSize": "page_size",
+        "syncPageSize": "sync_page_size",
+        "modelUpdateEventThreshold": "model_update_event_threshold",
+        "modelUpdateMaxWaitMinutes": "model_update_max_wait_minutes",
+        "modelUpdateMinIntervalMinutes": "model_update_min_interval_minutes",
+        "expandWildcard": "expand_wildcard",
+        "expandGender": "expand_gender",
+        "expandHorizonDays": "expand_horizon_days",
+        "pruneTagName": "prune_tag_name",
+    }
+    for key, config_key in expected_fields.items():
+        assert f'key: "{key}", configKey: "{config_key}"' in source
+    for key in (
+        "whisparrUrl",
+        "whisparrApiKey",
+        "whisparrRootFolder",
+        "whisparrQualityProfileId",
+        "whisparrSearchImmediately",
+    ):
+        assert f'key: "{key}"' in source
+
+    # whisparrApiKey renders as a masked input, matching the issue's "mask
+    # like a password field" requirement; nothing else in the panel does.
+    assert '{ key: "whisparrApiKey", type: "PASSWORD"' in source
+    assert 'field.type === "PASSWORD" ? "password"' in source
+
+
 def test_plugin_performer_hunt_keeps_results_and_reuses_external_cards() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- Adds a "Settings" section to the Manage shell (GH #150 Package 3) so common plugin settings can be changed without leaving Curator for Stash's native `/settings?tab=plugins` page.
- Groups fields as Sync & model timing / Discovery / Prune / Whisparr integration / Recommendations, reusing the existing `configurePlugin`/`get_config` read-write path — no new settings needed declaring in `stash-curator.yml`.
- Boolean and select fields save immediately on change; text/number fields save on blur (avoids firing a mutation per keystroke) — one `configurePlugin` call per field either way.
- The Recommendations group's diversity toggle reuses the existing `toggleDiversity` handler (passed down through `ManagePanel`) instead of duplicating its slate-cache invalidation logic.
- Whisparr fields aren't mirrored into `curator_config`, so they're read back via a new `getPluginSettings()` helper that queries Stash's `configuration { plugins }` directly (mirrors `plugin/backend.py`'s `SETTINGS_QUERY`) — no backend changes needed.
- `whisparrApiKey` renders as a masked `type="password"` input.

Closes #151

## Test plan
- [x] `pytest tests/plugin/test_runtime.py` — 47 passed, 1 pre-existing unrelated failure (missing local `curator-core` build artifact, not present on a fresh worktree)
- [x] Built the plugin zip and installed it into a local Stash test instance
- [x] Clicked through in a real browser: opened Manage → Settings, confirmed all groups/fields render with live config values, toggled a boolean field and edited a text field, confirmed both persist via the plugin's own read-back (`get_config`/`getPluginSettings`) with no console errors, then reverted both to their original values