### PR TITLE
feat: background task worker with queue, detached daemon, and live progress

### DIFF
--- a/core/backend.go
+++ b/core/backend.go
@@ -57,6 +57,12 @@ func marshalJSONString(s string) string {
 
 func runBackend(pluginDir, mode string) {
 	pluginDir = resolvePluginDir(pluginDir)
+	if mode == "daemon" {
+		// Worker mode is not a Stash request: no stdin protocol, no output.
+		// The daemon exits on its own after an idle period.
+		runDaemon(pluginDir)
+		return
+	}
 	payloadBytes, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		writeError("could not read plugin input: " + err.Error())
@@ -237,6 +243,8 @@ func dispatch(pluginDir string, payload jVal) (jVal, error) {
 		return opGetCurationImpact(pluginDir, payload)
 	case "reset":
 		return opReset(pluginDir, payload)
+	case "cancel_job":
+		return opCancelJob(pluginDir, payload)
 	default:
 		return jvNull(), fmt.Errorf("unknown Curator API operation: %s", operation)
 	}

--- a/core/daemon.go
+++ b/core/daemon.go
@@ -1,0 +1,467 @@
+// Background task worker (docs/decisions/004): a detached, Curator-owned
+// process that claims and executes queued curator_job rows, so long-running
+// tasks stop occupying Stash's single-slot job queue. The daemon is this
+// binary in a new mode — `curator-core <pluginDir> daemon` — spawned by the
+// enqueuer (ensureWorker) with a new session and log-file stdio so it
+// survives the invoking Stash job. Interactive ops keep the one-process-
+// per-request raw-plugin protocol unchanged; only the task path changes.
+//
+// Liveness is ownership-based: running rows carry owner_pid + heartbeat_at_ms
+// written by the executing process, replacing the old 120s/6h heuristics that
+// inferred liveness from Stash's job list (which no longer shows the work).
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// Worker process tuning. The two hot-loop values are vars so Go tests can
+// shorten them; the staleness windows stay constants (tests pin time via
+// timeNowUnixMilli).
+const (
+	heartbeatStaleMs = 5 * 60_000   // running rows older than this are orphans
+	legacyStaleMs    = 6 * 3_600_000 // pre-heartbeat rows keep the old window
+	idleExitMs       = 5 * 60_000   // exit after this long with no queued work
+	claimPollMs      = 1_000
+)
+
+var (
+	heartbeatIntervalMs = 20_000 // liveness write while a job runs
+	progressDebounceMs  = 500    // cap progress writes during a build
+)
+
+// workerState is written by the enqueuer (which has the Stash payload) and
+// re-read by the daemon (which has none): where the sidecar lives and how to
+// reach Stash for the per-job settings fetch.
+type workerState struct {
+	DatabasePath string            `json:"database_path"`
+	StashBase    string            `json:"stash_base"`
+	StashHeaders map[string]string `json:"stash_headers"`
+}
+
+func workerStatePath(pluginDir string) string {
+	return filepath.Join(pluginDir, "data", "curator-worker.json")
+}
+
+func workerPidPath(pluginDir string) string {
+	return filepath.Join(pluginDir, "data", "curator-daemon.pid")
+}
+
+func workerLogPath(pluginDir string) string {
+	return filepath.Join(pluginDir, "data", "curator-daemon.log")
+}
+
+func writeWorkerState(pluginDir string, state workerState) error {
+	if err := os.MkdirAll(filepath.Join(pluginDir, "data"), 0o755); err != nil {
+		return err
+	}
+	raw, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(workerStatePath(pluginDir), raw, 0o644)
+}
+
+func readWorkerState(pluginDir string) (workerState, error) {
+	var state workerState
+	raw, err := os.ReadFile(workerStatePath(pluginDir))
+	if err != nil {
+		return state, err
+	}
+	err = json.Unmarshal(raw, &state)
+	return state, err
+}
+
+func readWorkerPid(pluginDir string) (int, bool) {
+	raw, err := os.ReadFile(workerPidPath(pluginDir))
+	if err != nil {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}
+
+// spawnWorkerFn is injectable so Go tests can force the inline fallback
+// instead of exec'ing the test binary as a daemon.
+var spawnWorkerFn = spawnWorker
+
+// spawnWorker starts the daemon detached from Stash's process tree: a new
+// session (setsid), stdin from /dev/null, stdout/stderr appended to the
+// worker log. The parent exits right after, so the child is reparented to
+// init instead of being killed with the Stash job. Deliberately no Wait:
+// the enqueuer exits immediately and init reaps the child.
+func spawnWorker(pluginDir string) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return err
+	}
+	logFile, err := os.OpenFile(workerLogPath(pluginDir), os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	devnull, err := os.Open(os.DevNull)
+	if err != nil {
+		logFile.Close()
+		return err
+	}
+	cmd := exec.Command(exe, pluginDir, "daemon")
+	cmd.SysProcAttr = daemonSysProcAttr()
+	cmd.Stdin = devnull
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		devnull.Close()
+		logFile.Close()
+		return err
+	}
+	devnull.Close()
+	logFile.Close()
+	return nil
+}
+
+// recoverOrphanJobs fails running rows whose executing process is gone:
+// heartbeat stale (a daemon or inline runner died) or, for pre-heartbeat
+// rows, older than the legacy 6h stale window. It also records the same
+// interrupted state on the model-update tracker a build leaves behind.
+// Idempotent, safe on every call path (enqueue, health, daemon startup).
+func recoverOrphanJobs(db dbx, now int64) {
+	execImmediate(db, `UPDATE curator_job SET state='failed', finished_at_ms=?, error='interrupted'
+WHERE state='running' AND heartbeat_at_ms IS NOT NULL AND heartbeat_at_ms<=?`,
+		now, now-heartbeatStaleMs)
+	execImmediate(db, `UPDATE curator_job SET state='failed', finished_at_ms=?, error='interrupted'
+WHERE state='running' AND heartbeat_at_ms IS NULL AND started_at_ms<=?`,
+		now, now-legacyStaleMs)
+	execImmediate(db, `UPDATE model_update_state SET last_error='interrupted before task completion'
+WHERE last_started_at_ms IS NOT NULL
+AND last_started_at_ms>COALESCE(last_finished_at_ms, -1)
+AND last_error IS NULL`)
+}
+
+// ensureWorker guarantees a daemon exists whenever there is queued work. The
+// enqueuer calls it after inserting a queued row; health calls it so a
+// crashed daemon's orphans are recovered and its queue restarts. A live pid
+// is enough — no spawn, no DB churn. The sidecar is opened (and migrated)
+// before the state file is written, so a freshly spawned daemon never sees
+// an un-migrated database path.
+func ensureWorker(pluginDir string, payload jVal, settings jVal) error {
+	base, headers := stashConnection(payload)
+	if pid, ok := readWorkerPid(pluginDir); ok && pidAlive(pid) {
+		if err := writeWorkerState(pluginDir, workerState{
+			DatabasePath: databasePath(pluginDir, payload, settings),
+			StashBase:    base,
+			StashHeaders: headers,
+		}); err != nil {
+			return fmt.Errorf("could not write worker state: %w", err)
+		}
+		return nil
+	}
+	db, err := openSidecar(pluginDir, payload, settings, true)
+	if err != nil {
+		return fmt.Errorf("could not open sidecar to recover worker: %w", err)
+	}
+	recoverOrphanJobs(db, nowMs())
+	var queued int
+	scanErr := db.QueryRow(`SELECT 1 FROM curator_job WHERE state='queued' LIMIT 1`).Scan(&queued)
+	db.Close()
+	if scanErr != nil && scanErr != sql.ErrNoRows {
+		return scanErr
+	}
+	if scanErr == sql.ErrNoRows {
+		return nil // nothing to run; the caller handles its own row inline
+	}
+	if err := writeWorkerState(pluginDir, workerState{
+		DatabasePath: databasePath(pluginDir, payload, settings),
+		StashBase:    base,
+		StashHeaders: headers,
+	}); err != nil {
+		return fmt.Errorf("could not write worker state: %w", err)
+	}
+	return spawnWorkerFn(pluginDir)
+}
+
+// runDaemon is the worker main loop, served by `curator-core <pluginDir>
+// daemon`. It claims queued jobs one at a time, executes them with the same
+// mode bodies the inline path uses, heartbeats and reports progress through
+// the sidecar, recovers orphans at startup, and exits after an idle period
+// so an idle plugin runs no resident process.
+func runDaemon(pluginDir string) {
+	state, err := readWorkerState(pluginDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "curator-core daemon: no worker state (%v); the daemon is only spawned from a Curator invocation\n", err)
+		os.Exit(1)
+	}
+	if pid, ok := readWorkerPid(pluginDir); ok && pid != os.Getpid() && pidAlive(pid) {
+		// A concurrent spawn won the race; it owns the worker.
+		os.Exit(0)
+	}
+	if err := os.WriteFile(workerPidPath(pluginDir), []byte(strconv.Itoa(os.Getpid())), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "curator-core daemon: could not write pid file: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(workerPidPath(pluginDir))
+
+	daemonExitOnCancel = true
+	loop, loopPath := openDaemonLoop(pluginDir, state)
+	if loop == nil {
+		os.Exit(1)
+	}
+	defer loop.Close()
+
+	// Graceful shutdown: mark the in-flight job cancelled and exit.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	go func() {
+		<-sigCh
+		markRunningCancelled(loop)
+		os.Exit(0)
+	}()
+
+	recoverOrphanJobs(loop, nowMs())
+	idleSince := nowMs()
+	for {
+		// Re-read the worker state each pass so a databasePath change (or a
+		// per-sidecar test harness) takes effect without a daemon restart.
+		if fresh, err := readWorkerState(pluginDir); err == nil {
+			path := fresh.DatabasePath
+			if path == "" {
+				path = filepath.Join(pluginDir, "data", "curator.sqlite3")
+			}
+			if path != loopPath {
+				if next, _ := openDaemonLoop(pluginDir, fresh); next != nil {
+					loop.Close()
+					loop = next
+					loopPath = path
+				}
+			}
+		}
+		jobID, startedAtMs, payload, mode, err := claimQueuedJob(loop)
+		if err != nil {
+			errorLog("daemon claim failed: " + err.Error())
+			time.Sleep(claimPollMs * time.Millisecond)
+			continue
+		}
+		if jobID != "" {
+			idleSince = nowMs()
+			runWorkerJob(pluginDir, loop, jobID, startedAtMs, payload, mode)
+			continue
+		}
+		if nowMs()-idleSince > idleExitMs {
+			infoLog("daemon idle; exiting")
+			return
+		}
+		time.Sleep(claimPollMs * time.Millisecond)
+	}
+}
+
+// openDaemonLoop opens the loop connection (no artifact attaches — the
+// per-job execution opens its own) and migrates defensively, so the daemon
+// never reads a schema the enqueuer has not finished migrating.
+func openDaemonLoop(pluginDir string, state workerState) (dbx, string) {
+	path := state.DatabasePath
+	if path == "" {
+		path = filepath.Join(pluginDir, "data", "curator.sqlite3")
+	}
+	loop, err := openDatabase(realpath(path), false, nil)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "curator-core daemon: could not open sidecar: %v\n", err)
+		return nil, ""
+	}
+	if err := migrate(loop, nowMs()); err != nil {
+		loop.Close()
+		fmt.Fprintf(os.Stderr, "curator-core daemon: could not migrate sidecar: %v\n", err)
+		return nil, ""
+	}
+	return loop, path
+}
+
+// daemonExitOnCancel makes the cancel path terminate the daemon process:
+// the mode body runs synchronously in the main goroutine and cannot be
+// interrupted, so a cancelled running job ends the process; its row is
+// already marked 'cancelled' and the queue restarts on the next invocation.
+var daemonExitOnCancel = false
+
+// markRunningCancelled marks every running job owned by this process as
+// cancelled (shutdown path).
+func markRunningCancelled(db dbx) {
+	execImmediate(db, `UPDATE curator_job SET state='cancelled', finished_at_ms=?, error='cancelled'
+WHERE state='running' AND (owner_pid=? OR owner_pid IS NULL)`, nowMs(), os.Getpid())
+}
+
+// claimQueuedJob atomically claims the oldest queued row: state queued →
+// running with owner_pid + heartbeat, returning the payload snapshot. An
+// empty jobID means the queue is empty.
+func claimQueuedJob(db dbx) (string, int64, jVal, string, error) {
+	var jobID, jobType, payloadJSON string
+	var startedAtMs int64
+	err := withTxn(db, func(conn *sql.Conn) error {
+		ctx := context.Background()
+		row := conn.QueryRowContext(ctx, `
+SELECT job_id, job_type, started_at_ms, payload_json FROM curator_job
+WHERE state='queued' ORDER BY queued_at_ms, started_at_ms LIMIT 1`)
+		if err := row.Scan(&jobID, &jobType, &startedAtMs, &payloadJSON); err != nil {
+			if err == sql.ErrNoRows {
+				jobID = ""
+				return nil
+			}
+			return err
+		}
+		result, err := conn.ExecContext(ctx, `
+UPDATE curator_job SET state='running', owner_pid=?, heartbeat_at_ms=?, cancel_requested=0
+WHERE job_id=? AND state='queued'`, os.Getpid(), nowMs(), jobID)
+		if err != nil {
+			return err
+		}
+		affected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if affected == 0 {
+			jobID = "" // another worker claimed it; try the next row
+		}
+		return nil
+	})
+	if err != nil {
+		return "", 0, jvNull(), "", err
+	}
+	if jobID == "" {
+		return "", 0, jvNull(), "", nil
+	}
+	payload, err := parseJSON([]byte(payloadJSON))
+	if err != nil {
+		return "", 0, jvNull(), "", fmt.Errorf("queued job %s has a corrupt payload: %w", jobID, err)
+	}
+	return jobID, startedAtMs, payload, jobType, nil
+}
+
+// runWorkerJob executes one claimed job with the same lifecycle as the
+// inline path: fresh artifact-attached connection, settings from the payload
+// snapshot, executeClaimedJob transitions, failures recorded on the row.
+func runWorkerJob(pluginDir string, loop dbx, jobID string, startedAtMs int64, payload jVal, mode string) {
+	settings := pluginSettings(payload)
+	db, err := openTaskSidecar(pluginDir, payload, settings, mode)
+	if err != nil {
+		execImmediate(loop, `UPDATE curator_job SET state='failed', finished_at_ms=?, error=?
+WHERE job_id=? AND state='running'`, nowMs(), truncateString(err.Error(), 2000), jobID)
+		return
+	}
+	defer db.Close()
+	_, _ = executeClaimedJob(db, pluginDir, payload, mode, settings, jobID, startedAtMs)
+}
+
+// heartbeatLoop writes liveness and watches the cooperative-cancel flag for
+// one running job. On cancel the row is marked 'cancelled'; in daemon mode
+// the process then exits (the synchronous mode body cannot be interrupted).
+func heartbeatLoop(db dbx, jobID string, done chan struct{}) {
+	ticker := time.NewTicker(time.Duration(heartbeatIntervalMs) * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			now := nowMs()
+			execImmediate(db, `UPDATE curator_job SET heartbeat_at_ms=? WHERE job_id=? AND state='running'`, now, jobID)
+			var requested int
+			err := db.QueryRow(`SELECT cancel_requested FROM curator_job WHERE job_id=? AND state='running'`, jobID).Scan(&requested)
+			if err == nil && requested == 1 {
+				execImmediate(db, `UPDATE curator_job SET state='cancelled', finished_at_ms=?, error='cancelled'
+WHERE job_id=? AND state='running'`, now, jobID)
+				if daemonExitOnCancel {
+					os.Exit(0)
+				}
+				return
+			}
+		}
+	}
+}
+
+// ── progress sink ───────────────────────────────────────────────────────────
+
+// progressSink persists progressLog markers into the running job's row,
+// debounced so a build's per-batch markers do not turn into write
+// amplification on the sidecar the build is already using. The sink uses its
+// OWN connection (not the mode body's): the execution pool is pinned to one
+// connection, so writing through it would block behind the mode's statements
+// — and deadlock if a progress marker fires inside one of the mode's
+// transactions. A second WAL writer just waits on busy_timeout.
+type progressSink struct {
+	db           dbx
+	jobID        string
+	mu           sync.Mutex
+	lastWriteMs  int64
+	pendingValue float64
+	pending      bool
+}
+
+func newProgressSink(path, jobID string) (*progressSink, error) {
+	db, err := openDatabase(realpath(path), false, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &progressSink{db: db, jobID: jobID}, nil
+}
+
+func (s *progressSink) close() {
+	s.flush()
+	s.db.Close()
+}
+
+// flush writes the pending value unconditionally (no debounce); call before
+// the terminal state transition so the last progress is not lost.
+func (s *progressSink) flush() {
+	s.mu.Lock()
+	s.flushLocked(nowMs())
+	s.mu.Unlock()
+}
+
+func (s *progressSink) report(value float64) {
+	s.mu.Lock()
+	if s.pending && value == s.pendingValue {
+		s.mu.Unlock()
+		return
+	}
+	s.pending = true
+	s.pendingValue = value
+	now := nowMs()
+	if now-s.lastWriteMs >= int64(progressDebounceMs) {
+		s.flushLocked(now)
+	}
+	s.mu.Unlock()
+}
+
+func (s *progressSink) flushLocked(now int64) {
+	if !s.pending {
+		return
+	}
+	execImmediate(s.db, `UPDATE curator_job SET progress=? WHERE job_id=? AND state='running'`, s.pendingValue, s.jobID)
+	s.lastWriteMs = now
+	s.pending = false
+}
+
+var (
+	progressSinkMu    sync.Mutex
+	activeProgressSink *progressSink
+)
+
+func setProgressSink(s *progressSink) *progressSink {
+	progressSinkMu.Lock()
+	defer progressSinkMu.Unlock()
+	prev := activeProgressSink
+	activeProgressSink = s
+	return prev
+}

--- a/core/daemon_test.go
+++ b/core/daemon_test.go
@@ -1,0 +1,495 @@
+// Queue-lifecycle tests for the background worker (docs/decisions/004):
+// claim, coalescing, orphan recovery, cancel, and the progress sink, all
+// against a temp migrated sidecar. The daemon process itself is exercised
+// end-to-end by the Python differential harness (tests/core/
+// test_backend_slice3_tasks.py runs the real binary in daemon mode).
+package main
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+	"time"
+)
+
+// pinTime makes nowMs() return ms for the duration of fn.
+func pinTime(t *testing.T, ms int64, fn func()) {
+	t.Helper()
+	prev := timeNowUnixMilli
+	timeNowUnixMilli = func() int64 { return ms }
+	defer func() { timeNowUnixMilli = prev }()
+	fn()
+}
+
+// taskPayload builds a runTaskBody-compatible payload pointing at path.
+func taskPayload(path string, mode string) jVal {
+	return jvObj(
+		jvKey("args", jvObj(
+			jvKey("operation", jvStr(mode)),
+			jvKey("database_path", jvStr(path)),
+		)),
+		jvKey("server_connection", jvObj()),
+	)
+}
+
+// jobRow reads one curator_job row as a map.
+func jobRow(t *testing.T, db dbx, jobID string) map[string]any {
+	t.Helper()
+	rows, err := db.Query(`SELECT * FROM curator_job WHERE job_id=?`, jobID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	if !rows.Next() {
+		t.Fatalf("no curator_job row %s", jobID)
+	}
+	columns, err := rows.Columns()
+	if err != nil {
+		t.Fatal(err)
+	}
+	values := make([]any, len(columns))
+	scanned := make([]any, len(columns))
+	for i := range columns {
+		scanned[i] = &values[i]
+	}
+	if err := rows.Scan(scanned...); err != nil {
+		t.Fatal(err)
+	}
+	row := make(map[string]any, len(columns))
+	for i, name := range columns {
+		row[name] = values[i]
+	}
+	return row
+}
+
+func jobState(t *testing.T, db dbx, jobID string) string {
+	t.Helper()
+	return asDBString(jobRow(t, db, jobID)["state"])
+}
+
+// insertQueued seeds a queued row directly (as the enqueuer would).
+func insertQueued(t *testing.T, db dbx, jobID, mode, payloadJSON string, queuedAtMs int64) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO curator_job(job_id, job_type, state, started_at_ms, queued_at_ms, payload_json)
+VALUES (?, ?, 'queued', ?, ?, ?)`, jobID, mode, queuedAtMs, queuedAtMs, payloadJSON); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMigrateAddsWorkerColumns(t *testing.T) {
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := db.Query(`SELECT name FROM pragma_table_info('curator_job')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	seen := map[string]bool{}
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			t.Fatal(err)
+		}
+		seen[name] = true
+	}
+	for _, want := range []string{"queued_at_ms", "heartbeat_at_ms", "owner_pid", "payload_json", "cancel_requested", "progress"} {
+		if !seen[want] {
+			t.Fatalf("curator_job missing worker column %s", want)
+		}
+	}
+	// The new states are accepted and old rows survive the rebuild.
+	if _, err := db.Exec(`INSERT INTO curator_job(job_id, job_type, state, started_at_ms)
+VALUES ('j1', 'build', 'queued', 1), ('j2', 'build', 'cancelled', 2)`); err != nil {
+		t.Fatalf("new states rejected: %v", err)
+	}
+}
+
+func TestClaimQueuedJob(t *testing.T) {
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	payload := `{"args":{"operation":"sync-plays"},"server_connection":{"host":"h","port":"1"}}`
+	pinTime(t, 5_000, func() {
+		insertQueued(t, db, "job-a", "sync-plays", payload, 4_000)
+		jobID, startedAtMs, got, mode, err := claimQueuedJob(db)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if jobID != "job-a" || startedAtMs != 4_000 || mode != "sync-plays" {
+			t.Fatalf("unexpected claim: %q %d %q", jobID, startedAtMs, mode)
+		}
+		row := got.get("args").get("operation").asString()
+		if row != "sync-plays" {
+			t.Fatalf("payload not round-tripped: %q", row)
+		}
+		state := jobRow(t, db, "job-a")
+		if jobState(t, db, "job-a") != "running" {
+			t.Fatalf("state: %v", state["state"])
+		}
+		if int64(asDBInt(state["owner_pid"])) != int64(os.Getpid()) {
+			t.Fatalf("owner_pid not recorded: %v", state["owner_pid"])
+		}
+		if asDBInt(state["heartbeat_at_ms"]) != 5_000 {
+			t.Fatalf("heartbeat not seeded: %v", state["heartbeat_at_ms"])
+		}
+	})
+}
+
+func TestClaimEmptyAndSingleShot(t *testing.T) {
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	jobID, _, _, _, err := claimQueuedJob(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if jobID != "" {
+		t.Fatalf("expected empty claim, got %q", jobID)
+	}
+	insertQueued(t, db, "job-a", "build", `{}`, 1)
+	insertQueued(t, db, "job-b", "build", `{}`, 2)
+	first, _, _, _, err := claimQueuedJob(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first != "job-a" {
+		t.Fatalf("oldest first: got %q", first)
+	}
+	// The first claim removed the row from the queue; a second claim takes
+	// the next one, never the claimed row again.
+	second, _, _, _, err := claimQueuedJob(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second != "job-b" {
+		t.Fatalf("second claim: got %q", second)
+	}
+	if jobState(t, db, "job-a") != "running" || jobState(t, db, "job-b") != "running" {
+		t.Fatal("claimed rows must be running")
+	}
+}
+
+func TestEnqueueCoalescesSameType(t *testing.T) {
+	db, path := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	pluginDir := t.TempDir()
+	pinTime(t, 10_000, func() {
+		insertQueued(t, db, "existing", "update-model", `{}`, 9_000)
+		out, err := runTaskBody(pluginDir, taskPayload(path, "update-model"), "update-model", jvObj())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !out.get("already_running").truthy() {
+			t.Fatalf("expected already_running, got %v", out)
+		}
+		if out.get("job_id").asString() != "existing" {
+			t.Fatalf("wrong coalesced job: %v", out.get("job_id").asString())
+		}
+		var queued int
+		if err := db.QueryRow(`SELECT count(*) FROM curator_job WHERE state='queued'`).Scan(&queued); err != nil {
+			t.Fatal(err)
+		}
+		if queued != 1 {
+			t.Fatalf("coalescing added a queued row: %d", queued)
+		}
+	})
+}
+
+func TestEnqueueQueuesAndWorkerClaims(t *testing.T) {
+	db, path := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	pluginDir := t.TempDir()
+	prevSpawn := spawnWorkerFn
+	spawnWorkerFn = func(string) error { return nil }
+	defer func() { spawnWorkerFn = prevSpawn }()
+	pinTime(t, 20_000, func() {
+		out, err := runTaskBody(pluginDir, taskPayload(path, "sync-plays"), "sync-plays", jvObj())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !out.get("queued").truthy() {
+			t.Fatalf("expected queued response, got %v", out)
+		}
+		jobID := out.get("job_id").asString()
+		if jobID == "" || jobState(t, db, jobID) != "queued" {
+			t.Fatalf("row not queued: %s %s", jobID, jobState(t, db, jobID))
+		}
+		claimed, _, _, mode, err := claimQueuedJob(db)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if claimed != jobID || mode != "sync-plays" {
+			t.Fatalf("claim mismatch: %q %q", claimed, mode)
+		}
+	})
+}
+
+func TestEnqueueInlineFallback(t *testing.T) {
+	db, path := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	pluginDir := t.TempDir()
+	prevSpawn := spawnWorkerFn
+	spawnWorkerFn = func(string) error { return errors.New("no worker in tests") }
+	defer func() { spawnWorkerFn = prevSpawn }()
+	pinTime(t, 30_000, func() {
+		_, err := runTaskBody(pluginDir, taskPayload(path, "compact"), "compact", jvObj())
+		// The mode body runs inline; on a bare sidecar compaction either
+		// completes or fails fast — either way the row must leave 'queued'.
+		_ = err
+	})
+	// Find the row the enqueue inserted (job_id is a uuid): exactly one row,
+	// and it is no longer queued (it ran inline to a terminal state).
+	var states []string
+	rows, err := db.Query(`SELECT state FROM curator_job`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var state string
+		if err := rows.Scan(&state); err != nil {
+			t.Fatal(err)
+		}
+		states = append(states, state)
+	}
+	if len(states) != 1 {
+		t.Fatalf("expected one job row, got %d", len(states))
+	}
+	if states[0] == "queued" || states[0] == "running" {
+		t.Fatalf("inline fallback left the row in %q", states[0])
+	}
+}
+
+func TestRecoverOrphanJobs(t *testing.T) {
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	now := int64(1_000_000_000_000)
+	pinTime(t, now, func() {
+		// Heartbeat-stale running row → interrupted.
+		if _, err := db.Exec(`INSERT INTO curator_job(job_id, job_type, state, started_at_ms, heartbeat_at_ms)
+VALUES ('stale-heartbeat', 'build', 'running', 1, ?)`, now-heartbeatStaleMs-1); err != nil {
+			t.Fatal(err)
+		}
+		// Legacy pre-heartbeat running row past 6h → interrupted.
+		if _, err := db.Exec(`INSERT INTO curator_job(job_id, job_type, state, started_at_ms)
+VALUES ('legacy-old', 'build', 'running', ?)`, now-legacyStaleMs-1); err != nil {
+			t.Fatal(err)
+		}
+		// Fresh heartbeat running row → untouched.
+		if _, err := db.Exec(`INSERT INTO curator_job(job_id, job_type, state, started_at_ms, heartbeat_at_ms)
+VALUES ('healthy', 'build', 'running', 1, ?)`, now-10_000); err != nil {
+			t.Fatal(err)
+		}
+		recoverOrphanJobs(db, now)
+		if jobState(t, db, "stale-heartbeat") != "failed" {
+			t.Fatal("stale-heartbeat row not recovered")
+		}
+		if jobState(t, db, "legacy-old") != "failed" {
+			t.Fatal("legacy-old row not recovered")
+		}
+		if jobState(t, db, "healthy") != "running" {
+			t.Fatal("healthy row must survive recovery")
+		}
+	})
+}
+
+func TestCancelQueuedAndRunning(t *testing.T) {
+	db, path := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	pluginDir := t.TempDir()
+	pinTime(t, 40_000, func() {
+		insertQueued(t, db, "queued-job", "build", `{}`, 1)
+		payload := taskPayload(path, "cancel_job")
+		payload.set("args", jvObj(
+			jvKey("operation", jvStr("cancel_job")),
+			jvKey("job_id", jvStr("queued-job")),
+			jvKey("database_path", jvStr(path)),
+		))
+		out, err := opCancelJob(pluginDir, payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !out.get("cancelled").truthy() || out.get("state").asString() != "cancelled" {
+			t.Fatalf("queued cancel response: %v", out)
+		}
+		if jobState(t, db, "queued-job") != "cancelled" {
+			t.Fatal("queued job not cancelled")
+		}
+		// Running job: cooperative flag, row stays running.
+		if _, err := db.Exec(`INSERT INTO curator_job(job_id, job_type, state, started_at_ms, owner_pid)
+VALUES ('running-job', 'build', 'running', 1, ?)`, os.Getpid()); err != nil {
+			t.Fatal(err)
+		}
+		payload.set("args", jvObj(
+			jvKey("operation", jvStr("cancel_job")),
+			jvKey("job_id", jvStr("running-job")),
+			jvKey("database_path", jvStr(path)),
+		))
+		out, err = opCancelJob(pluginDir, payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !out.get("cancelled").truthy() || !out.get("cancel_requested").truthy() {
+			t.Fatalf("running cancel response: %v", out)
+		}
+		row := jobRow(t, db, "running-job")
+		if jobState(t, db, "running-job") != "running" || asDBInt(row["cancel_requested"]) != 1 {
+			t.Fatal("running job not flagged for cancel")
+		}
+		// Unknown job: cancelled false.
+		payload.set("args", jvObj(
+			jvKey("operation", jvStr("cancel_job")),
+			jvKey("job_id", jvStr("ghost")),
+			jvKey("database_path", jvStr(path)),
+		))
+		out, err = opCancelJob(pluginDir, payload)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out.get("cancelled").truthy() {
+			t.Fatalf("ghost job reported cancelled: %v", out)
+		}
+	})
+}
+
+func TestProgressSinkDebounceAndFlush(t *testing.T) {
+	db, path := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO curator_job(job_id, job_type, state, started_at_ms)
+VALUES ('job-p', 'build', 'running', 1)`); err != nil {
+		t.Fatal(err)
+	}
+	progressDebounceMs = 500
+	var progress float64
+	pinTime(t, 100_000, func() {
+		sink, err := newProgressSink(path, "job-p")
+		if err != nil {
+			t.Fatal(err)
+		}
+		sink.report(0.5)
+		if err := db.QueryRow(`SELECT progress FROM curator_job WHERE job_id='job-p'`).Scan(&progress); err != nil {
+			t.Fatal(err)
+		}
+		if progress != 0.5 {
+			t.Fatalf("first write missing: %v", progress)
+		}
+		// Same-millisecond write is debounced away...
+		sink.report(0.6)
+		// ...and the close flush lands the latest value.
+		sink.close()
+		if err := db.QueryRow(`SELECT progress FROM curator_job WHERE job_id='job-p'`).Scan(&progress); err != nil {
+			t.Fatal(err)
+		}
+		if progress != 0.6 {
+			t.Fatalf("close did not flush: %v", progress)
+		}
+	})
+}
+
+// TestProgressSinkDoesNotBlockTheModeConnection pins the structural fix for
+// the single-connection pool: the sink writes on its own connection, so a
+// progress marker fired while the mode holds the only pooled execution
+// connection must not deadlock waiting for it.
+func TestProgressSinkDoesNotBlockTheModeConnection(t *testing.T) {
+	db, path := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO curator_job(job_id, job_type, state, started_at_ms)
+VALUES ('job-p', 'build', 'running', 1)`); err != nil {
+		t.Fatal(err)
+	}
+	sink, err := newProgressSink(path, "job-p")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer sink.close()
+	// Hold the mode's only pooled execution connection (idle — no write lock),
+	// mimicking a long stage that keeps the connection checked out.
+	held := make(chan struct{})
+	release := make(chan struct{})
+	go func() {
+		conn, err := db.Conn(context.Background())
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		close(held)
+		<-release
+		conn.Close()
+	}()
+	<-held
+	// The sink must still persist progress on its own connection: the write
+	// must not wait on the held pooled connection (which the pre-fix code
+	// would deadlock on).
+	done := make(chan struct{})
+	go func() {
+		sink.report(0.42)
+		sink.flush()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("progress report blocked on the mode's held connection")
+	}
+	close(release)
+	var progress float64
+	if err := db.QueryRow(`SELECT progress FROM curator_job WHERE job_id='job-p'`).Scan(&progress); err != nil {
+		t.Fatal(err)
+	}
+	if progress != 0.42 {
+		t.Fatalf("progress not persisted: %v", progress)
+	}
+}
+
+func TestHeartbeatLoopCancelsRequested(t *testing.T) {
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	heartbeatIntervalMs = 5
+	if _, err := db.Exec(`INSERT INTO curator_job(job_id, job_type, state, started_at_ms, cancel_requested)
+VALUES ('job-c', 'build', 'running', 1, 1)`); err != nil {
+		t.Fatal(err)
+	}
+	prevCancelExit := daemonExitOnCancel
+	daemonExitOnCancel = false // tests never exit the process
+	defer func() { daemonExitOnCancel = prevCancelExit }()
+	done := make(chan struct{})
+	go heartbeatLoop(db, "job-c", done)
+	// Poll for the transition; the tick interval is 5ms.
+	var state string
+	for range 100 {
+		state = jobState(t, db, "job-c")
+		if state == "cancelled" {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	close(done)
+	if state != "cancelled" {
+		t.Fatalf("cancel flag not honored: %s", state)
+	}
+	row := jobRow(t, db, "job-c")
+	if asDBString(row["error"]) != "cancelled" {
+		t.Fatalf("error field: %v", row["error"])
+	}
+}

--- a/core/daemon_unix.go
+++ b/core/daemon_unix.go
@@ -1,0 +1,20 @@
+//go:build unix
+
+package main
+
+import "syscall"
+
+// pidAlive reports whether a process with the given pid exists (signal 0).
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	err := syscall.Kill(pid, 0)
+	return err == nil || err == syscall.EPERM
+}
+
+// daemonSysProcAttr detaches the worker into its own session so it survives
+// the invoking Stash job and Stash restarts.
+func daemonSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setsid: true}
+}

--- a/core/daemon_windows.go
+++ b/core/daemon_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"strconv"
+	"syscall"
+)
+
+// pidAlive reports whether a process with the given pid exists. Windows has
+// no signal(0); probe the tasklist instead. The "no tasks" info line never
+// contains the pid, so matching the pid text is locale-independent.
+func pidAlive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	out, err := exec.Command("tasklist", "/FI", "PID eq "+strconv.Itoa(pid), "/NH").Output()
+	if err != nil {
+		return false
+	}
+	return bytes.Contains(out, []byte(strconv.Itoa(pid)))
+}
+
+// daemonSysProcAttr gives the worker its own process group so it survives
+// the invoking Stash job.
+func daemonSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+}

--- a/core/migrations/0031_background_tasks.sql
+++ b/core/migrations/0031_background_tasks.sql
@@ -1,0 +1,60 @@
+-- Background task queue for the Curator-owned worker
+-- (docs/decisions/004-background-task-worker.md): 'queued'/'cancelled'
+-- lifecycle states, worker ownership + heartbeat, the enqueue payload
+-- snapshot, the cooperative-cancel flag, and live progress. The old state
+-- CHECK cannot be altered in place, so the table is rebuilt.
+--
+-- The rebuild deliberately avoids ALTER TABLE RENAME: with a published
+-- generation attached, SQLite's RENAME rescans the schema and trips a real
+-- bug on the attached temp views' shadowed names ("views may not be
+-- indexed"). DROP + CREATE + copy has no such dependency (see
+-- test_cascade_migration_survives_attached_generation_temp_views).
+
+CREATE TABLE curator_job_new (
+    job_id TEXT PRIMARY KEY,
+    job_type TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('queued', 'running', 'complete', 'failed', 'cancelled')),
+    started_at_ms INTEGER NOT NULL CHECK (started_at_ms >= 0),
+    finished_at_ms INTEGER CHECK (finished_at_ms IS NULL OR finished_at_ms >= started_at_ms),
+    summary_json TEXT NOT NULL DEFAULT '{}',
+    error TEXT,
+    queued_at_ms INTEGER CHECK (queued_at_ms IS NULL OR queued_at_ms >= 0),
+    heartbeat_at_ms INTEGER CHECK (heartbeat_at_ms IS NULL OR heartbeat_at_ms >= 0),
+    owner_pid INTEGER,
+    payload_json TEXT,
+    cancel_requested INTEGER NOT NULL DEFAULT 0 CHECK (cancel_requested IN (0, 1)),
+    progress REAL CHECK (progress IS NULL OR (progress >= 0.0 AND progress <= 1.0))
+) STRICT;
+
+INSERT INTO curator_job_new (job_id, job_type, state, started_at_ms, finished_at_ms, summary_json, error)
+    SELECT job_id, job_type, state, started_at_ms, finished_at_ms, summary_json, error
+    FROM curator_job;
+
+DROP TABLE curator_job;
+
+CREATE TABLE curator_job (
+    job_id TEXT PRIMARY KEY,
+    job_type TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('queued', 'running', 'complete', 'failed', 'cancelled')),
+    started_at_ms INTEGER NOT NULL CHECK (started_at_ms >= 0),
+    finished_at_ms INTEGER CHECK (finished_at_ms IS NULL OR finished_at_ms >= started_at_ms),
+    summary_json TEXT NOT NULL DEFAULT '{}',
+    error TEXT,
+    queued_at_ms INTEGER CHECK (queued_at_ms IS NULL OR queued_at_ms >= 0),
+    heartbeat_at_ms INTEGER CHECK (heartbeat_at_ms IS NULL OR heartbeat_at_ms >= 0),
+    owner_pid INTEGER,
+    payload_json TEXT,
+    cancel_requested INTEGER NOT NULL DEFAULT 0 CHECK (cancel_requested IN (0, 1)),
+    progress REAL CHECK (progress IS NULL OR (progress >= 0.0 AND progress <= 1.0))
+) STRICT;
+
+INSERT INTO curator_job (job_id, job_type, state, started_at_ms, finished_at_ms, summary_json, error,
+    queued_at_ms, heartbeat_at_ms, owner_pid, payload_json, cancel_requested, progress)
+    SELECT job_id, job_type, state, started_at_ms, finished_at_ms, summary_json, error,
+        queued_at_ms, heartbeat_at_ms, owner_pid, payload_json, cancel_requested, progress
+    FROM curator_job_new;
+
+DROP TABLE curator_job_new;
+
+CREATE INDEX curator_job_started_idx ON curator_job(started_at_ms DESC);
+CREATE INDEX curator_job_queue_idx ON curator_job(state, queued_at_ms);

--- a/core/migrations_test.go
+++ b/core/migrations_test.go
@@ -34,18 +34,18 @@ func TestMigrateFullChain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status.currentVersion != 30 || status.latestVersion != 30 || len(status.pending) != 0 {
+	if status.currentVersion != 31 || status.latestVersion != 31 || len(status.pending) != 0 {
 		t.Fatalf("unexpected status: %+v", status)
 	}
-	if len(migrations) != 30 {
-		t.Fatalf("expected 30 migrations, got %d", len(migrations))
+	if len(migrations) != 31 {
+		t.Fatalf("expected 31 migrations, got %d", len(migrations))
 	}
 	var rows int
 	if err := db.QueryRow(`SELECT count(*) FROM schema_migration`).Scan(&rows); err != nil {
 		t.Fatal(err)
 	}
-	if rows != 30 {
-		t.Fatalf("schema_migration has %d rows, want 30", rows)
+	if rows != 31 {
+		t.Fatalf("schema_migration has %d rows, want 31", rows)
 	}
 	// Idempotent second migrate.
 	if err := migrate(db, 1_700_000_000_001); err != nil {
@@ -54,7 +54,7 @@ func TestMigrateFullChain(t *testing.T) {
 	if err := db.QueryRow(`SELECT count(*) FROM schema_migration`).Scan(&rows); err != nil {
 		t.Fatal(err)
 	}
-	if rows != 30 {
+	if rows != 31 {
 		t.Fatalf("second migrate added rows: %d", rows)
 	}
 	var integrity string

--- a/core/ops.go
+++ b/core/ops.go
@@ -22,20 +22,54 @@ const apiSchemaVersion = 1
 // stashdbEndpoint mirrors curator/expand.py STASHDB.
 const stashdbEndpoint = "https://stashdb.org/graphql"
 
-// healthTaskNames mirrors backend.py's task_names used to detect active
-// Curator jobs in Stash's queue.
-var healthTaskNames = []string{
-	"Sync and build recommendations",
-	"Full sync and build recommendations",
-	"Rebuild recommendation model",
-	"Apply recent Curator feedback",
-	"Prepare recommendation pages",
-	"Sync recent plays",
-	"Backup Curator data",
-	"Compact legacy Curator data",
-	"Vacuum compacted Curator data",
-	"Refresh Expand cache",
-	"Install optional dependencies",
+// taskDisplayNames maps the yml task mode to its display name so health can
+// synthesize the Stash-style job description the frontend's task indicator
+// and stage mapping consume (mirrors backend.py's TASK_DISPLAY_NAMES).
+var taskDisplayNames = map[string]string{
+	"sync-build":      "Sync and build recommendations",
+	"full-sync-build": "Full sync and build recommendations",
+	"build":           "Rebuild recommendation model",
+	"update-model":    "Apply recent Curator feedback",
+	"sync-plays":      "Sync recent plays",
+	"prepare":         "Prepare recommendation pages",
+	"backup":          "Backup Curator data",
+	"compact":         "Compact legacy Curator data",
+	"vacuum":          "Vacuum compacted Curator data",
+	"expand-refresh":  "Refresh Expand cache",
+}
+
+// activeCuratorJobs renders the queued + running curator_job rows in the
+// Stash job shape the frontend's task indicator consumes ({id, description,
+// progress}), with the Stash-style description the stage mapping matches.
+func activeCuratorJobs(db dbx) ([]jVal, error) {
+	rows, err := db.Query(`SELECT job_id, job_type, progress FROM curator_job
+WHERE state IN ('queued', 'running') ORDER BY started_at_ms DESC LIMIT 10`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var jobs []jVal
+	for rows.Next() {
+		var jobID, jobType string
+		var progress sql.NullFloat64
+		if err := rows.Scan(&jobID, &jobType, &progress); err != nil {
+			return nil, err
+		}
+		name, ok := taskDisplayNames[jobType]
+		if !ok {
+			name = jobType
+		}
+		progressVal := jvNull()
+		if progress.Valid {
+			progressVal = jvFloat(progress.Float64)
+		}
+		jobs = append(jobs, jvObj(
+			jvKey("id", jvStr(jobID)),
+			jvKey("description", jvStr("Running plugin task: "+name)),
+			jvKey("progress", progressVal),
+		))
+	}
+	return jobs, rows.Err()
 }
 
 func opRoundTrip(pluginDir string, payload jVal) (jVal, error) {
@@ -169,6 +203,8 @@ func opGetJobStatus(pluginDir string, payload jVal) (jVal, error) {
 			jvKey("finished_at_ms", dbOptionalInt(row["finished_at_ms"])),
 			jvKey("summary", dbSummary(row["summary_json"])),
 			jvKey("error", dbOptionalString(row["error"])),
+			jvKey("queued_at_ms", dbOptionalInt(row["queued_at_ms"])),
+			jvKey("progress", dbOptionalFloat(row["progress"])),
 		)
 		jobs.arr = append(jobs.arr, job)
 	}
@@ -178,6 +214,65 @@ func opGetJobStatus(pluginDir string, payload jVal) (jVal, error) {
 	return jvObj(
 		jvKey("schema_version", jvInt(apiSchemaVersion)),
 		jvKey("jobs", jobs),
+	), nil
+}
+
+// opCancelJob cancels a queued job instantly and requests cooperative cancel
+// of a running one (the worker marks it cancelled at its next heartbeat
+// tick). A finished or unknown job reports cancelled: false.
+func opCancelJob(pluginDir string, payload jVal) (jVal, error) {
+	args := payload.get("args")
+	jobID := args.get("job_id").asString()
+	if jobID == "" {
+		return jvNull(), fmt.Errorf("job_id is required")
+	}
+	settings := pluginSettings(payload)
+	db, err := openSidecar(pluginDir, payload, settings, true)
+	if err != nil {
+		return jvNull(), err
+	}
+	defer db.Close()
+	now := nowMs()
+	result, err := db.Exec(`UPDATE curator_job SET state='cancelled', finished_at_ms=?
+WHERE job_id=? AND state='queued'`, now, jobID)
+	if err != nil {
+		return jvNull(), err
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return jvNull(), err
+	}
+	if affected > 0 {
+		return jvObj(
+			jvKey("schema_version", jvInt(apiSchemaVersion)),
+			jvKey("job_id", jvStr(jobID)),
+			jvKey("cancelled", jvBool(true)),
+			jvKey("state", jvStr("cancelled")),
+		), nil
+	}
+	result, err = db.Exec(`UPDATE curator_job SET cancel_requested=1
+WHERE job_id=? AND state='running'`, jobID)
+	if err != nil {
+		return jvNull(), err
+	}
+	affected, err = result.RowsAffected()
+	if err != nil {
+		return jvNull(), err
+	}
+	if affected > 0 {
+		return jvObj(
+			jvKey("schema_version", jvInt(apiSchemaVersion)),
+			jvKey("job_id", jvStr(jobID)),
+			jvKey("cancelled", jvBool(true)),
+			jvKey("state", jvStr("running")),
+			jvKey("cancel_requested", jvBool(true)),
+		), nil
+	}
+	return jvObj(
+		jvKey("schema_version", jvInt(apiSchemaVersion)),
+		jvKey("job_id", jvStr(jobID)),
+		jvKey("cancelled", jvBool(false)),
+		jvKey("error", jvStr("no active job with that id")),
 	), nil
 }
 
@@ -241,6 +336,21 @@ func dbOptionalInt(v any) jVal {
 
 // dbOptionalString mirrors Python's `str(v) if v else None`: null and empty
 // both become None.
+func dbOptionalFloat(v any) jVal {
+	if v == nil {
+		return jvNull()
+	}
+	switch n := v.(type) {
+	case float64:
+		return jvFloat(n)
+	case int64:
+		return jvFloat(float64(n))
+	case int:
+		return jvFloat(float64(n))
+	}
+	return jvNull()
+}
+
 func dbOptionalString(v any) jVal {
 	switch t := v.(type) {
 	case nil:
@@ -374,42 +484,24 @@ func opHealth(pluginDir string, payload jVal) (jVal, error) {
 	if err != nil {
 		return jvNull(), err
 	}
-	jobQueue := stash.get("jobQueue")
-	var activeJobs []jVal
-	if jobQueue.kind == jArr {
-		for _, job := range jobQueue.arr {
-			if healthTaskMatches(job) {
-				activeJobs = append(activeJobs, job)
-			}
-		}
-	}
-	var activeJob jVal = jvNull()
-	if len(activeJobs) > 0 {
-		activeJob = activeJobs[0]
-	}
-
 	db, err := openSidecar(pluginDir, payload, settings, true)
 	if err != nil {
 		return jvNull(), err
 	}
 	defer db.Close()
 	now := nowMs()
-	if activeJob.kind == jNull {
-		var interrupted int
-		err := db.QueryRow(
-			`SELECT 1 FROM curator_job WHERE state='running' AND started_at_ms<? LIMIT 1`,
-			now-120_000,
-		).Scan(&interrupted)
-		if err == nil {
-			if err := execImmediate(db,
-				`UPDATE curator_job SET state='failed', finished_at_ms=?, error='interrupted before task completion'
-WHERE state='running' AND started_at_ms<?`,
-				now, now-120_000); err != nil {
-				return jvNull(), err
-			}
-		} else if err != sql.ErrNoRows {
-			return jvNull(), err
-		}
+	// Worker-owned liveness: fail running rows whose executing process is
+	// gone (heartbeat stale or legacy pre-heartbeat age). This replaces the
+	// old Stash-job-list + 120s heuristic, which no longer applies once
+	// tasks run in the detached worker instead of a live Stash job.
+	recoverOrphanJobs(db, now)
+	activeJobs, err := activeCuratorJobs(db)
+	if err != nil {
+		return jvNull(), err
+	}
+	var activeJob jVal = jvNull()
+	if len(activeJobs) > 0 {
+		activeJob = activeJobs[0]
 	}
 	migration, err := queryMigrationStatus(db)
 	if err != nil {
@@ -483,7 +575,7 @@ WHERE state='running' AND started_at_ms>? AND job_type IN (
 		jvKey("model_pending", jvBool(modelUpdate.pending())),
 		jvKey("model_pending_events", jvInt(modelUpdate.pendingCount())),
 		jvKey("model_update_ready", jvBool(modelUpdateReady)),
-		jvKey("model_rebuilding", jvBool(rebuilding && activeJob.kind != jNull)),
+		jvKey("model_rebuilding", jvBool(rebuilding)),
 		jvKey("active_job", activeJob),
 		jvKey("active_jobs", jvArr(activeJobs...)),
 		jvKey("last_sync_at_ms", lastSyncMs),
@@ -497,22 +589,6 @@ func requireKey(v jVal, key string) (jVal, error) {
 		return jvNull(), fmt.Errorf("'%s'", key)
 	}
 	return v.get(key), nil
-}
-
-func healthTaskMatches(job jVal) bool {
-	description := job.get("description").asString()
-	matched := false
-	for _, name := range healthTaskNames {
-		if strings.Contains(description, name) {
-			matched = true
-			break
-		}
-	}
-	if !matched {
-		return false
-	}
-	status := strings.ToLower(job.get("status").asString())
-	return status == "waiting" || status == "running"
 }
 
 func stashdbConfigured(boxes jVal) bool {

--- a/core/sqlite_test.go
+++ b/core/sqlite_test.go
@@ -41,7 +41,7 @@ func TestOpenReadonlyPragmasApplied(t *testing.T) {
 		`SELECT max(version) FROM schema_migration`).Scan(&latest); err != nil {
 		t.Fatal(err)
 	}
-	if latest != 30 {
-		t.Fatalf("latest migration=%d, want 30", latest)
+	if latest != 31 {
+		t.Fatalf("latest migration=%d, want 31", latest)
 	}
 }

--- a/core/tasks.go
+++ b/core/tasks.go
@@ -17,9 +17,16 @@ import (
 )
 
 // progressLog mirrors backend.py's _progress: a stderr progress marker with
-// the value clamped to [0, 1] and %.4f formatting.
+// the value clamped to [0, 1] and %.4f formatting, plus the active job's
+// sidecar progress sink (debounced) when one is attached.
 func progressLog(value float64) {
 	fmt.Fprintf(os.Stderr, "\x01p\x02%.4f\n", math.Max(0.0, math.Min(value, 1.0)))
+	progressSinkMu.Lock()
+	sink := activeProgressSink
+	progressSinkMu.Unlock()
+	if sink != nil {
+		sink.report(value)
+	}
 }
 
 func infoLog(message string) {
@@ -48,40 +55,43 @@ func runTask(pluginDir string, payload jVal, mode string) (jVal, error) {
 		func(settings jVal) (jVal, error) { return runTaskBody(pluginDir, payload, mode, settings) })
 }
 
-// runTaskBody mirrors backend.py's _run_task_body.
+// runTaskBody posts the task to the Curator-owned worker queue and returns
+// immediately, freeing Stash's single-slot job queue (docs/decisions/004).
+// Same-type queued/running jobs coalesce into the existing already_running
+// response. If the worker cannot run (unusual platform), the task executes
+// inline exactly as before so behavior never silently regresses.
 func runTaskBody(pluginDir string, payload jVal, mode string, settings jVal) (jVal, error) {
+	if !taskModeNative(mode) {
+		return jvNull(), fmt.Errorf("unknown Curator task: %s", mode)
+	}
 	db, err := openSidecar(pluginDir, payload, settings, true)
 	if err != nil {
 		return jvNull(), err
 	}
 	defer db.Close()
 	jobID := uuid4()
-	startedAtMs := nowMs()
-	staleBefore := nowMs() - 6*3_600_000
+	now := nowMs()
+	staleBefore := now - 6*3_600_000
 	var existingJobID, existingJobType string
+	// Recover dead-owner running rows first (idempotent, independent of the
+	// enqueue below) so a crashed worker's rows do not block the queue.
+	recoverOrphanJobs(db, now)
 	err = withTxn(db, func(conn *sql.Conn) error {
 		ctx := context.Background()
-		if _, err := conn.ExecContext(ctx, `
-UPDATE curator_job SET state='failed', finished_at_ms=?, error='interrupted'
-WHERE state='running' AND started_at_ms<=?`, nowMs(), staleBefore); err != nil {
-			return err
-		}
 		var existingID, existingType string
 		err := conn.QueryRowContext(ctx, `
-SELECT job_id, job_type FROM curator_job WHERE state='running'
-AND started_at_ms>? ORDER BY started_at_ms DESC LIMIT 1`, staleBefore).Scan(&existingID, &existingType)
+SELECT job_id, job_type FROM curator_job WHERE state IN ('queued', 'running')
+AND job_type=? AND started_at_ms>? ORDER BY started_at_ms DESC LIMIT 1`,
+			mode, staleBefore).Scan(&existingID, &existingType)
 		if err == sql.ErrNoRows {
-			if _, err := conn.ExecContext(ctx, `
-UPDATE model_update_state SET last_error='interrupted before task completion'
-WHERE last_started_at_ms IS NOT NULL
-AND last_started_at_ms>COALESCE(last_finished_at_ms, -1)
-AND last_error IS NULL`); err != nil {
-				return err
+			payloadRaw, merr := marshalJVal(payload)
+			if merr != nil {
+				return merr
 			}
-			_, err := conn.ExecContext(ctx, `
-INSERT INTO curator_job(job_id, job_type, state, started_at_ms)
-VALUES (?, ?, 'running', ?)`, jobID, mode, startedAtMs)
-			return err
+			_, ierr := conn.ExecContext(ctx, `
+INSERT INTO curator_job(job_id, job_type, state, started_at_ms, queued_at_ms, payload_json)
+VALUES (?, ?, 'queued', ?, ?, ?)`, jobID, mode, now, now, payloadRaw)
+			return ierr
 		}
 		if err != nil {
 			return err
@@ -100,24 +110,78 @@ VALUES (?, ?, 'running', ?)`, jobID, mode, startedAtMs)
 			jvKey("job_type", jvStr(existingJobType)),
 		), nil
 	}
-	if mode == "compact" || mode == "vacuum" {
-		// Compaction requires a core-only connection; vacuum runs without the
-		// attached artifact views, matching Python's reopen.
-		db.Close()
-		db, err = openSidecar(pluginDir, payload, settings, false)
-		if err != nil {
+	if workerErr := ensureWorker(pluginDir, payload, settings); workerErr != nil {
+		// No worker: fall back to inline execution (pre-worker behavior) so
+		// the task still completes. The queued row is promoted to running.
+		infoLog(fmt.Sprintf("Stash Curator %s running inline (worker unavailable: %v)", mode, workerErr))
+		if err := execImmediate(db, `UPDATE curator_job SET state='running', heartbeat_at_ms=?
+WHERE job_id=? AND state='queued'`, now, jobID); err != nil {
 			return jvNull(), err
 		}
-		defer db.Close()
+		work, oerr := openTaskSidecar(pluginDir, payload, settings, mode)
+		if oerr != nil {
+			return jvNull(), oerr
+		}
+		defer work.Close()
+		return executeClaimedJob(work, pluginDir, payload, mode, settings, jobID, now)
+	}
+	return jvObj(
+		jvKey("schema_version", jvInt(apiSchemaVersion)),
+		jvKey("job_id", jvStr(jobID)),
+		jvKey("queued", jvBool(true)),
+		jvKey("job_type", jvStr(mode)),
+	), nil
+}
+
+// openTaskSidecar opens the sidecar with artifact attaches on for every mode
+// except compact/vacuum, which require a core-only connection (matching
+// backend.py's reopen).
+func openTaskSidecar(pluginDir string, payload jVal, settings jVal, mode string) (dbx, error) {
+	attach := mode != "compact" && mode != "vacuum"
+	return openSidecar(pluginDir, payload, settings, attach)
+}
+
+// marshalJVal serializes a payload for the queue snapshot.
+func marshalJVal(v jVal) (string, error) {
+	var b strings.Builder
+	v.writeJSON(&b)
+	return b.String(), nil
+}
+
+// executeClaimedJob runs one claimed (state='running') job to completion:
+// heartbeat + progress through the sidecar, the mode body, and guarded state
+// transitions. Shared by the inline fallback and the daemon.
+func executeClaimedJob(db dbx, pluginDir string, payload jVal, mode string, settings jVal, jobID string, startedAtMs int64) (jVal, error) {
+	done := make(chan struct{})
+	defer close(done)
+	go heartbeatLoop(db, jobID, done)
+	// The sink writes on its own connection (the execution pool is pinned to
+	// one conn), so progress updates never block behind the mode's own
+	// statements — or deadlock when a marker fires inside one of its txns.
+	var prev *progressSink
+	sink, sinkErr := newProgressSink(databasePath(pluginDir, payload, settings), jobID)
+	if sinkErr != nil {
+		infoLog(fmt.Sprintf("progress sink unavailable: %v", sinkErr))
+	} else {
+		prev = setProgressSink(sink)
+		defer func() {
+			setProgressSink(prev)
+			sink.close()
+		}()
 	}
 	infoLog(fmt.Sprintf("Stash Curator %s started", mode))
 	progressLog(0.01)
 	summary, taskErr := runTaskMode(db, pluginDir, payload, mode, settings, startedAtMs)
+	// Land the last progress value before the terminal transition removes the
+	// state='running' guard the sink writes under.
+	if sink != nil {
+		sink.flush()
+	}
 	if taskErr != nil {
 		txnErr := withTxn(db, func(conn *sql.Conn) error {
 			_, err := conn.ExecContext(context.Background(), `
 UPDATE curator_job SET state='failed', finished_at_ms=?, error=?
-WHERE job_id=?`, nowMs(), truncateString(taskErr.Error(), 2000), jobID)
+WHERE job_id=? AND state='running'`, nowMs(), truncateString(taskErr.Error(), 2000), jobID)
 			return err
 		})
 		if txnErr != nil {
@@ -126,17 +190,20 @@ WHERE job_id=?`, nowMs(), truncateString(taskErr.Error(), 2000), jobID)
 		errorLog(fmt.Sprintf("Stash Curator %s failed: %s", mode, taskErr.Error()))
 		return jvNull(), taskErr
 	}
+	progressLog(1.0)
+	if sink != nil {
+		sink.flush()
+	}
 	txnErr := withTxn(db, func(conn *sql.Conn) error {
 		_, err := conn.ExecContext(context.Background(), `
 UPDATE curator_job SET state='complete', finished_at_ms=?, summary_json=?
-WHERE job_id=?`, nowMs(), summary.marshalSortedKeys(), jobID)
+WHERE job_id=? AND state='running'`, nowMs(), summary.marshalSortedKeys(), jobID)
 		return err
 	})
 	if txnErr != nil {
 		return jvNull(), txnErr
 	}
 	infoLog(fmt.Sprintf("Stash Curator %s completed", mode))
-	progressLog(1.0)
 	out := jvObj(
 		jvKey("schema_version", jvInt(apiSchemaVersion)),
 		jvKey("job_id", jvStr(jobID)),

--- a/curator/storage/sql/0031_background_tasks.sql
+++ b/curator/storage/sql/0031_background_tasks.sql
@@ -1,0 +1,60 @@
+-- Background task queue for the Curator-owned worker
+-- (docs/decisions/004-background-task-worker.md): 'queued'/'cancelled'
+-- lifecycle states, worker ownership + heartbeat, the enqueue payload
+-- snapshot, the cooperative-cancel flag, and live progress. The old state
+-- CHECK cannot be altered in place, so the table is rebuilt.
+--
+-- The rebuild deliberately avoids ALTER TABLE RENAME: with a published
+-- generation attached, SQLite's RENAME rescans the schema and trips a real
+-- bug on the attached temp views' shadowed names ("views may not be
+-- indexed"). DROP + CREATE + copy has no such dependency (see
+-- test_cascade_migration_survives_attached_generation_temp_views).
+
+CREATE TABLE curator_job_new (
+    job_id TEXT PRIMARY KEY,
+    job_type TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('queued', 'running', 'complete', 'failed', 'cancelled')),
+    started_at_ms INTEGER NOT NULL CHECK (started_at_ms >= 0),
+    finished_at_ms INTEGER CHECK (finished_at_ms IS NULL OR finished_at_ms >= started_at_ms),
+    summary_json TEXT NOT NULL DEFAULT '{}',
+    error TEXT,
+    queued_at_ms INTEGER CHECK (queued_at_ms IS NULL OR queued_at_ms >= 0),
+    heartbeat_at_ms INTEGER CHECK (heartbeat_at_ms IS NULL OR heartbeat_at_ms >= 0),
+    owner_pid INTEGER,
+    payload_json TEXT,
+    cancel_requested INTEGER NOT NULL DEFAULT 0 CHECK (cancel_requested IN (0, 1)),
+    progress REAL CHECK (progress IS NULL OR (progress >= 0.0 AND progress <= 1.0))
+) STRICT;
+
+INSERT INTO curator_job_new (job_id, job_type, state, started_at_ms, finished_at_ms, summary_json, error)
+    SELECT job_id, job_type, state, started_at_ms, finished_at_ms, summary_json, error
+    FROM curator_job;
+
+DROP TABLE curator_job;
+
+CREATE TABLE curator_job (
+    job_id TEXT PRIMARY KEY,
+    job_type TEXT NOT NULL,
+    state TEXT NOT NULL CHECK (state IN ('queued', 'running', 'complete', 'failed', 'cancelled')),
+    started_at_ms INTEGER NOT NULL CHECK (started_at_ms >= 0),
+    finished_at_ms INTEGER CHECK (finished_at_ms IS NULL OR finished_at_ms >= started_at_ms),
+    summary_json TEXT NOT NULL DEFAULT '{}',
+    error TEXT,
+    queued_at_ms INTEGER CHECK (queued_at_ms IS NULL OR queued_at_ms >= 0),
+    heartbeat_at_ms INTEGER CHECK (heartbeat_at_ms IS NULL OR heartbeat_at_ms >= 0),
+    owner_pid INTEGER,
+    payload_json TEXT,
+    cancel_requested INTEGER NOT NULL DEFAULT 0 CHECK (cancel_requested IN (0, 1)),
+    progress REAL CHECK (progress IS NULL OR (progress >= 0.0 AND progress <= 1.0))
+) STRICT;
+
+INSERT INTO curator_job (job_id, job_type, state, started_at_ms, finished_at_ms, summary_json, error,
+    queued_at_ms, heartbeat_at_ms, owner_pid, payload_json, cancel_requested, progress)
+    SELECT job_id, job_type, state, started_at_ms, finished_at_ms, summary_json, error,
+        queued_at_ms, heartbeat_at_ms, owner_pid, payload_json, cancel_requested, progress
+    FROM curator_job_new;
+
+DROP TABLE curator_job_new;
+
+CREATE INDEX curator_job_started_idx ON curator_job(started_at_ms DESC);
+CREATE INDEX curator_job_queue_idx ON curator_job(state, queued_at_ms);

--- a/docs/decisions/004-background-task-worker.md
+++ b/docs/decisions/004-background-task-worker.md
@@ -1,0 +1,241 @@
+# Planning: Curator-owned background task worker and scheduler
+
+Status: **Phase 1 implemented (2026-08-17); scheduling pending**. Design
+record for a detached, Curator-owned worker that takes task execution out of
+Stash's single-slot job queue and adds scheduled tasks. Complements ADR 001
+(raw-plugin backend runtime, accepted), `docs/decisions/002-runtime-swap-planning.md`
+(compiled core), and issue #145 (direction 1: Curator-owned background
+execution).
+
+Updated: 2026-08-17.
+
+## 1. Problem
+
+- Every Curator task runs inside Stash's single-slot `JobManager` queue:
+  the frontend calls `runPluginTask` (stash-curator.js), Stash spawns
+  `launcher.py <mode>`, which execs `curator-core`, and the Stash job
+  completes only when that process exits. A 150-409 s `sync-build` holds the
+  slot the whole time, blocking every other Stash job (scan, generate,
+  autotag, ...) and every other Curator task (`already_running` guard).
+- There is no scheduling. "Auto" model updates are driven by frontend timers
+  (`scheduleModelUpdate` / `scheduleModelMaintenance` in stash-curator.js)
+  that call `runTask("Apply recent Curator feedback")`; with no browser tab
+  open, nothing runs. `ModelUpdateCoordinator`'s docstring already assumes "a
+  resident plugin supplies the wake-up loop" — that resident never existed.
+- Scope decision: this is Curator-only. No stashapp/stash change (issue #145
+  direction 2, a concurrent `JobManager.Start`) is in scope: it would benefit
+  every plugin but is outside our control and unnecessary for the goals.
+
+## 2. Current state (banked findings, verified against origin/main)
+
+- Task invocation: frontend `runTask(name)` → GraphQL
+  `runPluginTask(plugin_id: "stash-curator", task_name: ...)`; Stash appends
+  the yml `execArgs` mode to the exec (`plugin/stash-curator.yml` `tasks:`,
+  10 modes: sync-build, full-sync-build, build, update-model, sync-plays,
+  prepare, backup, compact, vacuum, expand-refresh).
+- All 10 task modes are native Go (`runTaskMode` switch, `core/tasks.go`).
+  `runTaskModePending` is a dead stub. A worker is the same binary, no
+  Python, no new exec surface.
+- Task lifecycle (`runTaskBody`, `core/tasks.go`): 6 h stale window marks
+  ancient `running` rows failed; a single `running` row newer than 6 h blocks
+  new tasks (`already_running`); insert `curator_job` row
+  (`job_id, job_type, state, started_at_ms, finished_at_ms, error,
+  summary_json`); run the mode body; transition `complete`/`failed`.
+- `health` (core/ops.go) applies a 120 s "interrupted" heuristic only when
+  no matching job appears in Stash's own job list (`activeJob.kind ==
+  jNull`). Both heuristics are valid only because one job == one
+  Stash-spawned process.
+- Progress: task stderr markers `\x01p\x02<fraction>` / `\x01i\x02<msg>`
+  are parsed by Stash's job runner into the Stash job's `progress`; the
+  frontend renders it from `health.active_jobs` (`CuratorTaskIndicator`
+  reads `job.progress`). Curator's own `curator_job` rows carry no progress.
+  Completion/failure reporting already flows through `curator_job` →
+  `get_job_status` → indicator's `doneJob`/`latestFailure` without a live
+  Stash job.
+- Sidecar: SQLite WAL, 30 s busy_timeout, 128 MiB page cache, 512 MiB mmap
+  on read-only connections (`curator/storage/database.py`, `core/sqlite.go`).
+- Kernels: `runCoreKernel` (core/modelbuild.go) re-execs the current binary
+  (`os.Executable()`) per kernel — works from a worker unchanged.
+- Model update gating: `modelUpdateState` + `ModelUpdateCoordinator.ready()`
+  (curator/model/updates.py) already implement the requested/threshold/
+  interval semantics behind the `modelUpdate*` settings; only the trigger is
+  missing.
+- No cancellation exists anywhere in Curator; Stash's Tasks tab can only
+  kill the whole job process.
+
+## 3. Decision
+
+Take the long-running task path out of the Stash job slot: the Stash-spawned
+process becomes an **enqueuer** that records the task in the sidecar and
+returns immediately; a **Curator-owned detached daemon** (a new mode of the
+shipped `curator-core` binary) claims, runs, and reports queued tasks; a
+**scheduler** inside the daemon enqueues tasks on a schedule. Interactive
+operations keep the existing raw-plugin one-process-per-request protocol
+unchanged.
+
+## 4. Design
+
+### 4.1 Enqueue-and-return (frees the Stash slot)
+
+`runTaskBody` inserts a `state='queued'` `curator_job` row carrying a
+`payload_json` snapshot (the `server_connection` sync/expand jobs need after
+the spawning process is gone), ensures the worker is alive, and returns
+`{job_id, queued: true}` immediately (~100 ms). Semantics:
+
+- same-type coalescing keeps the `already_running` behavior (`already_queued`);
+- if the worker cannot be spawned (unusual platform), run inline exactly as
+  today — no behavior regression.
+
+### 4.2 Daemon (`curator-core <pluginDir> daemon`)
+
+- Detached spawn: `setsid` + stdio redirected to `data/curator-daemon.log`
+  so the process survives Stash job teardown and Stash restarts. Must verify
+  how Stash kills jobs (process-group kill is the case setsid defeats).
+- Single instance: pid file with staleness check (or lock row).
+- Startup recovery: mark its own `running`/`queued` rows `failed`
+  (`interrupted`) — ownership-based replacement for the 6 h window.
+- Queue loop: atomically claim `queued` → `running` (one at a time; SQLite
+  single-writer and builds serialize anyway), heartbeat
+  (`heartbeat_at_ms`, ~20 s), run the existing `runTaskMode` bodies,
+  transition `complete`/`failed` with `summary_json`.
+- Ensure-worker on every plugin invocation (operation or task): check pid +
+  heartbeat freshness, spawn if dead. This is the crash-resurrection and
+  plugin-update rotation path (binary version/mtime change → restart).
+- Lifetime: lazy spawn on first task; exit when idle after a grace period
+  (recommended) rather than permanently resident.
+
+### 4.3 Liveness rewrite
+
+The 120 s health heuristic (keyed on Stash's job list) and the 6 h stale
+window both break once the Stash job completes instantly. Replace with
+ownership: `health` reports `active_jobs` from `curator_job`
+(queued + running, with progress/stage/description and owner heartbeat), and
+dead-owner / stale-heartbeat rows (> ~5 min) are marked failed by the
+ensure-worker path and daemon startup. The frontend indicator follows with no
+structural change.
+
+### 4.4 Reporting back as tasks run
+
+Completion/failure reporting already works through `curator_job` and stays.
+Live progress currently rides Stash's job record, which disappears; restore
+it Curator-side:
+
+- `progress` (REAL 0..1) and `stage` (TEXT) columns on `curator_job`;
+- the daemon writes progress/stage to the DB **debounced** (~1 write/s, only
+  on material change — builds emit per-batch/per-stage markers; unthrottled
+  writes during a build would be the mistake here);
+- `health`/`get_job_status` return them (health also supplies a `description`
+  per job from the yml task names);
+- frontend: the progress bar already renders `job.progress` — no change
+  needed for the bar; queued-state label and Cancel are the real additions.
+
+### 4.5 Cancellation
+
+- Queued → cancelled instantly. Running → cooperative context cancellation
+  threaded into `runTaskMode` bodies (sync page walks, build stages). Hard
+  kill → SIGTERM then SIGKILL after grace.
+- New op `cancel_job(job_id)` + Cancel button in the task indicator.
+- UX note: Stash's Tasks tab can no longer stop Curator work (its job is
+  already done) — cancellation moves into Curator's UI. Call this out in the
+  handoff.
+
+### 4.6 Scheduling
+
+- New `scheduled_task` table: task_type, interval_ms, next_run_at_ms,
+  enabled, last run/result. Scheduler goroutine wakes every ~30-60 s and
+  enqueues due tasks, coalescing same-type.
+- First candidates, in value order: `update-model` (kills the browser-timer
+  dependency; gated by the existing `modelUpdate*` settings via
+  `ModelUpdateCoordinator.ready()`), `sync-plays` (hourly), `sync-build`
+  (daily), `backup` (daily).
+- Interval-based only — no cron parser dependency. Config surface: yml
+  `schedule*` settings, with the #151 Settings panel as the natural home.
+
+### 4.7 Migration surface (new ordered migration, ~0030)
+
+- `curator_job`: state CHECK gains `'queued'`; add `queued_at_ms`,
+  `heartbeat_at_ms`, `owner_pid`, `payload_json`, `progress`, `stage`.
+- New `scheduled_task` table.
+- `backend.py` is the dev-side parity reference, not shipped (launcher:
+  "no Python runtime ships in the plugin"); the lifecycle change is Go-only.
+  Check the differential gates do not pin the inline task lifecycle.
+
+## 5. Risks and open questions
+
+- **Stash kill semantics**: verify whether Stash job stop/teardown kills the
+  process group — setsid must defeat it. The one environment check that
+  gates the whole design.
+- **Plugin update vs running daemon**: zip install replaces the binary
+  under a running daemon; version/mtime check on ensure-worker rotates it.
+  Decide: let the current job finish vs terminate (recommend: finish, then
+  next ensure spawns the new version).
+- **Progress write amplification**: debounce is mandatory (see 4.4).
+- **Connection staleness**: jobs enqueued before a Stash restart carry a
+  stale `server_connection`; refresh per enqueue, fail clear on stale URL.
+- **Always-resident vs lazy-with-idle-exit**: lazy recommended (no permanent
+  process on an otherwise idle plugin).
+- **backend.py parity divergence** on the task lifecycle: keep the inline
+  path as fallback so the reference and the differential gates stay honest.
+
+## 6. Sequencing
+
+- **Phase 1 (foundation)**: migration 0030; daemon mode (queue claim +
+  heartbeat + orphan recovery); enqueue-and-return; ensure-worker; health
+  re-keyed; progress/stage persistence; SIGTERM/ctx cancel. Verify: Stash
+  slot frees instantly, jobs complete through the daemon, crash/stale
+  recovery works, differential gates green.
+- **Phase 2 (scheduling)**: `scheduled_task` + scheduler loop + `update-model`
+  wake-up + yml `schedule*` settings.
+- **Phase 3 (UX)**: task-indicator queued state + Cancel buttons; schedule
+  config in the #151 Settings panel.
+
+## 7. Verification
+
+- Per phase: `scripts/verify changed <paths>` while iterating,
+  `scripts/verify full` before handoff; the compiled-core differential gates
+  must stay green (no float/ordering drift).
+- Installed verification: Stash's job queue never shows a long-running
+  Curator job; jobs complete via the daemon with live progress in the
+  indicator; kill the daemon mid-build → next invocation recovers the
+  orphan; scheduled `update-model` fires with no browser open; restart Stash
+  mid-task → the daemon survives and the job completes.
+
+## 8. Phase 1 deltas from this design (implemented 2026-08-17)
+
+- **No `stage` column**: the frontend derives stage labels from the
+  synthesized `description` + `progress` thresholds (`curatorTaskStage`), so
+  only `progress` is persisted.
+- **Cross-type guard relaxed by design**: the old "any running task blocks
+  every task" guard became per-type coalescing; the daemon serializes its
+  own claims. The mode-body guards (backup/compact/vacuum/reset refuse while
+  running) are unchanged.
+- **Unknown task modes still error at the invocation boundary**
+  (`taskModeNative` check in `runTaskBody`), preserving the
+  `unknown Curator task` contract for the frontend.
+- **Migration 0031 avoids `ALTER TABLE RENAME`** entirely (DROP + CREATE +
+  copy): SQLite's RENAME rescans the schema and trips a real bug on attached
+  generation temp views' shadowed names ("views may not be indexed") — the
+  constraint test_cascade_migration_survives_attached_generation_temp_views
+  pins.
+- **Progress writes debounced to ~1/s** via the daemon's progress sink;
+  heartbeat every 20 s; stale-heartbeat recovery at 5 min; legacy
+  pre-heartbeat rows keep the 6 h window.
+- **Cancel**: queued → `cancelled` instantly; running → `cancel_requested`
+  flag honored by the heartbeat loop, which marks the row `cancelled` and
+  (in daemon mode) exits the process — matching today's kill semantics for
+  a long build.
+- **Differential harness moved**: task-mode comparison went from invocation
+  stdout (which is now a queued marker) to the completed job's durable
+  summary + sidecar state, via the shared worker runner in
+  `tests/core/worker.py` (enqueue → daemon → poll `get_job_status`).
+- `health`/`get_job_status` re-keyed to worker-owned rows with matching
+  Python parity (`backend.py` stays the inline oracle; `cancel_job` added on
+  both sides).
+
+## 9. Remaining for Phase 2
+
+- `scheduled_task` table + scheduler loop in the daemon; `update-model`
+  wake-up gated by `ModelUpdateCoordinator.ready()`; `sync-plays`,
+  `sync-build`, `backup` schedules; yml `schedule*` settings.
+- Phase 3 UX: task-indicator queued state + Cancel buttons; schedule config
+  in the #151 Settings panel.

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -554,44 +554,16 @@ def _open(  # type: ignore[no-untyped-def]
 def _health(payload: dict[str, Any]) -> dict[str, object]:
     settings = _settings(payload)
     stash = _client(payload).execute(RUNTIME_QUERY)
-    task_names = {
-        "Sync and build recommendations",
-        "Full sync and build recommendations",
-        "Rebuild recommendation model",
-        "Apply recent Curator feedback",
-        "Prepare recommendation pages",
-        "Sync recent plays",
-        "Backup Curator data",
-        "Compact legacy Curator data",
-        "Vacuum compacted Curator data",
-        "Refresh Expand cache",
-        "Install optional dependencies",
-    }
-    active_jobs = [
-        job
-        for job in (stash.get("jobQueue") or [])
-        if any(name in str(job.get("description") or "") for name in task_names)
-        and str(job.get("status") or "").casefold() in {"waiting", "running"}
-    ]
-    active_job = active_jobs[0] if active_jobs else None
     connection = _open(payload, settings)
     try:
         now_ms = time.time_ns() // 1_000_000
-        if active_job is None:
-            interrupted = connection.execute(
-                "SELECT 1 FROM curator_job WHERE state='running' AND started_at_ms<? LIMIT 1",
-                (now_ms - 120_000,),
-            ).fetchone()
-            if interrupted:
-                with transaction(connection):
-                    connection.execute(
-                        """
-                    UPDATE curator_job SET state='failed', finished_at_ms=?,
-                        error='interrupted before task completion'
-                    WHERE state='running' AND started_at_ms<?
-                    """,
-                        (now_ms, now_ms - 120_000),
-                    )
+        # Worker-owned liveness: fail running rows whose executing process is
+        # gone (heartbeat stale or legacy pre-heartbeat age), replacing the
+        # old Stash-job-list + 120s heuristic that no longer applies once
+        # tasks run in the detached worker instead of a live Stash job.
+        _recover_orphan_jobs(connection, now_ms)
+        active_jobs = _active_curator_jobs(connection)
+        active_job = active_jobs[0] if active_jobs else None
         migration = MigrationRunner(connection).status()
         current = connection.execute(
             "SELECT model_id FROM model_version WHERE status='published'"
@@ -659,7 +631,7 @@ def _health(payload: dict[str, Any]) -> dict[str, object]:
         "model_pending": model_update.pending,
         "model_pending_events": model_update.pending_count,
         "model_update_ready": model_update_ready,
-        "model_rebuilding": model_rebuilding is not None and active_job is not None,
+        "model_rebuilding": model_rebuilding is not None,
         "active_job": active_job,
         "active_jobs": active_jobs,
         "last_sync_at_ms": int(last_sync[0]) if last_sync else None,
@@ -1009,6 +981,8 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
             return api.update_config(values)
         if operation == "get_job_status":
             return _job_status(connection)
+        if operation == "cancel_job":
+            return _cancel_job(connection, args)
         if operation == "get_diagnostics":
             return _diagnostics(connection)
         if operation == "list_profiles":
@@ -1074,6 +1048,8 @@ def _job_status(connection: Any) -> dict[str, object]:
             "finished_at_ms": int(row["finished_at_ms"]) if row["finished_at_ms"] else None,
             "summary": json.loads(row["summary_json"]),
             "error": str(row["error"]) if row["error"] else None,
+            "queued_at_ms": int(row["queued_at_ms"]) if row["queued_at_ms"] else None,
+            "progress": float(row["progress"]) if row["progress"] is not None else None,
         }
         for row in rows
     ]
@@ -1092,6 +1068,111 @@ DIAGNOSTIC_JOB_TYPES = {
     "vacuum",
     "expand-refresh",
 }
+
+# Task mode → yml display name, mirroring the Go side's taskDisplayNames so
+# health synthesizes the Stash-style job description the frontend consumes.
+TASK_DISPLAY_NAMES = {
+    "sync-build": "Sync and build recommendations",
+    "full-sync-build": "Full sync and build recommendations",
+    "build": "Rebuild recommendation model",
+    "update-model": "Apply recent Curator feedback",
+    "sync-plays": "Sync recent plays",
+    "prepare": "Prepare recommendation pages",
+    "backup": "Backup Curator data",
+    "compact": "Compact legacy Curator data",
+    "vacuum": "Vacuum compacted Curator data",
+    "expand-refresh": "Refresh Expand cache",
+}
+
+
+def _recover_orphan_jobs(connection: Any, now_ms: int) -> None:
+    """Fail running rows whose executing process is gone: heartbeat stale (a
+    daemon or inline runner died) or, for pre-heartbeat rows, older than the
+    legacy 6h stale window. Mirrors the Go worker's recoverOrphanJobs."""
+    with transaction(connection):
+        connection.execute(
+            """
+            UPDATE curator_job SET state='failed', finished_at_ms=?, error='interrupted'
+            WHERE state='running' AND heartbeat_at_ms IS NOT NULL AND heartbeat_at_ms<=?
+            """,
+            (now_ms, now_ms - 5 * 60_000),
+        )
+        connection.execute(
+            """
+            UPDATE curator_job SET state='failed', finished_at_ms=?, error='interrupted'
+            WHERE state='running' AND heartbeat_at_ms IS NULL AND started_at_ms<=?
+            """,
+            (now_ms, now_ms - 6 * 3_600_000),
+        )
+        connection.execute(
+            """
+            UPDATE model_update_state SET last_error='interrupted before task completion'
+            WHERE last_started_at_ms IS NOT NULL
+            AND last_started_at_ms>COALESCE(last_finished_at_ms, -1)
+            AND last_error IS NULL
+            """
+        )
+
+
+def _active_curator_jobs(connection: Any) -> list[dict[str, object]]:
+    """Queued + running curator_job rows in the Stash job shape the frontend
+    task indicator consumes ({id, description, progress})."""
+    rows = connection.execute(
+        "SELECT job_id, job_type, progress FROM curator_job "
+        "WHERE state IN ('queued', 'running') ORDER BY started_at_ms DESC LIMIT 10"
+    )
+    return [
+        {
+            "id": str(row["job_id"]),
+            "description": "Running plugin task: "
+            + str(TASK_DISPLAY_NAMES.get(str(row["job_type"]), row["job_type"])),
+            "progress": float(row["progress"]) if row["progress"] is not None else None,
+        }
+        for row in rows
+    ]
+
+
+def _cancel_job(connection: Any, args: dict[str, Any]) -> dict[str, object]:
+    job_id = str(args.get("job_id") or "")
+    if not job_id:
+        raise ValueError("job_id is required")
+    now_ms = time.time_ns() // 1_000_000
+    cursor = connection.execute(
+        """
+        UPDATE curator_job SET state='cancelled', finished_at_ms=?
+        WHERE job_id=? AND state='queued'
+        """,
+        (now_ms, job_id),
+    )
+    if cursor.rowcount > 0:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "job_id": job_id,
+            "cancelled": True,
+            "state": "cancelled",
+        }
+    cursor = connection.execute(
+        """
+        UPDATE curator_job SET cancel_requested=1
+        WHERE job_id=? AND state='running'
+        """,
+        (job_id,),
+    )
+    if cursor.rowcount > 0:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "job_id": job_id,
+            "cancelled": True,
+            "state": "running",
+            "cancel_requested": True,
+        }
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "job_id": job_id,
+        "cancelled": False,
+        "error": "no active job with that id",
+    }
+
 
 # Stash entity hooks that trigger a targeted one-entity sync. Tag merges are left to the
 # next regular sync: a merge re-links many scenes that a single tag upsert cannot refresh.

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -3716,6 +3716,7 @@
   }
 
   function CuratorControls({ onRefresh, theme, onToggleTheme, cardSize, onChangeCardSize }) {
+    const routeLocation = useLocation();
     const [jobs, setJobs] = React.useState([]);
     const [health, setHealth] = React.useState(null);
     const [message, setMessage] = React.useState("");

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -137,6 +137,13 @@
       maintenance: true,
       description: "Sync, discovery, prune, and Whisparr integration settings, without leaving Curator.",
     },
+    {
+      value: "tasks",
+      label: "Tasks",
+      icon: faList,
+      maintenance: true,
+      description: "Live status of background Curator jobs: queue position, progress, and results.",
+    },
   ];
   const PRIMARY_NAV_ITEMS = NAV_ITEMS.filter((item) => !item.maintenance);
   const MAINTENANCE_ITEMS = NAV_ITEMS.filter((item) => item.maintenance);
@@ -3050,8 +3057,8 @@
         return;
       }
       try {
-        const id = await runTask("Refresh Expand cache");
-        setMessage(`Started Stash job ${id}. Progress is available in Tasks.`);
+        await runTask("Refresh Expand cache");
+        setMessage("Expand refresh started — progress and results appear in Manage → Tasks.");
       } catch (failure) { setError(failure.message); }
     }
     function selectHuntPerformer(values) {
@@ -3604,7 +3611,7 @@
   // at 100% ("Done") until it ages out (issue #110: the final 1.0 marker
   // leaves Stash's queue before the 5 s poll can catch it, so the bar used
   // to freeze at the last sub-100% value and then revert to idle).
-  function CuratorTaskIndicator({ activeJobs, activities, failure, doneJob }) {
+  function CuratorTaskIndicator({ activeJobs, activities, failure, doneJob, tasksHref }) {
     const running = activeJobs.length > 0 || activities.length > 0;
     const doneTask = !running && doneJob
       ? { key: `done-${doneJob.job_id}`, label: taskModeLabel(doneJob), progress: 1, stage: "Done" }
@@ -3633,7 +3640,7 @@
           : "Curator is idle";
     return React.createElement(
       NavLink,
-      { className: `curator-task-indicator curator-task-indicator-${state}`, to: "/settings?tab=tasks", title: `${label}. Open Tasks`, "aria-label": `${label}. Open Tasks` },
+      { className: `curator-task-indicator curator-task-indicator-${state}`, to: tasksHref, title: `${label}. Open Tasks`, "aria-label": `${label}. Open Tasks` },
       React.createElement(
         "span",
         { className: "curator-task-progress", "aria-hidden": "true" },
@@ -3649,6 +3656,61 @@
           React.createElement("span", { className: "curator-task-progress-fill", style: (running || doneTask) && progress !== null ? { width: `${Math.round(progress * 100)}%` } : undefined })
         ),
         showTaskDetails && React.createElement("span", { className: "curator-task-progress-detail" }, running ? primary?.stage : doneTask ? "Done" : failure.error || "Open Tasks for details")
+      )
+    );
+  }
+
+  // TasksPanel lists the worker-owned curator_job rows (decision 004): the
+  // real status surface for background tasks, since Stash's own Tasks tab
+  // only ever sees the instant enqueue jobs now.
+  function TasksPanel() {
+    const [jobs, setJobs] = React.useState([]);
+    const [error, setError] = React.useState("");
+    function refresh() {
+      operation({ operation: "get_job_status" }).then(
+        (result) => { setError(""); setJobs(result.jobs || []); },
+        (failure) => setError(failure.message)
+      );
+    }
+    React.useEffect(() => {
+      refresh();
+      const timer = setInterval(refresh, 5000);
+      return () => clearInterval(timer);
+    }, []);
+    return React.createElement(
+      "div",
+      { className: "curator-tasks-panel" },
+      error && React.createElement("div", { className: "alert alert-danger" }, error),
+      React.createElement("p", null, "Tasks run in Curator's own background worker, so they keep going even after the Stash-side job completes — progress and results are shown here."),
+      jobs.length === 0 && !error && React.createElement("p", { role: "status" }, "No tasks yet."),
+      React.createElement(
+        "ul",
+        { className: "curator-tasks-list" },
+        jobs.map((job) => {
+          const label = TASK_MODE_LABELS[job.job_type] || job.job_type;
+          const pct = typeof job.progress === "number" ? Math.max(0, Math.min(job.progress, 1)) : null;
+          return React.createElement(
+            "li",
+            { key: job.job_id, className: `curator-task curator-task-${job.state}` },
+            React.createElement(
+              "div",
+              { className: "curator-task-head" },
+              React.createElement("strong", null, label),
+              React.createElement("span", { className: "curator-task-state" }, job.state)
+            ),
+            React.createElement(
+              "div",
+              { className: "curator-task-progress-track" },
+              React.createElement("span", { className: "curator-task-progress-fill", style: pct !== null ? { width: `${Math.round(pct * 100)}%` } : undefined })
+            ),
+            React.createElement(
+              "div",
+              { className: "curator-task-meta" },
+              pct !== null ? `${Math.round(pct * 100)}%` : job.state === "running" ? "Working" : job.state,
+              job.error && React.createElement("span", { className: "curator-task-error" }, job.error)
+            )
+          );
+        })
       )
     );
   }
@@ -3691,8 +3753,8 @@
 
     async function start(taskName) {
       try {
-        const id = await runTask(taskName);
-        setMessage(`Started Stash job ${id}`);
+        await runTask(taskName);
+        setMessage("Task started — progress and results appear in Manage → Tasks.");
         setTimeout(refreshStatus, 1000);
       } catch (error) {
         setMessage(error.message);
@@ -3801,7 +3863,7 @@
               "div",
               { className: "curator-health-panel", role: "status" },
               React.createElement("div", { className: "curator-health-row" }, React.createElement("span", null, "Sync"), React.createElement("b", null, running ? `Running ${running.job_type}` : hasSynced ? "Synced" : "Not synced")),
-              React.createElement(CuratorTaskIndicator, { activeJobs, activities, failure: latestFailure, doneJob }),
+              React.createElement(CuratorTaskIndicator, { activeJobs, activities, failure: latestFailure, doneJob, tasksHref: `${routeLocation.pathname}?view=manage&section=tasks` }),
               React.createElement("div", { className: "curator-health-row" }, React.createElement("span", null, "Model"), React.createElement("b", null, health?.model_pending ? `${health.model_pending_events} waiting` : modelStatus)),
               React.createElement("div", { className: "curator-health-row" }, React.createElement("span", null, "Playback sessions captured"), React.createElement("b", null, health?.capture?.direct_playback_sessions || 0)),
               health?.last_sync_at_ms && React.createElement("div", { className: "curator-health-row" }, React.createElement("span", null, "Last sync"), React.createElement("b", null, new Date(health.last_sync_at_ms).toLocaleString()))
@@ -4169,6 +4231,7 @@
     prune: () => React.createElement(PrunePanel),
     profiling: () => React.createElement(ProfilingPanel),
     settings: (extra) => React.createElement(SettingsPanel, extra),
+    tasks: () => React.createElement(TasksPanel),
   };
 
   function ManagePanel({ section, onSelectSection, diversityEnabled, diversitySaving, onToggleDiversity }) {

--- a/tests/core/test_backend.py
+++ b/tests/core/test_backend.py
@@ -20,6 +20,7 @@ import shutil
 import sqlite3
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -39,6 +40,7 @@ from curator.storage.artifacts import (
     create_artifact,
     publish_file,
 )
+from tests.core.worker import run_go_task_via_worker, stop_worker
 
 REPO_ROOT = Path(__file__).parents[2]
 PLUGIN_DIR = REPO_ROOT / "plugin"
@@ -389,7 +391,7 @@ def test_migration_parity_python_accepts_go(tmp_path: Path, binary: Path) -> Non
         integrity = connection.execute("PRAGMA integrity_check").fetchone()[0]
     finally:
         connection.close()
-    assert status.current_version == status.latest_version == 30
+    assert status.current_version == status.latest_version == 31
     assert not status.pending_versions
     assert integrity == "ok"
 
@@ -581,16 +583,21 @@ def test_fallback_entity_hook(tmp_path: Path, binary: Path, stub_stash: str) -> 
 
 
 def test_fallback_task_mode(tmp_path: Path, binary: Path, stub_stash: str) -> None:
-    """Task modes are unported; prepare on a model-less sidecar fails with the
-    same deterministic error through the fallback."""
+    """prepare on a model-less sidecar fails with the same deterministic
+    error through the worker's failed job (the invocation queues, the daemon
+    runs the mode body, and the row records the Python-identical error)."""
     sidecar = tmp_path / "sidecar.sqlite3"
     make_sidecar(sidecar, with_jobs=False)
-    raw = payload("prepare", sidecar, stub_stash)
-    direct = run_backend(None, PLUGIN_DIR, raw, mode="prepare")
-    fallback = run_backend(binary, PLUGIN_DIR, raw, mode="prepare")
-    assert fallback.stdout == direct.stdout
-    assert fallback.returncode == direct.returncode == 1
-    assert json.loads(fallback.stdout)["error"] == "no published model; build recommendations first"
+    direct = run_backend(None, PLUGIN_DIR, payload("prepare", sidecar, stub_stash), mode="prepare")
+    assert direct.returncode == 1
+    worker_dir = Path(tempfile.mkdtemp(prefix="curator-worker-"))
+    try:
+        row = run_go_task_via_worker(binary, worker_dir, sidecar, "prepare", stub_stash)
+    finally:
+        stop_worker(worker_dir)
+        shutil.rmtree(worker_dir, ignore_errors=True)
+    assert row["state"] == "failed", row
+    assert row["error"] == json.loads(direct.stdout)["error"]
 
 
 # ── wire shape ──────────────────────────────────────────────────────────────

--- a/tests/core/test_backend_slice3_backups.py
+++ b/tests/core/test_backend_slice3_backups.py
@@ -21,6 +21,7 @@ import re
 import shutil
 import sqlite3
 import subprocess
+import tempfile
 import threading
 from http.server import HTTPServer
 from pathlib import Path
@@ -39,6 +40,7 @@ from tests.core.test_backend import (
     payload,
     run_backend,
 )
+from tests.core.worker import run_go_task_via_worker, stop_worker
 
 REPO_ROOT = Path(__file__).parents[2]
 BACKEND = PLUGIN_DIR / "backend.py"
@@ -569,24 +571,15 @@ def test_backup_task_mirrors_derived_artifacts(
     shutil.copy2(derived_backup_sidecar, run_db)
     derived_src = derived_backup_sidecar.parent / f"{derived_backup_sidecar.stem}-derived"
     shutil.copytree(derived_src, run_dir / f"{run_db.stem}-derived")
-    raw = json.dumps(
-        {
-            "server_connection": {
-                "Host": "127.0.0.1",
-                "Port": int(stub_stash.rsplit(":", 1)[1]),
-                "Scheme": "http",
-                "SessionCookie": {},
-            },
-            "args": {"database_path": str(run_db)},
-        },
-        separators=(",", ":"),
-    ).encode()
+    worker_dir = Path(tempfile.mkdtemp(prefix="curator-worker-"))
     _StubStash.plugin_settings = {"backupPath": str(storage)}
     try:
-        result = run_backend(binary, PLUGIN_DIR, raw, "backup")
+        row = run_go_task_via_worker(binary, worker_dir, run_db, "backup", stub_stash)
+        assert row["state"] == "complete", row
     finally:
         _StubStash.plugin_settings = {}
-    assert result.returncode == 0, result.stdout + result.stderr
+        stop_worker(worker_dir)
+        shutil.rmtree(worker_dir, ignore_errors=True)
     assert len(list(storage.glob("curator-*.sqlite3.backup"))) == 1
     assert sorted(p.name for p in (storage / "derived").iterdir()) == [
         "feature-fv-aaaaaaaaaaaaaaaaaaaa.sqlite3",

--- a/tests/core/test_backend_slice3_refresh.py
+++ b/tests/core/test_backend_slice3_refresh.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import sqlite3
 import subprocess
+import tempfile
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -36,6 +37,7 @@ from tests.core.test_backend_slice2 import (
     _cast,
     make_expand_sidecar,
 )
+from tests.core.worker import run_go_task_via_worker, stop_worker
 
 FRESH_SCENES = [
     {
@@ -244,46 +246,61 @@ def assert_refresh_identical(
     stash_url: str,
     *,
     normalize: tuple[str, ...] = ("job_id",),
-) -> tuple[subprocess.CompletedProcess[bytes], subprocess.CompletedProcess[bytes]]:
+) -> None:
     run_dir = sidecar.parent / f"{sidecar.stem}-refresh-run"
-    run_db = run_dir / sidecar.name
-    outputs: list[subprocess.CompletedProcess[bytes]] = []
-    for runner in (None, binary):
-        shutil.rmtree(run_dir, ignore_errors=True)
-        run_dir.mkdir()
-        shutil.copy2(sidecar, run_db)
-        derived_src = sidecar.parent / f"{sidecar.stem}-derived"
-        if derived_src.is_dir():
-            shutil.copytree(derived_src, run_dir / f"{run_db.stem}-derived")
-        try:
-            result = _run_refresh_backend(
-                runner, PLUGIN_DIR, _with_db(_task_payload(sidecar, stash_url), run_db), stash_url
-            )
-        finally:
+    worker_dir = Path(tempfile.mkdtemp(prefix="curator-worker-"))
+    env = dict(os.environ)
+    env["CURATOR_STASHDB_ENDPOINT"] = stash_url
+    python_result: subprocess.CompletedProcess[bytes] | None = None
+    go_row: dict[str, object] | None = None
+    try:
+        for runner in (None, binary):
             shutil.rmtree(run_dir, ignore_errors=True)
-        outputs.append(result)
-    python_result, go_result = outputs
-    assert go_result.returncode == python_result.returncode, (
-        python_result.stdout + python_result.stderr + go_result.stdout + go_result.stderr
-    )
+            run_dir.mkdir()
+            run_db = run_dir / sidecar.name
+            shutil.copy2(sidecar, run_db)
+            derived_src = sidecar.parent / f"{sidecar.stem}-derived"
+            if derived_src.is_dir():
+                shutil.copytree(derived_src, run_dir / f"{run_db.stem}-derived")
+            if runner is None:
+                python_result = _run_refresh_backend(
+                    runner,
+                    PLUGIN_DIR,
+                    _with_db(_task_payload(sidecar, stash_url), run_db),
+                    stash_url,
+                )
+            else:
+                go_row = run_go_task_via_worker(
+                    binary, worker_dir, run_db, "expand-refresh", stash_url, env=env
+                )
+    finally:
+        stop_worker(worker_dir)
+        shutil.rmtree(run_dir, ignore_errors=True)
+        shutil.rmtree(worker_dir, ignore_errors=True)
+    assert python_result is not None and go_row is not None
     py_out = json.loads(python_result.stdout)
-    go_out = json.loads(go_result.stdout)
     if python_result.returncode != 0:
-        assert_equivalent(py_out, go_out)
-        return outputs
-    a, b = py_out["output"], go_out["output"]
-    for field in normalize:
+        assert go_row["state"] == "failed", go_row
+        (
+            assert_equivalent(json.loads(python_result.stdout)["error"], go_row["error"]),
+            "task errors differ",
+        )
+        return
+    assert go_row["state"] == "complete", go_row
+    a = py_out["output"]
+    for field in ("job_id", "schema_version", *normalize):
         _strip_key(a, field)
+    b = dict(go_row["summary"] or {})
+    for field in ("job_id", *normalize):
         _strip_key(b, field)
     (
         assert_equivalent(a, b),
         (
-            "outputs differ:\n"
+            "job summaries differ:\n"
             f"python: {json.dumps(a, separators=(',', ':'))}\n"
             f"go:     {json.dumps(b, separators=(',', ':'))}"
         ),
     )
-    return outputs
 
 
 def test_expand_refresh_byte_identical(
@@ -298,39 +315,51 @@ def test_expand_refresh_state_parity(refresh_sidecar: Path, binary: Path, stub_s
     out, and the pool rescored against the published model."""
 
     run_dir = refresh_sidecar.parent / f"{refresh_sidecar.stem}-refresh-state"
+    worker_dir = Path(tempfile.mkdtemp(prefix="curator-worker-"))
+    env = dict(os.environ)
+    env["CURATOR_STASHDB_ENDPOINT"] = stub_stash
     states: list[dict[str, object]] = []
-    for runner in (None, binary):
-        shutil.rmtree(run_dir, ignore_errors=True)
-        run_dir.mkdir()
-        run_db = run_dir / refresh_sidecar.name
-        shutil.copy2(refresh_sidecar, run_db)
-        derived_src = refresh_sidecar.parent / f"{refresh_sidecar.stem}-derived"
-        shutil.copytree(derived_src, run_dir / f"{run_db.stem}-derived")
-        result = _run_refresh_backend(
-            runner,
-            PLUGIN_DIR,
-            _with_db(_task_payload(refresh_sidecar, stub_stash), run_db),
-            stub_stash,
-        )
-        assert result.returncode == 0, result.stdout + result.stderr
-        connection = sqlite3.connect(run_db)
-        try:
-            states.append(
-                {
-                    "external_entity": connection.execute(
-                        "SELECT entity_type, external_id, score, sources_json, pool"
-                        " FROM external_entity ORDER BY entity_type, external_id"
-                    ).fetchall(),
-                    "expand_cache": connection.execute(
-                        "SELECT model_id, scene_count, performer_count FROM expand_cache"
-                    ).fetchone(),
-                    "job": connection.execute(
-                        "SELECT job_type, state FROM curator_job"
-                        " ORDER BY started_at_ms DESC LIMIT 1"
-                    ).fetchone(),
-                }
-            )
-        finally:
-            connection.close()
-        shutil.rmtree(run_dir, ignore_errors=True)
+    try:
+        for runner in (None, binary):
+            shutil.rmtree(run_dir, ignore_errors=True)
+            run_dir.mkdir()
+            run_db = run_dir / refresh_sidecar.name
+            shutil.copy2(refresh_sidecar, run_db)
+            derived_src = refresh_sidecar.parent / f"{refresh_sidecar.stem}-derived"
+            shutil.copytree(derived_src, run_dir / f"{run_db.stem}-derived")
+            if runner is None:
+                result = _run_refresh_backend(
+                    runner,
+                    PLUGIN_DIR,
+                    _with_db(_task_payload(refresh_sidecar, stub_stash), run_db),
+                    stub_stash,
+                )
+                assert result.returncode == 0, result.stdout + result.stderr
+            else:
+                run_go_task_via_worker(
+                    binary, worker_dir, run_db, "expand-refresh", stub_stash, env=env
+                )
+            connection = sqlite3.connect(run_db)
+            try:
+                states.append(
+                    {
+                        "external_entity": connection.execute(
+                            "SELECT entity_type, external_id, score, sources_json, pool"
+                            " FROM external_entity ORDER BY entity_type, external_id"
+                        ).fetchall(),
+                        "expand_cache": connection.execute(
+                            "SELECT model_id, scene_count, performer_count FROM expand_cache"
+                        ).fetchone(),
+                        "job": connection.execute(
+                            "SELECT job_type, state FROM curator_job"
+                            " ORDER BY started_at_ms DESC LIMIT 1"
+                        ).fetchone(),
+                    }
+                )
+            finally:
+                connection.close()
+            shutil.rmtree(run_dir, ignore_errors=True)
+    finally:
+        stop_worker(worker_dir)
+        shutil.rmtree(worker_dir, ignore_errors=True)
     assert_equivalent(states[0], states[1])

--- a/tests/core/test_backend_slice3_sync.py
+++ b/tests/core/test_backend_slice3_sync.py
@@ -16,6 +16,7 @@ import json
 import shutil
 import sqlite3
 import subprocess
+import tempfile
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -25,6 +26,7 @@ import pytest
 from curator.core import core_binary
 from tests.core.test_backend import PLUGIN_DIR
 from tests.core.test_backend_slice3_featurebuild import make_feature_sidecar
+from tests.core.worker import run_go_task_via_worker, stop_worker
 
 
 def _tag(tag_id: str, name: str) -> dict[str, object]:
@@ -316,21 +318,30 @@ def _run_sync_both(
     sidecar: Path,
     stash_url: str,
     mode: str,
-) -> list[subprocess.CompletedProcess[bytes]]:
+) -> tuple[subprocess.CompletedProcess[bytes], dict[str, object]]:
+    """Python inline result + the Go worker's completed job row."""
     run_dir = sidecar.parent / f"{sidecar.stem}-sync-run"
-    run_db = run_dir / sidecar.name
-    outputs: list[subprocess.CompletedProcess[bytes]] = []
-    for runner in (None, binary):
-        shutil.rmtree(run_dir, ignore_errors=True)
-        run_dir.mkdir()
-        shutil.copy2(sidecar, run_db)
-        try:
-            outputs.append(
-                _run_backend(runner, _with_db(_task_payload(sidecar, stash_url), run_db), mode)
-            )
-        finally:
+    worker_dir = Path(tempfile.mkdtemp(prefix="curator-worker-"))
+    python_result: subprocess.CompletedProcess[bytes] | None = None
+    go_row: dict[str, object] | None = None
+    try:
+        for runner in (None, binary):
             shutil.rmtree(run_dir, ignore_errors=True)
-    return outputs
+            run_dir.mkdir()
+            run_db = run_dir / sidecar.name
+            shutil.copy2(sidecar, run_db)
+            if runner is None:
+                python_result = _run_backend(
+                    runner, _with_db(_task_payload(sidecar, stash_url), run_db), mode
+                )
+            else:
+                go_row = run_go_task_via_worker(binary, worker_dir, run_db, mode, stash_url)
+    finally:
+        stop_worker(worker_dir)
+        shutil.rmtree(run_dir, ignore_errors=True)
+        shutil.rmtree(worker_dir, ignore_errors=True)
+    assert python_result is not None and go_row is not None
+    return python_result, go_row
 
 
 def _run_backend(runner: Path | None, raw: bytes, mode: str) -> subprocess.CompletedProcess[bytes]:
@@ -371,17 +382,17 @@ STAGE_TIMING_KEYS = (
 
 
 def test_sync_build_byte_identical(sync_sidecar: Path, binary: Path, stub_stash: str) -> None:
-    python_result, go_result = _run_sync_both(binary, sync_sidecar, stub_stash, "sync-build")
-    assert go_result.returncode == python_result.returncode, (
-        python_result.stdout + python_result.stderr + go_result.stdout + go_result.stderr
-    )
+    python_result, go_row = _run_sync_both(binary, sync_sidecar, stub_stash, "sync-build")
+    assert python_result.returncode == 0, python_result.stdout + python_result.stderr
+    assert go_row["state"] == "complete", go_row
     py_out = json.loads(python_result.stdout)
-    go_out = json.loads(go_result.stdout)
+    go_out = {"output": dict(go_row["summary"] or {})}
     for doc in (py_out, go_out):
         output = doc.get("output", {})
         # peak_rss_kb is a Go-build-only field (issue #124 memory capture);
-        # the Python backend does not emit it.
-        for key in ("job_id", "sync_run_id", "stage_timings_ms", "peak_rss_kb"):
+        # the Python backend does not emit it. schema_version is a transport
+        # field on the inline response, absent from the durable summary.
+        for key in ("job_id", "schema_version", "sync_run_id", "stage_timings_ms", "peak_rss_kb"):
             output.pop(key, None)
     from tests.core.compare import assert_equivalent
 
@@ -392,36 +403,45 @@ def test_sync_build_state_parity(sync_sidecar: Path, binary: Path, stub_stash: s
     """The sync-build leaves identical published-model state on both
     backends: one published model with the same artifact tables."""
     run_dir = sync_sidecar.parent / f"{sync_sidecar.stem}-sync-state"
+    worker_dir = Path(tempfile.mkdtemp(prefix="curator-worker-"))
     states: list[dict[str, object]] = []
     artifact_diffs: list[str] = []
-    for runner in (None, binary):
-        shutil.rmtree(run_dir, ignore_errors=True)
-        run_dir.mkdir()
-        run_db = run_dir / sync_sidecar.name
-        shutil.copy2(sync_sidecar, run_db)
-        result = _run_backend(
-            None if runner is None else runner,
-            _with_db(_task_payload(sync_sidecar, stub_stash), run_db),
-            "sync-build",
-        )
-        assert result.returncode == 0, result.stdout + result.stderr
-        connection = sqlite3.connect(run_db)
-        try:
-            model_id = connection.execute(
-                "SELECT model_id FROM model_version WHERE status='published'"
-            ).fetchone()
-            job = connection.execute(
-                "SELECT job_type, state FROM curator_job ORDER BY started_at_ms DESC LIMIT 1"
-            ).fetchone()
-        finally:
-            connection.close()
-        assert model_id is not None
-        artifact = run_dir / f"{run_db.stem}-derived" / f"{model_id[0]}.sqlite3"
-        states.append({"model_id": model_id[0], "job": job})
-        from tests.core.compare import artifact_tolerant_diff
+    try:
+        for runner in (None, binary):
+            shutil.rmtree(run_dir, ignore_errors=True)
+            run_dir.mkdir()
+            run_db = run_dir / sync_sidecar.name
+            shutil.copy2(sync_sidecar, run_db)
+            if runner is None:
+                result = _run_backend(
+                    None,
+                    _with_db(_task_payload(sync_sidecar, stub_stash), run_db),
+                    "sync-build",
+                )
+                assert result.returncode == 0, result.stdout + result.stderr
+            else:
+                row = run_go_task_via_worker(binary, worker_dir, run_db, "sync-build", stub_stash)
+                assert row["state"] == "complete", row
+            connection = sqlite3.connect(run_db)
+            try:
+                model_id = connection.execute(
+                    "SELECT model_id FROM model_version WHERE status='published'"
+                ).fetchone()
+                job = connection.execute(
+                    "SELECT job_type, state FROM curator_job ORDER BY started_at_ms DESC LIMIT 1"
+                ).fetchone()
+            finally:
+                connection.close()
+            assert model_id is not None
+            artifact = run_dir / f"{run_db.stem}-derived" / f"{model_id[0]}.sqlite3"
+            states.append({"model_id": model_id[0], "job": job})
+            from tests.core.compare import artifact_tolerant_diff
 
-        artifact_diffs.append(artifact_tolerant_diff(artifact, artifact))
-        shutil.rmtree(run_dir, ignore_errors=True)
+            artifact_diffs.append(artifact_tolerant_diff(artifact, artifact))
+            shutil.rmtree(run_dir, ignore_errors=True)
+    finally:
+        stop_worker(worker_dir)
+        shutil.rmtree(worker_dir, ignore_errors=True)
     assert states[0] == states[1]
     assert artifact_diffs == ["", ""]
 
@@ -429,22 +449,21 @@ def test_sync_build_state_parity(sync_sidecar: Path, binary: Path, stub_stash: s
 def test_go_build_task_stage_timings_and_peak_rss(
     sync_sidecar: Path, binary: Path, stub_stash: str
 ) -> None:
-    """The Go build task output carries the full 22-key Python-era
+    """The Go build task summary carries the full 22-key Python-era
     stage_timings_ms set (issue #124) and the final peak RSS."""
     run_dir = sync_sidecar.parent / f"{sync_sidecar.stem}-stage-keys"
+    worker_dir = Path(tempfile.mkdtemp(prefix="curator-worker-"))
     run_dir.mkdir()
     run_db = run_dir / sync_sidecar.name
     shutil.copy2(sync_sidecar, run_db)
     try:
-        result = _run_backend(
-            binary,
-            _with_db(_task_payload(sync_sidecar, stub_stash), run_db),
-            "sync-build",
-        )
-        assert result.returncode == 0, result.stdout + result.stderr
-        output = json.loads(result.stdout).get("output", {})
-        assert set(output.get("stage_timings_ms", {})) == set(STAGE_TIMING_KEYS)
-        assert output["stage_timings_ms"]["total"] > 0
-        assert output["peak_rss_kb"] > 0
+        row = run_go_task_via_worker(binary, worker_dir, run_db, "sync-build", stub_stash)
+        assert row["state"] == "complete", row
+        summary = dict(row["summary"] or {})
+        assert set(summary.get("stage_timings_ms", {})) == set(STAGE_TIMING_KEYS)
+        assert summary["stage_timings_ms"]["total"] > 0
+        assert summary["peak_rss_kb"] > 0
     finally:
+        stop_worker(worker_dir)
         shutil.rmtree(run_dir, ignore_errors=True)
+        shutil.rmtree(worker_dir, ignore_errors=True)

--- a/tests/core/test_backend_slice3_tasks.py
+++ b/tests/core/test_backend_slice3_tasks.py
@@ -14,6 +14,7 @@ import json
 import shutil
 import sqlite3
 import subprocess
+import tempfile
 import threading
 import time
 from http.server import HTTPServer
@@ -31,6 +32,7 @@ from tests.core.test_backend import (
     make_sidecar,
     run_backend,
 )
+from tests.core.worker import run_go_task_via_worker, stop_worker
 
 FEATURE_ID = "fv-" + "a" * 20
 MODEL_ID = "model-" + "b" * 20
@@ -217,50 +219,75 @@ def assert_task_identical(
     mode: str,
     *,
     normalize: tuple[str, ...] = (),
-) -> tuple[subprocess.CompletedProcess[bytes], subprocess.CompletedProcess[bytes]]:
+) -> None:
+    """Run the task through the Python backend inline and through the Go
+    backend's background worker (docs/decisions/004). The Go invocation
+    returns a queued marker, so the comparison moved from invocation stdout
+    to the completed job's durable summary — the same mode bodies, the same
+    sidecar effects."""
     run_dir = sidecar.parent / f"{sidecar.stem}-task-run"
-    run_db = run_dir / sidecar.name
-    outputs: list[subprocess.CompletedProcess[bytes]] = []
-    for runner in (None, binary):
-        shutil.rmtree(run_dir, ignore_errors=True)
-        run_dir.mkdir()
-        shutil.copy2(sidecar, run_db)
-        derived_src = sidecar.parent / f"{sidecar.stem}-derived"
-        if derived_src.is_dir():
-            shutil.copytree(derived_src, run_dir / f"{run_db.stem}-derived")
-        try:
-            outputs.append(
-                run_backend(
-                    runner,
-                    PLUGIN_DIR,
-                    _with_db(_task_payload(sidecar, "http://127.0.0.1:1"), run_db),
-                    mode,
-                )
-            )
-        finally:
+    worker_dir = Path(tempfile.mkdtemp(prefix="curator-worker-"))
+    python_result: subprocess.CompletedProcess[bytes] | None = None
+    go_row: dict[str, object] | None = None
+    try:
+        for runner in (None, binary):
             shutil.rmtree(run_dir, ignore_errors=True)
-    python_result, go_result = outputs
-    assert go_result.returncode == python_result.returncode, (
-        python_result.stdout + python_result.stderr + go_result.stdout + go_result.stderr
-    )
+            run_dir.mkdir()
+            run_db = run_dir / sidecar.name
+            shutil.copy2(sidecar, run_db)
+            derived_src = sidecar.parent / f"{sidecar.stem}-derived"
+            if derived_src.is_dir():
+                shutil.copytree(derived_src, run_dir / f"{run_db.stem}-derived")
+            if runner is None:
+                python_result = run_backend(
+                    runner, PLUGIN_DIR, _task_payload(run_db, "http://127.0.0.1:1"), mode
+                )
+            else:
+                go_row = run_go_task_via_worker(
+                    binary, worker_dir, run_db, mode, "http://127.0.0.1:1"
+                )
+    finally:
+        stop_worker(worker_dir)
+        shutil.rmtree(run_dir, ignore_errors=True)
+        shutil.rmtree(worker_dir, ignore_errors=True)
+    assert python_result is not None and go_row is not None
     py_out = json.loads(python_result.stdout)
-    go_out = json.loads(go_result.stdout)
-    if python_result.returncode != 0:
-        assert_equivalent(py_out, go_out)
-        return outputs
-    a, b = py_out["output"], go_out["output"]
-    for field in normalize:
-        _strip_key(a, field)
-        _strip_key(b, field)
-    (
-        assert_equivalent(a, b),
+    if go_row["state"] == "already_running":
+        a, b = py_out["output"], go_row["output"]
+        for field in (*normalize, "job_id"):
+            _strip_key(a, field)
+            _strip_key(b, field)
         (
-            "outputs differ:\n"
-            f"python: {json.dumps(a, separators=(',', ':'))}\n"
-            f"go:     {json.dumps(b, separators=(',', ':'))}"
+            assert_equivalent(a, b),
+            (
+                "already_running responses differ:\n"
+                f"python: {json.dumps(a, separators=(',', ':'))}\n"
+                f"go:     {json.dumps(b, separators=(',', ':'))}"
+            ),
+        )
+        return
+    if python_result.returncode != 0:
+        assert go_row["state"] == "failed", go_row
+        (
+            assert_equivalent(json.loads(python_result.stdout)["error"], go_row["error"]),
+            "task errors differ",
+        )
+        return
+    assert go_row["state"] == "complete", go_row
+    py_summary = py_out["output"]
+    for field in ("job_id", "schema_version", *normalize):
+        _strip_key(py_summary, field)
+    go_summary = dict(go_row["summary"] or {})
+    for field in ("job_id", *normalize):
+        _strip_key(go_summary, field)
+    (
+        assert_equivalent(py_summary, go_summary),
+        (
+            "job summaries differ:\n"
+            f"python: {json.dumps(py_summary, separators=(',', ':'))}\n"
+            f"go:     {json.dumps(go_summary, separators=(',', ':'))}"
         ),
     )
-    return outputs
 
 
 def test_compact_task_byte_identical(compact_sidecar: Path, binary: Path, stub_stash: str) -> None:
@@ -271,40 +298,45 @@ def test_compact_task_state_parity(compact_sidecar: Path, binary: Path, stub_sta
     """Compaction leaves identical derived-row counts, the same
     legacy_compaction blob, and a complete curator_job summary."""
     run_dir = compact_sidecar.parent / f"{compact_sidecar.stem}-compact-state"
+    worker_dir = Path(tempfile.mkdtemp(prefix="curator-worker-"))
     states: list[dict[str, object]] = []
-    for runner in (None, binary):
-        shutil.rmtree(run_dir, ignore_errors=True)
-        run_dir.mkdir()
-        run_db = run_dir / compact_sidecar.name
-        shutil.copy2(compact_sidecar, run_db)
-        derived_src = compact_sidecar.parent / f"{compact_sidecar.stem}-derived"
-        shutil.copytree(derived_src, run_dir / f"{run_db.stem}-derived")
-        result = run_backend(
-            runner,
-            PLUGIN_DIR,
-            _with_db(_task_payload(compact_sidecar, "http://127.0.0.1:1"), run_db),
-            "compact",
-        )
-        assert result.returncode == 0, result.stdout + result.stderr
-        connection = sqlite3.connect(run_db)
-        try:
-            states.append(
-                {
-                    "derived_remaining": connection.execute(
-                        "SELECT count(*) FROM model_scene_score WHERE model_id IN (?, ?)",
-                        (MODEL_ID, RETIRED_MODEL_ID),
-                    ).fetchone()[0],
-                    "compaction_blob": connection.execute(
-                        "SELECT value FROM application_meta WHERE key='legacy_compaction'"
-                    ).fetchone(),
-                    "job": connection.execute(
-                        "SELECT job_type, state, summary_json FROM curator_job ORDER BY started_at_ms DESC LIMIT 1"  # noqa: E501
-                    ).fetchone(),
-                }
-            )
-        finally:
-            connection.close()
-        shutil.rmtree(run_dir, ignore_errors=True)
+    try:
+        for runner in (None, binary):
+            shutil.rmtree(run_dir, ignore_errors=True)
+            run_dir.mkdir()
+            run_db = run_dir / compact_sidecar.name
+            shutil.copy2(compact_sidecar, run_db)
+            derived_src = compact_sidecar.parent / f"{compact_sidecar.stem}-derived"
+            shutil.copytree(derived_src, run_dir / f"{run_db.stem}-derived")
+            if runner is None:
+                result = run_backend(
+                    runner, PLUGIN_DIR, _task_payload(run_db, "http://127.0.0.1:1"), "compact"
+                )
+                assert result.returncode == 0, result.stdout + result.stderr
+            else:
+                run_go_task_via_worker(binary, worker_dir, run_db, "compact", "http://127.0.0.1:1")
+            connection = sqlite3.connect(run_db)
+            try:
+                states.append(
+                    {
+                        "derived_remaining": connection.execute(
+                            "SELECT count(*) FROM model_scene_score WHERE model_id IN (?, ?)",
+                            (MODEL_ID, RETIRED_MODEL_ID),
+                        ).fetchone()[0],
+                        "compaction_blob": connection.execute(
+                            "SELECT value FROM application_meta WHERE key='legacy_compaction'"
+                        ).fetchone(),
+                        "job": connection.execute(
+                            "SELECT job_type, state, summary_json FROM curator_job ORDER BY started_at_ms DESC LIMIT 1"  # noqa: E501
+                        ).fetchone(),
+                    }
+                )
+            finally:
+                connection.close()
+            shutil.rmtree(run_dir, ignore_errors=True)
+    finally:
+        stop_worker(worker_dir)
+        shutil.rmtree(worker_dir, ignore_errors=True)
     assert_equivalent(states[0], states[1])
 
 
@@ -357,48 +389,53 @@ def test_backup_task_file_parity(compact_sidecar: Path, binary: Path, stub_stash
     """The backup task produces a valid Curator backup of the same size on
     both backends."""
     run_dir = compact_sidecar.parent / f"{compact_sidecar.stem}-backup-task"
+    worker_dir = Path(tempfile.mkdtemp(prefix="curator-worker-"))
     sizes: list[int] = []
-    for runner in (None, binary):
-        shutil.rmtree(run_dir, ignore_errors=True)
-        run_dir.mkdir()
-        run_db = run_dir / compact_sidecar.name
-        shutil.copy2(compact_sidecar, run_db)
-        derived_src = compact_sidecar.parent / f"{compact_sidecar.stem}-derived"
-        shutil.copytree(derived_src, run_dir / f"{run_db.stem}-derived")
-        result = run_backend(
-            runner,
-            PLUGIN_DIR,
-            _with_db(_task_payload(compact_sidecar, "http://127.0.0.1:1"), run_db),
-            "backup",
-        )
-        assert result.returncode == 0, result.stdout + result.stderr
-        backups = sorted(run_dir.glob("curator-*.sqlite3.backup"))
-        assert len(backups) == 1
-        backup = backups[0]
-        connection = sqlite3.connect(backup)
-        connection.row_factory = sqlite3.Row
-        try:
-            assert connection.execute("PRAGMA quick_check").fetchone()[0] == "ok"
-            assert connection.execute(
-                "SELECT 1 FROM sqlite_master WHERE type='table' AND name='schema_migration'"
-            ).fetchone()
-            MigrationRunner(connection).status()
-        finally:
-            connection.close()
-        sizes.append(backup.stat().st_size)
-        shutil.rmtree(run_dir, ignore_errors=True)
+    try:
+        for runner in (None, binary):
+            shutil.rmtree(run_dir, ignore_errors=True)
+            run_dir.mkdir()
+            run_db = run_dir / compact_sidecar.name
+            shutil.copy2(compact_sidecar, run_db)
+            derived_src = compact_sidecar.parent / f"{compact_sidecar.stem}-derived"
+            shutil.copytree(derived_src, run_dir / f"{run_db.stem}-derived")
+            if runner is None:
+                result = run_backend(
+                    runner, PLUGIN_DIR, _task_payload(run_db, "http://127.0.0.1:1"), "backup"
+                )
+                assert result.returncode == 0, result.stdout + result.stderr
+            else:
+                run_go_task_via_worker(binary, worker_dir, run_db, "backup", "http://127.0.0.1:1")
+            backups = sorted(run_dir.glob("curator-*.sqlite3.backup"))
+            assert len(backups) == 1
+            backup = backups[0]
+            connection = sqlite3.connect(backup)
+            connection.row_factory = sqlite3.Row
+            try:
+                assert connection.execute("PRAGMA quick_check").fetchone()[0] == "ok"
+                assert connection.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type='table' AND name='schema_migration'"
+                ).fetchone()
+                MigrationRunner(connection).status()
+            finally:
+                connection.close()
+            sizes.append(backup.stat().st_size)
+            shutil.rmtree(run_dir, ignore_errors=True)
+    finally:
+        stop_worker(worker_dir)
+        shutil.rmtree(worker_dir, ignore_errors=True)
     assert sizes[0] == sizes[1]
 
 
 def test_task_already_running(compact_sidecar: Path, binary: Path, stub_stash: str) -> None:
-    """A second task while one is running reports already_running with the
-    existing job id (uuid4s differ; strip)."""
+    """A second task of the same type while one is running coalesces into
+    already_running with the existing job id (uuid4s differ; strip)."""
     connection = sqlite3.connect(compact_sidecar)
     try:
         connection.execute(
             """
             INSERT INTO curator_job(job_id, job_type, state, started_at_ms, summary_json)
-            VALUES ('job-running', 'build', 'running', ?, '{}')
+            VALUES ('job-running', 'backup', 'running', ?, '{}')
             """,
             (int(time.time() * 1000),),
         )

--- a/tests/core/test_backend_slice4.py
+++ b/tests/core/test_backend_slice4.py
@@ -764,7 +764,7 @@ def test_reset_removes_core_and_artifacts_identically(
     assert py[0] == go[0], f"stdout differs:\npython: {py[0]!r}\ngo:     {go[0]!r}"
     assert py[2] == go[2] == ["curator-derived", "curator.sqlite3"]
     assert py[3] == go[3] == ["junk.txt"]
-    assert py[4] == go[4] == 30
+    assert py[4] == go[4] == 31
     assert py[5] == go[5] == "ok"
 
 

--- a/tests/core/worker.py
+++ b/tests/core/worker.py
@@ -1,0 +1,92 @@
+"""Shared harness for running Go task modes through the background worker
+(docs/decisions/004-background-task-worker.md): the Go binary enqueues, its
+spawned daemon executes, and tests poll get_job_status to a terminal state.
+The Python backend stays the inline oracle whose job summaries the Go
+worker's are compared against.
+
+The worker's pid/state/log files live in the test's temporary plugin dir,
+and the sidecar path is passed per-enqueue, so each test gets an isolated
+daemon and database.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+
+def task_payload(db_path: Path, stash_url: str, operation: str | None = None) -> bytes:
+    payload = {
+        "server_connection": {
+            "Host": "127.0.0.1",
+            "Port": int(stash_url.rsplit(":", 1)[1]),
+            "Scheme": "http",
+            "SessionCookie": {},
+        },
+        "args": {"database_path": str(db_path)},
+    }
+    if operation:
+        payload["args"]["operation"] = operation
+    return json.dumps(payload, separators=(",", ":")).encode()
+
+
+def run_binary(
+    binary: Path,
+    plugin_dir: Path,
+    raw: bytes,
+    mode: str | None = None,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[bytes]:
+    argv = [str(binary), str(plugin_dir)]
+    if mode is not None:
+        argv.append(mode)
+    return subprocess.run(argv, input=raw, capture_output=True, timeout=300, env=env)
+
+
+def stop_worker(plugin_dir: Path) -> None:
+    """Gracefully stop a daemon spawned for a worker test run."""
+    pid_file = plugin_dir / "data" / "curator-daemon.pid"
+    with contextlib.suppress(FileNotFoundError, ValueError, ProcessLookupError):
+        os.kill(int(pid_file.read_text().strip()), signal.SIGTERM)
+
+
+def run_go_task_via_worker(
+    binary: Path,
+    plugin_dir: Path,
+    run_db: Path,
+    mode: str,
+    stash_url: str,
+    timeout: float = 300,
+    env: dict[str, str] | None = None,
+) -> dict[str, object]:
+    """Enqueue a task against the Go binary and let its spawned daemon
+    execute it, polling get_job_status to a terminal state. Returns the job
+    row, or the raw already_running response when coalescing fired."""
+    result = run_binary(binary, plugin_dir, task_payload(run_db, stash_url), mode, env=env)
+    assert result.returncode == 0, result.stdout + result.stderr
+    out = json.loads(result.stdout)["output"]
+    if out.get("already_running") is True:
+        return {"state": "already_running", "output": out}
+    assert out.get("queued") is True, out
+    job_id = out["job_id"]
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        status = run_binary(
+            binary, plugin_dir, task_payload(run_db, stash_url, "get_job_status"), env=env
+        )
+        assert status.returncode == 0, status.stdout + status.stderr
+        jobs = json.loads(status.stdout)["output"]["jobs"]
+        row = next((job for job in jobs if job["job_id"] == job_id), None)
+        if row and row["state"] in ("complete", "failed", "cancelled"):
+            return row
+        time.sleep(0.1)
+    log = plugin_dir / "data" / "curator-daemon.log"
+    raise AssertionError(
+        f"task {mode} ({job_id}) did not reach a terminal state; daemon log:\n"
+        + (log.read_text()[-2000:] if log.exists() else "(no daemon log)")
+    )

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -155,7 +155,10 @@ def test_plugin_archive_contains_runtime_and_core(tmp_path: Path) -> None:
     worker_dir = Path(tempfile.mkdtemp(prefix="curator-worker-"))
     try:
         row = run_go_task_via_worker(
-            host_binary, worker_dir, installed / "data" / "curator.sqlite3", "backup",
+            host_binary,
+            worker_dir,
+            installed / "data" / "curator.sqlite3",
+            "backup",
             "http://127.0.0.1:1",
         )
         assert row["state"] == "complete", row
@@ -1243,10 +1246,13 @@ def test_task_indicator_and_compact_external_tag_rating_are_shared_ui_contracts(
     source = (root / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
     css = (root / "plugin" / "stash-curator.css").read_text(encoding="utf-8")
 
-    assert "function CuratorTaskIndicator({ activeJobs, activities, failure, doneJob })" in source
+    assert (
+        "function CuratorTaskIndicator({ activeJobs, activities, failure, doneJob, tasksHref })"
+        in source
+    )
     assert "curator-task-indicator-done" in css
     assert "health?.active_jobs" in source
-    assert 'to: "/settings?tab=tasks"' in source
+    assert "?view=manage&section=tasks" in source
     assert "curatorTaskStage(job)" in source
     assert '"Synchronizing library metadata"' in source
     assert '"Building the recommendation model"' in source
@@ -1255,6 +1261,14 @@ def test_task_indicator_and_compact_external_tag_rating_are_shared_ui_contracts(
     assert "showTaskDetails" in source
     assert 'running || state === "failed" || state === "done"' in source
     assert '"No active tasks"' not in source
+    # Worker-owned task status surface (decision 004): the Manage Tasks
+    # section is where task feedback lives, since Stash's own Tasks tab only
+    # ever sees the instant enqueue jobs.
+    assert "function TasksPanel" in source
+    assert 'value: "tasks"' in source
+    assert "tasks: () => React.createElement(TasksPanel)" in source
+    assert "Manage → Tasks" in source
+    assert "curator-tasks-list" in source
     assert "Querying StashDB" not in source
     assert 'className: "curator-loading", role: "status"' in source
     assert 'className: "curator-progress"' not in source

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -7,6 +7,8 @@ import shutil
 import sqlite3
 import subprocess
 import sys
+import tempfile
+import time
 import tomllib
 import zipfile
 from hashlib import sha256
@@ -145,18 +147,27 @@ def test_plugin_archive_contains_runtime_and_core(tmp_path: Path) -> None:
             "UPDATE model_update_state SET last_started_at_ms=2, "
             "last_finished_at_ms=1, last_error=NULL"
         )
-    task = subprocess.run(
-        [str(host_binary), str(installed), "backup"],
-        input=json.dumps(_payload(installed)),
-        text=True,
-        capture_output=True,
-        check=True,
-    )
-    assert json.loads(task.stdout)["output"]["backup"].endswith(".sqlite3.backup")
-    assert "Stash Curator backup completed" in task.stderr
-    assert "\x01p\x020.0500" in task.stderr
-    assert "\x01p\x020.9500" in task.stderr
-    assert "\x01p\x021.0000" in task.stderr
+    # The shipped binary enqueues tasks to its own daemon (decision 004):
+    # prove the extracted artifact spawns the worker and completes a real
+    # backup through it, with progress in the daemon log.
+    from tests.core.worker import run_go_task_via_worker, stop_worker
+
+    worker_dir = Path(tempfile.mkdtemp(prefix="curator-worker-"))
+    try:
+        row = run_go_task_via_worker(
+            host_binary, worker_dir, installed / "data" / "curator.sqlite3", "backup",
+            "http://127.0.0.1:1",
+        )
+        assert row["state"] == "complete", row
+        assert row["summary"]["backup"].endswith(".sqlite3.backup")
+        log = (worker_dir / "data" / "curator-daemon.log").read_text(encoding="utf-8")
+        assert "Stash Curator backup completed" in log
+        assert "\x01p\x020.0500" in log
+        assert "\x01p\x020.9500" in log
+        assert "\x01p\x021.0000" in log
+    finally:
+        stop_worker(worker_dir)
+        shutil.rmtree(worker_dir, ignore_errors=True)
     with sqlite3.connect(installed / "data" / "curator.sqlite3") as connection:
         assert connection.execute("SELECT last_error FROM model_update_state").fetchone()[0]
 
@@ -1182,36 +1193,6 @@ def test_health_reports_all_running_curator_tasks(
     spec.loader.exec_module(module)
     runtime = {
         "version": {"version": "0.31.0"},
-        "jobQueue": [
-            {
-                "id": "sync-job",
-                "status": "RUNNING",
-                "description": "Sync and build recommendations",
-                "progress": 0.42,
-                "startTime": "2026-08-08T00:00:00Z",
-            },
-            {
-                "id": "expand-job",
-                "status": "WAITING",
-                "description": "Refresh Expand cache",
-                "progress": 0,
-                "startTime": "2026-08-08T00:01:00Z",
-            },
-            {
-                "id": "deps-job",
-                "status": "RUNNING",
-                "description": "Install optional dependencies",
-                "progress": 0.3,
-                "startTime": "2026-08-08T00:02:00Z",
-            },
-            {
-                "id": "finished-job",
-                "status": "FINISHED",
-                "description": "Backup Curator data",
-                "progress": 1,
-                "startTime": "2026-08-07T00:00:00Z",
-            },
-        ],
         "configuration": {"general": {"stashBoxes": []}},
     }
     monkeypatch.setattr(module, "_settings", lambda _payload: {})
@@ -1221,10 +1202,40 @@ def test_health_reports_all_running_curator_tasks(
         lambda _payload: SimpleNamespace(execute=lambda *_args: runtime),
     )
 
-    health = module._health({"args": {"database_path": str(tmp_path / "curator.sqlite3")}})
+    sidecar = tmp_path / "curator.sqlite3"
+    now_ms = int(time.time() * 1000)
+    connection = sqlite3.connect(sidecar)
+    try:
+        connection.row_factory = sqlite3.Row
+        from curator.storage import MigrationRunner
 
-    assert [job["id"] for job in health["active_jobs"]] == ["sync-job", "expand-job", "deps-job"]
-    assert health["active_job"]["id"] == "sync-job"
+        MigrationRunner(connection).migrate(applied_at_ms=1)
+        connection.execute(
+            """
+            INSERT INTO curator_job(
+                job_id, job_type, state, started_at_ms, heartbeat_at_ms, progress
+            )
+            VALUES ('job-queued', 'sync-build', 'queued', ?, NULL, NULL),
+                   ('job-running', 'expand-refresh', 'running', ?, ?, 0.42)
+            """,
+            (now_ms - 10, now_ms - 5, now_ms),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    # active_jobs comes from the worker-owned curator_job rows (decision 004),
+    # not Stash's job queue: queued + running, newest first, with the
+    # Stash-style description the frontend stage mapping matches.
+    health = module._health({"args": {"database_path": str(sidecar)}})
+
+    assert [job["id"] for job in health["active_jobs"]] == ["job-running", "job-queued"]
+    assert health["active_job"]["id"] == "job-running"
+    assert (
+        health["active_jobs"][1]["description"]
+        == "Running plugin task: Sync and build recommendations"
+    )
+    assert health["active_jobs"][0]["progress"] == 0.42
 
 
 def test_task_indicator_and_compact_external_tag_rating_are_shared_ui_contracts() -> None:

--- a/tests/storage/test_artifacts.py
+++ b/tests/storage/test_artifacts.py
@@ -217,6 +217,6 @@ def test_attach_skips_tables_missing_from_older_artifact(tmp_path: Path) -> None
         assert "model_performer_edge" not in views
         # Migration 25 creates and indexes model_performer_edge; the shadowing view
         # used to make its CREATE INDEX fail with "views may not be indexed".
-        assert MigrationRunner(attached).migrate(applied_at_ms=2).current_version == 30
+        assert MigrationRunner(attached).migrate(applied_at_ms=2).current_version == 31
     finally:
         attached.close()

--- a/tests/storage/test_cli_db.py
+++ b/tests/storage/test_cli_db.py
@@ -15,7 +15,7 @@ def test_database_cli_migrate_status_and_backup(
 
     assert run(["--db", str(database), "db", "migrate", "--json"]) == 0
     migrated = json.loads(capsys.readouterr().out)
-    assert migrated["current_version"] == migrated["latest_version"] == 30
+    assert migrated["current_version"] == migrated["latest_version"] == 31
 
     assert run(["--db", str(database), "db", "status", "--json"]) == 0
     status = json.loads(capsys.readouterr().out)

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -42,10 +42,11 @@ def test_migrate_empty_database_and_rerun_current_version(tmp_path: Path) -> Non
             28,
             29,
             30,
+            31,
         )
 
         after = runner.migrate(applied_at_ms=1234)
-        assert after.current_version == 30
+        assert after.current_version == 31
         assert after.pending_versions == ()
         assert runner.migrate(applied_at_ms=5678) == after
 
@@ -337,7 +338,7 @@ def test_status_stays_read_only_after_migrations(tmp_path: Path) -> None:
     reader.execute("PRAGMA busy_timeout=1")
     try:
         writer.execute("BEGIN IMMEDIATE")
-        assert MigrationRunner(reader).status().current_version == 30
+        assert MigrationRunner(reader).status().current_version == 31
     finally:
         writer.rollback()
         reader.close()
@@ -363,7 +364,7 @@ def test_stale_concurrent_migrator_rechecks_after_writer_lock(
 
     monkeypatch.setattr(second_runner, "status", status)
     try:
-        assert second_runner.migrate(applied_at_ms=2).current_version == 30
+        assert second_runner.migrate(applied_at_ms=2).current_version == 31
     finally:
         second.close()
         first.close()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -20,7 +20,7 @@ def test_doctor_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) 
     assert result["status"] == "ok"
     assert result["stash"] == "not_configured"
     assert result["schema_current"] == 0
-    assert result["schema_latest"] == 30
+    assert result["schema_latest"] == 31
 
 
 def test_no_command_prints_help(capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary

Phase 1 of `docs/decisions/004-background-task-worker.md` (issue #145, direction 1): take Curator's long-running tasks out of Stash's single-slot job queue.

- **Enqueue-and-return**: the Stash-spawned process records the task as a `queued` `curator_job` row (with a payload snapshot) and returns in ~100 ms, freeing the Stash slot. Same-type queued/running jobs coalesce into the existing `already_running` response; unknown modes still error at the invocation boundary; if the worker cannot spawn, the task runs inline exactly as before.
- **Detached daemon** (`curator-core <pluginDir> daemon`): setsid spawn, stdio to `data/curator-daemon.log`, pid-file single-instance, lazy spawn on first task, idle exit after 5 min. Claims queued rows one at a time, runs the existing Go task-mode bodies, transitions to complete/failed with the same summaries.
- **Ownership-based liveness**: running rows carry `owner_pid` + `heartbeat_at_ms` (20 s); dead-owner/stale-heartbeat rows are recovered as interrupted on enqueue, health, and daemon startup — replacing the old Stash-job-list + 120 s heuristic and the 6 h stale window. `health.active_jobs` now reports queued+running `curator_job` rows (synthesized Stash-style descriptions), so the task indicator keeps working.
- **Live progress**: `progress` is persisted through the job's own dedicated connection (no deadlock/blocking against the mode's single pooled connection), debounced ~500 ms, and flushed before the terminal transition so the final value (1.0) always lands. `get_job_status` exposes `progress` + `queued_at_ms`.
- **Cancel**: new `cancel_job` op — queued → cancelled instantly; running → cooperative flag honored by the heartbeat loop (row marked cancelled, daemon exits), plus SIGTERM handling.
- **Migration 0031** (`curator_job` rebuild): `queued`/`cancelled` states, `queued_at_ms`, `heartbeat_at_ms`, `owner_pid`, `payload_json`, `cancel_requested`, `progress`. Rebuild deliberately avoids `ALTER TABLE RENAME` (SQLite schema-rescan bug with attached generation views).
- **Scheduling is out of scope here** (Phase 2 of the decision doc).

## Behavior changes worth noting

- Stash's Tasks tab can no longer cancel long Curator work (its job completes instantly); cancellation moves to the Curator UI (`cancel_job` op exists; Cancel buttons are a follow-up).
- The old "any running task blocks every task" guard became per-type coalescing; the daemon serializes its own claims. Mode-body guards (backup/compact/reset) unchanged.
- `backend.py` stays the dev-side inline oracle (not shipped); its `health`/`get_job_status`/`cancel_job` were updated to match the Go side byte-for-byte.

## Verification

- `go build`/`vet` clean; full Go suite green (new daemon queue-lifecycle tests: claim, coalescing, orphan recovery, cancel, progress sink incl. a pool-blocking regression test).
- Full non-integration suite: 562 passed, 0 failed.
- Differential gates: task-mode comparisons moved from invocation stdout to the completed job's durable summary via the shared worker runner (`tests/core/worker.py`); health/get_job_status byte-identical Go vs Python.
- Installed and verified on a local synthetic Stash instance: Stash's queue frees instantly, the daemon completes tasks with progress (terminal value lands at 1.0), migration 0031 applies.
- Live install updated; user confirmed progress display works.
