### PR TITLE
feat: automatic model updates and play sync in the background worker

### DIFF
--- a/core/autotasks.go
+++ b/core/autotasks.go
@@ -1,0 +1,192 @@
+// Auto-scheduler (docs/decisions/004, Phase 2a): the daemon's event-driven
+// wake-up loop. It replaces the browser-tab timers that used to drive model
+// updates and play syncs — with auto_tasks_enabled on, pending model updates
+// are applied and new plays are synced without any tab open. Gated entirely
+// by the existing modelUpdate* settings; the daemon stays resident while work
+// is pending (schedulerStayAlive) so the max-wait backstop can fire.
+package main
+
+import (
+	"context"
+	"database/sql"
+)
+
+var (
+	// autoTickMs is the scheduler cadence inside the daemon.
+	autoTickMs int64 = 30_000
+	// autoPlayQuietMs is the trailing quiet window before new plays trigger
+	// a sync-plays run (mirrors the frontend's play-sync debounce).
+	autoPlayQuietMs int64 = 60_000
+)
+
+// autoPayloadFromState builds the enqueue payload for auto-scheduled tasks
+// from the worker's stored Stash connection (the daemon has no per-request
+// payload of its own).
+func autoPayloadFromState(state workerState) jVal {
+	server := jvObj()
+	if state.ServerConnection != "" {
+		if parsed, err := parseJSON([]byte(state.ServerConnection)); err == nil && parsed.kind == jObj {
+			server = parsed
+		}
+	}
+	return jvObj(
+		jvKey("server_connection", server),
+		jvKey("args", jvObj()),
+	)
+}
+
+// enqueueAutoTask inserts a queued job the same way the Stash-facing enqueue
+// does, but without the worker-ensure dance (the daemon IS the worker). An
+// active job of the same type coalesces into a no-op.
+func enqueueAutoTask(db dbx, mode string, payload jVal, now int64) (bool, error) {
+	payloadRaw, err := marshalJVal(payload)
+	if err != nil {
+		return false, err
+	}
+	jobID := uuid4()
+	enqueued := false
+	err = withTxn(db, func(conn *sql.Conn) error {
+		ctx := context.Background()
+		var existing int
+		err := conn.QueryRowContext(ctx, `
+SELECT 1 FROM curator_job WHERE state IN ('queued', 'running')
+AND job_type=? AND started_at_ms>? LIMIT 1`,
+			mode, now-6*3_600_000).Scan(&existing)
+		if err == nil {
+			return nil // coalesced: this task type is already active
+		}
+		if err != sql.ErrNoRows {
+			return err
+		}
+		if _, err := conn.ExecContext(ctx, `
+INSERT INTO curator_job(job_id, job_type, state, started_at_ms, queued_at_ms, payload_json)
+VALUES (?, ?, 'queued', ?, ?, ?)`, jobID, mode, now, now, payloadRaw); err != nil {
+			return err
+		}
+		enqueued = true
+		return nil
+	})
+	return enqueued, err
+}
+
+// modelRebuilding reports whether a model-touching job is running (build,
+// update-model, sync-build, full-sync-build), matching health's query.
+func modelRebuilding(db dbx, now int64) (bool, error) {
+	var probe int
+	err := db.QueryRow(`SELECT 1 FROM curator_job
+WHERE state='running' AND started_at_ms>? AND job_type IN (
+    'build', 'update-model', 'sync-build', 'full-sync-build'
+) LIMIT 1`, now-6*3_600_000).Scan(&probe)
+	if err == nil {
+		return true, nil
+	}
+	if err == sql.ErrNoRows {
+		return false, nil
+	}
+	return false, err
+}
+
+// playWatermark is the sync-plays trigger state: are there plays newer than
+// the last completed sync-plays, and when did the newest one end?
+type playWatermark struct {
+	unsynced    bool
+	lastEndedAt int64
+}
+
+// playWatermarkFn reads the sidecar play stream vs the last sync-plays run.
+// A NULL play stream (never played) is not unsynced.
+func playWatermarkFn(db dbx) (playWatermark, error) {
+	var lastSync sql.NullInt64
+	err := db.QueryRow(`SELECT finished_at_ms FROM curator_job
+WHERE job_type='sync-plays' AND state='complete' ORDER BY finished_at_ms DESC LIMIT 1`).Scan(&lastSync)
+	if err != nil && err != sql.ErrNoRows {
+		return playWatermark{}, err
+	}
+	var lastPlay sql.NullInt64
+	if err := db.QueryRow(`SELECT max(ended_at_ms) FROM play_session`).Scan(&lastPlay); err != nil {
+		return playWatermark{}, err
+	}
+	if !lastPlay.Valid {
+		return playWatermark{}, nil
+	}
+	return playWatermark{
+		unsynced:    !lastSync.Valid || lastPlay.Int64 > lastSync.Int64,
+		lastEndedAt: lastPlay.Int64,
+	}, nil
+}
+
+// schedulerTick runs one auto-scheduler pass: enqueue update-model when the
+// coordinator is ready and nothing is rebuilding, and sync-plays when new
+// plays have been quiet for the debounce window. Returns the modes enqueued.
+func schedulerTick(db dbx, payload jVal, now int64) ([]string, error) {
+	cfg, err := sidecarConfig(db)
+	if err != nil {
+		return nil, err
+	}
+	config := cfg.get("config")
+	if !config.get("auto_tasks_enabled").truthy() {
+		return nil, nil
+	}
+	var enqueued []string
+	status, err := modelUpdateStatus(db)
+	if err != nil {
+		return nil, err
+	}
+	rebuilding, err := modelRebuilding(db, now)
+	if err != nil {
+		return nil, err
+	}
+	ready := modelUpdateReady(status, now,
+		int(pythonInt(config.get("model_update_event_threshold"))),
+		pyRound(pythonFloatOr(config.get("model_update_max_wait_minutes"), 0)*60_000),
+		pyRound(pythonFloatOr(config.get("model_update_min_interval_minutes"), 0)*60_000),
+	)
+	if ready && !rebuilding {
+		ok, err := enqueueAutoTask(db, "update-model", payload, now)
+		if err != nil {
+			return enqueued, err
+		}
+		if ok {
+			enqueued = append(enqueued, "update-model")
+		}
+	}
+	watermark, err := playWatermarkFn(db)
+	if err != nil {
+		return enqueued, err
+	}
+	if watermark.unsynced && now-watermark.lastEndedAt >= autoPlayQuietMs {
+		ok, err := enqueueAutoTask(db, "sync-plays", payload, now)
+		if err != nil {
+			return enqueued, err
+		}
+		if ok {
+			enqueued = append(enqueued, "sync-plays")
+		}
+	}
+	return enqueued, nil
+}
+
+// schedulerStayAlive reports whether the daemon should stay resident for the
+// auto-scheduler: a dirty (pending) model or unsynced plays. The claim loop
+// already keeps it alive while jobs are queued.
+func schedulerStayAlive(db dbx, now int64) (bool, error) {
+	cfg, err := sidecarConfig(db)
+	if err != nil {
+		return false, err
+	}
+	if !cfg.get("config").get("auto_tasks_enabled").truthy() {
+		return false, nil
+	}
+	status, err := modelUpdateStatus(db)
+	if err != nil {
+		return false, err
+	}
+	if status.pending() {
+		return true, nil
+	}
+	watermark, err := playWatermarkFn(db)
+	if err != nil {
+		return false, err
+	}
+	return watermark.unsynced, nil
+}

--- a/core/autotasks_test.go
+++ b/core/autotasks_test.go
@@ -1,0 +1,266 @@
+// Auto-scheduler tests (docs/decisions/004, Phase 2a): the daemon's
+// event-driven update-model / sync-plays triggers and the stay-alive rule,
+// against a temp migrated sidecar.
+package main
+
+import (
+	"testing"
+)
+
+// enableAutoTasks flips the stored config so sidecarConfig merges
+// auto_tasks_enabled=true.
+func enableAutoTasks(t *testing.T, db dbx) {
+	t.Helper()
+	if _, err := db.Exec(`UPDATE curator_config SET config_json=?, updated_at_ms=? WHERE singleton=1`,
+		`{"auto_tasks_enabled": true}`, nowMs()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedModelUpdate(t *testing.T, db dbx, requested int64, published int64, requestedAtMs int64) {
+	t.Helper()
+	if _, err := db.Exec(`UPDATE model_update_state SET requested_generation=?, published_generation=?, requested_at_ms=? WHERE singleton=1`,
+		requested, published, requestedAtMs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedPlay(t *testing.T, db dbx, sessionID string, endedAtMs int64) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT OR IGNORE INTO source_scene(scene_id, source_hash)
+VALUES ('s1', 'h-s1')`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(`INSERT INTO play_session(session_id, scene_id, started_at_ms, ended_at_ms, active_seconds, provenance, confidence)
+VALUES (?, 's1', ?, ?, 1, 'direct_player', 1)`, sessionID, endedAtMs-1000, endedAtMs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedSyncPlaysDone(t *testing.T, db dbx, finishedAtMs int64) {
+	t.Helper()
+	if _, err := db.Exec(`INSERT INTO curator_job(job_id, job_type, state, started_at_ms, finished_at_ms, summary_json)
+VALUES (?, 'sync-plays', 'complete', ?, ?, '{}')`, uuid4(), finishedAtMs-1000, finishedAtMs); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func queuedModes(t *testing.T, db dbx) map[string]bool {
+	t.Helper()
+	rows, err := db.Query(`SELECT job_type FROM curator_job WHERE state='queued'`)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	modes := map[string]bool{}
+	for rows.Next() {
+		var mode string
+		if err := rows.Scan(&mode); err != nil {
+			t.Fatal(err)
+		}
+		modes[mode] = true
+	}
+	return modes
+}
+
+func TestSchedulerDisabledByDefault(t *testing.T) {
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	now := int64(1_000_000_000_000)
+	pinTime(t, now, func() {
+		seedModelUpdate(t, db, 5, 0, now-1_000)
+		seedPlay(t, db, "p1", now-120_000)
+		enqueued, err := schedulerTick(db, jvObj(), now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(enqueued) != 0 || len(queuedModes(t, db)) != 0 {
+			t.Fatalf("auto tasks must be off by default: %v", enqueued)
+		}
+	})
+}
+
+func TestSchedulerModelUpdateReady(t *testing.T) {
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	enableAutoTasks(t, db)
+	now := int64(1_000_000_000_000)
+	pinTime(t, now, func() {
+		// Threshold met (5 pending events) → enqueue update-model.
+		seedModelUpdate(t, db, 5, 0, now-1_000)
+		enqueued, err := schedulerTick(db, jvObj(), now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(enqueued) != 1 || enqueued[0] != "update-model" {
+			t.Fatalf("expected update-model enqueue, got %v", enqueued)
+		}
+		if !queuedModes(t, db)["update-model"] {
+			t.Fatal("no queued update-model row")
+		}
+	})
+}
+
+func TestSchedulerModelUpdateNotReadyYet(t *testing.T) {
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	enableAutoTasks(t, db)
+	now := int64(1_000_000_000_000)
+	pinTime(t, now, func() {
+		// One event, far below threshold and inside the max-wait window.
+		seedModelUpdate(t, db, 1, 0, now-1_000)
+		enqueued, err := schedulerTick(db, jvObj(), now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(enqueued) != 0 {
+			t.Fatalf("not ready, must not enqueue: %v", enqueued)
+		}
+	})
+}
+
+func TestSchedulerSkipsWhileRebuilding(t *testing.T) {
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	enableAutoTasks(t, db)
+	now := int64(1_000_000_000_000)
+	pinTime(t, now, func() {
+		if _, err := db.Exec(`INSERT INTO curator_job(job_id, job_type, state, started_at_ms)
+VALUES ('b1', 'build', 'running', ?)`, now-10_000); err != nil {
+			t.Fatal(err)
+		}
+		seedModelUpdate(t, db, 5, 0, now-1_000)
+		enqueued, err := schedulerTick(db, jvObj(), now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(enqueued) != 0 {
+			t.Fatalf("must not enqueue while rebuilding: %v", enqueued)
+		}
+	})
+}
+
+func TestSchedulerCoalescesActiveSameType(t *testing.T) {
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	enableAutoTasks(t, db)
+	now := int64(1_000_000_000_000)
+	pinTime(t, now, func() {
+		if _, err := db.Exec(`INSERT INTO curator_job(job_id, job_type, state, started_at_ms)
+VALUES ('u1', 'update-model', 'queued', ?)`, now-10_000); err != nil {
+			t.Fatal(err)
+		}
+		seedModelUpdate(t, db, 5, 0, now-1_000)
+		enqueued, err := schedulerTick(db, jvObj(), now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(enqueued) != 0 {
+			t.Fatalf("coalescing must skip: %v", enqueued)
+		}
+		if len(queuedModes(t, db)) != 1 {
+			t.Fatalf("coalescing added a row: %v", queuedModes(t, db))
+		}
+	})
+}
+
+func TestSchedulerPlaySyncQuietWindow(t *testing.T) {
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	enableAutoTasks(t, db)
+	now := int64(1_000_000_000_000)
+	pinTime(t, now, func() {
+		// Play ended 10s ago — still in the quiet window → no sync yet.
+		seedPlay(t, db, "p1", now-10_000)
+		enqueued, err := schedulerTick(db, jvObj(), now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(enqueued) != 0 {
+			t.Fatalf("must wait for the quiet window: %v", enqueued)
+		}
+	})
+}
+
+func TestSchedulerPlaySyncFiresWhenQuiet(t *testing.T) {
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	enableAutoTasks(t, db)
+	now := int64(1_000_000_000_000)
+	pinTime(t, now, func() {
+		// Play ended 120s ago, no sync-plays ever ran → enqueue.
+		seedPlay(t, db, "p1", now-120_000)
+		enqueued, err := schedulerTick(db, jvObj(), now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(enqueued) != 1 || enqueued[0] != "sync-plays" {
+			t.Fatalf("expected sync-plays enqueue, got %v", enqueued)
+		}
+	})
+}
+
+func TestSchedulerPlaySyncAlreadySynced(t *testing.T) {
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	enableAutoTasks(t, db)
+	now := int64(1_000_000_000_000)
+	pinTime(t, now, func() {
+		// A sync-plays completed after the newest play → nothing to sync.
+		seedPlay(t, db, "p1", now-300_000)
+		seedSyncPlaysDone(t, db, now-200_000)
+		enqueued, err := schedulerTick(db, jvObj(), now)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(enqueued) != 0 {
+			t.Fatalf("plays already synced: %v", enqueued)
+		}
+	})
+}
+
+func TestSchedulerStayAlive(t *testing.T) {
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	now := int64(1_000_000_000_000)
+	pinTime(t, now, func() {
+		// Auto off → never stays for scheduler reasons.
+		seedModelUpdate(t, db, 5, 0, now-1_000)
+		if stay, err := schedulerStayAlive(db, now); err != nil || stay {
+			t.Fatalf("auto off must not stay alive: %v %v", stay, err)
+		}
+		enableAutoTasks(t, db)
+		// Pending model → stay.
+		if stay, err := schedulerStayAlive(db, now); err != nil || !stay {
+			t.Fatalf("pending model must stay alive: %v %v", stay, err)
+		}
+		// Published → no longer stays (nothing pending, no unsynced plays).
+		seedModelUpdate(t, db, 5, 5, now-1_000)
+		if stay, err := schedulerStayAlive(db, now); err != nil || stay {
+			t.Fatalf("clean state must not stay alive: %v %v", stay, err)
+		}
+		// Unsynced plays → stays.
+		seedPlay(t, db, "p1", now-120_000)
+		if stay, err := schedulerStayAlive(db, now); err != nil || !stay {
+			t.Fatalf("unsynced plays must stay alive: %v %v", stay, err)
+		}
+	})
+}

--- a/core/daemon.go
+++ b/core/daemon.go
@@ -46,9 +46,10 @@ var (
 // re-read by the daemon (which has none): where the sidecar lives and how to
 // reach Stash for the per-job settings fetch.
 type workerState struct {
-	DatabasePath string            `json:"database_path"`
-	StashBase    string            `json:"stash_base"`
-	StashHeaders map[string]string `json:"stash_headers"`
+	DatabasePath     string            `json:"database_path"`
+	StashBase        string            `json:"stash_base"`
+	StashHeaders     map[string]string `json:"stash_headers"`
+	ServerConnection string            `json:"server_connection,omitempty"`
 }
 
 func workerStatePath(pluginDir string) string {
@@ -134,6 +135,22 @@ func spawnWorker(pluginDir string) error {
 	return nil
 }
 
+// ensureAutoWorker spawns the daemon from event-driven operations when
+// automatic tasks are enabled. The coordinator's dirty signals (feedback,
+// plays, prune decisions) arrive as plugin invocations, and the daemon must
+// exist to act on them — without this, auto tasks would only ever start
+// after a task invocation.
+func ensureAutoWorker(pluginDir string, payload jVal, settings jVal, db dbx) {
+	cfg, err := sidecarConfig(db)
+	if err != nil {
+		return
+	}
+	if !cfg.get("config").get("auto_tasks_enabled").truthy() {
+		return
+	}
+	_ = ensureWorker(pluginDir, payload, settings)
+}
+
 // recoverOrphanJobs fails running rows whose executing process is gone:
 // heartbeat stale (a daemon or inline runner died) or, for pre-heartbeat
 // rows, older than the legacy 6h stale window. It also records the same
@@ -160,11 +177,13 @@ AND last_error IS NULL`)
 // an un-migrated database path.
 func ensureWorker(pluginDir string, payload jVal, settings jVal) error {
 	base, headers := stashConnection(payload)
+	serverConn, _ := marshalJVal(payload.get("server_connection"))
 	if pid, ok := readWorkerPid(pluginDir); ok && pidAlive(pid) {
 		if err := writeWorkerState(pluginDir, workerState{
-			DatabasePath: databasePath(pluginDir, payload, settings),
-			StashBase:    base,
-			StashHeaders: headers,
+			DatabasePath:     databasePath(pluginDir, payload, settings),
+			StashBase:        base,
+			StashHeaders:     headers,
+			ServerConnection: serverConn,
 		}); err != nil {
 			return fmt.Errorf("could not write worker state: %w", err)
 		}
@@ -185,9 +204,10 @@ func ensureWorker(pluginDir string, payload jVal, settings jVal) error {
 		return nil // nothing to run; the caller handles its own row inline
 	}
 	if err := writeWorkerState(pluginDir, workerState{
-		DatabasePath: databasePath(pluginDir, payload, settings),
-		StashBase:    base,
-		StashHeaders: headers,
+		DatabasePath:     databasePath(pluginDir, payload, settings),
+		StashBase:        base,
+		StashHeaders:     headers,
+		ServerConnection: serverConn,
 	}); err != nil {
 		return fmt.Errorf("could not write worker state: %w", err)
 	}
@@ -232,6 +252,8 @@ func runDaemon(pluginDir string) {
 	}()
 
 	recoverOrphanJobs(loop, nowMs())
+	autoPayload := autoPayloadFromState(state)
+	lastTick := nowMs()
 	idleSince := nowMs()
 	for {
 		// Re-read the worker state each pass so a databasePath change (or a
@@ -248,6 +270,18 @@ func runDaemon(pluginDir string) {
 					loopPath = path
 				}
 			}
+			autoPayload = autoPayloadFromState(fresh)
+		}
+		now := nowMs()
+		if now-lastTick >= autoTickMs {
+			lastTick = now
+			if enqueued, err := schedulerTick(loop, autoPayload, now); err != nil {
+				errorLog("auto-scheduler failed: " + err.Error())
+			} else {
+				for _, mode := range enqueued {
+					infoLog("auto-enqueued task " + mode)
+				}
+			}
 		}
 		jobID, startedAtMs, payload, mode, err := claimQueuedJob(loop)
 		if err != nil {
@@ -260,7 +294,14 @@ func runDaemon(pluginDir string) {
 			runWorkerJob(pluginDir, loop, jobID, startedAtMs, payload, mode)
 			continue
 		}
-		if nowMs()-idleSince > idleExitMs {
+		// Idle-exit only when nothing is queued AND the auto-scheduler has no
+		// pending work (a dirty model or unsynced plays keep the daemon alive
+		// so the gated update fires without a browser tab).
+		stayAlive, stayErr := schedulerStayAlive(loop, nowMs())
+		if stayErr != nil {
+			errorLog("stay-alive check failed: " + stayErr.Error())
+		}
+		if !stayAlive && nowMs()-idleSince > idleExitMs {
 			infoLog("daemon idle; exiting")
 			return
 		}

--- a/core/entity_hook.go
+++ b/core/entity_hook.go
@@ -69,6 +69,7 @@ func runEntityHook(pluginDir string, payload jVal) jVal {
 		return neutralHookResult(err)
 	}
 	defer db.Close()
+	ensureAutoWorker(pluginDir, payload, settings, db)
 	now := nowMs()
 	err = withTxn(db, func(conn *sql.Conn) error {
 		ctx := context.Background()

--- a/core/prune.go
+++ b/core/prune.go
@@ -428,6 +428,7 @@ func updatePruningBody(pluginDir string, payload, settings jVal) (jVal, error) {
 		return jvNull(), err
 	}
 	defer db.Close()
+	ensureAutoWorker(pluginDir, payload, settings, db)
 	now := nowMs()
 	err = withTxn(db, func(conn *sql.Conn) error {
 		ctx := context.Background()
@@ -511,11 +512,12 @@ func reverseExclusionBody(pluginDir string, payload, settings jVal) (jVal, error
 		return jvNull(), err
 	}
 	defer db.Close()
+	ensureAutoWorker(pluginDir, payload, settings, db)
 	now := nowMs()
 	err = withTxn(db, func(conn *sql.Conn) error {
 		ctx := context.Background()
-		res, err := conn.ExecContext(ctx, `
-UPDATE exclusion SET reversed_at_ms=?
+		res, err := conn.ExecContext(ctx,
+			`UPDATE exclusion SET reversed_at_ms=?
 WHERE entity_type='scene' AND entity_id=? AND exclusion_type='never_show'
   AND reversed_at_ms IS NULL`, now, sceneID)
 		if err != nil {

--- a/core/settings.go
+++ b/core/settings.go
@@ -25,6 +25,7 @@ var defaultPluginConfig = jvObj(
 	jvKey("expand_horizon_days", jvInt(90)),
 	jvKey("expand_gender", jvStr("FEMALE")),
 	jvKey("expand_wildcard", jvBool(false)),
+	jvKey("auto_tasks_enabled", jvBool(false)),
 )
 
 type settingConv int
@@ -52,6 +53,7 @@ var settingMapping = []struct {
 	{"expandHorizonDays", "expand_horizon_days", convInt},
 	{"expandGender", "expand_gender", convStr},
 	{"expandWildcard", "expand_wildcard", convBool},
+	{"autoTasksEnabled", "auto_tasks_enabled", convBool},
 }
 
 func convertSetting(v jVal, conv settingConv) (jVal, error) {

--- a/core/writes.go
+++ b/core/writes.go
@@ -220,6 +220,7 @@ func submitFeedbackBody(pluginDir string, payload, settings jVal) (jVal, error) 
 		return jvNull(), err
 	}
 	defer db.Close()
+	ensureAutoWorker(pluginDir, payload, settings, db)
 	inserted := int64(0)
 	err = withTxn(db, func(conn *sql.Conn) error {
 		ctx := context.Background()
@@ -294,6 +295,7 @@ func correctFeedbackBody(pluginDir string, payload, settings jVal) (jVal, error)
 		return jvNull(), err
 	}
 	defer db.Close()
+	ensureAutoWorker(pluginDir, payload, settings, db)
 	err = withTxn(db, func(conn *sql.Conn) error {
 		ctx := context.Background()
 		var sceneID, originalType string
@@ -457,6 +459,7 @@ func submitTagPreferencesBody(pluginDir string, payload, settings jVal) (jVal, e
 		return jvNull(), err
 	}
 	defer db.Close()
+	ensureAutoWorker(pluginDir, payload, settings, db)
 	normalized := make([]tagPreferenceEntry, len(entries.arr))
 	for i, entry := range entries.arr {
 		item, err := normalizeTagPreferenceEntry(db, entry)
@@ -615,6 +618,7 @@ func submitTermPreferencesBody(pluginDir string, payload, settings jVal) (jVal, 
 		return jvNull(), err
 	}
 	defer db.Close()
+	ensureAutoWorker(pluginDir, payload, settings, db)
 	normalized := make([]termPreferenceEntry, len(entries.arr))
 	for i, entry := range entries.arr {
 		item, err := normalizeTermPreferenceEntry(entry)
@@ -751,6 +755,7 @@ func submitEventsBody(pluginDir string, payload, settings jVal) (jVal, error) {
 		return jvNull(), err
 	}
 	defer db.Close()
+	ensureAutoWorker(pluginDir, payload, settings, db)
 	qualified, err := qualifyImpressions(db, impressions)
 	if err != nil {
 		return jvNull(), err

--- a/curator/api.py
+++ b/curator/api.py
@@ -35,6 +35,7 @@ DEFAULT_PLUGIN_CONFIG: dict[str, object] = {
     "expand_horizon_days": 90,
     "expand_gender": "FEMALE",
     "expand_wildcard": False,
+    "auto_tasks_enabled": False,
 }
 
 
@@ -1180,6 +1181,7 @@ class CuratorAPI:
             "expand_horizon_days",
             "expand_gender",
             "expand_wildcard",
+            "auto_tasks_enabled",
         }
         unknown = set(values) - allowed
         if unknown:

--- a/docs/decisions/004-background-task-worker.md
+++ b/docs/decisions/004-background-task-worker.md
@@ -234,8 +234,17 @@ it Curator-side:
 
 ## 9. Remaining for Phase 2
 
-- `scheduled_task` table + scheduler loop in the daemon; `update-model`
-  wake-up gated by `ModelUpdateCoordinator.ready()`; `sync-plays`,
-  `sync-build`, `backup` schedules; yml `schedule*` settings.
-- Phase 3 UX: task-indicator queued state + Cancel buttons; schedule config
-  in the #151 Settings panel.
+- **Phase 2a implemented (2026-08-17)**: the daemon's event-driven auto-scheduler
+  (`core/autotasks.go`) — replaces the browser-tab wake-up loop. With the new
+  `autoTasksEnabled` setting on: `update-model` is enqueued when the existing
+  `ModelUpdateCoordinator` gating (`modelUpdate*` settings) is ready and nothing
+  is rebuilding; `sync-plays` is enqueued when plays newer than the last sync
+  have been quiet for ~60 s. The dirtying operations (feedback, corrections,
+  tag/term preferences, events, prune decisions, entity hooks) ensure the
+  worker exists (`ensureAutoWorker`), and the daemon stays resident while a
+  model update is pending or plays are unsynced — so the max-wait backstop
+  fires with no browser open. Toggle exposed in Manage → Settings.
+- **Phase 2b**: `scheduled_task` table + scheduler loop for daily `sync-build`
+  / `backup` schedules + yml `schedule*` settings.
+- Phase 3 UX: task-indicator Cancel buttons; schedule config in the Settings
+  panel.

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -4036,6 +4036,7 @@
         { key: "modelUpdateEventThreshold", configKey: "model_update_event_threshold", type: "NUMBER", label: "Actions before model update", description: "Rebuild after this many new playback or feedback actions. Default 5." },
         { key: "modelUpdateMaxWaitMinutes", configKey: "model_update_max_wait_minutes", type: "NUMBER", label: "Maximum model update delay (minutes)", description: "Rebuild pending preference changes after this delay. Default 30." },
         { key: "modelUpdateMinIntervalMinutes", configKey: "model_update_min_interval_minutes", type: "NUMBER", label: "Minimum model update interval (minutes)", description: "Minimum time between automatic preference-model rebuilds. Default 60." },
+        { key: "autoTasksEnabled", configKey: "auto_tasks_enabled", type: "BOOLEAN", label: "Automatic background tasks", description: "Let the background worker apply pending model updates and sync recent plays on its own, without needing a browser tab open." },
       ],
     },
     {

--- a/plugin/stash-curator.yml
+++ b/plugin/stash-curator.yml
@@ -58,6 +58,10 @@ settings:
     displayName: Minimum model update interval (minutes)
     description: Minimum time between automatic preference-model rebuilds. Default 60.
     type: NUMBER
+  autoTasksEnabled:
+    displayName: Automatic background tasks
+    description: Let the background worker apply pending model updates and sync recent plays on its own, without needing a browser tab open. Uses the model-update timing settings above.
+    type: BOOLEAN
   pruneTagName:
     displayName: Prune tag
     description: Tag applied by the Prune page. Default [Prune].

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -683,6 +683,10 @@ def test_settings_panel_reads_and_saves_every_configured_field() -> None:
     assert (
         "function SettingsPanel({ diversityEnabled, diversitySaving, onToggleDiversity })" in source
     )
+    assert (
+        'configKey: "auto_tasks_enabled", type: "BOOLEAN", label: "Automatic background tasks"'
+        in source
+    )
     assert "body && body({ diversityEnabled, diversitySaving, onToggleDiversity })" in source
     assert (
         "React.createElement(ManagePanel, { section: currentSection, "


### PR DESCRIPTION
## Summary

Phase 2a of `docs/decisions/004-background-task-worker.md`: the daemon's event-driven auto-scheduler. With the new `autoTasksEnabled` setting on, pending model updates are applied and recent plays are synced **without any browser tab open** — replacing the frontend timers (`scheduleModelUpdate` / `schedulePlaySync`) that were the only wake-up loop until now.

- **`core/autotasks.go`** — `schedulerTick` runs inside the daemon (~30 s cadence):
  - enqueues `update-model` when the existing `ModelUpdateCoordinator` gating (`modelUpdate*` settings: event threshold 5 / max wait 30 min / min interval 60 min) is ready and no model-touching job is running;
  - enqueues `sync-plays` when plays newer than the last completed sync have been quiet for ~60 s;
  - `enqueueAutoTask` coalesces against active same-type jobs (no double runs).
- **Daemon residency**: `schedulerStayAlive` keeps the daemon resident while a model update is pending or plays are unsynced, so the max-wait backstop can fire; it still idle-exits when there is nothing to do (5 min).
- **Event-driven spawn**: the dirtying operations (submit_feedback, correct_feedback, tag/term preferences, submit_events, prune decisions, exclusion reversal, entity hooks) call `ensureAutoWorker`, so the first event spawns the daemon — no task invocation needed to start automation.
- **Config**: new `autoTasksEnabled` yml setting (default **off**) mirrored through the Go/Python config parity surfaces (defaults, apply mapping, allowed keys), exposed as a toggle in Manage → Settings.
- Worker state now carries the Stash `server_connection` so auto-scheduled jobs can execute their mode bodies (settings fetch etc.).

## Verification

- Full Go suite green (new scheduler tests: disabled-by-default, ready gating, skip-while-rebuilding, coalescing, play quiet window, stay-alive).
- Full non-integration suite: **562 passed, 0 failed**; config-parity differentials green.
- End-to-end on a local synthetic Stash instance: enabled the setting, submitted feedback events via GraphQL (no browser, no manual task) → the daemon spawned, auto-enqueued `sync-plays` then `update-model`, both completed with progress 1, and health flipped to `model_pending: False`.

## Notes

- Defaults **off** — enable in Manage → Settings ("Automatic background tasks") or Stash's plugin settings page; the existing `modelUpdate*` timing settings gate the rebuild frequency.
- The frontend timers are left in place as a fallback; they coalesce harmlessly with the daemon's enqueues.
- Tier 2b (scheduled daily sync-build / backup) is the follow-up.
