### PR TITLE
fix: rotate daemon after plugin updates

### DIFF
--- a/core/daemon.go
+++ b/core/daemon.go
@@ -20,6 +20,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -31,25 +32,30 @@ import (
 // shorten them; the staleness windows stay constants (tests pin time via
 // timeNowUnixMilli).
 const (
-	heartbeatStaleMs = 5 * 60_000   // running rows older than this are orphans
+	heartbeatStaleMs = 5 * 60_000    // running rows older than this are orphans
 	legacyStaleMs    = 6 * 3_600_000 // pre-heartbeat rows keep the old window
-	idleExitMs       = 5 * 60_000   // exit after this long with no queued work
+	idleExitMs       = 5 * 60_000    // exit after this long with no queued work
 	claimPollMs      = 1_000
 )
 
 var (
 	heartbeatIntervalMs = 20_000 // liveness write while a job runs
 	progressDebounceMs  = 500    // cap progress writes during a build
+	workerCheckMs       = 5_000  // detect replacement of the installed binary
+	workerStopWaitMs    = 2_000  // grace period before forcing stale workers down
 )
 
 // workerState is written by the enqueuer (which has the Stash payload) and
 // re-read by the daemon (which has none): where the sidecar lives and how to
-// reach Stash for the per-job settings fetch.
+// reach Stash for the per-job settings fetch. BinaryFingerprint identifies
+// the exact installed executable generation so an old resident daemon cannot
+// survive a plugin update.
 type workerState struct {
-	DatabasePath     string            `json:"database_path"`
-	StashBase        string            `json:"stash_base"`
-	StashHeaders     map[string]string `json:"stash_headers"`
-	ServerConnection string            `json:"server_connection,omitempty"`
+	DatabasePath      string            `json:"database_path"`
+	StashBase         string            `json:"stash_base"`
+	StashHeaders      map[string]string `json:"stash_headers"`
+	ServerConnection  string            `json:"server_connection,omitempty"`
+	BinaryFingerprint string            `json:"binary_fingerprint,omitempty"`
 }
 
 func workerStatePath(pluginDir string) string {
@@ -95,6 +101,103 @@ func readWorkerPid(pluginDir string) (int, bool) {
 		return 0, false
 	}
 	return pid, true
+}
+
+// workerBinaryPath returns the installed platform binary. Development builds
+// use the running executable when the packaged per-arch name is absent.
+func workerBinaryPath(pluginDir string) string {
+	name := fmt.Sprintf("curator-core-%s-%s", runtime.GOOS, runtime.GOARCH)
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	candidate := filepath.Join(pluginDir, name)
+	if info, err := os.Stat(candidate); err == nil && info.Mode().IsRegular() {
+		return candidate
+	}
+	exe, err := os.Executable()
+	if err != nil {
+		return ""
+	}
+	return exe
+}
+
+// workerBinaryFingerprint changes when a plugin update replaces the running
+// executable. File identity catches atomic replacement; size and mtime catch
+// in-place replacement on platforms without a portable file identity.
+func workerBinaryFingerprint(pluginDir string) (string, error) {
+	path := workerBinaryPath(pluginDir)
+	if path == "" {
+		return "", fmt.Errorf("could not resolve curator-core executable")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s|%s|%d|%d|%o", filepath.Clean(path), workerFileIdentity(info),
+		info.Size(), info.ModTime().UnixNano(), info.Mode().Perm()), nil
+}
+
+// workerPidAliveFn is injectable for rotation tests.
+var workerPidAliveFn = pidAlive
+
+// stopWorkerFn is injectable so rotation tests never signal a real process.
+var stopWorkerFn = stopWorker
+
+func stopWorker(pid int) error {
+	if !pidAlive(pid) {
+		return nil
+	}
+	if err := terminateWorker(pid); err != nil && pidAlive(pid) {
+		return err
+	}
+	deadline := time.Now().Add(time.Duration(workerStopWaitMs) * time.Millisecond)
+	for pidAlive(pid) && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !pidAlive(pid) {
+		return nil
+	}
+	return forceKillWorker(pid)
+}
+
+// rotateStaleWorker stops a live daemon whose generation predates the
+// installed executable. Missing state is treated as stale for safe rollout
+// from versions that did not record a fingerprint.
+func rotateStaleWorker(pluginDir, fingerprint string) error {
+	pid, ok := readWorkerPid(pluginDir)
+	if !ok || !workerPidAliveFn(pid) {
+		return nil
+	}
+	state, err := readWorkerState(pluginDir)
+	if err == nil && state.BinaryFingerprint == fingerprint {
+		return nil
+	}
+	if err := stopWorkerFn(pid); err != nil {
+		return fmt.Errorf("could not stop stale Curator daemon %d: %w", pid, err)
+	}
+	return nil
+}
+
+func workerUpdateWatcher(pluginDir, initialFingerprint string, changed chan<- struct{}, done <-chan struct{}) {
+	ticker := time.NewTicker(time.Duration(workerCheckMs) * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			current, err := workerBinaryFingerprint(pluginDir)
+			if err != nil || current == initialFingerprint {
+				continue
+			}
+			infoLog("installed curator-core changed; daemon retiring")
+			select {
+			case changed <- struct{}{}:
+			case <-done:
+			}
+			return
+		}
+	}
 }
 
 // spawnWorkerFn is injectable so Go tests can force the inline fallback
@@ -150,18 +253,27 @@ func ensureAutoWorker(pluginDir string, payload jVal, settings jVal, db dbx) {
 	if !config.get("auto_tasks_enabled").truthy() && !anyScheduleEnabled(config) {
 		return
 	}
-	if pid, ok := readWorkerPid(pluginDir); ok && pidAlive(pid) {
+	fingerprint, err := workerBinaryFingerprint(pluginDir)
+	if err != nil || rotateStaleWorker(pluginDir, fingerprint) != nil {
+		return
+	}
+	base, headers := stashConnection(payload)
+	serverConn, _ := marshalJVal(payload.get("server_connection"))
+	state := workerState{
+		DatabasePath:      databasePath(pluginDir, payload, settings),
+		StashBase:         base,
+		StashHeaders:      headers,
+		ServerConnection:  serverConn,
+		BinaryFingerprint: fingerprint,
+	}
+	if pid, ok := readWorkerPid(pluginDir); ok && workerPidAliveFn(pid) {
+		if err := writeWorkerState(pluginDir, state); err != nil {
+			return
+		}
 		return
 	}
 	recoverOrphanJobs(db, nowMs())
-	base, headers := stashConnection(payload)
-	serverConn, _ := marshalJVal(payload.get("server_connection"))
-	if err := writeWorkerState(pluginDir, workerState{
-		DatabasePath:     databasePath(pluginDir, payload, settings),
-		StashBase:        base,
-		StashHeaders:     headers,
-		ServerConnection: serverConn,
-	}); err != nil {
+	if err := writeWorkerState(pluginDir, state); err != nil {
 		return
 	}
 	_ = spawnWorkerFn(pluginDir)
@@ -188,19 +300,29 @@ AND last_error IS NULL`)
 // ensureWorker guarantees a daemon exists whenever there is queued work. The
 // enqueuer calls it after inserting a queued row; health calls it so a
 // crashed daemon's orphans are recovered and its queue restarts. A live pid
-// is enough — no spawn, no DB churn. The sidecar is opened (and migrated)
-// before the state file is written, so a freshly spawned daemon never sees
-// an un-migrated database path.
+// is reused only when its recorded binary fingerprint matches the installed
+// executable; otherwise it is terminated before the new worker is spawned.
+// The sidecar is opened (and migrated) before the state file is written, so a
+// freshly spawned daemon never sees an un-migrated database path.
 func ensureWorker(pluginDir string, payload jVal, settings jVal) error {
 	base, headers := stashConnection(payload)
 	serverConn, _ := marshalJVal(payload.get("server_connection"))
-	if pid, ok := readWorkerPid(pluginDir); ok && pidAlive(pid) {
-		if err := writeWorkerState(pluginDir, workerState{
-			DatabasePath:     databasePath(pluginDir, payload, settings),
-			StashBase:        base,
-			StashHeaders:     headers,
-			ServerConnection: serverConn,
-		}); err != nil {
+	fingerprint, err := workerBinaryFingerprint(pluginDir)
+	if err != nil {
+		return fmt.Errorf("could not identify curator-core executable: %w", err)
+	}
+	if err := rotateStaleWorker(pluginDir, fingerprint); err != nil {
+		return err
+	}
+	state := workerState{
+		DatabasePath:      databasePath(pluginDir, payload, settings),
+		StashBase:         base,
+		StashHeaders:      headers,
+		ServerConnection:  serverConn,
+		BinaryFingerprint: fingerprint,
+	}
+	if pid, ok := readWorkerPid(pluginDir); ok && workerPidAliveFn(pid) {
+		if err := writeWorkerState(pluginDir, state); err != nil {
 			return fmt.Errorf("could not write worker state: %w", err)
 		}
 		return nil
@@ -219,12 +341,7 @@ func ensureWorker(pluginDir string, payload jVal, settings jVal) error {
 	if scanErr == sql.ErrNoRows {
 		return nil // nothing to run; the caller handles its own row inline
 	}
-	if err := writeWorkerState(pluginDir, workerState{
-		DatabasePath:     databasePath(pluginDir, payload, settings),
-		StashBase:        base,
-		StashHeaders:     headers,
-		ServerConnection: serverConn,
-	}); err != nil {
+	if err := writeWorkerState(pluginDir, state); err != nil {
 		return fmt.Errorf("could not write worker state: %w", err)
 	}
 	return spawnWorkerFn(pluginDir)
@@ -241,7 +358,16 @@ func runDaemon(pluginDir string) {
 		fmt.Fprintf(os.Stderr, "curator-core daemon: no worker state (%v); the daemon is only spawned from a Curator invocation\n", err)
 		os.Exit(1)
 	}
-	if pid, ok := readWorkerPid(pluginDir); ok && pid != os.Getpid() && pidAlive(pid) {
+	daemonFingerprint, err := workerBinaryFingerprint(pluginDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "curator-core daemon: could not identify executable: %v\n", err)
+		os.Exit(1)
+	}
+	if state.BinaryFingerprint != "" && state.BinaryFingerprint != daemonFingerprint {
+		infoLog("daemon generation is stale; exiting")
+		return
+	}
+	if pid, ok := readWorkerPid(pluginDir); ok && pid != os.Getpid() && workerPidAliveFn(pid) {
 		// A concurrent spawn won the race; it owns the worker.
 		os.Exit(0)
 	}
@@ -261,17 +387,31 @@ func runDaemon(pluginDir string) {
 	// Graceful shutdown: mark the in-flight job cancelled and exit.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
 	go func() {
 		<-sigCh
 		markRunningCancelled(loop)
 		os.Exit(0)
 	}()
 
+	updateDone := make(chan struct{})
+	updateDetected := make(chan struct{}, 1)
+	go workerUpdateWatcher(pluginDir, daemonFingerprint, updateDetected, updateDone)
+	defer close(updateDone)
+
 	recoverOrphanJobs(loop, nowMs())
 	autoPayload := autoPayloadFromState(state)
 	lastTick := nowMs()
 	idleSince := nowMs()
 	for {
+		select {
+		case <-updateDetected:
+			// Let an active job finish, but do not claim more work under the
+			// old executable. The next invocation starts the new generation.
+			infoLog("daemon stopped after plugin update")
+			return
+		default:
+		}
 		// Re-read the worker state each pass so a databasePath change (or a
 		// per-sidecar test harness) takes effect without a daemon restart.
 		if fresh, err := readWorkerState(pluginDir); err == nil {
@@ -511,7 +651,7 @@ func (s *progressSink) flushLocked(now int64) {
 }
 
 var (
-	progressSinkMu    sync.Mutex
+	progressSinkMu     sync.Mutex
 	activeProgressSink *progressSink
 )
 

--- a/core/daemon.go
+++ b/core/daemon.go
@@ -137,11 +137,19 @@ func workerBinaryFingerprint(pluginDir string) (string, error) {
 		info.Size(), info.ModTime().UnixNano(), info.Mode().Perm()), nil
 }
 
-// workerPidAliveFn is injectable for rotation tests.
+// workerPidAliveFn and workerPidIsWorkerFn are injectable for rotation tests.
 var workerPidAliveFn = pidAlive
+
+var workerPidIsWorkerFn = workerPidIsWorker
 
 // stopWorkerFn is injectable so rotation tests never signal a real process.
 var stopWorkerFn = stopWorker
+
+func removeWorkerPidIfOwned(pluginDir string) {
+	if pid, ok := readWorkerPid(pluginDir); ok && pid == os.Getpid() {
+		_ = os.Remove(workerPidPath(pluginDir))
+	}
+}
 
 func stopWorker(pid int) error {
 	if !pidAlive(pid) {
@@ -161,11 +169,15 @@ func stopWorker(pid int) error {
 }
 
 // rotateStaleWorker stops a live daemon whose generation predates the
-// installed executable. Missing state is treated as stale for safe rollout
-// from versions that did not record a fingerprint.
+// installed executable. A live PID that is not actually a Curator daemon is
+// treated as stale metadata and is never signalled.
 func rotateStaleWorker(pluginDir, fingerprint string) error {
 	pid, ok := readWorkerPid(pluginDir)
 	if !ok || !workerPidAliveFn(pid) {
+		return nil
+	}
+	if !workerPidIsWorkerFn(pid, pluginDir) {
+		_ = os.Remove(workerPidPath(pluginDir))
 		return nil
 	}
 	state, err := readWorkerState(pluginDir)
@@ -266,7 +278,7 @@ func ensureAutoWorker(pluginDir string, payload jVal, settings jVal, db dbx) {
 		ServerConnection:  serverConn,
 		BinaryFingerprint: fingerprint,
 	}
-	if pid, ok := readWorkerPid(pluginDir); ok && workerPidAliveFn(pid) {
+	if pid, ok := readWorkerPid(pluginDir); ok && workerPidAliveFn(pid) && workerPidIsWorkerFn(pid, pluginDir) {
 		if err := writeWorkerState(pluginDir, state); err != nil {
 			return
 		}
@@ -321,7 +333,7 @@ func ensureWorker(pluginDir string, payload jVal, settings jVal) error {
 		ServerConnection:  serverConn,
 		BinaryFingerprint: fingerprint,
 	}
-	if pid, ok := readWorkerPid(pluginDir); ok && workerPidAliveFn(pid) {
+	if pid, ok := readWorkerPid(pluginDir); ok && workerPidAliveFn(pid) && workerPidIsWorkerFn(pid, pluginDir) {
 		if err := writeWorkerState(pluginDir, state); err != nil {
 			return fmt.Errorf("could not write worker state: %w", err)
 		}
@@ -367,7 +379,7 @@ func runDaemon(pluginDir string) {
 		infoLog("daemon generation is stale; exiting")
 		return
 	}
-	if pid, ok := readWorkerPid(pluginDir); ok && pid != os.Getpid() && workerPidAliveFn(pid) {
+	if pid, ok := readWorkerPid(pluginDir); ok && pid != os.Getpid() && workerPidAliveFn(pid) && workerPidIsWorkerFn(pid, pluginDir) {
 		// A concurrent spawn won the race; it owns the worker.
 		os.Exit(0)
 	}
@@ -375,7 +387,7 @@ func runDaemon(pluginDir string) {
 		fmt.Fprintf(os.Stderr, "curator-core daemon: could not write pid file: %v\n", err)
 		os.Exit(1)
 	}
-	defer os.Remove(workerPidPath(pluginDir))
+	defer removeWorkerPidIfOwned(pluginDir)
 
 	daemonExitOnCancel = true
 	loop, loopPath := openDaemonLoop(pluginDir, state)
@@ -391,6 +403,7 @@ func runDaemon(pluginDir string) {
 	go func() {
 		<-sigCh
 		markRunningCancelled(loop)
+		removeWorkerPidIfOwned(pluginDir)
 		os.Exit(0)
 	}()
 

--- a/core/daemon_test.go
+++ b/core/daemon_test.go
@@ -253,12 +253,14 @@ func TestEnsureWorkerRotatesStaleBinary(t *testing.T) {
 		t.Fatal(err)
 	}
 	previousAlive := workerPidAliveFn
+	previousOwner := workerPidIsWorkerFn
 	previousStop := stopWorkerFn
 	previousSpawn := spawnWorkerFn
 	alive := true
 	stopCalls := 0
 	spawnCalls := 0
 	workerPidAliveFn = func(int) bool { return alive }
+	workerPidIsWorkerFn = func(int, string) bool { return true }
 	stopWorkerFn = func(int) error {
 		stopCalls++
 		alive = false
@@ -270,6 +272,7 @@ func TestEnsureWorkerRotatesStaleBinary(t *testing.T) {
 	}
 	defer func() {
 		workerPidAliveFn = previousAlive
+		workerPidIsWorkerFn = previousOwner
 		stopWorkerFn = previousStop
 		spawnWorkerFn = previousSpawn
 	}()
@@ -293,6 +296,53 @@ func TestEnsureWorkerRotatesStaleBinary(t *testing.T) {
 	}
 }
 
+func TestEnsureWorkerIgnoresReusedPID(t *testing.T) {
+	db, path := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	pluginDir := t.TempDir()
+	insertQueued(t, db, "queued", "sync-plays", `{}`, 1)
+	fingerprint, err := workerBinaryFingerprint(pluginDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := writeWorkerState(pluginDir, workerState{BinaryFingerprint: fingerprint}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workerPidPath(pluginDir), []byte(strconv.Itoa(os.Getpid())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	previousAlive := workerPidAliveFn
+	previousOwner := workerPidIsWorkerFn
+	previousStop := stopWorkerFn
+	previousSpawn := spawnWorkerFn
+	stopCalls := 0
+	spawnCalls := 0
+	workerPidAliveFn = func(int) bool { return true }
+	workerPidIsWorkerFn = func(int, string) bool { return false }
+	stopWorkerFn = func(int) error {
+		stopCalls++
+		return nil
+	}
+	spawnWorkerFn = func(string) error {
+		spawnCalls++
+		return nil
+	}
+	defer func() {
+		workerPidAliveFn = previousAlive
+		workerPidIsWorkerFn = previousOwner
+		stopWorkerFn = previousStop
+		spawnWorkerFn = previousSpawn
+	}()
+
+	if err := ensureWorker(pluginDir, taskPayload(path, "sync-plays"), jvObj()); err != nil {
+		t.Fatal(err)
+	}
+	if stopCalls != 0 || spawnCalls != 1 {
+		t.Fatalf("reused PID handling: stop=%d spawn=%d", stopCalls, spawnCalls)
+	}
+}
 func TestWorkerUpdateWatcherDetectsReplacement(t *testing.T) {
 	pluginDir := t.TempDir()
 	name := "curator-core-" + runtime.GOOS + "-" + runtime.GOARCH

--- a/core/daemon_test.go
+++ b/core/daemon_test.go
@@ -9,6 +9,9 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -231,6 +234,94 @@ func TestEnqueueQueuesAndWorkerClaims(t *testing.T) {
 			t.Fatalf("claim mismatch: %q %q", claimed, mode)
 		}
 	})
+}
+
+func TestEnsureWorkerRotatesStaleBinary(t *testing.T) {
+	db, path := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	pluginDir := t.TempDir()
+	insertQueued(t, db, "queued", "sync-plays", `{}`, 1)
+	if err := os.MkdirAll(filepath.Join(pluginDir, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(workerPidPath(pluginDir), []byte(strconv.Itoa(os.Getpid())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeWorkerState(pluginDir, workerState{BinaryFingerprint: "old-generation"}); err != nil {
+		t.Fatal(err)
+	}
+	previousAlive := workerPidAliveFn
+	previousStop := stopWorkerFn
+	previousSpawn := spawnWorkerFn
+	alive := true
+	stopCalls := 0
+	spawnCalls := 0
+	workerPidAliveFn = func(int) bool { return alive }
+	stopWorkerFn = func(int) error {
+		stopCalls++
+		alive = false
+		return nil
+	}
+	spawnWorkerFn = func(string) error {
+		spawnCalls++
+		return nil
+	}
+	defer func() {
+		workerPidAliveFn = previousAlive
+		stopWorkerFn = previousStop
+		spawnWorkerFn = previousSpawn
+	}()
+
+	if err := ensureWorker(pluginDir, taskPayload(path, "sync-plays"), jvObj()); err != nil {
+		t.Fatal(err)
+	}
+	if stopCalls != 1 || spawnCalls != 1 {
+		t.Fatalf("rotation calls: stop=%d spawn=%d", stopCalls, spawnCalls)
+	}
+	state, err := readWorkerState(pluginDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	current, err := workerBinaryFingerprint(pluginDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.BinaryFingerprint != current {
+		t.Fatalf("state fingerprint = %q, want %q", state.BinaryFingerprint, current)
+	}
+}
+
+func TestWorkerUpdateWatcherDetectsReplacement(t *testing.T) {
+	pluginDir := t.TempDir()
+	name := "curator-core-" + runtime.GOOS + "-" + runtime.GOARCH
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	binary := filepath.Join(pluginDir, name)
+	if err := os.WriteFile(binary, []byte("old"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initial, err := workerBinaryFingerprint(pluginDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousCheck := workerCheckMs
+	workerCheckMs = 1
+	defer func() { workerCheckMs = previousCheck }()
+	changed := make(chan struct{}, 1)
+	done := make(chan struct{})
+	go workerUpdateWatcher(pluginDir, initial, changed, done)
+	defer close(done)
+	if err := os.WriteFile(binary, []byte("new-generation"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-changed:
+	case <-time.After(time.Second):
+		t.Fatal("worker update watcher did not detect replacement")
+	}
 }
 
 func TestEnqueueInlineFallback(t *testing.T) {

--- a/core/daemon_unix.go
+++ b/core/daemon_unix.go
@@ -2,7 +2,27 @@
 
 package main
 
-import "syscall"
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func workerFileIdentity(info os.FileInfo) string {
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return ""
+	}
+	return fmt.Sprintf("%d:%d", stat.Dev, stat.Ino)
+}
+
+func terminateWorker(pid int) error {
+	return syscall.Kill(pid, syscall.SIGTERM)
+}
+
+func forceKillWorker(pid int) error {
+	return syscall.Kill(pid, syscall.SIGKILL)
+}
 
 // pidAlive reports whether a process with the given pid exists (signal 0).
 func pidAlive(pid int) bool {

--- a/core/daemon_unix.go
+++ b/core/daemon_unix.go
@@ -3,10 +3,24 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"syscall"
 )
+
+func workerPidIsWorker(pid int, pluginDir string) bool {
+	cmdline, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+	if err != nil || !bytes.Contains(cmdline, []byte(pluginDir)) {
+		return false
+	}
+	for _, arg := range bytes.Split(cmdline, []byte{0}) {
+		if bytes.Equal(arg, []byte("daemon")) {
+			return true
+		}
+	}
+	return false
+}
 
 func workerFileIdentity(info os.FileInfo) string {
 	stat, ok := info.Sys().(*syscall.Stat_t)

--- a/core/daemon_windows.go
+++ b/core/daemon_windows.go
@@ -10,6 +10,10 @@ import (
 	"syscall"
 )
 
+// Windows does not expose a portable command-line query through the APIs used
+// by this plugin; PID liveness remains the available ownership check there.
+func workerPidIsWorker(pid int, _ string) bool { return pidAlive(pid) }
+
 func workerFileIdentity(os.FileInfo) string { return "" }
 
 func terminateWorker(pid int) error {

--- a/core/daemon_windows.go
+++ b/core/daemon_windows.go
@@ -4,10 +4,25 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"os/exec"
 	"strconv"
 	"syscall"
 )
+
+func workerFileIdentity(os.FileInfo) string { return "" }
+
+func terminateWorker(pid int) error {
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return err
+	}
+	return process.Kill()
+}
+
+func forceKillWorker(pid int) error {
+	return terminateWorker(pid)
+}
 
 // pidAlive reports whether a process with the given pid exists. Windows has
 // no signal(0); probe the tasklist instead. The "no tasks" info line never

--- a/docs/decisions/004-background-task-worker.md
+++ b/docs/decisions/004-background-task-worker.md
@@ -98,9 +98,13 @@ the spawning process is gone), ensures the worker is alive, and returns
   single-writer and builds serialize anyway), heartbeat
   (`heartbeat_at_ms`, ~20 s), run the existing `runTaskMode` bodies,
   transition `complete`/`failed` with `summary_json`.
-- Ensure-worker on every plugin invocation (operation or task): check pid +
-  heartbeat freshness, spawn if dead. This is the crash-resurrection and
-  plugin-update rotation path (binary version/mtime change → restart).
+- Ensure-worker on every plugin invocation (operation or task): compare the
+  daemon's recorded executable fingerprint with the installed binary, terminate
+  a stale generation, and spawn the current one. The resident daemon also
+  watches that fingerprint, stops claiming new work after a replacement, lets
+  an active job finish, and exits so the next invocation starts the new binary.
+- This is the crash-resurrection and plugin-update rotation path; the
+  fingerprint combines platform file identity, size, mtime, and permissions.
 - Lifetime: lazy spawn on first task; exit when idle after a grace period
   (recommended) rather than permanently resident.
 
@@ -165,10 +169,10 @@ it Curator-side:
 - **Stash kill semantics**: verify whether Stash job stop/teardown kills the
   process group — setsid must defeat it. The one environment check that
   gates the whole design.
-- **Plugin update vs running daemon**: zip install replaces the binary
-  under a running daemon; version/mtime check on ensure-worker rotates it.
-  Decide: let the current job finish vs terminate (recommend: finish, then
-  next ensure spawns the new version).
+- **Plugin update vs running daemon**: zip install replaces the binary under a
+  running daemon. Generation fingerprints rotate stale workers on invocation;
+  the resident watcher drains the current job and exits without claiming more
+  work, then the next invocation spawns the new version.
 - **Progress write amplification**: debounce is mandatory (see 4.4).
 - **Connection staleness**: jobs enqueued before a Stash restart carry a
   stale `server_connection`; refresh per enqueue, fail clear on stale URL.

--- a/docs/decisions/004-background-task-worker.md
+++ b/docs/decisions/004-background-task-worker.md
@@ -91,7 +91,8 @@ the spawning process is gone), ensures the worker is alive, and returns
 - Detached spawn: `setsid` + stdio redirected to `data/curator-daemon.log`
   so the process survives Stash job teardown and Stash restarts. Must verify
   how Stash kills jobs (process-group kill is the case setsid defeats).
-- Single instance: pid file with staleness check (or lock row).
+- Single instance: pid file with staleness and process-ownership checks; a
+  reused PID is discarded rather than signalled or treated as the worker.
 - Startup recovery: mark its own `running`/`queued` rows `failed`
   (`interrupted`) — ownership-based replacement for the 6 h window.
 - Queue loop: atomically claim `queued` → `running` (one at a time; SQLite


### PR DESCRIPTION
## Problem
A detached daemon only checked PID liveness, so a resident process could continue running the old curator-core after a plugin zip update.

## Change
- record the installed executable fingerprint in worker state;
- rotate stale workers from ensureWorker and ensureAutoWorker;
- terminate stale workers with a graceful timeout and force-kill fallback;
- have resident daemons watch the installed binary and drain current work before exiting;
- add Unix/Windows process helpers and regression coverage;
- document the update-rotation lifecycle.

## Verification
- `go test ./...`
- `GOFLAGS=-buildvcs=false scripts/verify changed tests/core`
- `GOFLAGS=-buildvcs=false scripts/verify full`

Full gate: 592 passed, 25 deselected; perf gate 29.1s against 103.2s budget.