### PR TITLE
fix(model): bound score components without collapsing ordering at the cap

### DIFF
--- a/core/modelbuild.go
+++ b/core/modelbuild.go
@@ -85,6 +85,25 @@ func clampValue(value, low, high float64) float64 {
 	return value
 }
 
+// softBound mirrors _soft_bound: bound a component without collapsing
+// ordering at the cap. Exact below knee*bound — where a hard clamp was
+// inactive anyway — then smoothly asymptotic to bound. A hard clamp maps
+// every strong scene to the identical value, and appeal is ranked and
+// thresholded directly (prune, sentiment review), so those ties lose real
+// information. 1-exp(-t) rather than tanh: same shape, and the exponential
+// already agrees bit-for-bit across the Go/Python boundary, which the
+// artifact parity gate requires.
+func softBound(value, bound float64) float64 {
+	const knee = 0.8
+	kneeAt := knee * bound
+	head := bound - kneeAt
+	magnitude := math.Abs(value)
+	if magnitude <= kneeAt || head <= 0 {
+		return clampValue(value, -bound, bound)
+	}
+	return math.Copysign(kneeAt+head*(1-math.Exp(-(magnitude-kneeAt)/head)), value)
+}
+
 // clamp mirrors _clamp.
 func clamp(value float64) float64 {
 	return clampValue(value, -1, 1)

--- a/core/modelbuild2.go
+++ b/core/modelbuild2.go
@@ -670,7 +670,7 @@ func (c *scoringContext) scoreScene(sceneID string) buildModelScore {
 		} else {
 			components.set(family.name, jvObj(
 				jvKey("raw", jvFloat(raw)),
-				jvKey("value", jvFloat(clampValue(raw, -family.bound, family.bound))),
+				jvKey("value", jvFloat(softBound(raw, family.bound))),
 				jvKey("evidence_confidence", jvFloat(evidenceConfidence)),
 				jvKey("top", top),
 			))
@@ -732,13 +732,13 @@ func (c *scoringContext) scoreScene(sceneID string) buildModelScore {
 	familyConfidences["performer_similarity"] = similarityConfidence
 	components.set("performer_identity", jvObj(
 		jvKey("raw", jvFloat(identityRaw)),
-		jvKey("value", jvFloat(clampValue(identityRaw, -0.30, 0.30))),
+		jvKey("value", jvFloat(softBound(identityRaw, 0.30))),
 		jvKey("performers", identityValues),
 		jvKey("evidence_confidence", jvFloat(identityConfidence)),
 	))
 	components.set("performer_similarity", jvObj(
 		jvKey("raw", jvFloat(similarityRaw)),
-		jvKey("value", jvFloat(clampValue(similarityRaw, -0.16, 0.16))),
+		jvKey("value", jvFloat(softBound(similarityRaw, 0.16))),
 		jvKey("performers", similarityValues),
 		jvKey("evidence_confidence", jvFloat(similarityConfidence)),
 	))
@@ -784,7 +784,7 @@ func (c *scoringContext) scoreScene(sceneID string) buildModelScore {
 	} else {
 		components.set("studio", jvObj(
 			jvKey("raw", jvFloat(studioRaw)),
-			jvKey("value", jvFloat(clampValue(studioRaw, -0.12, 0.12))),
+			jvKey("value", jvFloat(softBound(studioRaw, 0.12))),
 			jvKey("studios", studioItems),
 			jvKey("evidence_confidence", jvFloat(studioConfidence)),
 		))
@@ -804,7 +804,7 @@ func (c *scoringContext) scoreScene(sceneID string) buildModelScore {
 	familyConfidences["content_neighbor"] = neighborConfidence
 	components.set("content_neighbor", jvObj(
 		jvKey("raw", jvFloat(neighborValue)),
-		jvKey("value", jvFloat(clampValue(neighborValue, -0.20, 0.20))),
+		jvKey("value", jvFloat(softBound(neighborValue, 0.20))),
 		jvKey("outcome_mean", jvFloat(neighborOutcomeMean)),
 		jvKey("training_outcome_mean", jvFloat(c.labelMean)),
 		jvKey("lift", jvFloat(neighborLift)),
@@ -822,7 +822,7 @@ func (c *scoringContext) scoreScene(sceneID string) buildModelScore {
 		}
 	}
 	componentTotal := sumFloats(componentValues)
-	general := clamp(componentTotal)
+	general := softBound(componentTotal, 1.0)
 	direct := c.labels[sceneID]
 	// Absolute channel only: a pairwise pick is evidence about the features
 	// that differed, not a verdict on this scene's own appeal.
@@ -970,7 +970,7 @@ func buildModelScores(db dbx, featureVersion string, sceneFeatures map[string][]
 	}
 	baselineSupport := sumFloats(baselineConfidences)
 	baseline := labelMean * baselineSupport / (1.0 + baselineSupport)
-	baseline = clampValue(baseline, -0.10, 0.10)
+	baseline = softBound(baseline, 0.10)
 	lastPlayed := map[string]int64{}
 	rows, err := db.Query(`SELECT scene_id, max(played_at_ms) AS last_played FROM source_play GROUP BY scene_id`)
 	if err != nil {

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -145,6 +145,29 @@ def _clamp(value: float, lower: float = -1.0, upper: float = 1.0) -> float:
     return max(lower, min(upper, value))
 
 
+def _soft_bound(value: float, bound: float, knee: float = 0.8) -> float:
+    """Bound a component without collapsing ordering at the cap.
+
+    Exact below ``knee * bound`` — where a hard clamp was inactive anyway —
+    then smoothly asymptotic to ``bound``. A hard clamp maps every strong
+    scene to the identical value, so scenes that saturate stop being
+    comparable: 41 scenes shared an appeal of exactly 1.0 on a real library,
+    and 43 of the top 200 shared a score with another scene. Appeal is
+    ranked and thresholded directly (Prune, Sentiment review), so those ties
+    are lost information, not a harmless display detail.
+
+    ``1 - exp(-t)`` rather than ``tanh(t)``: the same saturating shape, but
+    the exponential is already used across the Go/Python boundary here and
+    is proven to agree bit-for-bit, which the artifact parity gate requires.
+    """
+    knee_at = knee * bound
+    head = bound - knee_at
+    magnitude = abs(value)
+    if magnitude <= knee_at or head <= 0:
+        return _clamp(value, -bound, bound)
+    return math.copysign(knee_at + head * (1 - math.exp(-(magnitude - knee_at) / head)), value)
+
+
 def _number(value: object) -> float:
     return float(value) if isinstance(value, (int, float)) else 0.0
 
@@ -924,9 +947,7 @@ class PreferenceModelBuilder:
         baseline = (
             label_mean * baseline_support / (self.config.model.affinity_prior + baseline_support)
         )
-        baseline = _clamp(
-            baseline, -self.config.model.baseline_bound, self.config.model.baseline_bound
-        )
+        baseline = _soft_bound(baseline, self.config.model.baseline_bound)
         last_played = {
             str(row["scene_id"]): int(row["last_played"])
             for row in self.connection.execute(
@@ -991,7 +1012,7 @@ class PreferenceModelBuilder:
                 family_confidences[family] = evidence_confidence
                 components[family] = {
                     "raw": raw,
-                    "value": _clamp(raw, -bound, bound),
+                    "value": _soft_bound(raw, bound),
                     "evidence_confidence": evidence_confidence,
                     "top": sorted(
                         contributions,
@@ -1056,21 +1077,13 @@ class PreferenceModelBuilder:
             family_confidences["performer_similarity"] = similarity_confidence
             components["performer_identity"] = {
                 "raw": identity_raw,
-                "value": _clamp(
-                    identity_raw,
-                    -self.config.model.performer_identity_bound,
-                    self.config.model.performer_identity_bound,
-                ),
+                "value": _soft_bound(identity_raw, self.config.model.performer_identity_bound),
                 "performers": identity_values,
                 "evidence_confidence": identity_confidence,
             }
             components["performer_similarity"] = {
                 "raw": similarity_raw,
-                "value": _clamp(
-                    similarity_raw,
-                    -self.config.model.performer_similarity_bound,
-                    self.config.model.performer_similarity_bound,
-                ),
+                "value": _soft_bound(similarity_raw, self.config.model.performer_similarity_bound),
                 "performers": similarity_values,
                 "evidence_confidence": similarity_confidence,
             }
@@ -1100,9 +1113,7 @@ class PreferenceModelBuilder:
             family_confidences["studio"] = studio_confidence
             components["studio"] = {
                 "raw": studio_raw,
-                "value": _clamp(
-                    studio_raw, -self.config.model.studio_bound, self.config.model.studio_bound
-                ),
+                "value": _soft_bound(studio_raw, self.config.model.studio_bound),
                 "studios": studio_items,
                 "evidence_confidence": studio_confidence,
             }
@@ -1113,11 +1124,7 @@ class PreferenceModelBuilder:
             family_confidences["content_neighbor"] = neighbor_data.confidence
             components["content_neighbor"] = {
                 "raw": neighbor_data.value,
-                "value": _clamp(
-                    neighbor_data.value,
-                    -self.config.model.neighbor_bound,
-                    self.config.model.neighbor_bound,
-                ),
+                "value": _soft_bound(neighbor_data.value, self.config.model.neighbor_bound),
                 "outcome_mean": neighbor_data.outcome_mean,
                 "training_outcome_mean": label_mean,
                 "lift": neighbor_data.lift,
@@ -1131,7 +1138,7 @@ class PreferenceModelBuilder:
                 for value in components.values()
                 if isinstance(value, dict) and "value" in value
             )
-            general = _clamp(component_total)
+            general = _soft_bound(component_total, 1.0)
             direct = labels.get(scene_id, _SceneLabel(0.0, 0.0, 0.0, ()))
             # Absolute channel only: a pairwise pick is evidence about the
             # features that differed, not a verdict on this scene's own appeal.

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -157,6 +157,33 @@ def test_curation_rating_feeds_scene_labels(tmp_path: Path) -> None:
     assert "unusual" not in labels
 
 
+def test_soft_bound_keeps_saturated_components_comparable() -> None:
+    """Two scenes whose raw signal exceeds the bound must not end up equal.
+
+    A hard clamp mapped every strong scene to the identical value, so the
+    families that saturate stopped discriminating. Appeal is ranked and
+    thresholded directly (prune, sentiment review), so those ties are lost
+    information rather than a display detail.
+    """
+    bound = 0.35
+    # Below the knee the transform is exact: it only acts where a hard clamp
+    # was already discarding the difference.
+    for raw in (0.0, 0.1, 0.2, 0.8 * bound):
+        assert builder_module._soft_bound(raw, bound) == pytest.approx(raw)
+    # Above the bound it stays inside it, where a hard clamp would tie them...
+    strong = builder_module._soft_bound(0.45, bound)
+    stronger = builder_module._soft_bound(0.90, bound)
+    assert 0.8 * bound < strong < stronger < bound
+    # ...and the ordering survives, which is the whole point.
+    assert stronger > strong
+    # Symmetric, and the bound still holds for extreme input: the tail
+    # saturates to exactly the bound (exp underflows) and never past it.
+    assert builder_module._soft_bound(-0.90, bound) == pytest.approx(-stronger)
+    assert abs(builder_module._soft_bound(1e6, bound)) <= bound
+    # A degenerate bound cannot produce a value outside it.
+    assert builder_module._soft_bound(5.0, 0.0) == pytest.approx(0.0)
+
+
 def test_curation_pair_labels_surprise_confidence(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     # 'unseen-good' beats 'unlabeled'; both carry tag 'good' (the shared-tag


### PR DESCRIPTION
## Problem

Component values are hard-clamped to their family bound, and the summed score hard-clamped to 1.0. A hard clamp maps every sufficiently strong scene to the *identical* value, so scenes that saturate stop being comparable to each other.

On a real library that left **41 scenes sharing an appeal of exactly 1.0**, and **43 of the top 200** sharing a score with some other scene. Appeal is ranked and thresholded directly — prune orders by it through `model_scene_score_prune_idx`, sentiment review sorts on it — so those ties discard real information rather than being a display artifact.

Saturation is concentrated exactly where it hurts. In the top 200 scenes: `content` clamped for **77%**, `performer_identity` **53%**, `content_neighbor` **53%** — against 13%, 10% and 8% corpus-wide.

## Change

Replace the seven component/total clamps with a soft bound: exact below 80% of the bound — where a hard clamp was inactive anyway — then smoothly asymptotic to the bound. Only values the hard clamp was already flattening change at all.

| | before | after |
|---|---|---|
| scenes at appeal exactly 1.0 | 41 | **0** |
| top-200 sharing an identical appeal | 43 | **2** |
| Spearman vs observed behaviour | +0.3519 | +0.3517 · 95% CI [−0.0015, +0.0011] |
| Best Bets Jaccard / top-20 / top-100 | — | 0.995 / 18-20 / 93-100 |

Granularity is restored at no measurable cost to fit and with a small blast radius.

## Scope — what this is not

**It is not a ranking fix.** Lane ordering uses `lane_value`, which was already distinct for **5037 of 5065** best-bets rows, so these ties were never visible in lane order. The benefit is to appeal as a *score* and to the surfaces that rank by it.

**It does not affect variety.** Top-20 distinct studios is unchanged across every variant tested; that is the diversity re-ranker's job.

## Rejected alternative

Raising the bounds — the intuitive fix — was measured and is **strictly worse**. The seven bounds sum to 1.28, so uncapping the components pushes the total into the 1.0 ceiling, which then becomes the binding constraint:

| variant | scenes at ceiling | distinct scores in top-200 | ρ |
|---|---|---|---|
| current | 51 | 134/200 | +0.3519 |
| **soft bound (this PR)** | **0** | **196/200** | +0.3517 |
| bounds ×1.5 | 462 | 1/200 | +0.3431 |
| bounds ×2.0 | 569 | 1/200 | +0.3415 |
| no component clamp | 577 | 1/200 | +0.3409 |

## Parity

Both runtimes updated together — `curator/model/builder.py` and `core/modelbuild.go` / `core/modelbuild2.go`, seven sites each. `test_model_build_artifact_parity` passes, confirming bit-identical output.

`1 - exp(-t)` rather than `tanh(t)`: same saturating shape and identical measured results, but the exponential already crosses the Go/Python boundary elsewhere in this codebase and is proven to agree bit-for-bit. `tanh` is used nowhere today and would put a new libm dependency on the parity gate.

The numpy oracle covers only the neighbour and similarity kernels, so it is unaffected.

## Tests

New `test_soft_bound_keeps_saturated_components_comparable`: exact below the knee, ordering preserved above the bound where a hard clamp would tie, symmetric, and never exceeding the bound (for extreme input `exp(-t)` underflows and the value lands exactly *on* it).

`scripts/verify full`: 592 passed. `tests/core/test_backend.py::test_fallback_entity_hook` fails identically on clean `main` — unrelated, left alone.

## Notes

Independent of #176 (pair-confidence saturation); different files, no conflict, either order merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)