### PR TITLE
feat(core): run the background worker at low CPU and I/O priority

### DIFF
--- a/core/daemon.go
+++ b/core/daemon.go
@@ -424,6 +424,11 @@ func ensureWorker(pluginDir string, payload jVal, settings jVal) error {
 // the sidecar, recovers orphans at startup, and exits after an idle period
 // so an idle plugin runs no resident process.
 func runDaemon(pluginDir string) {
+	// Before anything else, and only on this path: the daemon is background
+	// work competing with a Stash the user is actively using. Foreground
+	// plugin invocations deliberately do not call this.
+	lowerWorkerPriority()
+
 	state, err := readWorkerState(pluginDir)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "curator-core daemon: no worker state (%v); the daemon is only spawned from a Curator invocation\n", err)

--- a/core/priority_linux.go
+++ b/core/priority_linux.go
@@ -1,0 +1,30 @@
+//go:build linux
+
+package main
+
+import "syscall"
+
+// I/O priority is the half that matters most here: the build's disk writes are
+// what make a co-hosted Stash unresponsive, and CPU niceness does nothing
+// about them.
+const (
+	ioprioWhoProcess = 1 // IOPRIO_WHO_PROCESS
+	ioprioClassBE    = 2 // IOPRIO_CLASS_BE
+	ioprioClassShift = 13
+	ioprioBELowest   = 7 // best-effort levels run 0 (highest) to 7 (lowest)
+)
+
+// lowerIOPriority puts the worker in the lowest best-effort I/O band.
+//
+// Deliberately not IOPRIO_CLASS_IDLE: idle only gets serviced when the disk is
+// otherwise quiet, which on a busy host can stall a build indefinitely rather
+// than merely slowing it. Lowest best-effort still yields to everything else
+// while guaranteeing forward progress.
+func lowerIOPriority() {
+	_, _, _ = syscall.Syscall(
+		syscall.SYS_IOPRIO_SET,
+		ioprioWhoProcess,
+		0, // the calling process
+		uintptr(ioprioClassBE<<ioprioClassShift|ioprioBELowest),
+	)
+}

--- a/core/priority_linux_test.go
+++ b/core/priority_linux_test.go
@@ -1,0 +1,24 @@
+//go:build linux
+
+package main
+
+import (
+	"syscall"
+	"testing"
+)
+
+const sysIoprioGet = syscall.SYS_IOPRIO_SET + 1 // ioprio_get follows ioprio_set
+
+func TestLowerIOPriorityMovesToLowestBestEffort(t *testing.T) {
+	lowerIOPriority()
+	value, _, errno := syscall.Syscall(sysIoprioGet, ioprioWhoProcess, 0, 0)
+	if errno != 0 {
+		t.Skipf("ioprio_get unavailable: %v", errno)
+	}
+	if class := int(value) >> ioprioClassShift; class != ioprioClassBE {
+		t.Errorf("io class = %d, want %d (best-effort)", class, ioprioClassBE)
+	}
+	if level := int(value) & 7; level != ioprioBELowest {
+		t.Errorf("io level = %d, want %d (lowest)", level, ioprioBELowest)
+	}
+}

--- a/core/priority_test.go
+++ b/core/priority_test.go
@@ -1,0 +1,60 @@
+//go:build unix
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// Raising niceness is irreversible without privileges, so the assertion runs
+// in a re-exec of the test binary: doing it in-process would leave every
+// later test in the package running at +10.
+const lowerPriorityChildEnv = "CURATOR_TEST_LOWER_PRIORITY_CHILD"
+
+func TestLowerWorkerPriorityLowersCPUPriority(t *testing.T) {
+	if os.Getenv(lowerPriorityChildEnv) == "1" {
+		before, err := syscall.Getpriority(syscall.PRIO_PROCESS, 0)
+		if err != nil {
+			fmt.Printf("ERR before %v\n", err)
+			return
+		}
+		lowerWorkerPriority()
+		after, err := syscall.Getpriority(syscall.PRIO_PROCESS, 0)
+		if err != nil {
+			fmt.Printf("ERR after %v\n", err)
+			return
+		}
+		fmt.Printf("RESULT %d %d\n", before, after)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestLowerWorkerPriorityLowersCPUPriority", "-test.v")
+	cmd.Env = append(os.Environ(), lowerPriorityChildEnv+"=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("child failed: %v\n%s", err, out)
+	}
+	var before, after int
+	var found bool
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "RESULT ") {
+			if _, err := fmt.Sscanf(line, "RESULT %d %d", &before, &after); err != nil {
+				t.Fatalf("unparsable result %q: %v", line, err)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("child produced no result:\n%s", out)
+	}
+	// getpriority reports 20-nice, not the nice value, so a *lower* number is
+	// a *lower* priority. Asserting after > before would be backwards.
+	if after >= before {
+		t.Fatalf("priority not lowered: getpriority before=%d after=%d (lower is nicer)", before, after)
+	}
+}

--- a/core/priority_unix.go
+++ b/core/priority_unix.go
@@ -1,0 +1,26 @@
+//go:build unix
+
+package main
+
+import "syscall"
+
+// workerNiceness is how far the background worker is pushed below everything
+// else on the box. A model build peaks around 5 GiB RSS and writes a
+// multi-hundred-megabyte artifact, so on a machine that is also serving Stash
+// it competes directly with the thing the user is looking at. +10 is a large
+// step down without being so extreme that the build never finishes on a busy
+// host.
+const workerNiceness = 10
+
+// lowerWorkerPriority de-prioritizes the calling process for CPU and, where
+// the platform supports it, disk. Only the daemon calls this: foreground
+// plugin invocations are answering a user action and must stay at normal
+// priority. Children inherit both settings, so the build kernels the daemon
+// spawns are covered without touching their spawn sites.
+//
+// Failures are ignored by design. Lower priority is an optimization, and a
+// sandbox that forbids setpriority is not a reason to refuse to run.
+func lowerWorkerPriority() {
+	_ = syscall.Setpriority(syscall.PRIO_PROCESS, 0, workerNiceness)
+	lowerIOPriority()
+}

--- a/core/priority_unix_other.go
+++ b/core/priority_unix_other.go
@@ -1,0 +1,8 @@
+//go:build unix && !linux
+
+package main
+
+// lowerIOPriority is a no-op away from Linux: darwin has no ioprio_set, and
+// its setiopolicy_np equivalent is not reachable from the standard library.
+// CPU niceness still applies there.
+func lowerIOPriority() {}

--- a/core/priority_windows.go
+++ b/core/priority_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package main
+
+import "syscall"
+
+// BELOW_NORMAL_PRIORITY_CLASS. PROCESS_MODE_BACKGROUND_BEGIN would also lower
+// I/O priority, but it is only valid for the calling process on Vista+ and
+// silently fails when the process is already in background mode, so the plain
+// class change is the predictable choice.
+const belowNormalPriorityClass = 0x00004000
+
+// lowerWorkerPriority mirrors the unix implementation. Failures are ignored:
+// lower priority is an optimization, not a precondition for running.
+func lowerWorkerPriority() {
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	setPriorityClass := kernel32.NewProc("SetPriorityClass")
+	handle, err := syscall.GetCurrentProcess()
+	if err != nil {
+		return
+	}
+	_, _, _ = setPriorityClass.Call(uintptr(handle), belowNormalPriorityClass)
+}


### PR DESCRIPTION
## Problem

A model build peaks near **5 GiB RSS** and writes a multi-hundred-megabyte artifact. On a host that is also serving Stash it competes directly with the thing the user is looking at, and an unattended background rebuild can make the UI unusable.

This came out of a real incident: an `update-model` job started unprompted, and Stash became unresponsive while it ran.

## Change

Lower the daemon's CPU **and** I/O priority at startup.

Only `runDaemon` calls it — foreground plugin invocations are answering a user action and stay at normal priority. Children inherit both settings, so the build kernels the daemon spawns are covered without touching their spawn sites.

| platform | CPU | I/O |
|---|---|---|
| Linux | `setpriority` +10 | `ioprio_set`, lowest best-effort |
| darwin | `setpriority` +10 | — (no reachable API) |
| Windows | `BELOW_NORMAL_PRIORITY_CLASS` | — |

**I/O priority is the half that matters most.** CPU niceness does nothing about the artifact writes, which are what starve a co-hosted Stash. `syscall.SYS_IOPRIO_SET` comes from the standard library and is defined per architecture, so linux/amd64 and linux/arm64 both work with **no new dependency**.

## Decisions worth reviewing

**Lowest best-effort, not `IOPRIO_CLASS_IDLE`.** Idle is only serviced when the disk is otherwise quiet, which on a busy host can stall a build indefinitely rather than merely slowing it. Lowest best-effort still yields to everything else while guaranteeing forward progress.

**Failures are ignored throughout.** Lower priority is an optimization; a sandbox that forbids `setpriority` is not a reason to refuse to run.

## Tests

Two things here are easy to get wrong, and the tests pin both:

- `getpriority` reports `20 - nice`, not the nice value, so a lowered priority reads as a **smaller** number. The obvious assertion (`after > before`) would be backwards and pass for the wrong reason.
- Raising niceness is **irreversible without privileges**, so calling it in-process would leave every later test in the package running at +10. The CPU test re-execs the test binary instead.
- The Linux test reads the I/O priority back and asserts class **and** level, rather than trusting a zero return.

Verified across all five shipped architectures via `scripts/build_plugin.py` (linux amd64/arm64, darwin amd64/arm64, windows amd64).

## Scope

**This does not address the memory footprint**, which is the other half of why a build disrupts a co-hosted Stash. Neither nice nor ionice does anything about ~5 GiB RSS; if a lockup is memory pressure, this will not prevent it. That is being looked at separately.

`scripts/verify full`: 593 passed. `tests/core/test_backend.py::test_fallback_entity_hook` fails identically on clean `main` — unrelated, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)