### PR TITLE
ci: stop the Playwright job cancelling itself on a slow browser install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,9 @@ jobs:
     name: Integration (Playwright)
     runs-on: ubuntu-latest
     needs: quality
-    timeout-minutes: 10
+    # A green run takes ~9.5 minutes, so a 10 minute cap left no headroom and
+    # any variance in the browser install cancelled the whole job mid-step.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
       - name: Install uv and Python
@@ -113,8 +115,44 @@ jobs:
             build-${{ runner.os }}-
       - name: Install dependencies
         run: uv sync --locked --group integration
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+      # Split from the browser download so a cache hit still gets the system
+      # libraries, and so the apt half carries its own timeout and retry: the
+      # hang that cancelled this job was apt-get stalling on an Ubuntu mirror,
+      # not the browser download.
+      - name: Install Playwright system dependencies
+        timeout-minutes: 12
+        run: |
+          # Per-attempt timeout, not just a step timeout: the observed failure
+          # was apt-get hanging on a mirror, and a step-level timeout would
+          # cancel the step outright rather than letting the retry fire.
+          for attempt in 1 2 3; do
+            if timeout 180 uv run playwright install-deps chromium; then
+              exit 0
+            fi
+            echo "playwright install-deps failed or hung (attempt $attempt); retrying"
+            sleep 15
+          done
+          echo "playwright install-deps failed after 3 attempts" >&2
+          exit 1
       - name: Install Playwright browsers
-        run: uv run playwright install chromium --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 12
+        run: |
+          for attempt in 1 2 3; do
+            if timeout 240 uv run playwright install chromium; then
+              exit 0
+            fi
+            echo "playwright install failed or hung (attempt $attempt); retrying"
+            sleep 15
+          done
+          echo "playwright install failed after 3 attempts" >&2
+          exit 1
       - name: Build plugin
         run: uv run --frozen python scripts/build_plugin.py
       - name: Run integration tests


### PR DESCRIPTION
## Problem

The integration job has been failing on unrelated PRs (#172, #178), always identically:

```
20:10:24  Get:5 https://archive.ubuntu.com/ubuntu noble-security InRelease
20:19:26  ##[error]The operation was canceled.
```

Nine minutes stalled in apt, then cancelled. Step status confirms it: `Install Playwright browsers` → `cancelled`, everything after → `skipped`.

**The mirror is the trigger, not the cause.** The job budget was `timeout-minutes: 10` and a healthy run takes about **9.5 minutes** — #179 passed at 9m24s, thirty-six seconds under the cap. There was no headroom, so any variance in the install cancelled the whole job. Re-running just rolled the dice again.

## Changes

**Raise the job budget to 25 minutes.** A cap barely above the normal runtime turns ordinary variance into a failure.

**Cache `~/.cache/ms-playwright`,** keyed on `uv.lock`, so the browser download is skipped on a hit.

**Split `playwright install --with-deps` into its two halves.** This matters for two reasons: a cache hit still needs the system libraries, and the flaky half is the apt one. It now retries three times with a **per-attempt `timeout`** rather than relying on a step-level timeout — a step timeout cancels the step outright and the retry would never fire, which is precisely the failure being fixed.

## Note

This lands on `main`, so #172 and #178 will keep failing until they pick it up — `pull_request` runs use the workflow from the PR branch. I'll rebase them once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)