### PR TITLE
feat(model): shrink tag affinities toward the taxonomy instead of toward zero

### DIFF
--- a/core/modelbuild.go
+++ b/core/modelbuild.go
@@ -25,6 +25,8 @@ import (
 const (
 	performerSimilarityAffinityCutoff = 0.005
 	modelBuildVersion                 = 4
+	affinityPrior                     = 1.0
+	affinitySiblingPrior              = 1.0
 	// Mirrors ModelConfig.curation_pair_* in curator/config.py. The product of
 	// the base confidence and the IPS cap bounds a pick's weight: keeping it
 	// under 1.0 is what stops every comparison clamping to the ceiling, which
@@ -813,6 +815,22 @@ func modelAffinities(db dbx, sceneFeatures map[string][]storedFeature,
 	if err != nil {
 		return nil, err
 	}
+	supports := map[string]float64{}
+	numerators := map[string]float64{}
+	for featureID, values := range accumulators {
+		weights := make([]float64, 0, len(values))
+		weightedOutcomes := make([]float64, 0, len(values))
+		for _, item := range values {
+			weights = append(weights, item.weight)
+			weightedOutcomes = append(weightedOutcomes, item.weight*item.outcome)
+		}
+		supports[featureID] = sumFloats(weights)
+		numerators[featureID] = sumFloats(weightedOutcomes)
+	}
+	siblingPriors, err := modelSiblingPriors(db, sceneFeatures, supports, numerators)
+	if err != nil {
+		return nil, err
+	}
 	result := map[string]modelAffinity{}
 	for featureID, values := range accumulators {
 		studios := map[string]bool{}
@@ -833,9 +851,12 @@ func modelAffinities(db dbx, sceneFeatures map[string][]storedFeature,
 				}
 			}
 		}
-		support := sumFloats(weights)
-		numerator := sumFloats(weightedOutcomes)
-		affinity := numerator / (1.0 + support)
+		support := supports[featureID]
+		numerator := numerators[featureID]
+		// Shrink toward what the tag's siblings say rather than toward zero;
+		// mirrors PreferenceModelBuilder._sibling_priors' use in _affinities.
+		priorPseudo := affinityPrior * affinitySiblingPrior * siblingPriors[featureID]
+		affinity := (numerator + priorPseudo) / (affinityPrior + support)
 		result[featureID] = modelAffinity{
 			featureID:  featureID,
 			affinity:   clamp(affinity),
@@ -1190,4 +1211,99 @@ func deriveNeighborEvidence(selected []neighborTuple, labelMean, confidenceScale
 		totalWeight: denominator,
 		neighbors:   neighbors,
 	}
+}
+
+// modelSiblingPriors mirrors PreferenceModelBuilder._sibling_priors: a tag's
+// prior is the support-weighted mean of its siblings' unsmoothed affinities,
+// itself excluded. Tags with no parent, and tags whose siblings carry no
+// support, are absent and keep the previous zero prior.
+func modelSiblingPriors(
+	db dbx,
+	sceneFeatures map[string][]storedFeature,
+	supports, numerators map[string]float64,
+) (map[string]float64, error) {
+	priors := map[string]float64{}
+	if affinitySiblingPrior <= 0 {
+		return priors, nil
+	}
+	featureOfTag := map[string]string{}
+	for _, features := range sceneFeatures {
+		for _, feature := range features {
+			if feature.family != "content" {
+				continue
+			}
+			if tagID := feature.metadata.get("tag_id").asString(); tagID != "" {
+				if _, seen := featureOfTag[tagID]; !seen {
+					featureOfTag[tagID] = feature.featureID
+				}
+			}
+		}
+	}
+	if len(featureOfTag) == 0 {
+		return priors, nil
+	}
+	parents := map[string][]string{}
+	children := map[string][]string{}
+	rows, err := db.Query(`SELECT tag_id, parent_tag_id FROM tag_parent ORDER BY tag_id, parent_tag_id`)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var tagID, parentTagID string
+		if err := rows.Scan(&tagID, &parentTagID); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		parents[tagID] = append(parents[tagID], parentTagID)
+		children[parentTagID] = append(children[parentTagID], tagID)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	tagIDs := make([]string, 0, len(parents))
+	for tagID := range parents {
+		tagIDs = append(tagIDs, tagID)
+	}
+	sort.Strings(tagIDs)
+	for _, tagID := range tagIDs {
+		featureID, ok := featureOfTag[tagID]
+		if !ok {
+			continue
+		}
+		siblingSet := map[string]bool{}
+		for _, parentTagID := range parents[tagID] {
+			for _, sibling := range children[parentTagID] {
+				if sibling != tagID {
+					siblingSet[sibling] = true
+				}
+			}
+		}
+		siblings := make([]string, 0, len(siblingSet))
+		for sibling := range siblingSet {
+			siblings = append(siblings, sibling)
+		}
+		// sort: these feed floating-point sums that must stay byte-identical
+		// run to run and against the Python oracle.
+		sort.Strings(siblings)
+		weight := 0.0
+		total := 0.0
+		for _, sibling := range siblings {
+			siblingFeature, ok := featureOfTag[sibling]
+			if !ok {
+				continue
+			}
+			support := supports[siblingFeature]
+			if support <= 0 {
+				continue
+			}
+			affinity := numerators[siblingFeature] / (affinityPrior + support)
+			total += affinity * support
+			weight += support
+		}
+		if weight > 0 {
+			priors[featureID] = total / weight
+		}
+	}
+	return priors, nil
 }

--- a/core/modelbuild3.go
+++ b/core/modelbuild3.go
@@ -506,6 +506,7 @@ func modelSubConfig() jVal {
 	return jvObj(
 		jvKey("affinity_confidence_scale", jvFloat(3.0)),
 		jvKey("affinity_prior", jvFloat(1.0)),
+		jvKey("affinity_sibling_prior", jvFloat(affinitySiblingPrior)),
 		jvKey("algorithm_version", jvInt(6)),
 		jvKey("baseline_bound", jvFloat(0.10)),
 		jvKey("content_bound", jvFloat(0.35)),

--- a/curator/config.py
+++ b/curator/config.py
@@ -77,6 +77,12 @@ class FeatureConfig:
 class ModelConfig:
     algorithm_version: int = 6
     affinity_prior: float = 1.0
+    # Weight on the taxonomy prior. A tag with a parent is shrunk toward
+    # what its siblings say rather than toward zero, so the prior means
+    # "what we know about this category" instead of "no opinion". A tag
+    # with no parent, or whose siblings carry no support, borrows nothing
+    # and behaves exactly as before. 0.0 disables the borrowing entirely.
+    affinity_sibling_prior: float = 1.0
     affinity_confidence_scale: float = 3.0
     direct_confidence_scale: float = 0.8
     cooldown_center_days: float = 90.0

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -939,6 +939,81 @@ class PreferenceModelBuilder:
             if "winner_scene" in entry and "loser_scene" in entry
         ]
 
+    def _sibling_priors(
+        self,
+        scene_features: dict[str, tuple[StoredFeature, ...]],
+        supports: dict[str, float],
+        numerators: dict[str, float],
+    ) -> dict[str, float]:
+        """Per-tag prior means borrowed from the taxonomy.
+
+        A tag's prior is the support-weighted mean of its *siblings'* unsmoothed
+        affinities -- the other children of its parents, itself excluded. The
+        parent's own affinity is deliberately not used: a scene usually carries
+        both a tag and its parent, so a parent's affinity is partly learned from
+        the very child being smoothed, and shrinking a value toward something
+        derived from itself is not borrowing.
+
+        Measured on a real library, this prior predicts a held-out tag's
+        affinity materially better than zero does (about 15% of squared error,
+        r = +0.33 over 333 tags with support), and shuffling the parent
+        assignments destroys the effect (permutation p = 0.0025).
+
+        Tags with no parent, and tags whose siblings carry no support, are
+        absent from the result and keep the previous zero prior.
+        """
+        if self.config.model.affinity_sibling_prior <= 0:
+            return {}
+        feature_of_tag: dict[str, str] = {}
+        for features in scene_features.values():
+            for feature in features:
+                tag_id = feature.metadata.get("tag_id") if feature.family == "content" else None
+                if tag_id is not None:
+                    feature_of_tag.setdefault(str(tag_id), feature.feature_id)
+        if not feature_of_tag:
+            return {}
+
+        parents: dict[str, list[str]] = defaultdict(list)
+        children: dict[str, list[str]] = defaultdict(list)
+        for row in self.connection.execute(
+            "SELECT tag_id, parent_tag_id FROM tag_parent ORDER BY tag_id, parent_tag_id"
+        ):
+            tag_id = str(row["tag_id"])
+            parent_tag_id = str(row["parent_tag_id"])
+            parents[tag_id].append(parent_tag_id)
+            children[parent_tag_id].append(tag_id)
+
+        priors: dict[str, float] = {}
+        for tag_id in sorted(parents):
+            feature_id = feature_of_tag.get(tag_id)
+            if feature_id is None:
+                continue
+            siblings = {
+                sibling
+                for parent_tag_id in parents[tag_id]
+                for sibling in children[parent_tag_id]
+                if sibling != tag_id
+            }
+            weight = 0.0
+            total = 0.0
+            # sorted(): these feed floating-point sums that must stay
+            # byte-identical run to run and against the Go mirror.
+            for sibling in sorted(siblings):
+                sibling_feature = feature_of_tag.get(sibling)
+                if sibling_feature is None:
+                    continue
+                support = supports.get(sibling_feature, 0.0)
+                if support <= 0:
+                    continue
+                affinity = numerators[sibling_feature] / (
+                    self.config.model.affinity_prior + support
+                )
+                total += affinity * support
+                weight += support
+            if weight > 0:
+                priors[feature_id] = total / weight
+        return priors
+
     def _affinities(
         self,
         scene_features: dict[str, tuple[StoredFeature, ...]],
@@ -986,11 +1061,32 @@ class PreferenceModelBuilder:
                     (event.loser_scene, weight, -math.copysign(1, feature.value))
                 )
         scene_context = self._scene_contexts()
+        supports = {
+            feature_id: sum(weight for _, weight, _ in values)
+            for feature_id, values in accumulators.items()
+        }
+        numerators = {
+            feature_id: sum(weight * outcome for _, weight, outcome in values)
+            for feature_id, values in accumulators.items()
+        }
+        sibling_priors = self._sibling_priors(scene_features, supports, numerators)
         result: dict[str, _Affinity] = {}
         for feature_id, values in accumulators.items():
-            support = sum(weight for _, weight, _ in values)
-            numerator = sum(weight * outcome for _, weight, outcome in values)
-            affinity = numerator / (self.config.model.affinity_prior + support)
+            support = supports[feature_id]
+            numerator = numerators[feature_id]
+            # Shrink toward what the tag's siblings say rather than toward zero,
+            # so a thin tag inherits its category's evidence instead of "no
+            # opinion". The prior is scaled by affinity_sibling_prior and enters
+            # as pseudo-observations at the sibling mean; a tag with no parent,
+            # or none whose siblings carry support, gets 0.0 here and reduces
+            # exactly to the previous expression.
+            prior_mean = sibling_priors.get(feature_id, 0.0)
+            prior_pseudo = (
+                self.config.model.affinity_prior
+                * self.config.model.affinity_sibling_prior
+                * prior_mean
+            )
+            affinity = (numerator + prior_pseudo) / (self.config.model.affinity_prior + support)
             studios = {
                 scene_context[scene_id][0]
                 for scene_id, _, _ in values

--- a/tests/core/test_backend_slice3_modelbuild.py
+++ b/tests/core/test_backend_slice3_modelbuild.py
@@ -184,6 +184,73 @@ def test_model_build_recovers_from_building_row(binary: Path, tmp_path: Path) ->
     assert _artifact_schema_diff(results[0][1], results[1][1]) == ""
 
 
+def _seed_tag_hierarchy(sidecar: Path) -> None:
+    """Give the corpus a tag taxonomy so hierarchical affinity smoothing runs.
+
+    Without parents every tag borrows nothing and the smoothing is a no-op, so
+    a divergence between the two implementations would go unnoticed here.
+    """
+    connection = sqlite3.connect(sidecar)
+    try:
+        connection.execute(
+            "INSERT INTO source_tag(tag_id, name, source_hash) VALUES (?, ?, ?)",
+            ("scenario", "Scenario", "tsc"),
+        )
+        connection.executemany(
+            "INSERT INTO tag_parent(tag_id, parent_tag_id) VALUES (?, ?)",
+            (("good", "scenario"), ("bad", "scenario"), ("unusual", "scenario")),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def test_model_build_artifact_parity_with_tag_hierarchy(binary: Path, tmp_path: Path) -> None:
+    """Parity holds once tags have parents, which is what makes the sibling
+    prior do anything. The default corpus is deliberately flat, so this is the
+    only place the smoothing path is compared across implementations."""
+
+    py_dir = tmp_path / "py"
+    py_dir.mkdir()
+    py_db = py_dir / "curator.sqlite3"
+    make_feature_sidecar(py_db)
+    _seed_tag_hierarchy(py_db)
+    py_model, py_artifact = _run_python_build(py_db)
+
+    go_dir = tmp_path / "go"
+    go_dir.mkdir()
+    go_db = go_dir / "curator.sqlite3"
+    make_feature_sidecar(go_db)
+    _seed_tag_hierarchy(go_db)
+    go_model, go_artifact = _run_go_build(binary, go_db)
+
+    assert go_model == py_model
+    assert artifact_tolerant_diff(go_artifact, py_artifact) == "", (
+        f"artifact content differs: {artifact_tolerant_diff(go_artifact, py_artifact)}"
+    )
+
+
+def test_tag_hierarchy_changes_the_model(binary: Path, tmp_path: Path) -> None:
+    """The smoothing must actually bite: the same corpus with and without a
+    taxonomy has to produce different affinities, or the parity test above
+    would be comparing two no-ops."""
+
+    flat_dir = tmp_path / "flat"
+    flat_dir.mkdir()
+    flat_db = flat_dir / "curator.sqlite3"
+    make_feature_sidecar(flat_db)
+    flat_model, _ = _run_python_build(flat_db)
+
+    nested_dir = tmp_path / "nested"
+    nested_dir.mkdir()
+    nested_db = nested_dir / "curator.sqlite3"
+    make_feature_sidecar(nested_db)
+    _seed_tag_hierarchy(nested_db)
+    nested_model, _ = _run_python_build(nested_db)
+
+    assert nested_model != flat_model
+
+
 def test_model_build_artifact_parity(binary: Path, tmp_path: Path) -> None:
     """Both implementations produce the same model_id and content-identical
     model artifacts; the sidecar model_version / current_model_id writes

--- a/tests/model/test_hierarchical_affinity.py
+++ b/tests/model/test_hierarchical_affinity.py
@@ -1,0 +1,129 @@
+"""A tag borrows its prior from its siblings rather than from zero.
+
+Affinities were learned per flat feature and shrunk toward a global zero, so a
+thin tag meant "no opinion" no matter how much its category was known. Measured
+on a real library the taxonomy carries real signal: predicting a held-out tag's
+affinity from its siblings beats predicting zero by about 15% of squared error
+(r = +0.33 over 333 tags with support), and shuffling the parent assignments
+destroys the effect (permutation p = 0.0025).
+
+The safety property is that nothing without a parent can move.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from curator.config import DEFAULT_CONFIG
+from curator.features.store import StoredFeature
+from curator.model.builder import PreferenceModelBuilder
+from tests.model.test_builder import _database
+
+
+def _content(feature_id: str, tag_id: str) -> StoredFeature:
+    return StoredFeature(feature_id, "content", f"tag:{tag_id}", 1.0, 1.0, {"tag_id": tag_id})
+
+
+def _builder(tmp_path: Path, hierarchy: tuple[tuple[str, str], ...]) -> PreferenceModelBuilder:
+    connection = _database(tmp_path / "curator.sqlite3")
+    connection.executemany(
+        "INSERT OR IGNORE INTO source_tag(tag_id, name, source_hash) VALUES (?, ?, ?)",
+        tuple((parent, parent.title(), f"h-{parent}") for _, parent in hierarchy),
+    )
+    connection.executemany("INSERT INTO tag_parent(tag_id, parent_tag_id) VALUES (?, ?)", hierarchy)
+    connection.commit()
+    return PreferenceModelBuilder(connection)
+
+
+SCENE_FEATURES = {
+    "s1": (_content("f-good", "good"), _content("f-bad", "bad"), _content("f-thin", "unusual")),
+}
+
+
+def test_a_tag_with_no_parent_borrows_nothing(tmp_path: Path) -> None:
+    builder = _builder(tmp_path, ())
+
+    priors = builder._sibling_priors(
+        SCENE_FEATURES, {"f-good": 10.0, "f-bad": 10.0}, {"f-good": 5.0, "f-bad": -5.0}
+    )
+
+    assert priors == {}
+
+
+def test_prior_is_the_support_weighted_mean_of_siblings(tmp_path: Path) -> None:
+    builder = _builder(
+        tmp_path, (("good", "scenario"), ("bad", "scenario"), ("unusual", "scenario"))
+    )
+    supports = {"f-good": 9.0, "f-bad": 1.0, "f-thin": 0.5}
+    numerators = {"f-good": 9.0, "f-bad": -1.0, "f-thin": 0.0}
+
+    priors = builder._sibling_priors(SCENE_FEATURES, supports, numerators)
+
+    # Unsmoothed affinities: good 9/(1+9) = 0.9 at support 9,
+    # bad -1/(1+1) = -0.5 at support 1, thin 0/(1+0.5) = 0.0 at support 0.5.
+    assert priors["f-thin"] == pytest.approx((0.9 * 9.0 - 0.5 * 1.0) / 10.0)
+    # Each tag's own value is excluded from its own prior, and every other
+    # sibling is included -- thin counts toward good's and bad's priors.
+    assert priors["f-good"] == pytest.approx((-0.5 * 1.0 + 0.0 * 0.5) / 1.5)
+    assert priors["f-bad"] == pytest.approx((0.9 * 9.0 + 0.0 * 0.5) / 9.5)
+
+
+def test_siblings_without_support_are_ignored(tmp_path: Path) -> None:
+    builder = _builder(tmp_path, (("good", "scenario"), ("bad", "scenario")))
+
+    priors = builder._sibling_priors(
+        SCENE_FEATURES, {"f-good": 9.0, "f-bad": 0.0}, {"f-good": 9.0, "f-bad": 0.0}
+    )
+
+    assert "f-good" not in priors, "a zero-support sibling must not create a prior"
+    assert priors["f-bad"] == pytest.approx(0.9)
+
+
+def test_disabling_the_prior_restores_the_previous_behaviour(tmp_path: Path) -> None:
+    builder = _builder(tmp_path, (("good", "scenario"), ("bad", "scenario")))
+    builder.config = replace(
+        DEFAULT_CONFIG, model=replace(DEFAULT_CONFIG.model, affinity_sibling_prior=0.0)
+    )
+
+    priors = builder._sibling_priors(
+        SCENE_FEATURES, {"f-good": 9.0, "f-bad": 9.0}, {"f-good": 9.0, "f-bad": -9.0}
+    )
+
+    assert priors == {}
+
+
+def test_hierarchy_moves_a_thin_tag_and_leaves_orphans_alone(tmp_path: Path) -> None:
+    """End to end: the same corpus with and without a taxonomy."""
+    flat = _database(tmp_path / "flat.sqlite3")
+    flat_result = PreferenceModelBuilder(flat).build()
+
+    nested_path = tmp_path / "nested.sqlite3"
+    nested = _database(nested_path)
+    nested.execute(
+        "INSERT INTO source_tag(tag_id, name, source_hash) VALUES ('scenario', 'Scenario', 'h')"
+    )
+    nested.executemany(
+        "INSERT INTO tag_parent(tag_id, parent_tag_id) VALUES (?, ?)",
+        (("good", "scenario"), ("bad", "scenario"), ("unusual", "scenario")),
+    )
+    nested.commit()
+    nested_result = PreferenceModelBuilder(nested).build()
+
+    assert nested_result.model_id != flat_result.model_id
+
+
+def test_affinities_are_unchanged_without_any_taxonomy(tmp_path: Path) -> None:
+    """The safety claim: a library with no tag parents is bit-identical to
+    what it produced before the sibling prior existed."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    assert connection.execute("SELECT COUNT(*) FROM tag_parent").fetchone()[0] == 0
+    builder = PreferenceModelBuilder(connection)
+
+    priors = builder._sibling_priors(
+        SCENE_FEATURES, {"f-good": 9.0, "f-bad": 9.0}, {"f-good": 9.0, "f-bad": -9.0}
+    )
+
+    assert priors == {}


### PR DESCRIPTION
Implements **WP5** from the signal-improvements workpackage (#181).

## Premise, checked before building

WP5's acceptance criterion is explicit — *"Parent-level affinity predicts child-tag behaviour better than the global prior — check before building."* Three of the five packages in that document have now failed on premise, so this was run first.

Leave-one-out: predict a tag's affinity from its siblings' (support-weighted), against predicting zero.

| minimum support | tags | SSE, zero prior | SSE, sibling prior | improvement | r |
|---|---|---|---|---|---|
| all | 465 | 30.107 | 27.489 | +8.7% | +0.291 |
| ≥ 1 | 347 | 29.588 | 25.441 | +14.0% | +0.322 |
| ≥ 5 | 333 | 29.520 | 25.195 | **+14.7%** | **+0.329** |
| ≥ 20 | 33 | 0.2597 | 0.2267 | +12.7% | +0.224 |

Consistent across thresholds. And a permutation test, because a support-weighted mean could improve error for reasons having nothing to do with the taxonomy: shuffling parent assignments 400 times gives a mean improvement of **−2.3%** (sd 3.68, max +8.69%) against the observed +14.6%. **p = 0.0025.** The signal is the hierarchy.

## Change

`affinity = numerator / (affinity_prior + support)` shrinks toward zero. The prior now sits at the support-weighted mean of the tag's **siblings'** unsmoothed affinities — the other children of its parents, itself excluded — entering as pseudo-observations at that mean.

Siblings rather than the parent's own affinity, deliberately: a scene usually carries both a tag and its parent, so a parent's affinity is partly learned from the very child being smoothed, and shrinking a value toward something derived from itself is not borrowing. The sibling form is also the one that was measured, which is the version worth shipping.

## Safety is structural, not argued

A tag with no parent, or none whose siblings carry support, gets a prior of exactly `0.0` and the expression reduces to the previous one term for term. `affinity_sibling_prior = 0.0` disables it outright.

Measured on a real library, the movement lands where it should:

| | |
|---|---|
| parented tags with sibling support | 466 |
| moved > 0.01 | 221 |
| tags with support ≥ 5 | 335, **largest move 0.054** |

Every large mover carries support under 0.3 — thin tags that previously read as "no opinion" (−0.001, −0.008) and now inherit their category's evidence. Well-supported tags barely shift, because their own evidence dominates. Spot-checking the names, the moves are coherent: sibling variants of the same act move together and in the same direction.

## Measured scene-level impact

Tag-level movement is the input; what a user experiences is the scene-level `appeal` score, so that was measured too — a full model build with the change against an identical build without it, both on the same real-library sidecar (config differing only in whether the sibling prior is applied).

| | |
|---|---|
| scenes | 23,938 |
| mean delta | **+0.0001** (no systematic drift) |
| moved by more than 0.01 | 3,314 (14%) |
| moved by more than 0.05 | 514 (2%) |
| largest single move | **+0.187 / −0.135** |

No scene crosses from strongly negative to near-maximum or the reverse; the nerfed scenes stay clearly positive. This build-pair comparison surfaced a separate, pre-existing defect independent of this PR's diff — filed as #186 — where the very first attempt at this comparison silently produced a model with an empty `feature_affinity` table (reported success, `published`/`valid`, but zero content-based scoring for every scene). That artifact is what a prior version of this description's numbers here were based on before the defect was caught; the table above is from a verified-complete rebuild.

## Test gap this closed

Neither test corpus had a single `tag_parent` row, so the smoothing path was not exercised anywhere and a Go/Python divergence in it would have shipped unnoticed. The model-build parity suite now seeds a taxonomy and compares both implementations across it, with a companion test asserting the taxonomy changes the model at all — so the parity check cannot pass by comparing two no-ops.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...`
- [x] `uv run mypy curator plugin/backend.py`, ruff check + format
- [x] Full non-integration suite: 606 passed (one failure, `test_fallback_entity_hook`, is a test-isolation bug against the repository's own `plugin/data` sidecar — fixed separately in #182, and passes on a clean checkout)
- [x] New Go/Python parity test over a seeded tag hierarchy, plus a test that the hierarchy changes the model
- [x] Unit tests: sibling mean excludes self, zero-support siblings ignored, parentless tags borrow nothing, disable knob restores previous behaviour
- [x] Perf gate: 21733 ms against a 103232 ms budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)

