### PR TITLE
feat(core): attribute plays to a recent impression when no direct link exists

### DIFF
--- a/core/writes.go
+++ b/core/writes.go
@@ -851,6 +851,7 @@ type sessionInput struct {
 	naturalCompletion      bool
 	impressionID           string
 	hasImpression          bool
+	impressionProvenance   string
 	lane                   string
 	hasLane                bool
 	impressionPosition     int64
@@ -916,6 +917,14 @@ func normalizeSession(entry jVal) (sessionInput, error) {
 	if v := entry.get("impression_id"); v.truthy() {
 		out.impressionID = v.asString()
 		out.hasImpression = true
+	}
+	if v := entry.get("impression_provenance"); v.truthy() {
+		out.impressionProvenance = v.asString()
+		if out.impressionProvenance != "observed" && out.impressionProvenance != "inferred" {
+			return sessionInput{}, fmt.Errorf("impression provenance must be 'observed', 'inferred', or null")
+		}
+	} else if out.hasImpression {
+		out.impressionProvenance = "observed"
 	}
 	if v := entry.get("lane"); v.truthy() {
 		out.lane = v.asString()
@@ -1057,6 +1066,39 @@ AND reversed_by_id IS NULL AND occurred_at_ms BETWEEN ? AND ? LIMIT 1`,
 		original.sceneID, original.sessionID, signal)
 }
 
+// impressionAttributionWindowMs mirrors
+// IMPRESSION_ATTRIBUTION_WINDOW_MS: a play that arrived without a direct
+// impression_id is attributed to the most recent impression of the same
+// scene shown within this window. Direct-player sessions average ~10s
+// (Curator observes starts, not whole plays), so the gap between a scene
+// being shown in a Curator lane and the user clicking into it is a
+// browsing-session-scale gap; 30 minutes bounds the join to the same
+// browsing session without crediting plays that came from elsewhere.
+const impressionAttributionWindowMs = int64(30 * 60 * 1000)
+
+// attributeImpression mirrors InteractionStore._attribute_impression.
+func attributeImpression(conn *sql.Conn, session sessionInput) (sessionInput, error) {
+	var impressionID string
+	err := conn.QueryRowContext(context.Background(), `
+SELECT i.impression_id
+FROM impression_item ii
+JOIN impression i ON i.impression_id = ii.impression_id
+WHERE ii.scene_id=? AND i.requested_at_ms<=? AND i.requested_at_ms>=?
+ORDER BY i.requested_at_ms DESC, i.impression_id DESC
+LIMIT 1`,
+		session.sceneID, session.startedAtMs, session.startedAtMs-impressionAttributionWindowMs).Scan(&impressionID)
+	if err == sql.ErrNoRows {
+		return session, nil
+	}
+	if err != nil {
+		return session, err
+	}
+	session.impressionID = impressionID
+	session.hasImpression = true
+	session.impressionProvenance = "inferred"
+	return session, nil
+}
+
 // submitSessions mirrors InteractionStore.submit_sessions.
 func submitSessions(db dbx, entries []jVal) (int64, error) {
 	sessions := make([]sessionInput, len(entries))
@@ -1072,6 +1114,13 @@ func submitSessions(db dbx, entries []jVal) (int64, error) {
 	err := withTxn(db, func(conn *sql.Conn) error {
 		ctx := context.Background()
 		for _, session := range sessions {
+			if !session.hasImpression {
+				attributed, err := attributeImpression(conn, session)
+				if err != nil {
+					return err
+				}
+				session = attributed
+			}
 			summary := sessionSummaryJSON(session)
 			res, err := conn.ExecContext(ctx, `
 INSERT OR IGNORE INTO play_session(
@@ -1156,6 +1205,7 @@ func sessionSummaryJSON(s sessionInput) string {
 		jvKey("final_position_seconds", jvFloat(s.finalPositionSeconds)),
 		jvKey("impression_id", optStrValue(s.impressionID, s.hasImpression)),
 		jvKey("impression_position", jvOptionalInt(s.impressionPositionPtr())),
+		jvKey("impression_provenance", optStrValue(s.impressionProvenance, s.impressionProvenance != "")),
 		jvKey("lane", optStrValue(s.lane, s.hasLane)),
 		jvKey("maximum_position_seconds", jvFloat(s.maximumPositionSeconds)),
 		jvKey("model_id", optStrValue(s.modelID, s.hasModelID)),

--- a/curator/events/__init__.py
+++ b/curator/events/__init__.py
@@ -1,6 +1,7 @@
 """Behavioral session and outcome normalization."""
 
 from curator.events.contracts import (
+    IMPRESSION_ATTRIBUTION_WINDOW_MS,
     OBSERVED_PLAYBACK_SQL,
     DirectSessionInput,
     EventCalibration,
@@ -15,6 +16,7 @@ from curator.events.replacements import quick_replacement_outcome
 from curator.events.repository import HistoricalEventStore
 
 __all__ = [
+    "IMPRESSION_ATTRIBUTION_WINDOW_MS",
     "OBSERVED_PLAYBACK_SQL",
     "DirectSessionInput",
     "EventCalibration",

--- a/curator/events/contracts.py
+++ b/curator/events/contracts.py
@@ -72,6 +72,15 @@ class EventCalibration:
 
 DEFAULT_CALIBRATION = EventCalibration()
 
+# A play that arrives without a direct impression_id is attributed to the most
+# recent impression of the same scene shown within this window. Direct-player
+# sessions average ~10s (Curator observes starts, not whole plays), so the gap
+# between a scene being shown in a Curator lane and the user clicking into it
+# is a browsing-session-scale gap; 30 minutes bounds the join to the same
+# browsing session without crediting plays that came from elsewhere (search,
+# later navigation) hours later.
+IMPRESSION_ATTRIBUTION_WINDOW_MS = 30 * 60 * 1000
+
 
 @dataclass(frozen=True)
 class PlayedRange:
@@ -107,6 +116,7 @@ class DirectSessionInput:
     nearby_marker_ids: tuple[str, ...] = ()
     natural_completion: bool = False
     impression_id: str | None = None
+    impression_provenance: str | None = None
     lane: str | None = None
     impression_position: int | None = None
     model_id: str | None = None
@@ -127,6 +137,8 @@ class DirectSessionInput:
             raise ValueError("session durations and positions must be non-negative")
         if self.impression_position is not None and self.impression_position < 0:
             raise ValueError("impression_position must be non-negative")
+        if self.impression_provenance not in (None, "observed", "inferred"):
+            raise ValueError("impression provenance must be 'observed', 'inferred', or null")
         if self.origin is SessionOrigin.CURATOR and self.impression_id is None:
             raise ValueError("Curator-originated sessions require an impression_id")
 

--- a/curator/interactions.py
+++ b/curator/interactions.py
@@ -6,11 +6,12 @@ import json
 import re
 import sqlite3
 from collections.abc import Iterable
-from dataclasses import asdict
+from dataclasses import asdict, replace
 from typing import Any
 
 from curator.config import DEFAULT_CONFIG
 from curator.events import (
+    IMPRESSION_ATTRIBUTION_WINDOW_MS,
     OBSERVED_PLAYBACK_SQL,
     DirectSessionInput,
     PlayedRange,
@@ -421,6 +422,8 @@ class InteractionStore:
         signaled = False
         with transaction(self.connection):
             for session in sessions:
+                if session.impression_id is None:
+                    session = self._attribute_impression(session)
                 try:
                     cursor = self.connection.execute(
                         """
@@ -467,6 +470,29 @@ class InteractionStore:
             if signaled:
                 ModelUpdateCoordinator(self.connection).request("session_outcome")
         return inserted
+
+    def _attribute_impression(self, session: DirectSessionInput) -> DirectSessionInput:
+        """Attribute a play that arrived without a direct impression_id to the
+        most recent impression of the same scene shown within the attribution
+        window, marking the link inferred rather than observed."""
+        row = self.connection.execute(
+            """
+            SELECT i.impression_id
+            FROM impression_item ii
+            JOIN impression i ON i.impression_id = ii.impression_id
+            WHERE ii.scene_id=? AND i.requested_at_ms<=? AND i.requested_at_ms>=?
+            ORDER BY i.requested_at_ms DESC, i.impression_id DESC
+            LIMIT 1
+            """,
+            (
+                session.scene_id,
+                session.started_at_ms,
+                session.started_at_ms - IMPRESSION_ATTRIBUTION_WINDOW_MS,
+            ),
+        ).fetchone()
+        if row is None:
+            return session
+        return replace(session, impression_id=str(row[0]), impression_provenance="inferred")
 
     def _apply_feedback(self, entry: dict[str, Any]) -> None:
         feedback_type = entry["feedback_type"]
@@ -671,6 +697,12 @@ class InteractionStore:
             PlayedRange(float(item["start_seconds"]), float(item["end_seconds"]))
             for item in entry.get("played_ranges", [])
         )
+        impression_id = str(entry["impression_id"]) if entry.get("impression_id") else None
+        impression_provenance = (
+            str(entry["impression_provenance"]) if entry.get("impression_provenance") else None
+        )
+        if impression_provenance is None and impression_id is not None:
+            impression_provenance = "observed"
         return DirectSessionInput(
             session_id=str(entry.get("session_id") or ""),
             scene_id=str(entry.get("scene_id") or ""),
@@ -688,7 +720,8 @@ class InteractionStore:
             ),
             nearby_marker_ids=tuple(str(value) for value in entry.get("nearby_marker_ids", [])),
             natural_completion=bool(entry.get("natural_completion", False)),
-            impression_id=str(entry["impression_id"]) if entry.get("impression_id") else None,
+            impression_id=impression_id,
+            impression_provenance=impression_provenance,
             lane=str(entry["lane"]) if entry.get("lane") else None,
             impression_position=(
                 int(entry["impression_position"])

--- a/tests/core/test_backend_slice3_writes.py
+++ b/tests/core/test_backend_slice3_writes.py
@@ -670,6 +670,108 @@ def test_submit_events_view_signal_state_parity(
     assert_equivalent(states[0], states[1])
 
 
+def test_submit_events_impression_attribution_state_parity(
+    writes_sidecar: Path, binary: Path, stub_stash: str
+) -> None:
+    """A play without a direct impression_id is attributed identically by both
+    backends: the most recent same-scene impression shown within the window is
+    written into play_session at write time, with the summary carrying an
+    inferred marker that stays distinguishable from an observed link."""
+    import shutil
+
+    run_dir = writes_sidecar.parent / f"{writes_sidecar.stem}-attribution-state"
+    states: list[list[tuple[object, ...]]] = []
+    for runner in (None, binary):
+        shutil.rmtree(run_dir, ignore_errors=True)
+        run_dir.mkdir()
+        run_db = run_dir / writes_sidecar.name
+        shutil.copy2(writes_sidecar, run_db)
+        result = run_backend(
+            runner,
+            PLUGIN_DIR,
+            json.dumps(
+                {
+                    "server_connection": {
+                        "Host": "127.0.0.1",
+                        "Port": int(stub_stash.rsplit(":", 1)[1]),
+                        "Scheme": "http",
+                        "SessionCookie": {},
+                    },
+                    "args": {
+                        "operation": "submit_events",
+                        "database_path": str(run_db),
+                        "entries": [
+                            {
+                                # Within the window of imp-1 (requested 100) -> inferred link.
+                                "event_type": "play_session",
+                                "session_id": "ps-in",
+                                "scene_id": "s1",
+                                "started_at_ms": 2_000,
+                                "ended_at_ms": 2_100,
+                                "active_seconds": 45.0,
+                                "origin": "stash",
+                                "played_ranges": [],
+                                "seek_destinations_seconds": [],
+                                "nearby_marker_ids": [],
+                                "natural_completion": False,
+                            },
+                            {
+                                # After the window (100 + 30min + 1) -> no attribution.
+                                "event_type": "play_session",
+                                "session_id": "ps-stale",
+                                "scene_id": "s1",
+                                "started_at_ms": 1_800_101,
+                                "ended_at_ms": 1_800_201,
+                                "active_seconds": 1.0,
+                                "origin": "stash",
+                                "played_ranges": [],
+                                "seek_destinations_seconds": [],
+                                "nearby_marker_ids": [],
+                                "natural_completion": False,
+                            },
+                            {
+                                # A direct Curator-originated link stays observed.
+                                "event_type": "play_session",
+                                "session_id": "ps-observed",
+                                "scene_id": "s1",
+                                "started_at_ms": 3_000,
+                                "ended_at_ms": 3_100,
+                                "active_seconds": 5.0,
+                                "origin": "curator",
+                                "impression_id": "imp-1",
+                                "played_ranges": [],
+                                "seek_destinations_seconds": [],
+                                "nearby_marker_ids": [],
+                                "natural_completion": False,
+                            },
+                        ],
+                    },
+                },
+                separators=(",", ":"),
+            ).encode(),
+        )
+        assert result.returncode == 0, result.stdout + result.stderr
+        connection = sqlite3.connect(run_db)
+        try:
+            rows = connection.execute(
+                "SELECT session_id, impression_id, provenance, summary_json"
+                " FROM play_session ORDER BY session_id"
+            ).fetchall()
+            states.append(rows)
+        finally:
+            connection.close()
+        shutil.rmtree(run_dir, ignore_errors=True)
+    # Byte-identical rows, including the serialized summaries.
+    assert states[0] == states[1]
+    python = {row[0]: row for row in states[0]}
+    assert python["ps-in"][1] == "imp-1"
+    assert json.loads(python["ps-in"][3])["impression_provenance"] == "inferred"
+    assert python["ps-stale"][1] is None
+    assert json.loads(python["ps-stale"][3])["impression_provenance"] is None
+    assert python["ps-observed"][1] == "imp-1"
+    assert json.loads(python["ps-observed"][3])["impression_provenance"] == "observed"
+
+
 # ── update_config ────────────────────────────────────────────────────────────
 
 

--- a/tests/test_interactions.py
+++ b/tests/test_interactions.py
@@ -1,7 +1,9 @@
+import json
 from pathlib import Path
 
 import pytest
 
+from curator.events import IMPRESSION_ATTRIBUTION_WINDOW_MS
 from curator.interactions import InteractionStore
 from curator.model import ModelUpdateCoordinator, PreferenceModelBuilder
 from curator.ranking import SlateBuilder
@@ -459,3 +461,126 @@ def test_short_curator_session_followed_by_another_scene_records_replacement(
         ).fetchone()[0]
         == -0.25
     )
+
+
+def test_play_attributes_to_most_recent_impression_within_window(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    connection.executemany(
+        """
+        INSERT INTO impression(impression_id, requested_at_ms, lane, config_version)
+        VALUES (?, ?, 'for_you', 'builtin')
+        """,
+        (("imp-old", 100), ("imp-new", 500)),
+    )
+    connection.executemany(
+        """
+        INSERT INTO impression_item(
+            impression_id, scene_id, position, policy_score, reason_snapshot_json
+        ) VALUES (?, 'old-good', ?, 0.5, '[]')
+        """,
+        (("imp-old", 0), ("imp-new", 1)),
+    )
+    store = InteractionStore(connection)
+    play = {
+        "session_id": "attributed",
+        "scene_id": "old-good",
+        "started_at_ms": 1_000,
+        "ended_at_ms": 11_000,
+        "active_seconds": 10,
+        "origin": "stash",
+        "source_route": "/scenes/old-good",
+        "start_position_seconds": 0,
+        "maximum_position_seconds": 10,
+        "final_position_seconds": 10,
+    }
+
+    assert store.submit_sessions([play]) == 1
+
+    row = connection.execute(
+        "SELECT impression_id, provenance, summary_json FROM play_session"
+        " WHERE session_id='attributed'"
+    ).fetchone()
+    assert row[0] == "imp-new"  # the most recent same-scene impression in the window
+    assert row[1] == "direct_player"  # the session-source provenance is unchanged
+    summary = json.loads(row[2])
+    assert summary["impression_id"] == "imp-new"
+    assert summary["impression_provenance"] == "inferred"
+
+
+def test_play_outside_window_or_without_impression_gets_no_attribution(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    connection.execute(
+        """
+        INSERT INTO impression(impression_id, requested_at_ms, lane, config_version)
+        VALUES ('imp-stale', 100, 'for_you', 'builtin')
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO impression_item(
+            impression_id, scene_id, position, policy_score, reason_snapshot_json
+        ) VALUES ('imp-stale', 'old-good', 0, 0.5, '[]')
+        """
+    )
+    store = InteractionStore(connection)
+    stale = {
+        "session_id": "stale",
+        "scene_id": "old-good",
+        "started_at_ms": 100 + IMPRESSION_ATTRIBUTION_WINDOW_MS + 1,
+        "ended_at_ms": 100 + IMPRESSION_ATTRIBUTION_WINDOW_MS + 10_000,
+        "active_seconds": 10,
+        "origin": "stash",
+        "source_route": "/scenes/old-good",
+        "start_position_seconds": 0,
+        "maximum_position_seconds": 10,
+        "final_position_seconds": 10,
+    }
+    unseen = {**stale, "session_id": "unseen", "scene_id": "recent-good"}
+
+    assert store.submit_sessions([stale, unseen]) == 2
+
+    for session_id in ("stale", "unseen"):
+        row = connection.execute(
+            "SELECT impression_id, summary_json FROM play_session WHERE session_id=?", (session_id,)
+        ).fetchone()
+        assert row[0] is None
+        assert json.loads(row[1])["impression_provenance"] is None
+
+
+def test_direct_impression_link_records_observed_provenance(tmp_path: Path) -> None:
+    connection = _database(tmp_path / "curator.sqlite3")
+    connection.execute(
+        """
+        INSERT INTO impression(impression_id, requested_at_ms, lane, config_version)
+        VALUES ('imp-direct', 100, 'for_you', 'builtin')
+        """
+    )
+    connection.execute(
+        """
+        INSERT INTO impression_item(
+            impression_id, scene_id, position, policy_score, reason_snapshot_json
+        ) VALUES ('imp-direct', 'old-good', 0, 0.5, '[]')
+        """
+    )
+    store = InteractionStore(connection)
+    play = {
+        "session_id": "observed",
+        "scene_id": "old-good",
+        "started_at_ms": 1_000,
+        "ended_at_ms": 11_000,
+        "active_seconds": 10,
+        "origin": "curator",
+        "source_route": "/plugins/stash-curator",
+        "start_position_seconds": 0,
+        "maximum_position_seconds": 10,
+        "final_position_seconds": 10,
+        "impression_id": "imp-direct",
+    }
+
+    assert store.submit_sessions([play]) == 1
+
+    row = connection.execute(
+        "SELECT impression_id, summary_json FROM play_session WHERE session_id='observed'"
+    ).fetchone()
+    assert row[0] == "imp-direct"
+    assert json.loads(row[1])["impression_provenance"] == "observed"


### PR DESCRIPTION
# Issue 187 — impression→play attribution (WP4)

Read the full issue: issue://mrx-31415/stash-curator/187

## Your files (exclusive ownership this wave)
- core/writes.go (runtime session/play write path — sessionInput around writes.go:916-957, session writes ~1079/1157, impression/linkage contract ~782-810)
- curator/events/repository.py and curator/interactions.py (Python mirrors of the write path — confirm via tests/core differential tests e.g. test_backend_slice3_writes.py which one mirrors writes.go)
- Tests: differential (Go/Python identical) + behavioral tests (tests/test_interactions.py style)

Do NOT touch: core/modelbuild*.go, plugin/* (other agents own these).

## Change
1. Understand the session model first: Curator-originated sessions REQUIRE an impression_id (writes.go:951 validation). Direct-player sessions mostly lack one (13/172 carry it; 10s average). Keep that validation contract intact.
2. When a play/session arrives without a direct impression_id, attribute it to the most recent impression of the SAME scene within a bounded time window (scene-plus-time-window join, e.g. shown within the last N minutes — pick one defensible bound, record it as a named constant), recorded AT WRITE TIME with provenance distinguishing inferred from observed (follow the existing provenance vocabulary in writes.go — add a value like inferred_impression vs observed, don't invent a parallel column if provenance already exists).
3. Mirror the identical logic in the Python oracle (repository.py / interactions.py) so differential tests stay byte-identical.
4. No schema change unless strictly needed — if a new column/table is unavoidable, follow the ordered-migration pattern mirrored in core/migrations/ and curator/storage/sql/ (checksum-guarded).

## Acceptance
- Play within the window after a showing of the same scene → session carries the inferred impression_id + inferred provenance.
- Outside the window (or no impression of that scene) → no attribution, existing behavior.
- Observed vs inferred links are distinguishable in the written rows.
- Differential Go/Python test byte-identical; targeted behavioral test passes.
- `cd core && go build ./... && go vet ./... && go test ./...` passes. Scripts/build_core.sh run once first. NEVER run `scripts/verify full`.

## Report
Files changed; the window constant chosen and why; test names + results; whether provenance reused an existing column or needed a migration.