### PR TITLE
fix(plugin): make Manage → Settings 1:1 with the plugin settings view

### DIFF
--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -4338,6 +4338,20 @@
         { key: "whisparrSearchImmediately", type: "BOOLEAN", default: true, label: "Search Whisparr immediately", description: "Start a release search after adding a scene. Enabled by default." },
       ],
     },
+    {
+      title: "Storage",
+      fields: [
+        { key: "databasePath", type: "STRING", label: "Sidecar database path", description: "Leave empty to store data in the plugin's data directory." },
+        { key: "backupPath", type: "STRING", label: "Backup directory", description: "Leave empty to store Curator backups beside the sidecar database." },
+      ],
+    },
+    {
+      title: "Development",
+      fields: [
+        { key: "profilingEnabled", type: "BOOLEAN", label: "Enable profiling", description: "Record recent Curator operation timings for the Profiling page." },
+        { key: "pprofEnabled", type: "BOOLEAN", label: "Capture CPU profiles", description: "Write a Go CPU and heap profile per operation into the sidecar's profiles directory, browsable and downloadable from the Profiling page. Analyze with go tool pprof. Off by default; keep off unless investigating performance." },
+      ],
+    },
   ];
 
   function SettingsField({ field, value, saving, error, onSave }) {

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -774,6 +774,44 @@ def test_settings_panel_reads_and_saves_every_configured_field() -> None:
     assert '{ key: "whisparrApiKey", type: "PASSWORD"' in source
     assert 'field.type === "PASSWORD" ? "password"' in source
 
+    # GH #188: the Storage and Development groups surface the remaining
+    # plugin settings with the exact stash-curator.yml displayName/type text.
+    # Like the Whisparr fields they are raw plugin settings (no configKey),
+    # read back via getPluginSettings() rather than curator_config.
+    assert 'title: "Storage"' in source
+    assert 'title: "Development"' in source
+    for key, field_type, label in (
+        ("databasePath", "STRING", "Sidecar database path"),
+        ("backupPath", "STRING", "Backup directory"),
+        ("profilingEnabled", "BOOLEAN", "Enable profiling"),
+        ("pprofEnabled", "BOOLEAN", "Capture CPU profiles"),
+    ):
+        assert f'key: "{key}", type: "{field_type}", label: "{label}"' in source
+
+
+def test_settings_panel_mirrors_plugin_settings_schema() -> None:
+    """The Manage → Settings panel and the plugin settings view cannot drift:
+    every settings key in stash-curator.yml has a SETTINGS_FIELD_GROUPS entry
+    and vice versa. diversityDisabled is the one documented exception — it is
+    surfaced through the panel's own recommendation-variety toggle.
+    """
+    root = Path(__file__).parents[2]
+    manifest = (root / "plugin" / "stash-curator.yml").read_text(encoding="utf-8")
+    settings_block = manifest.split("settings:", 1)[1].split("\ntasks:", 1)[0]
+    manifest_keys = {
+        match.group(1)
+        for line in settings_block.splitlines()
+        if (match := re.match(r"^  ([A-Za-z][A-Za-z0-9]*):$", line))
+    }
+
+    source = (root / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
+    start = source.index("const SETTINGS_FIELD_GROUPS = [")
+    end = source.index("function SettingsField({")
+    panel_keys = set(re.findall(r'key: "([A-Za-z][A-Za-z0-9]*)"', source[start:end]))
+
+    assert manifest_keys - panel_keys == {"diversityDisabled"}
+    assert panel_keys - manifest_keys == set()
+
 
 def test_plugin_performer_hunt_keeps_results_and_reuses_external_cards() -> None:
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")


### PR DESCRIPTION
# Issue 188 — Manage → Settings panel must be 1:1 with the plugin settings view

Read the full issue: issue://mrx-31415/stash-curator/188

## Your files (exclusive ownership this wave)
- plugin/stash-curator.js — SETTINGS_FIELD_GROUPS (~line 4284) and SettingsPanel (~4405-4510); the SaveField/commit machinery
- plugin/backend.py — ONLY if the four settings need config plumbing (check how existing panel fields persist: configurePlugin vs getPluginSettings)
- plugin/stash-curator.yml — read-only reference (the settings schema is the source of truth)
- tests/plugin/test_runtime.py — drift test + panel assertions

Do NOT touch: core/*, curator/events/repository.py, curator/interactions.py (other agents own these).

## Change
1. Add the four missing settings to SETTINGS_FIELD_GROUPS, keys matching stash-curator.yml exactly:
   - New group "Storage": databasePath (STRING), backupPath (STRING)
   - New group "Development": profilingEnabled (BOOLEAN), pprofEnabled (BOOLEAN)
   Use the exact displayName/description text from stash-curator.yml for labels/descriptions.
2. Confirm the four save and load through the same path as existing fields (read how SettingsField commits — configurePlugin round-trip or setPluginSettings) and wire anything needed in plugin/backend.py only if a field is not mirrored into curator_config (follow the existing configKey/_apply_plugin_settings convention noted in the SETTINGS_FIELD_GROUPS comment).
3. Add a drift test in tests/plugin/test_runtime.py following the existing test conventions: every settings key in plugin/stash-curator.yml has a SETTINGS_FIELD_GROUPS entry and vice versa, so the two surfaces cannot drift again. Check how existing runtime tests read the JS/config (there may be an existing settings test to extend).
4. Settings panel is plugin chrome — the SFW Switch card contract and card-section classes are untouched.

## Acceptance
- All four settings render in Manage → Settings with the right types/labels.
- The drift test fails if a key is added to stash-curator.yml without a panel entry.
- `uv run pytest tests/plugin/test_runtime.py` passes (and any test file you touch). NEVER run `scripts/verify full`.

## Report
Files changed; the persistence path used for the four fields; drift test name + result.