### PR TITLE
fix(daemon): retire the worker when the sidecar schema is newer than the binary

### DIFF
--- a/core/daemon.go
+++ b/core/daemon.go
@@ -43,6 +43,14 @@ var (
 	progressDebounceMs  = 500    // cap progress writes during a build
 	workerCheckMs       = 5_000  // detect replacement of the installed binary
 	workerStopWaitMs    = 2_000  // grace period before forcing stale workers down
+	// schedulerFailureLimit is the number of consecutive auto-scheduler
+	// failures (a sidecar that will not open or a build loop that cannot make
+	// progress) before the daemon retires. A runaway loop keeps re-enqueuing
+	// a task that fails at sidecar open (e.g. the installed binary is older
+	// than the sidecar's schema); retiring hands the queue back to a fresh
+	// daemon spawned by the next Curator invocation with the current binary,
+	// instead of spinning forever.
+	schedulerFailureLimit = 3
 )
 
 // workerState is written by the enqueuer (which has the Stash payload) and
@@ -203,6 +211,21 @@ var workerPidIsWorkerFn = workerPidIsWorker
 
 // stopWorkerFn is injectable so rotation tests never signal a real process.
 var stopWorkerFn = stopWorker
+
+// isSchemaSkewError reports whether a sidecar error means the installed
+// binary's migration set is older than the sidecar schema. The daemon cannot
+// make progress against such a sidecar (the open and every query fail), and
+// retrying only re-enqueues a task that can never run, so the daemon retires
+// and the next Curator invocation spawns a fresh worker with the current
+// binary.
+func isSchemaSkewError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "unknown migration versions") ||
+		strings.Contains(msg, "does not match the packaged checksum")
+}
 
 func removeWorkerPidIfOwned(pluginDir string) {
 	if pid, ok := readWorkerPid(pluginDir); ok && pid == os.Getpid() {
@@ -480,6 +503,7 @@ func runDaemon(pluginDir string) {
 	autoPayload := autoPayloadFromState(state)
 	lastTick := nowMs()
 	idleSince := nowMs()
+	schedulerFailures := 0
 	for {
 		select {
 		case <-updateDetected:
@@ -510,10 +534,23 @@ func runDaemon(pluginDir string) {
 			lastTick = now
 			if enqueued, err := schedulerTick(loop, autoPayload, now); err != nil {
 				errorLog("auto-scheduler failed: " + err.Error())
+				schedulerFailures++
+				if isSchemaSkewError(err) {
+					// The installed binary is older than the sidecar schema;
+					// retrying cannot help. Retire so a fresh daemon with the
+					// current binary takes over on the next invocation.
+					infoLog("daemon retiring: schema is newer than the installed binary")
+					return
+				}
+				if schedulerFailures >= schedulerFailureLimit {
+					infoLog(fmt.Sprintf("daemon retiring after %d consecutive auto-scheduler failures", schedulerFailures))
+					return
+				}
 			} else {
 				for _, mode := range enqueued {
 					infoLog("auto-enqueued task " + mode)
 				}
+				schedulerFailures = 0
 			}
 		}
 		jobID, startedAtMs, payload, mode, err := claimQueuedJob(loop)
@@ -524,7 +561,10 @@ func runDaemon(pluginDir string) {
 		}
 		if jobID != "" {
 			idleSince = nowMs()
-			runWorkerJob(pluginDir, loop, jobID, startedAtMs, payload, mode)
+			if runWorkerJob(pluginDir, loop, jobID, startedAtMs, payload, mode) {
+				infoLog("daemon retiring: schema is newer than the installed binary")
+				return
+			}
 			// The job's peak is garbage now, and the daemon may stay resident
 			// for a while yet (see the stay-alive check below), so give the
 			// pages back rather than idling at the build's high-water mark.
@@ -537,6 +577,18 @@ func runDaemon(pluginDir string) {
 		stayAlive, stayErr := schedulerStayAlive(loop, nowMs())
 		if stayErr != nil {
 			errorLog("stay-alive check failed: " + stayErr.Error())
+			schedulerFailures++
+			if isSchemaSkewError(stayErr) {
+				infoLog("daemon retiring: schema is newer than the installed binary")
+				return
+			}
+			if schedulerFailures >= schedulerFailureLimit {
+				infoLog(fmt.Sprintf("daemon retiring after %d consecutive auto-scheduler failures", schedulerFailures))
+				return
+			}
+		} else if schedulerFailures > 0 {
+			// A healthy pass means the sidecar is reachable again; reset.
+			schedulerFailures = 0
 		}
 		if !stayAlive && nowMs()-idleSince > idleExitMs {
 			infoLog("daemon idle; exiting")
@@ -628,17 +680,21 @@ WHERE job_id=? AND state='queued'`, os.Getpid(), nowMs(), jobID)
 
 // runWorkerJob executes one claimed job with the same lifecycle as the
 // inline path: fresh artifact-attached connection, settings from the payload
-// snapshot, executeClaimedJob transitions, failures recorded on the row.
-func runWorkerJob(pluginDir string, loop dbx, jobID string, startedAtMs int64, payload jVal, mode string) {
+// snapshot, executeClaimedJob transitions, failures recorded on the row. It
+// returns true when the daemon should retire: the job's sidecar could not be
+// opened because the installed binary is older than the sidecar schema, so no
+// job can ever run and a fresh worker with the current binary must take over.
+func runWorkerJob(pluginDir string, loop dbx, jobID string, startedAtMs int64, payload jVal, mode string) bool {
 	settings := pluginSettings(payload)
-	db, err := openTaskSidecar(pluginDir, payload, settings, mode)
+	db, err := openTaskSidecarFn(pluginDir, payload, settings, mode)
 	if err != nil {
 		execImmediate(loop, `UPDATE curator_job SET state='failed', finished_at_ms=?, error=?
 WHERE job_id=? AND state='running'`, nowMs(), truncateString(err.Error(), 2000), jobID)
-		return
+		return isSchemaSkewError(err)
 	}
 	defer db.Close()
 	_, _ = executeClaimedJob(db, pluginDir, payload, mode, settings, jobID, startedAtMs)
+	return false
 }
 
 // heartbeatLoop writes liveness and watches the cooperative-cancel flag for

--- a/core/daemon_test.go
+++ b/core/daemon_test.go
@@ -435,6 +435,85 @@ func TestEnqueueFailsClosedWhenWorkerUnavailable(t *testing.T) {
 	}
 }
 
+func TestIsSchemaSkewError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil is not skew", nil, false},
+		{"unknown migration versions", errors.New("database contains unknown migration versions: [33]"), true},
+		{"unknown multiple migrations", errors.New("database contains unknown migration versions: [33 34]"), true},
+		{"checksum mismatch", errors.New("migration 33 does not match the packaged checksum"), true},
+		{"unrelated open error", errors.New("database disk image is malformed"), false},
+		{"busy error", errors.New("database is locked"), false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := isSchemaSkewError(c.err); got != c.want {
+				t.Fatalf("isSchemaSkewError(%q) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+func TestRunWorkerJobRetiresOnSchemaSkew(t *testing.T) {
+	pluginDir := t.TempDir()
+	path := filepath.Join(t.TempDir(), "curator.sqlite3")
+	payload := taskPayload(path, "update-model")
+	previous := openTaskSidecarFn
+	openTaskSidecarFn = func(string, jVal, jVal, string) (dbx, error) {
+		return nil, errors.New("database contains unknown migration versions: [33]")
+	}
+	defer func() { openTaskSidecarFn = previous }()
+
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	insertQueued(t, db, "job-1", "update-model", "{}", 1_700_000_000_000)
+	// The job must be marked running so the failure transition applies.
+	if _, err := db.Exec(`UPDATE curator_job SET state='running', owner_pid=?, heartbeat_at_ms=? WHERE job_id='job-1'`, os.Getpid(), nowMs()); err != nil {
+		t.Fatal(err)
+	}
+
+	retire := runWorkerJob(pluginDir, db, "job-1", 1_700_000_000_000, payload, "update-model")
+	if !retire {
+		t.Fatal("schema-skew sidecar open must signal daemon retirement")
+	}
+	if got := jobState(t, db, "job-1"); got != "failed" {
+		t.Fatalf("job left in %q, want failed", got)
+	}
+	row := jobRow(t, db, "job-1")
+	if !strings.Contains(asDBString(row["error"]), "unknown migration versions") {
+		t.Fatalf("job error not recorded: %q", asDBString(row["error"]))
+	}
+}
+
+func TestRunWorkerJobDoesNotRetireOnTransientOpenFailure(t *testing.T) {
+	pluginDir := t.TempDir()
+	path := filepath.Join(t.TempDir(), "curator.sqlite3")
+	payload := taskPayload(path, "update-model")
+	previous := openTaskSidecarFn
+	openTaskSidecarFn = func(string, jVal, jVal, string) (dbx, error) {
+		return nil, errors.New("database is locked")
+	}
+	defer func() { openTaskSidecarFn = previous }()
+
+	db, _ := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	insertQueued(t, db, "job-1", "update-model", "{}", 1_700_000_000_000)
+	if _, err := db.Exec(`UPDATE curator_job SET state='running', owner_pid=?, heartbeat_at_ms=? WHERE job_id='job-1'`, os.Getpid(), nowMs()); err != nil {
+		t.Fatal(err)
+	}
+
+	if retire := runWorkerJob(pluginDir, db, "job-1", 1_700_000_000_000, payload, "update-model"); retire {
+		t.Fatal("transient open failure must not retire the daemon")
+	}
+}
+
 func TestRecoverOrphanJobs(t *testing.T) {
 	db, _ := openTempDB(t)
 	if err := migrate(db, 1_700_000_000_000); err != nil {

--- a/core/tasks.go
+++ b/core/tasks.go
@@ -132,7 +132,10 @@ WHERE job_id=? AND state='queued'`, nowMs(), truncateString(failure.Error(), 200
 
 // openTaskSidecar opens the sidecar with artifact attaches on for every mode
 // except compact/vacuum, which require a core-only connection (matching
-// backend.py's reopen).
+// backend.py's reopen). It is a var so daemon tests can force an open failure
+// and assert the fail-closed retirement path.
+var openTaskSidecarFn = openTaskSidecar
+
 func openTaskSidecar(pluginDir string, payload jVal, settings jVal, mode string) (dbx, error) {
 	attach := mode != "compact" && mode != "vacuum"
 	return openSidecar(pluginDir, payload, settings, attach)


### PR DESCRIPTION
## Summary

Fixes the runaway `update-model` enqueue loop (issue #195): a stale resident daemon survives a plugin update that migrates the sidecar forward, keeps re-enqueuing `update-model`, and every job fails at sidecar open with `database contains unknown migration versions`. Because the model stays pending, the scheduler re-enqueues forever.

Instead of looping, the daemon now **retires** when it cannot make progress against the sidecar.

## Root cause (from #195)

- A plugin update replaced the installed binary and migrated the sidecar to a newer schema (`schema_migration` at 37).
- An old resident daemon (binary embedding migrations ≤32) kept its loop connection open, so `schedulerTick` still succeeded and re-enqueued `update-model` every 30s.
- Each job opened a *fresh* sidecar → `queryMigrationStatus` threw `database contains unknown migration versions: [33]` → job failed.
- The model never published → stayed `pending` → `modelUpdateReady` stayed true → infinite re-enqueue (1584 failed jobs observed).

## Change

`core/daemon.go`:
- `runWorkerJob` now returns whether the daemon should retire. When the job's sidecar open fails with a schema-skew error (`isSchemaSkewError`), it records the failure and signals retirement. The daemon exits so the next Curator invocation spawns a fresh worker with the current binary.
- `runDaemon` tracks consecutive auto-scheduler / stay-alive failures and retires after a small threshold (`schedulerFailureLimit`), so an unreadable (corrupted/locked) sidecar cannot spin the daemon either. A schema-skew error retires immediately.

`core/tasks.go`:
- `openTaskSidecar` is now an injectable seam (`openTaskSidecarFn`) so the retire path is testable, matching the existing `checkWorkerStateWritableFn`/`spawnWorkerFn` pattern.

## Tests

- `TestIsSchemaSkewError` — unit-tests the skew/checksum detection (and that unrelated errors don't match).
- `TestRunWorkerJobRetiresOnSchemaSkew` — a job-open schema-skew failure marks the job failed and signals retirement.
- `TestRunWorkerJobDoesNotRetireOnTransientOpenFailure` — a transient failure (e.g. locked) does not retire the daemon.

## Verification

- `go build -buildvcs=false ./...` — OK
- `go vet ./...` — clean
- `go test ./...` (full core suite) — **pass**
- Differential core gate (`tests/core`, `tests/model/test_core.py`) with the built binary — **223 pass**
- Daemon/task backend tests (`test_backend_slice3_tasks.py`, `test_backend.py`) with the built binary — **26 pass**
- `gofmt` — clean; `git diff --check` — clean

**Note:** `scripts/verify full` and the full non-integration pytest suite report 16 pre-existing failures that are unrelated to this change and also fail on `origin/main`:
- 15 are a stale scoring fingerprint (`180b040391fac931` ≠ checked-in `036c04cb34ad4503`) — `core/daemon.go`/`core/tasks.go` are not in the scoring MANIFEST, so my change cannot affect it.
- 1 is `test_plugin_archive_contains_runtime_and_core`, which calls `go build` without `-buildvcs=false` and fails in a git worktree (confirmed it succeeds with `-buildvcs=false`; environment-only).

No migration was added — the fix is a daemon-side fail-closed retirement, not a schema change.


Closes #195