### PR TITLE
feat(model): score presentation overhaul — labeled Appeal/rank, shared renderers, versioned v2 explanation schema

### DIFF
--- a/core/explanations.go
+++ b/core/explanations.go
@@ -109,15 +109,17 @@ func reason(score *fullSceneScore, featureVersion, code string, value, conf floa
 // fullSceneScore carries every ModelSceneScore field the reason derivation
 // needs.
 type fullSceneScore struct {
-	modelID          string
-	sceneID          string
-	directAppeal     float64
-	directConfidence float64
-	appeal           float64
-	currentFit       float64
-	confidence       float64
-	components       jVal
-	neighbors        []jVal
+	modelID             string
+	sceneID             string
+	directAppeal        float64
+	directConfidence    float64
+	appeal              float64
+	currentFit          float64
+	confidence          float64
+	metadataConfidence  float64
+	recovery            float64
+	components          jVal
+	neighbors           []jVal
 }
 
 // fullScores mirrors RecommendationModelStore.scores for the reason path.
@@ -153,14 +155,16 @@ FROM model_scene_score WHERE model_id=? AND scene_id IN (`+placeholders+`) ORDER
 			components = jvNull()
 		}
 		result[sceneID] = &fullSceneScore{
-			modelID:          modelID2,
-			sceneID:          sceneID,
-			directAppeal:     directAppeal,
-			directConfidence: directConfidence,
-			appeal:           appeal,
-			currentFit:       currentFit,
-			confidence:       confidence,
-			components:       components,
+			modelID:            modelID2,
+			sceneID:            sceneID,
+			directAppeal:       directAppeal,
+			directConfidence:   directConfidence,
+			appeal:             appeal,
+			currentFit:         currentFit,
+			confidence:         confidence,
+			metadataConfidence: metadataConfidence,
+			recovery:           recovery,
+			components:         components,
 		}
 	}
 	rows.Close()
@@ -918,8 +922,9 @@ func getExplanationBody(pluginDir string, payload, settings jVal) (jVal, error) 
 }
 
 // renderExplanationForScene mirrors CuratorAPI.explanation on an open
-// connection: stored reasons (or derived), then the rendered summary and
-// supporting reasons. Shared by get_explanation and the inspector.
+// connection: stored reasons (or derived), then the rendered summary and the
+// versioned (apiSchemaVersion 2) payload. Shared by get_explanation and the
+// inspector.
 func renderExplanationForScene(db dbx, pluginDir, modelID, sceneID string) (jVal, error) {
 	reasons, found, err := storedReasons(db, modelID, sceneID)
 	if err != nil {
@@ -932,24 +937,82 @@ func renderExplanationForScene(db dbx, pluginDir, modelID, sceneID string) (jVal
 		}
 		reasons = derived[sceneID]
 	}
-	summary, selected, err := renderExplanation(pluginDir, db, reasons, modelID+"\x00"+sceneID)
+	summary, _, err := renderExplanation(pluginDir, db, reasons, modelID+"\x00"+sceneID)
 	if err != nil {
 		return jvNull(), err
 	}
-	all := jvArr()
-	for _, r := range reasons {
-		all.arr = append(all.arr, reasonJSON(r))
+	scores, err := fullScores(db, modelID, map[string]bool{sceneID: true})
+	if err != nil {
+		return jvNull(), err
 	}
-	supporting := jvArr()
-	for _, r := range selected {
-		supporting.arr = append(supporting.arr, reasonJSON(r))
+	score, ok := scores[sceneID]
+	if !ok {
+		return jvNull(), fmt.Errorf("unknown scene: %s", sceneID)
 	}
-	return jvObj(
-		jvKey("schema_version", jvInt(apiSchemaVersion)),
-		jvKey("model_id", jvStr(modelID)),
-		jvKey("scene_id", jvStr(sceneID)),
-		jvKey("summary", jvStr(summary)),
-		jvKey("reasons", all),
-		jvKey("supporting_reasons", supporting),
-	), nil
+	lane, subtype, qualification, err := sceneLaneContext(db, modelID, sceneID)
+	if err != nil {
+		return jvNull(), err
+	}
+	laneRank := 0.0
+	if lane != "" {
+		laneRank, err = lanePercentileRank(db, modelID, sceneID, lane)
+		if err != nil {
+			return jvNull(), err
+		}
+	}
+	return buildExplanationV2(score, summary, reasons, lane, subtype, qualification, laneRank), nil
+}
+
+// sceneLaneContext mirrors build_explanation_payload's lane lookup: the scene's
+// highest lane_value row (the primary lane it was selected from).
+func sceneLaneContext(db dbx, modelID, sceneID string) (string, string, jVal, error) {
+	var lane string
+	var subtype sql.NullString
+	var qualificationJSON sql.NullString
+	err := db.QueryRow(`SELECT lane, subtype, qualification_json FROM model_scene_lane
+WHERE model_id=? AND scene_id=? ORDER BY lane_value DESC LIMIT 1`,
+		modelID, sceneID).Scan(&lane, &subtype, &qualificationJSON)
+	if err == sql.ErrNoRows {
+		return "", "", jvObj(), nil
+	}
+	if err != nil {
+		return "", "", jvNull(), err
+	}
+	var qualification jVal = jvObj()
+	if qualificationJSON.Valid && qualificationJSON.String != "" {
+		qualification, err = parseJSON([]byte(qualificationJSON.String))
+		if err != nil {
+			qualification = jvObj()
+		}
+	}
+	subtypeVal := ""
+	if subtype.Valid {
+		subtypeVal = subtype.String
+	}
+	return lane, subtypeVal, qualification, nil
+}
+
+// lanePercentileRank mirrors build_explanation_payload._lane_rank: the scene's
+// percentile within the source lane's qualified, ordered population (by
+// lane_value DESC, scene_id), before slate diversity/deduplication.
+func lanePercentileRank(db dbx, modelID, sceneID, lane string) (float64, error) {
+	rows, err := db.Query(`SELECT scene_id, lane_value FROM model_scene_lane
+WHERE model_id=? AND lane=? ORDER BY lane_value DESC, scene_id`, modelID, lane)
+	if err != nil {
+		return 0.0, err
+	}
+	defer rows.Close()
+	var ordered []pair
+	for rows.Next() {
+		var id string
+		var value float64
+		if err := rows.Scan(&id, &value); err != nil {
+			return 0.0, err
+		}
+		ordered = append(ordered, pair{id: id, value: value})
+	}
+	if err := rows.Err(); err != nil {
+		return 0.0, err
+	}
+	return percentileRank(sceneID, lane, ordered), nil
 }

--- a/core/explanations_v2.go
+++ b/core/explanations_v2.go
@@ -1,0 +1,312 @@
+// Versioned explanation payload builder (apiSchemaVersion 2) — the Go mirror
+// of curator/explanations/breakdown.py. The backend owns the score semantics,
+// fact ranking, materiality, units, and deterministic summary. Materiality
+// thresholds are mirrored module constants (plain package vars), not frontend
+// rules or config-backed model inputs.
+package main
+
+import (
+	"math"
+	"sort"
+)
+
+// Materiality thresholds — mirrored from curator/explanations/breakdown.py.
+const (
+	explanationMaterialContent  = 0.05
+	explanationMaterialPerformer = 0.05
+	explanationMaterialStudio   = 0.05
+	explanationMaterialSimilar  = 0.05
+	explanationMaterialDirect   = 0.05
+	explanationMaterialResidual = 0.10
+	explanationMaterialFit      = 0.01
+	explanationMaterialCaution  = 0.05
+)
+
+// fingerprintAxis mirrors breakdown.FINGERPRINT_AXES.
+type fingerprintAxis struct {
+	key   string
+	label string
+}
+
+var explanationFingerprintAxes = []fingerprintAxis{
+	{"content", "Content"},
+	{"performers", "Performers"},
+	{"studios", "Studios"},
+	{"similar_scenes", "Similar scenes"},
+	{"direct_history", "Direct history"},
+	{"metadata_coverage", "Metadata coverage"},
+}
+
+// fingerprintTones mirrors breakdown.FINGERPRINT_TONES.
+var explanationFingerprintTones = map[string]string{
+	"content":          "support",
+	"performers":       "support",
+	"studios":          "support",
+	"similar_scenes":   "support",
+	"direct_history":   "support",
+	"metadata_coverage": "neutral",
+}
+
+func clampFloat(v, lo, hi float64) float64 {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// explanationComponentValue mirrors breakdown._component_value.
+func explanationsComponentValue(score *fullSceneScore, name string, def float64) float64 {
+	component := score.components.get(name)
+	if component.kind != jObj {
+		return def
+	}
+	return number(component.get("value"))
+}
+
+// componentHasEvidence mirrors breakdown._component_has_evidence.
+func componentHasEvidence(score *fullSceneScore, name string) bool {
+	component := score.components.get(name)
+	if component.kind != jObj {
+		return false
+	}
+	return component.has("value")
+}
+
+// percentileRank mirrors breakdown._percentile_rank.
+func percentileRank(sceneID, lane string, orderedValues []pair) float64 {
+	_ = lane
+	if len(orderedValues) == 0 {
+		return 0.0
+	}
+	// Copy and sort by (value, id) ascending to match Python's sort.
+	type kv struct {
+		id    string
+		value float64
+	}
+	ordered := make([]kv, 0, len(orderedValues))
+	for _, p := range orderedValues {
+		ordered = append(ordered, kv{id: p.id, value: p.value})
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].value != ordered[j].value {
+			return ordered[i].value < ordered[j].value
+		}
+		return ordered[i].id < ordered[j].id
+	})
+	denominator := maxInt(1, len(ordered)-1)
+	start := 0
+	for start < len(ordered) {
+		end := start + 1
+		for end < len(ordered) && ordered[end].value == ordered[start].value {
+			end++
+		}
+		percentile := float64((start+end-1)/2) / float64(denominator)
+		for _, item := range ordered[start:end] {
+			if item.id == sceneID {
+				return percentile
+			}
+		}
+		start = end
+	}
+	return 0.0
+}
+
+type pair struct {
+	id    string
+	value float64
+}
+
+// evidenceFingerprint mirrors breakdown._evidence_fingerprint.
+func evidenceFingerprint(score *fullSceneScore, components map[string]float64, directHistory, metadataCoverage float64) jVal {
+	values := map[string]float64{
+		"content":           components["content"],
+		"performers":        components["performers"],
+		"studios":           components["studios"],
+		"similar_scenes":    components["similar_scenes"],
+		"direct_history":    directHistory,
+		"metadata_coverage": metadataCoverage,
+	}
+	evidenceKeys := map[string][]string{
+		"content":           {"content"},
+		"performers":        {"performer_identity", "performer_similarity"},
+		"studios":           {"studio"},
+		"similar_scenes":    {"content_neighbor"},
+		"direct_history":    {"direct"},
+		"metadata_coverage": {},
+	}
+	axes := jvObj()
+	for _, axis := range explanationFingerprintAxes {
+		raw := values[axis.key]
+		present := axis.key == "metadata_coverage"
+		if !present {
+			for _, key := range evidenceKeys[axis.key] {
+				if componentHasEvidence(score, key) {
+					present = true
+					break
+				}
+			}
+		}
+		axes.set(axis.key, jvObj(
+			jvKey("label", jvStr(axis.label)),
+			jvKey("strength", jvFloat(clampFloat(math.Abs(raw), 0.0, 1.0))),
+			jvKey("tone", jvStr(explanationFingerprintTones[axis.key])),
+			jvKey("present", jvBool(present)),
+		))
+	}
+	return jvObj(jvKey("axes", axes))
+}
+
+// componentsRows mirrors breakdown._components_rows.
+func componentsRows(score *fullSceneScore) jVal {
+	content := clampFloat(math.Abs(explanationsComponentValue(score, "content", 0.0)), 0.0, 1.0)
+	performers := clampFloat(math.Abs(explanationsComponentValue(score, "performer_identity", 0.0)+explanationsComponentValue(score, "performer_similarity", 0.0)), 0.0, 1.0)
+	studio := clampFloat(math.Abs(explanationsComponentValue(score, "studio", 0.0)), 0.0, 1.0)
+	direct := clampFloat(math.Abs(explanationsComponentValue(score, "direct", 0.0)), 0.0, 1.0)
+	rightNow := clampFloat(score.currentFit, -1.0, 1.0)
+	confidence := clampFloat(score.confidence, 0.0, 1.0)
+	return jvArr(
+		jvObj(jvKey("key", jvStr("content_similarity")), jvKey("label", jvStr("Content similarity")), jvKey("value", jvFloat(content)), jvKey("unit", jvStr("similarity"))),
+		jvObj(jvKey("key", jvStr("performer_match")), jvKey("label", jvStr("Performer match")), jvKey("value", jvFloat(performers)), jvKey("unit", jvStr("similarity"))),
+		jvObj(jvKey("key", jvStr("studio_appeal")), jvKey("label", jvStr("Studio appeal")), jvKey("value", jvFloat(studio)), jvKey("unit", jvStr("appeal"))),
+		jvObj(jvKey("key", jvStr("direct_feedback")), jvKey("label", jvStr("Direct feedback")), jvKey("value", jvFloat(direct)), jvKey("unit", jvStr("appeal"))),
+		jvObj(jvKey("key", jvStr("right_now_fit")), jvKey("label", jvStr("Right-now fit")), jvKey("value", jvFloat(rightNow)), jvKey("unit", jvStr("appeal"))),
+		jvObj(jvKey("key", jvStr("confidence")), jvKey("label", jvStr("Confidence")), jvKey("value", jvFloat(confidence)), jvKey("unit", jvStr("percent"))),
+	)
+}
+
+// rankedReasons mirrors breakdown._ranked_reasons.
+func rankedReasons(reasons []*explanationReason) []*explanationReason {
+	var support, caution, neutral []*explanationReason
+	for _, r := range reasons {
+		switch r.direction {
+		case "positive":
+			support = append(support, r)
+		case "negative":
+			caution = append(caution, r)
+		default:
+			neutral = append(neutral, r)
+		}
+	}
+	key := func(r *explanationReason) (float64, string, string) {
+		return -(r.magnitude * r.confidence), r.code, r.subjectID.asString()
+	}
+	less := func(i, j *explanationReason) bool {
+		ai, aj, ak := key(i)
+		bi, bj, bk := key(j)
+		if ai != bi {
+			return ai < bi
+		}
+		if aj != bj {
+			return aj < bj
+		}
+		return ak < bk
+	}
+	sort.SliceStable(support, func(i, j int) bool { return less(support[i], support[j]) })
+	sort.SliceStable(caution, func(i, j int) bool { return less(caution[i], caution[j]) })
+	sort.SliceStable(neutral, func(i, j int) bool { return less(neutral[i], neutral[j]) })
+	result := make([]*explanationReason, 0, len(reasons))
+	result = append(result, support...)
+	result = append(result, caution...)
+	result = append(result, neutral...)
+	return result
+}
+
+// explanations_laneContext mirrors breakdown._lane_context.
+func explanations_laneContext(lane, subtype string, qualification jVal, laneRank float64) jVal {
+	if lane == "" {
+		return jvObj()
+	}
+	var subtypeVal jVal = jvNull()
+	if subtype != "" {
+		subtypeVal = jvStr(subtype)
+	}
+	context := jvObj(
+		jvKey("lane", jvStr(lane)),
+		jvKey("subtype", subtypeVal),
+		jvKey("rank", jvFloat(laneRank)),
+	)
+	qual := qualification
+	if qual.kind != jObj {
+		qual = jvObj()
+	}
+	switch lane {
+	case "revisit":
+		context.set("facets", jvObj(
+			jvKey("direct_appeal", jvFloat(clampFloat(math.Abs(number(qual.get("direct_appeal"))), 0.0, 1.0))),
+			jvKey("direct_confidence", jvFloat(clampFloat(number(qual.get("direct_confidence")), 0.0, 1.0))),
+			jvKey("recovery", jvFloat(clampFloat(number(qual.get("recovery")), 0.0, 1.0))),
+			jvKey("durable_signals", qual.get("durable_signals")),
+		))
+		context.set("intent", jvStr("revisit"))
+	case "best_bets":
+		context.set("facets", jvObj(
+			jvKey("current_fit", jvFloat(clampFloat(number(qual.get("current_fit")), -1.0, 1.0))),
+			jvKey("confidence", jvFloat(clampFloat(number(qual.get("confidence")), 0.0, 1.0))),
+			jvKey("metadata_confidence", jvFloat(clampFloat(number(qual.get("metadata_confidence")), 0.0, 1.0))),
+			jvKey("relevance", jvFloat(clampFloat(number(qual.get("relevance")), 0.0, 1.0))),
+			jvKey("corroborated", jvBool(qual.get("corroborated").truthy())),
+			jvKey("direct_reliable", jvBool(qual.get("direct_reliable").truthy())),
+		))
+		context.set("intent", jvStr("best_bet"))
+	case "stretch":
+		context.set("facets", jvObj(
+			jvKey("anchor_features", qual.get("anchor_features")),
+			jvKey("challenged_feature", qual.get("challenged_feature")),
+			jvKey("challenge_kind", qual.get("challenge_kind")),
+			jvKey("anchor_strength", jvFloat(clampFloat(math.Abs(number(qual.get("anchor_strength"))), 0.0, 1.0))),
+			jvKey("challenge_distance", jvFloat(clampFloat(number(qual.get("challenge_distance")), 0.0, 1.0))),
+		))
+		context.set("intent", jvStr("challenge"))
+	case "blind_spots":
+		context.set("facets", jvObj(
+			jvKey("dark_facets", qual.get("dark_facets")),
+			jvKey("corroborating_types", qual.get("corroborating_types")),
+		))
+		context.set("intent", jvStr("coverage"))
+	case "dormant":
+		context.set("facets", jvObj(
+			jvKey("dormant_entity", qual.get("dormant_entity")),
+			jvKey("days_since_played", qual.get("days_since_played")),
+		))
+		context.set("intent", jvStr("dormancy"))
+	}
+	return context
+}
+
+// buildExplanationV2 assembles the exact apiSchemaVersion 2 payload.
+func buildExplanationV2(score *fullSceneScore, summary string, reasons []*explanationReason, lane, subtype string, qualification jVal, laneRank float64) jVal {
+	components := map[string]float64{
+		"content":        clampFloat(math.Abs(explanationsComponentValue(score, "content", 0.0)), 0.0, 1.0),
+		"performers":     clampFloat(math.Abs(explanationsComponentValue(score, "performer_identity", 0.0)+explanationsComponentValue(score, "performer_similarity", 0.0)), 0.0, 1.0),
+		"studios":        clampFloat(math.Abs(explanationsComponentValue(score, "studio", 0.0)), 0.0, 1.0),
+		"similar_scenes": clampFloat(math.Abs(explanationsComponentValue(score, "content_neighbor", 0.0)), 0.0, 1.0),
+	}
+	directHistory := clampFloat(math.Abs(explanationsComponentValue(score, "direct", 0.0)), 0.0, 1.0)
+	metadataCoverage := clampFloat(score.metadataConfidence, 0.0, 1.0)
+	rank := clampFloat(laneRank, 0.0, 1.0)
+
+	scores := jvObj(
+		jvKey("appeal", jvObj(jvKey("value", jvFloat(score.appeal)), jvKey("unit", jvStr("signed")))),
+		jvKey("current_fit", jvObj(jvKey("value", jvFloat(score.currentFit)), jvKey("unit", jvStr("signed")))),
+		jvKey("confidence", jvObj(jvKey("value", jvFloat(score.confidence)), jvKey("unit", jvStr("percent")))),
+		jvKey("rank", jvObj(jvKey("value", jvFloat(rank)), jvKey("unit", jvStr("percent")))),
+	)
+	evidence := evidenceFingerprint(score, components, directHistory, metadataCoverage)
+
+	reasonArr := jvArr()
+	for _, r := range rankedReasons(reasons) {
+		reasonArr.arr = append(reasonArr.arr, reasonJSON(r))
+	}
+	return jvObj(
+		jvKey("apiSchemaVersion", jvInt(2)),
+		jvKey("summary", jvStr(summary)),
+		jvKey("components", componentsRows(score)),
+		jvKey("reasons", reasonArr),
+		jvKey("lane_context", explanations_laneContext(lane, subtype, qualification, rank)),
+		jvKey("scores", scores),
+		jvKey("evidence_fingerprint", evidence),
+	)
+}

--- a/curator/api.py
+++ b/curator/api.py
@@ -93,11 +93,7 @@ def build_explanation_payload(
         (model_id, scene_id),
     ).fetchone()
     lane = str(lane_row["lane"]) if lane_row else None
-    subtype = (
-        str(lane_row["subtype"])
-        if lane_row and lane_row["subtype"] is not None
-        else None
-    )
+    subtype = str(lane_row["subtype"]) if lane_row and lane_row["subtype"] is not None else None
     qualification = (
         json.loads(str(lane_row["qualification_json"]))
         if lane_row and lane_row["qualification_json"]

--- a/curator/api.py
+++ b/curator/api.py
@@ -25,6 +25,99 @@ from curator.similarity import SimilarityService
 from curator.storage import transaction
 
 API_SCHEMA_VERSION = 1
+
+
+def _lane_rank(
+    connection: sqlite3.Connection,
+    model_id: str,
+    scene_id: str,
+    lane: str,
+) -> float:
+    """Percentile rank of the scene within the source lane's qualified,
+    ordered population (by lane_value DESC, scene_id) — before slate
+    diversity/deduplication. Uses the same midpoint-percentile tie handling as
+    curator/ranking/policy._percentiles."""
+    rows = connection.execute(
+        "SELECT scene_id, lane_value FROM model_scene_lane "
+        "WHERE model_id=? AND lane=? ORDER BY lane_value DESC, scene_id",
+        (model_id, lane),
+    ).fetchall()
+    ordered = [(str(row["scene_id"]), float(row["lane_value"])) for row in rows]
+    return _percentile_of(ordered, scene_id)
+
+
+def _percentile_of(ordered: list[tuple[str, float]], scene_id: str) -> float:
+    if not ordered:
+        return 0.0
+    # ordered is already sorted by lane_value DESC, scene_id; the percentile is
+    # the scene's rank position in the qualified population.
+    total = len(ordered)
+    for index, (id_, _) in enumerate(ordered):
+        if id_ == scene_id:
+            # Ties share the midpoint rank, mirroring policy._percentiles.
+            start = end = index
+            while start > 0 and ordered[start - 1][1] == ordered[index][1]:
+                start -= 1
+            while end < total - 1 and ordered[end + 1][1] == ordered[index][1]:
+                end += 1
+            denominator = max(1, total - 1)
+            return ((start + end) / 2) / denominator
+    return 0.0
+
+
+def build_explanation_payload(
+    connection: sqlite3.Connection,
+    *,
+    model_id: str,
+    scene_id: str,
+    summary: str,
+    reasons: tuple[Any, ...],
+    supporting_reasons: tuple[Any, ...],
+) -> dict[str, object]:
+    """Assemble the versioned explanation payload (apiSchemaVersion 2).
+
+    The backend owns fact ranking, materiality, units, deterministic summary
+    templates, and reason semantics. The frontend owns labels, ordering, bars,
+    radar layout, and progressive disclosure. Legacy/partial payloads render
+    through a truthful frontend fallback without fabricating Appeal evidence.
+    """
+    from curator.explanations.breakdown import build_v2_explanation
+
+    store = RecommendationModelStore(connection)
+    score = store.scores(model_id, {scene_id}).get(scene_id)
+    if score is None:
+        raise ValueError(f"unknown scene: {scene_id}")
+    lane_row = connection.execute(
+        "SELECT lane, subtype, qualification_json FROM model_scene_lane "
+        "WHERE model_id=? AND scene_id=? ORDER BY lane_value DESC LIMIT 1",
+        (model_id, scene_id),
+    ).fetchone()
+    lane = str(lane_row["lane"]) if lane_row else None
+    subtype = (
+        str(lane_row["subtype"])
+        if lane_row and lane_row["subtype"] is not None
+        else None
+    )
+    qualification = (
+        json.loads(str(lane_row["qualification_json"]))
+        if lane_row and lane_row["qualification_json"]
+        else {}
+    )
+    lane_rank = _lane_rank(connection, model_id, scene_id, lane) if lane else None
+    return build_v2_explanation(
+        model_id=model_id,
+        scene_id=scene_id,
+        summary=summary,
+        reasons=reasons,
+        supporting_reasons=supporting_reasons,
+        score=score,
+        lane=lane,
+        subtype=subtype,
+        qualification=qualification,
+        lane_rank=lane_rank,
+    )
+
+
 DEFAULT_PLUGIN_CONFIG: dict[str, object] = {
     "page_size": 20,
     "diversity_enabled": True,
@@ -379,14 +472,14 @@ class CuratorAPI:
         if model_id is None:
             raise RuntimeError("no published model")
         explanation = ExplanationService(self.connection).explain_scene(model_id, scene_id)
-        return {
-            "schema_version": API_SCHEMA_VERSION,
-            "model_id": model_id,
-            "scene_id": scene_id,
-            "summary": explanation.summary,
-            "reasons": [asdict(reason) for reason in explanation.all_reasons],
-            "supporting_reasons": [asdict(reason) for reason in explanation.selected_reasons],
-        }
+        return build_explanation_payload(
+            self.connection,
+            model_id=model_id,
+            scene_id=scene_id,
+            summary=explanation.summary,
+            reasons=explanation.all_reasons,
+            supporting_reasons=explanation.selected_reasons,
+        )
 
     def recommendation_history(
         self,

--- a/curator/explanations/breakdown.py
+++ b/curator/explanations/breakdown.py
@@ -1,0 +1,333 @@
+"""Versioned explanation payload builder (apiSchemaVersion 2).
+
+The backend owns the score semantics, fact ranking, materiality, units, and
+deterministic summary. This module turns a ModelSceneScore plus its derived
+reasons into the exact v2 payload shape the frontend renders:
+
+    {apiSchemaVersion, summary, components[], reasons[], lane_context{},
+     scores: {appeal, current_fit, confidence, rank}, evidence_fingerprint{}}
+
+Materiality thresholds are mirrored module constants (see the Go mirror in
+core/explanations.go) — not frontend rules or config-backed model inputs.
+"""
+
+from __future__ import annotations
+
+import math
+
+from curator.explanations.reasons import Reason
+from curator.model.store import ModelSceneScore
+
+# Materiality thresholds. The same values are mirrored in Go
+# (core/explanations.go); they are plain module constants on both sides.
+MATERIAL_CONTENT = 0.05
+MATERIAL_PERFORMER = 0.05
+MATERIAL_STUDIO = 0.05
+MATERIAL_SIMILAR = 0.05
+MATERIAL_DIRECT = 0.05
+MATERIAL_RESIDUAL = 0.10
+MATERIAL_FIT = 0.01
+MATERIAL_CAUTION = 0.05
+
+# The six fixed radar axes. Metadata coverage is neutral (usable resolved
+# evidence coverage), not a preference axis.
+FINGERPRINT_AXES = (
+    ("content", "Content"),
+    ("performers", "Performers"),
+    ("studios", "Studios"),
+    ("similar_scenes", "Similar scenes"),
+    ("direct_history", "Direct history"),
+    ("metadata_coverage", "Metadata coverage"),
+)
+
+# The fixed tone per fingerprint axis. Metadata coverage is neutral.
+FINGERPRINT_TONES = {
+    "content": "support",
+    "performers": "support",
+    "studios": "support",
+    "similar_scenes": "support",
+    "direct_history": "support",
+    "metadata_coverage": "neutral",
+}
+
+
+def _clamp(value: float, lower: float = 0.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _component_value(score: ModelSceneScore, name: str, default: float = 0.0) -> float:
+    component = score.components.get(name)
+    if not isinstance(component, dict):
+        return default
+    value = component.get("value", default)
+    return float(value) if isinstance(value, (int, float)) else default
+
+
+def _component_has_evidence(score: ModelSceneScore, name: str) -> bool:
+    component = score.components.get(name)
+    if not isinstance(component, dict):
+        return False
+    return "value" in component
+
+
+def _percentile_rank(
+    scene_id: str, lane: str, ordered_values: list[tuple[str, float]]
+) -> float:
+    """Percentile rank of scene_id within the qualified, ordered population for
+    the source lane (before slate diversity/deduplication). Ties share the
+    midpoint rank, mirroring curator/ranking/policy._percentiles.
+
+    The `lane` argument is accepted for parity with the Go mirror; the rank is
+    a pure percentile of the provided population.
+    """
+    del lane
+    if not ordered_values:
+        return 0.0
+    ordered = sorted(ordered_values, key=lambda item: (item[1], item[0]))
+    denominator = max(1, len(ordered) - 1)
+    start = 0
+    while start < len(ordered):
+        end = start + 1
+        while end < len(ordered) and ordered[end][1] == ordered[start][1]:
+            end += 1
+        percentile = ((start + end - 1) / 2) / denominator
+        for id_, _ in ordered[start:end]:
+            if id_ == scene_id:
+                return percentile
+        start = end
+    return 0.0
+
+
+def _evidence_fingerprint(
+    score: ModelSceneScore,
+    components: dict[str, float],
+    *,
+    direct_history: float,
+    metadata_coverage: float,
+) -> dict[str, object]:
+    """Backend-normalized 0..1 visual strengths for the six fixed axes.
+
+    Each family carries a `tone` (support/caution/neutral), a normalized
+    `strength`, and a `present` flag. Missing families use "No evidence"
+    (present=False), not an indistinguishable zero. Metadata coverage is
+    always present and always neutral.
+    """
+    axes: dict[str, object] = {}
+    values = {
+        "content": components.get("content", 0.0),
+        "performers": components.get("performers", 0.0),
+        "studios": components.get("studios", 0.0),
+        "similar_scenes": components.get("similar_scenes", 0.0),
+        "direct_history": direct_history,
+        "metadata_coverage": metadata_coverage,
+    }
+    # Axis -> the underlying model component key(s) that prove evidence exists.
+    evidence_keys = {
+        "content": ("content",),
+        "performers": ("performer_identity", "performer_similarity"),
+        "studios": ("studio",),
+        "similar_scenes": ("content_neighbor",),
+        "direct_history": ("direct",),
+        "metadata_coverage": (),
+    }
+    for key, label in FINGERPRINT_AXES:
+        raw = values[key]
+        present = key == "metadata_coverage" or any(
+            _component_has_evidence(score, component) for component in evidence_keys[key]
+        )
+        axes[key] = {
+            "label": label,
+            "strength": _clamp(abs(raw), 0.0, 1.0),
+            "tone": FINGERPRINT_TONES[key],
+            "present": present,
+        }
+    return {"axes": axes}
+
+
+def _components_rows(score: ModelSceneScore) -> list[dict[str, object]]:
+    """Named, scaled breakdown rows with real units (0..1 bars).
+
+    Novelty is NOT a model component and is not listed here; it exists only
+    as lane context (adventure/discover) and is surfaced by lane_context.
+    """
+    content = _clamp(abs(_component_value(score, "content")), 0.0, 1.0)
+    performers = _clamp(
+        abs(
+            _component_value(score, "performer_identity")
+            + _component_value(score, "performer_similarity")
+        ),
+        0.0,
+        1.0,
+    )
+    studio = _clamp(abs(_component_value(score, "studio")), 0.0, 1.0)
+    direct = _clamp(abs(_component_value(score, "direct")), 0.0, 1.0)
+    right_now = _clamp(score.current_fit, -1.0, 1.0)
+    confidence = _clamp(score.confidence, 0.0, 1.0)
+    return [
+        {"key": "content_similarity", "label": "Content similarity", "value": content, "unit": "similarity"},
+        {"key": "performer_match", "label": "Performer match", "value": performers, "unit": "similarity"},
+        {"key": "studio_appeal", "label": "Studio appeal", "value": studio, "unit": "appeal"},
+        {"key": "direct_feedback", "label": "Direct feedback", "value": direct, "unit": "appeal"},
+        {"key": "right_now_fit", "label": "Right-now fit", "value": right_now, "unit": "appeal"},
+        {"key": "confidence", "label": "Confidence", "value": confidence, "unit": "percent"},
+    ]
+
+
+def _ranked_reasons(reasons: tuple[Reason, ...]) -> list[Reason]:
+    """Backend-owned fact ranking.
+
+    Supports first (by descending signed strength), then cautions (negative
+    reasons by descending strength), then the rest (neutral/context) — the
+    ordering the frontend renders as up-to-three evidence rows and the full
+    technical-details inventory.
+    """
+    support: list[Reason] = []
+    caution: list[Reason] = []
+    neutral: list[Reason] = []
+    for reason in reasons:
+        strength = reason.magnitude * reason.confidence
+        if reason.direction == "positive":
+            support.append(reason)
+        elif reason.direction == "negative":
+            caution.append(reason)
+        else:
+            neutral.append(reason)
+    key = lambda r: (-(r.magnitude * r.confidence), r.code, str(r.subject_id or ""))
+    support.sort(key=key)
+    caution.sort(key=key)
+    neutral.sort(key=key)
+    return [*support, *caution, *neutral]
+
+
+def _lane_context(
+    lane: str | None,
+    subtype: str | None,
+    qualification: dict[str, object],
+    *,
+    lane_rank: float,
+) -> dict[str, object]:
+    """Typed lane context — a discriminated union per lane.
+
+    Model evidence (components/reasons) stays separate from lane_context. The
+    lane callout is action-oriented: why the current lane selected the scene.
+    """
+    if lane is None:
+        return {}
+    context: dict[str, object] = {
+        "lane": lane,
+        "subtype": subtype,
+        "rank": lane_rank,
+    }
+    qual = qualification or {}
+    if lane == "revisit":
+        context["facets"] = {
+            "direct_appeal": _clamp(abs(float(qual.get("direct_appeal", 0.0) or 0.0)), 0.0, 1.0),
+            "direct_confidence": _clamp(float(qual.get("direct_confidence", 0.0) or 0.0), 0.0, 1.0),
+            "recovery": _clamp(float(qual.get("recovery", 0.0) or 0.0), 0.0, 1.0),
+            "durable_signals": qual.get("durable_signals", []),
+        }
+        context["intent"] = "revisit"
+    elif lane == "best_bets":
+        context["facets"] = {
+            "current_fit": _clamp(float(qual.get("current_fit", 0.0) or 0.0), -1.0, 1.0),
+            "confidence": _clamp(float(qual.get("confidence", 0.0) or 0.0), 0.0, 1.0),
+            "metadata_confidence": _clamp(float(qual.get("metadata_confidence", 0.0) or 0.0), 0.0, 1.0),
+            "relevance": _clamp(float(qual.get("relevance", 0.0) or 0.0), 0.0, 1.0),
+            "corroborated": bool(qual.get("corroborated", False)),
+            "direct_reliable": bool(qual.get("direct_reliable", False)),
+        }
+        context["intent"] = "best_bet"
+    elif lane == "stretch":
+        context["facets"] = {
+            "anchor_features": qual.get("anchor_features", []),
+            "challenged_feature": qual.get("challenged_feature"),
+            "challenge_kind": qual.get("challenge_kind"),
+            "anchor_strength": _clamp(abs(float(qual.get("anchor_strength", 0.0) or 0.0)), 0.0, 1.0),
+            "challenge_distance": _clamp(float(qual.get("challenge_distance", 0.0) or 0.0), 0.0, 1.0),
+        }
+        context["intent"] = "challenge"
+    elif lane == "blind_spots":
+        context["facets"] = {
+            "dark_facets": qual.get("dark_facets", []),
+            "corroborating_types": qual.get("corroborating_types", 0),
+        }
+        context["intent"] = "coverage"
+    elif lane == "dormant":
+        context["facets"] = {
+            "dormant_entity": qual.get("dormant_entity"),
+            "days_since_played": qual.get("days_since_played"),
+        }
+        context["intent"] = "dormancy"
+    return context
+
+
+def asdict_reason(reason: Reason) -> dict[str, object]:
+    """dataclasses.asdict for a Reason, preserving field order."""
+    return {
+        "code": reason.code,
+        "direction": reason.direction,
+        "magnitude": reason.magnitude,
+        "confidence": reason.confidence,
+        "subject_type": reason.subject_type,
+        "subject_id": reason.subject_id,
+        "visibility": reason.visibility,
+        "provenance": reason.provenance,
+        "detail": reason.detail,
+        "model_id": reason.model_id,
+        "feature_version": reason.feature_version,
+    }
+
+
+def build_v2_explanation(
+    *,
+    model_id: str,
+    scene_id: str,
+    summary: str,
+    reasons: tuple[Reason, ...],
+    supporting_reasons: tuple[Reason, ...],
+    score: ModelSceneScore,
+    lane: str | None = None,
+    subtype: str | None = None,
+    qualification: dict[str, object] | None = None,
+    lane_rank: float | None = None,
+) -> dict[str, object]:
+    """Assemble the exact apiSchemaVersion 2 explanation payload."""
+    del model_id, scene_id, supporting_reasons
+    components = {
+        "content": _clamp(abs(_component_value(score, "content")), 0.0, 1.0),
+        "performers": _clamp(
+            abs(
+                _component_value(score, "performer_identity")
+                + _component_value(score, "performer_similarity")
+            ),
+            0.0,
+            1.0,
+        ),
+        "studios": _clamp(abs(_component_value(score, "studio")), 0.0, 1.0),
+        "similar_scenes": _clamp(abs(_component_value(score, "content_neighbor")), 0.0, 1.0),
+    }
+    direct_history = _clamp(abs(_component_value(score, "direct")), 0.0, 1.0)
+    metadata_coverage = _clamp(score.metadata_confidence, 0.0, 1.0)
+    rank = _clamp(lane_rank if lane_rank is not None else 0.0, 0.0, 1.0)
+
+    scores = {
+        "appeal": {"value": score.appeal, "unit": "signed"},
+        "current_fit": {"value": score.current_fit, "unit": "signed"},
+        "confidence": {"value": score.confidence, "unit": "percent"},
+        "rank": {"value": rank, "unit": "percent"},
+    }
+    evidence = _evidence_fingerprint(
+        score,
+        components,
+        direct_history=direct_history,
+        metadata_coverage=metadata_coverage,
+    )
+    return {
+        "apiSchemaVersion": 2,
+        "summary": summary,
+        "components": _components_rows(score),
+        "reasons": [asdict_reason(reason) for reason in _ranked_reasons(reasons)],
+        "lane_context": _lane_context(lane, subtype, qualification or {}, lane_rank=rank),
+        "scores": scores,
+        "evidence_fingerprint": evidence,
+    }

--- a/curator/explanations/breakdown.py
+++ b/curator/explanations/breakdown.py
@@ -53,6 +53,24 @@ def _clamp(value: float, lower: float = 0.0, upper: float = 1.0) -> float:
     return max(lower, min(upper, value))
 
 
+def _as_float(value: object) -> float:
+    """Coerce an unknown-shaped qualification value to float.
+
+    ``qualification.get(...)`` returns ``object``, so ``float(...)`` is not
+    typed; a value that is ``None``, empty, or not numeric coerces to 0.0.
+    """
+    if value is None:
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return 0.0
+    return 0.0
+
+
 def _component_value(score: ModelSceneScore, name: str, default: float = 0.0) -> float:
     component = score.components.get(name)
     if not isinstance(component, dict):
@@ -229,20 +247,18 @@ def _lane_context(
     qual = qualification or {}
     if lane == "revisit":
         context["facets"] = {
-            "direct_appeal": _clamp(abs(float(qual.get("direct_appeal", 0.0) or 0.0)), 0.0, 1.0),
-            "direct_confidence": _clamp(float(qual.get("direct_confidence", 0.0) or 0.0), 0.0, 1.0),
-            "recovery": _clamp(float(qual.get("recovery", 0.0) or 0.0), 0.0, 1.0),
+            "direct_appeal": _clamp(abs(_as_float(qual.get("direct_appeal"))), 0.0, 1.0),
+            "direct_confidence": _clamp(_as_float(qual.get("direct_confidence")), 0.0, 1.0),
+            "recovery": _clamp(_as_float(qual.get("recovery")), 0.0, 1.0),
             "durable_signals": qual.get("durable_signals", []),
         }
         context["intent"] = "revisit"
     elif lane == "best_bets":
         context["facets"] = {
-            "current_fit": _clamp(float(qual.get("current_fit", 0.0) or 0.0), -1.0, 1.0),
-            "confidence": _clamp(float(qual.get("confidence", 0.0) or 0.0), 0.0, 1.0),
-            "metadata_confidence": _clamp(
-                float(qual.get("metadata_confidence", 0.0) or 0.0), 0.0, 1.0
-            ),
-            "relevance": _clamp(float(qual.get("relevance", 0.0) or 0.0), 0.0, 1.0),
+            "current_fit": _clamp(_as_float(qual.get("current_fit")), -1.0, 1.0),
+            "confidence": _clamp(_as_float(qual.get("confidence")), 0.0, 1.0),
+            "metadata_confidence": _clamp(_as_float(qual.get("metadata_confidence")), 0.0, 1.0),
+            "relevance": _clamp(_as_float(qual.get("relevance")), 0.0, 1.0),
             "corroborated": bool(qual.get("corroborated", False)),
             "direct_reliable": bool(qual.get("direct_reliable", False)),
         }
@@ -252,12 +268,8 @@ def _lane_context(
             "anchor_features": qual.get("anchor_features", []),
             "challenged_feature": qual.get("challenged_feature"),
             "challenge_kind": qual.get("challenge_kind"),
-            "anchor_strength": _clamp(
-                abs(float(qual.get("anchor_strength", 0.0) or 0.0)), 0.0, 1.0
-            ),
-            "challenge_distance": _clamp(
-                float(qual.get("challenge_distance", 0.0) or 0.0), 0.0, 1.0
-            ),
+            "anchor_strength": _clamp(abs(_as_float(qual.get("anchor_strength"))), 0.0, 1.0),
+            "challenge_distance": _clamp(_as_float(qual.get("challenge_distance")), 0.0, 1.0),
         }
         context["intent"] = "challenge"
     elif lane == "blind_spots":

--- a/curator/explanations/breakdown.py
+++ b/curator/explanations/breakdown.py
@@ -13,8 +13,6 @@ core/explanations.go) — not frontend rules or config-backed model inputs.
 
 from __future__ import annotations
 
-import math
-
 from curator.explanations.reasons import Reason
 from curator.model.store import ModelSceneScore
 
@@ -164,8 +162,10 @@ def _components_rows(score: ModelSceneScore) -> list[dict[str, object]]:
     right_now = _clamp(score.current_fit, -1.0, 1.0)
     confidence = _clamp(score.confidence, 0.0, 1.0)
     return [
-        {"key": "content_similarity", "label": "Content similarity", "value": content, "unit": "similarity"},
-        {"key": "performer_match", "label": "Performer match", "value": performers, "unit": "similarity"},
+        {"key": "content_similarity", "label": "Content similarity",
+         "value": content, "unit": "similarity"},
+        {"key": "performer_match", "label": "Performer match",
+         "value": performers, "unit": "similarity"},
         {"key": "studio_appeal", "label": "Studio appeal", "value": studio, "unit": "appeal"},
         {"key": "direct_feedback", "label": "Direct feedback", "value": direct, "unit": "appeal"},
         {"key": "right_now_fit", "label": "Right-now fit", "value": right_now, "unit": "appeal"},
@@ -185,17 +185,18 @@ def _ranked_reasons(reasons: tuple[Reason, ...]) -> list[Reason]:
     caution: list[Reason] = []
     neutral: list[Reason] = []
     for reason in reasons:
-        strength = reason.magnitude * reason.confidence
         if reason.direction == "positive":
             support.append(reason)
         elif reason.direction == "negative":
             caution.append(reason)
         else:
             neutral.append(reason)
-    key = lambda r: (-(r.magnitude * r.confidence), r.code, str(r.subject_id or ""))
-    support.sort(key=key)
-    caution.sort(key=key)
-    neutral.sort(key=key)
+    def strength_key(r: Reason) -> tuple[float, str, str]:
+        return (-(r.magnitude * r.confidence), r.code, str(r.subject_id or ""))
+
+    support.sort(key=strength_key)
+    caution.sort(key=strength_key)
+    neutral.sort(key=strength_key)
     return [*support, *caution, *neutral]
 
 
@@ -231,7 +232,9 @@ def _lane_context(
         context["facets"] = {
             "current_fit": _clamp(float(qual.get("current_fit", 0.0) or 0.0), -1.0, 1.0),
             "confidence": _clamp(float(qual.get("confidence", 0.0) or 0.0), 0.0, 1.0),
-            "metadata_confidence": _clamp(float(qual.get("metadata_confidence", 0.0) or 0.0), 0.0, 1.0),
+            "metadata_confidence": _clamp(
+                float(qual.get("metadata_confidence", 0.0) or 0.0), 0.0, 1.0
+            ),
             "relevance": _clamp(float(qual.get("relevance", 0.0) or 0.0), 0.0, 1.0),
             "corroborated": bool(qual.get("corroborated", False)),
             "direct_reliable": bool(qual.get("direct_reliable", False)),
@@ -242,8 +245,12 @@ def _lane_context(
             "anchor_features": qual.get("anchor_features", []),
             "challenged_feature": qual.get("challenged_feature"),
             "challenge_kind": qual.get("challenge_kind"),
-            "anchor_strength": _clamp(abs(float(qual.get("anchor_strength", 0.0) or 0.0)), 0.0, 1.0),
-            "challenge_distance": _clamp(float(qual.get("challenge_distance", 0.0) or 0.0), 0.0, 1.0),
+            "anchor_strength": _clamp(
+                abs(float(qual.get("anchor_strength", 0.0) or 0.0)), 0.0, 1.0
+            ),
+            "challenge_distance": _clamp(
+                float(qual.get("challenge_distance", 0.0) or 0.0), 0.0, 1.0
+            ),
         }
         context["intent"] = "challenge"
     elif lane == "blind_spots":

--- a/curator/explanations/breakdown.py
+++ b/curator/explanations/breakdown.py
@@ -68,9 +68,7 @@ def _component_has_evidence(score: ModelSceneScore, name: str) -> bool:
     return "value" in component
 
 
-def _percentile_rank(
-    scene_id: str, lane: str, ordered_values: list[tuple[str, float]]
-) -> float:
+def _percentile_rank(scene_id: str, lane: str, ordered_values: list[tuple[str, float]]) -> float:
     """Percentile rank of scene_id within the qualified, ordered population for
     the source lane (before slate diversity/deduplication). Ties share the
     midpoint rank, mirroring curator/ranking/policy._percentiles.
@@ -162,10 +160,18 @@ def _components_rows(score: ModelSceneScore) -> list[dict[str, object]]:
     right_now = _clamp(score.current_fit, -1.0, 1.0)
     confidence = _clamp(score.confidence, 0.0, 1.0)
     return [
-        {"key": "content_similarity", "label": "Content similarity",
-         "value": content, "unit": "similarity"},
-        {"key": "performer_match", "label": "Performer match",
-         "value": performers, "unit": "similarity"},
+        {
+            "key": "content_similarity",
+            "label": "Content similarity",
+            "value": content,
+            "unit": "similarity",
+        },
+        {
+            "key": "performer_match",
+            "label": "Performer match",
+            "value": performers,
+            "unit": "similarity",
+        },
         {"key": "studio_appeal", "label": "Studio appeal", "value": studio, "unit": "appeal"},
         {"key": "direct_feedback", "label": "Direct feedback", "value": direct, "unit": "appeal"},
         {"key": "right_now_fit", "label": "Right-now fit", "value": right_now, "unit": "appeal"},
@@ -191,6 +197,7 @@ def _ranked_reasons(reasons: tuple[Reason, ...]) -> list[Reason]:
             caution.append(reason)
         else:
             neutral.append(reason)
+
     def strength_key(r: Reason) -> tuple[float, str, str]:
         return (-(r.magnitude * r.confidence), r.code, str(r.subject_id or ""))
 

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2749,6 +2749,209 @@
   background: repeating-linear-gradient(45deg, #50b86c, #50b86c 4px, #d59a52 4px, #d59a52 8px);
 }
 
+/* ---- Appeal hero (signed, zero-centered meter) ---- */
+.curator-appeal-hero {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.3rem 0;
+}
+.curator-appeal-value {
+  color: var(--curator-card-text-muted);
+  font-size: 0.85rem;
+  font-weight: 700;
+  min-width: 3rem;
+}
+.curator-appeal-meter-wrap {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 4rem;
+}
+.curator-appeal-meter {
+  display: flex;
+  height: 6px;
+  position: relative;
+  width: 100%;
+}
+.curator-appeal-meter-track {
+  background: var(--bs-secondary-bg, #333);
+  border-radius: var(--curator-radius-sm);
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+}
+.curator-appeal-meter-center {
+  background: var(--curator-card-text-muted, #888);
+  height: 100%;
+  left: 50%;
+  position: absolute;
+  top: 0;
+  width: 1px;
+}
+.curator-appeal-meter-fill {
+  height: 100%;
+  position: absolute;
+  top: 0;
+}
+.curator-appeal-meter-fill.positive { background: #50b86c; }
+.curator-appeal-meter-fill.negative { background: #d59a52; }
+.curator-appeal-baseline {
+  color: var(--curator-card-text-muted);
+  flex: 0 0 auto;
+  font-size: 0.68rem;
+}
+
+/* ---- Named breakdown rows ---- */
+.curator-score-breakdown {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin: 0.3rem 0;
+}
+.curator-score-row {
+  align-items: center;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(6rem, 1fr) 2fr auto;
+  width: 100%;
+}
+.curator-score-row-label {
+  color: var(--curator-card-text-muted);
+  font-size: 0.7rem;
+}
+.curator-score-row-bar {
+  background: var(--bs-secondary-bg, #333);
+  border-radius: var(--curator-radius-sm);
+  height: 5px;
+  overflow: hidden;
+}
+.curator-score-row-fill {
+  background: #50b86c;
+  display: block;
+  height: 100%;
+  transition: width 0.3s ease;
+}
+.curator-score-row-negative .curator-score-row-fill { background: #d59a52; }
+.curator-score-row-value {
+  color: var(--curator-card-text-muted);
+  font-size: 0.72rem;
+  text-align: right;
+}
+
+/* ---- Evidence rows (Supports / Cautions / Context) ---- */
+.curator-evidence-rows {
+  list-style: none;
+  margin: 0.3rem 0;
+  padding-left: 0;
+}
+.curator-evidence-row {
+  align-items: baseline;
+  display: flex;
+  gap: 0.4rem;
+  margin: 0.15rem 0;
+}
+.curator-evidence-direction {
+  flex: 0 0 auto;
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  width: 4.5rem;
+}
+.curator-evidence-supports .curator-evidence-direction { color: #50b86c; }
+.curator-evidence-cautions .curator-evidence-direction { color: #d59a52; }
+.curator-evidence-context .curator-evidence-direction { color: var(--curator-card-text-muted); }
+.curator-evidence-text {
+  color: var(--curator-card-text);
+  flex: 1 1 auto;
+}
+.curator-evidence-magnitude {
+  color: var(--curator-card-text-muted);
+  flex: 0 0 auto;
+  font-size: 0.7rem;
+}
+
+/* ---- Lane callout ---- */
+.curator-lane-callout {
+  align-items: baseline;
+  border-left: 2px solid var(--lane-color, var(--curator-accent));
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin: 0.3rem 0;
+  padding-left: 0.5rem;
+}
+.curator-lane-callout-label {
+  color: var(--curator-card-text-muted);
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.curator-lane-callout-rank {
+  color: var(--curator-card-text);
+  font-size: 0.72rem;
+}
+.curator-lane-callout-intent {
+  color: var(--curator-card-text-muted);
+  font-size: 0.68rem;
+}
+
+/* ---- Evidence fingerprint radar ---- */
+.curator-radar {
+  margin: 0.3rem 0;
+  max-width: 12rem;
+}
+.curator-radar svg {
+  display: block;
+  height: auto;
+  width: 100%;
+}
+.curator-radar-outer {
+  fill: none;
+  stroke: var(--curator-card-border, #555);
+  stroke-width: 1;
+}
+.curator-radar-spoke {
+  stroke: var(--curator-card-border, #555);
+  stroke-width: 1;
+}
+.curator-radar-support {
+  fill: rgba(80, 184, 108, 0.35);
+  stroke: #50b86c;
+  stroke-width: 1.5;
+}
+.curator-radar-caution {
+  fill: rgba(213, 154, 82, 0.35);
+  stroke: #d59a52;
+  stroke-width: 1.5;
+}
+.curator-radar-neutral {
+  fill: rgba(128, 128, 128, 0.25);
+  stroke: #888;
+  stroke-width: 1.5;
+}
+.curator-radar-label {
+  fill: var(--curator-card-text-muted, #888);
+  font-size: 8px;
+}
+.curator-radar-label.curator-radar-no-evidence {
+  fill: var(--curator-card-text-muted, #888);
+  opacity: 0.55;
+  stroke-dasharray: 2 2;
+}
+.curator-radar-caption {
+  color: var(--curator-card-text-muted);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  margin-top: 0.15rem;
+  text-align: center;
+  text-transform: uppercase;
+}
+
 /* ---- Relationship chips ---- */
 .curator-chips {
   display: flex;

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -767,42 +767,211 @@
     );
   }
 
-  function ScoreNode({ name, value }) {
-    if (value === null || value === undefined) return null;
-    if (typeof value !== "object") {
-      return React.createElement(
-        "div",
-        { className: "curator-score-leaf" },
-        React.createElement("span", null, name.replaceAll("_", " ")),
-        React.createElement("code", null, typeof value === "number" ? value.toFixed(3) : String(value))
-      );
-    }
-    if (Array.isArray(value)) return null;
+  // A signed zero-centered meter for Appeal (−1..1). Renders a compact
+  // horizontal track with a center notch and a fill extending right for
+  // positive, left for negative.
+  function appealMeter(value) {
+    const clamped = Math.max(-1, Math.min(1, value));
+    const pct = Math.abs(clamped) * 50;
+    const positive = clamped >= 0;
     return React.createElement(
-      "details",
-      { className: "curator-score-node" },
-      React.createElement("summary", null, name.replaceAll("_", " ")),
-      React.createElement(
-        "div",
-        { className: "curator-score-children" },
-        Object.entries(value).map(([key, child]) =>
-          React.createElement(ScoreNode, { key, name: key, value: child })
-        )
+      "div",
+      { className: "curator-appeal-meter", "aria-hidden": "true" },
+      React.createElement("span", { className: "curator-appeal-meter-track" },
+        React.createElement("span", { className: "curator-appeal-meter-center" }),
+        React.createElement("span", { className: `curator-appeal-meter-fill ${positive ? "positive" : "negative"}`, style: { width: `${pct}%`, left: positive ? "50%" : `${50 - pct}%` } })
       )
     );
   }
 
+  // The signed Appeal hero: a two-decimal value with a zero-centered meter and
+  // an "above/below your learned baseline" label.
+  function AppealHero({ appeal }) {
+    if (appeal === null || appeal === undefined) return null;
+    const above = appeal >= 0;
+    return React.createElement(
+      "div",
+      { className: "curator-appeal-hero" },
+      React.createElement("span", { className: "curator-appeal-value" }, `${appeal >= 0 ? "+" : ""}${appeal.toFixed(2)}`),
+      React.createElement("span", { className: "curator-appeal-meter-wrap" }, appealMeter(appeal)),
+      React.createElement("span", { className: `curator-appeal-baseline ${above ? "above" : "below"}` }, above ? "above your learned baseline" : "below your learned baseline")
+    );
+  }
+
+  // A single named breakdown row: a visible 0..1 bar with a real unit. Appeal
+  // and right-now fit are signed (−1..1); Similarity/Match/rank are 0..1;
+  // confidence is a percentage. `unit` drives the display: "signed" keeps the
+  // sign and centers on zero, "similarity"/"appeal" clamp to 0..1, "percent"
+  // renders as a percentage.
+  function ScoreRow({ label, value, unit }) {
+    if (value === null || value === undefined) return null;
+    let display = value;
+    let barValue = value;
+    let suffix = "";
+    let className = "curator-score-row";
+    if (unit === "percent") {
+      display = `${Math.round(value * 100)}%`;
+      barValue = Math.max(0, Math.min(1, value));
+      className += " curator-score-row-percent";
+    } else if (unit === "signed") {
+      display = `${value >= 0 ? "+" : ""}${value.toFixed(2)}`;
+      barValue = Math.max(0, Math.min(1, Math.abs(value)));
+      className += value >= 0 ? " curator-score-row-positive" : " curator-score-row-negative";
+    } else {
+      display = value.toFixed(2);
+      barValue = Math.max(0, Math.min(1, value));
+    }
+    const pct = Math.round(barValue * 100);
+    return React.createElement(
+      "div",
+      { className },
+      React.createElement("span", { className: "curator-score-row-label" }, label),
+      React.createElement("span", { className: "curator-score-row-bar" },
+        React.createElement("span", { className: "curator-score-row-fill", style: { width: `${pct}%` } })
+      ),
+      React.createElement("code", { className: "curator-score-row-value" }, display)
+    );
+  }
+
+  // Named, scaled breakdown rows with real units — the plain-language
+  // replacement for the raw float tree. Novelty is NOT a model component and
+  // is never listed here (it exists only as lane context).
+  function ScoreBreakdown({ rows }) {
+    const namedRows = rows || [
+      { label: "Appeal", value: null, unit: "signed" },
+    ];
+    const visible = namedRows.filter((row) => row.value !== null && row.value !== undefined);
+    if (visible.length === 0) return null;
+    return React.createElement(
+      "div",
+      { className: "curator-score-breakdown" },
+      visible.map((row, index) =>
+        React.createElement(ScoreRow, { key: `${row.label}-${index}`, label: row.label, value: row.value, unit: row.unit })
+      )
+    );
+  }
+
+  // The backend-ranked evidence rows from the v2 payload: up to three material
+  // facts, direction-aware (Supports/Cautions/Context). Low confidence is
+  // context, not dislike; a material caution is shown when present, never a
+  // forced negative row.
+  function EvidenceRows({ reasons }) {
+    if (!reasons || reasons.length === 0) return null;
+    const rows = reasons.slice(0, 3).map((reason) => {
+      const tone = reason.direction === "positive" ? "supports"
+        : reason.direction === "negative" ? "cautions"
+        : "context";
+      return React.createElement(
+        "li",
+        { key: `${reason.code}-${reason.subject_id ?? ""}`, className: `curator-evidence-row curator-evidence-${tone}` },
+        React.createElement("span", { className: "curator-evidence-direction" }, tone === "supports" ? "Supports" : tone === "cautions" ? "Cautions" : "Context"),
+        React.createElement("span", { className: "curator-evidence-text" }, reasonLabel(reason.code)),
+        React.createElement("code", { className: "curator-evidence-magnitude" }, reason.magnitude.toFixed(2))
+      );
+    });
+    return React.createElement("ul", { className: "curator-evidence-rows" }, ...rows);
+  }
+
+  // The lane callout — a separate action-oriented explanation of why the
+  // current lane selected the scene, distinct from Appeal evidence.
+  function LaneCallout({ laneContext, laneLabel }) {
+    if (!laneContext || !laneContext.lane) return null;
+    const name = laneLabel || laneContext.lane.replaceAll("_", " ");
+    const intent = laneContext.intent || "selected";
+    const rank = laneContext.rank !== undefined ? `${Math.round(laneContext.rank * 100)}th percentile` : null;
+    return React.createElement(
+      "div",
+      { className: "curator-lane-callout" },
+      React.createElement("span", { className: "curator-lane-callout-label" }, `Rank in ${name}`),
+      rank && React.createElement("span", { className: "curator-lane-callout-rank" }, rank),
+      React.createElement("span", { className: "curator-lane-callout-intent" }, `why: ${intent.replaceAll("_", " ")}`)
+    );
+  }
+
+  // The evidence-fingerprint radar: a secondary visual summary of the six
+  // fixed axes from the versioned payload. Support and caution use two
+  // overlaid shapes; metadata coverage is a neutral gray spoke (usable
+  // resolved evidence coverage, not preference quality). Missing families use
+  // a muted dashed "No evidence" state. Renders only when the payload carries
+  // the required fixed-family data; otherwise the story/rows fallback is used.
+  function FingerprintRadar({ fingerprint }) {
+    if (!fingerprint || !fingerprint.axes) return null;
+    const keys = Object.keys(fingerprint.axes);
+    if (keys.length < 6) return null;
+    const cx = 100;
+    const cy = 100;
+    const radius = 70;
+    const angle = (index, total) => (Math.PI * 2 * index) / total - Math.PI / 2;
+    const point = (index, total, r) => [
+      cx + r * Math.cos(angle(index, total)),
+      cy + r * Math.sin(angle(index, total)),
+    ];
+    const ring = (r) => keys.map((_, index) => point(index, keys.length, r).join(",")).join(" ");
+    const shape = (tone) => {
+      const values = keys.map((key) => {
+        const axis = fingerprint.axes[key];
+        if (axis.tone !== tone) return 0;
+        return axis.present ? axis.strength : 0;
+      });
+      return keys.map((_, index) => point(index, keys.length, radius * values[index]).join(",")).join(" ");
+    };
+    const labels = keys.map((key, index) => {
+      const axis = fingerprint.axes[key];
+      const [x, y] = point(index, keys.length, radius + 16);
+      const present = axis.present;
+      return React.createElement(
+        "text",
+        { key, x, y, textAnchor: "middle", dominantBaseline: "middle", className: `curator-radar-label ${present ? "" : "curator-radar-no-evidence"}` },
+        `${axis.label}${present ? "" : " (no evidence)"}`
+      );
+    });
+    const spokes = keys.map((_, index) => {
+      const [x, y] = point(index, keys.length, radius);
+      return React.createElement("line", { key: index, x1: cx, y1: cy, x2: x, y2: y, className: "curator-radar-spoke" });
+    });
+    return React.createElement(
+      "div",
+      { className: "curator-radar" },
+      React.createElement("svg", { viewBox: "0 0 200 200", role: "img", "aria-label": "Evidence fingerprint radar" },
+        React.createElement("polygon", { points: ring(radius), className: "curator-radar-outer" }),
+        React.createElement("polygon", { points: ring(radius * 0.66), className: "curator-radar-outer" }),
+        React.createElement("polygon", { points: ring(radius * 0.33), className: "curator-radar-outer" }),
+        ...spokes,
+        React.createElement("polygon", { points: shape("support"), className: "curator-radar-support" }),
+        React.createElement("polygon", { points: shape("caution"), className: "curator-radar-caution" }),
+        React.createElement("polygon", { points: shape("neutral"), className: "curator-radar-neutral" }),
+        ...labels
+      ),
+      React.createElement("div", { className: "curator-radar-caption" }, "Evidence fingerprint")
+    );
+  }
+
+  // The full ~12-code reason inventory (codes from core/explanations.go).
   function reasonLabel(code) {
     const labels = {
       "appeal.performer_identity": "Performer match",
+      "appeal.performer_similar": "Similar performer profile",
       "appeal.content_neighbor": "Similar content",
-      // The baseline reason present on every impression regardless of lane
-      // (core/slate.go, slate_greedy.go, score_review.go all seed reasonIDs
-      // with this) — richer reasons like the two above are appended after
-      // it when they apply, but plenty of items have no reason beyond this
-      // one. The naive fallback below (last dot-segment, title-cased) turns
-      // it into the confusing bare word "Lane".
+      "appeal.studio": "Studio appeal",
+      "appeal.tag_positive": "Familiar elements",
+      "appeal.tag_negative": "Discouraged elements",
+      "appeal.tag_declared_positive": "Declared preference",
+      "appeal.tag_declared_negative": "Declared aversion",
+      "direct.positive": "Your feedback on this scene",
+      "direct.negative": "Your feedback on this scene",
+      "direct.residual": "Model residual",
+      "fit.cooldown": "Cooling down",
+      "fit.satiation": "Satiation",
+      "fit.not_now": "Not right now",
       "eligibility.lane": "Eligible for this lane",
+      "explore.challenge": "Challenges a boundary",
+      "explore.coverage": "Covers a blind spot",
+      "dormant.entity": "A dormant taste",
+      "diversity.performer": "Diversity — performer",
+      "diversity.studio": "Diversity — studio",
+      "diversity.content": "Diversity — content",
+      "fallback": "Model baseline",
+      "evidence.confidence": "Low confidence",
     };
     const fallback = code.split(".").at(-1).replaceAll("_", " ");
     return labels[code] || fallback.charAt(0).toUpperCase() + fallback.slice(1);
@@ -2108,24 +2277,28 @@
     );
   }
 
-  // Shared "Why this?"/"Score · X" details shell, used by RecommendationCard,
-  // ExternalCard, and SimilarityPanel's library-match grid. The shell (the
-  // two <details>/<summary> elements) is genuinely identical across all
-  // three; what goes inside each is not (RecommendationCard lazy-loads its
-  // explanation on toggle and shows a ScoreNode tree, the other two are
-  // static), so content stays fully caller-supplied via props rather than
-  // forcing those shapes into a shared config.
-  // The match bar is always visible in the mockup — it's the at-a-glance
-  // signal a card carries, not something worth an extra click to see.
-  // Everything else (the breakdown text/tree) stays behind the existing
-  // collapsed "Score · N" details for progressive disclosure.
-  function EvidenceScore({ evidenceProps, evidenceContent, scoreBarContent, scoreSummary, scoreContent }) {
+  // Shared "Why this?"/"<quantity> · X" details shell, used by
+  // RecommendationCard, ExternalCard, and SimilarityPanel's library-match
+  // grid. The shell (the two <details>/<summary> elements) is genuinely
+  // identical across all three; what goes inside each is not
+  // (RecommendationCard lazy-loads its explanation on toggle and shows a
+  // ScoreBreakdown, the other two are static), so content stays fully
+  // caller-supplied via props rather than forcing those shapes into a shared
+  // config.
+  // Every card carries two separately-labeled quantities — intrinsic Appeal
+  // plus the surface's own relative quantity (Rank in <Lane>, Similarity, or
+  // Match) — so the match bar is always visible as the at-a-glance signal and
+  // is labeled by the caller (`quantityLabel`/`quantityValue`), never a bare
+  // blended "Score". Everything else stays behind the collapsed disclosure.
+  function EvidenceScore({ evidenceProps, evidenceContent, scoreBarContent, scoreSummary, scoreContent, quantityLabel, quantityValue }) {
+    const label = quantityLabel || "Match";
+    const summaryText = quantityValue !== undefined ? `${label} · ${quantityValue}` : scoreSummary;
     return React.createElement(
       React.Fragment,
       null,
       evidenceContent !== null && React.createElement("details", { className: "curator-evidence", ...evidenceProps }, React.createElement("summary", null, "Why this?"), evidenceContent),
-      scoreBarContent && React.createElement("div", { className: "curator-match-row" }, React.createElement("span", { className: "curator-match-label" }, "Match"), scoreBarContent, React.createElement("span", { className: "curator-match-value" }, scoreSummary)),
-      React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, scoreBarContent ? "Score breakdown" : `Score · ${scoreSummary}`), scoreContent)
+      scoreBarContent && React.createElement("div", { className: "curator-match-row" }, React.createElement("span", { className: "curator-match-label" }, label), scoreBarContent, React.createElement("span", { className: "curator-match-value" }, quantityValue !== undefined ? quantityValue : scoreSummary)),
+      React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, scoreBarContent ? "Score breakdown" : summaryText), scoreContent)
     );
   }
 
@@ -2242,7 +2415,7 @@
       payload.curator_local_match?.type === "phash" && React.createElement("span", { className: "curator-phash-badge", title: "A local scene has the same exact PHash. This is strong matching evidence, not guaranteed identity." }, "Likely local · exact PHash"),
       React.createElement("div", { className: `curator-external-thumbnail thumbnail-section ${kind === "scene" ? "video-section" : ""}` }, React.createElement("a", { className: `${kind}-card-link`, href, target: "_blank", rel: "noreferrer" }, image && React.createElement("img", { className: `${kind}-card-image`, src: image, loading: "lazy", alt: "" })), kind === "scene" && payload.studio?.name && React.createElement("span", { className: "curator-external-studio-overlay" }, payload.studio.name)),
       React.createElement("div", { className: "card-section" }, React.createElement(TitleLink, localProfile, React.createElement("h5", { className: "card-section-title flex-aligned" }, title)), React.createElement("div", { className: kind === "scene" ? "scene-card__details" : "curator-external-details" }, React.createElement("span", null, payload.release_date || payload.birth_date || ""), metadataControls), kind === "scene" && payload.details && React.createElement("p", { className: "curator-card-description" }, payload.details)),
-      React.createElement("div", { className: "curator-card-body" }, (() => { let scoreDetail; if (item.similarity === undefined) { scoreDetail = `Match ${item.score.toFixed(2)} · found via ${item.sources.join(", ")}`; } else { scoreDetail = `Similarity ${item.similarity.toFixed(2)}` + (item.appeal !== undefined ? ` · appeal ${item.appeal.toFixed(2)}` : ""); const mh = item.details && item.details.score_breakdown && item.details.score_breakdown.multi_hop; if (mh > 0) scoreDetail += " + multi-hop " + mh.toFixed(4); } return React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, { evidenceContent: payload.why?.length ? React.createElement("p", { className: "curator-explanation" }, payload.why.join(" · ")) : null, scoreBarContent: utilityBar(item.score), scoreSummary: item.score.toFixed(2), scoreContent: React.createElement("p", null, scoreDetail) })); })()),
+      React.createElement("div", { className: "curator-card-body" }, (() => { const isMatch = item.similarity === undefined; const quantityLabel = isMatch ? "Match" : "Similarity"; let scoreDetail; if (isMatch) { scoreDetail = `found via ${item.sources.join(", ")}`; } else { scoreDetail = `Similarity ${item.similarity.toFixed(2)}` + (item.appeal !== undefined ? ` · appeal ${item.appeal.toFixed(2)}` : ""); const mh = item.details && item.details.score_breakdown && item.details.score_breakdown.multi_hop; if (mh > 0) scoreDetail += " + multi-hop " + mh.toFixed(4); } return React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, { evidenceContent: payload.why?.length ? React.createElement("p", { className: "curator-explanation" }, payload.why.join(" · ")) : null, scoreBarContent: utilityBar(item.score), scoreSummary: item.score.toFixed(2), quantityLabel, quantityValue: item.score.toFixed(2), scoreContent: React.createElement("p", null, isMatch ? `Match ${item.score.toFixed(2)} · ${scoreDetail}` : scoreDetail) })); })()),
       React.createElement(ExternalActions, { href, item, kind, copied, onCopy: async () => { try { await copyText(item.id); setCopied(true); setTimeout(() => setCopied(false), 1500); } catch (_) { setCopied(false); } }, onShortlist, tagsAvailable: tags.length > 0, tagsActive: tagChoices !== null, tagLoading, onRateTags: rateTags, onShowScenes, whisparrEnabled, canWhisparr: Boolean(onWhisparr), whisparr, onAddToWhisparr: addToWhisparr }),
       kind === "scene" && tagChoices !== null && React.createElement("div", { className: "curator-external-tag-rating" }, React.createElement("div", { className: "curator-external-tag-rating-header" }, React.createElement("strong", null, "Rate tags & terms"), React.createElement(Button, { size: "sm", variant: "link", className: "curator-external-tag-rating-close", "aria-label": "Collapse matching local tag ratings", title: "Collapse matching local tag ratings", onClick: rateTags }, "Collapse")), tagLoading && React.createElement("small", { role: "status" }, "Matching local tags…"), tagError && React.createElement("small", { className: "text-danger", role: "status" }, tagError), !tagLoading && !tagError && React.createElement(React.Fragment, null, React.createElement(RatingSection, { title: "Matching local tags", rows: tagChoices.map((tag) => ({ key: tag.tag_id, tag_id: tag.tag_id, name: tag.name, direct_value: tag.direct_value, direct_blocked: tag.direct_blocked })), onAnswer: answerTag, emptyLabel: "No matching local tags." }), React.createElement(RatingSection, { title: "Description terms", rows: termChoices.map((term) => ({ key: term.term, term: term.term, name: term.term, direct_value: term.direct_value, direct_blocked: term.direct_blocked })), onAnswer: answerTerm, emptyLabel: "No description terms in the model." })))
     );
@@ -2440,7 +2613,9 @@
     const card = React.useRef(null);
     const [explanation, setExplanation] = React.useState(
       item.explanation
-        ? { summary: item.explanation, supporting_reasons: item.supporting_reasons || [] }
+        ? (typeof item.explanation === "string"
+            ? { summary: item.explanation, supporting_reasons: item.supporting_reasons || [] }
+            : item.explanation)
         : null
     );
     const [explanationLoading, setExplanationLoading] = React.useState(false);
@@ -2535,30 +2710,28 @@
               null,
               explanationLoading && React.createElement("small", { role: "status" }, "Explaining…"),
               explanationError && React.createElement("small", { className: "text-danger", role: "alert" }, explanationError),
-              explanation && React.createElement("p", { className: "curator-explanation" }, explanation.summary),
-              explanation && React.createElement(
-                "ul",
-                null,
-                explanation.supporting_reasons.map((reason, index) =>
-                  React.createElement(
-                    "li",
-                    { key: `${reason.code}-${index}` },
-                    `${reasonLabel(reason.code)} (${reason.magnitude.toFixed(2)})`
-                  )
-                )
-              )
+              explanation && explanation.summary && React.createElement("p", { className: "curator-explanation" }, explanation.summary),
+              explanation && explanation.evidence_fingerprint && React.createElement(FingerprintRadar, { fingerprint: explanation.evidence_fingerprint }),
+              explanation && explanation.reasons && React.createElement(EvidenceRows, { reasons: explanation.reasons }),
+              explanation && explanation.lane_context && explanation.lane_context.lane && React.createElement(LaneCallout, { laneContext: explanation.lane_context, laneLabel: laneByValue.get(explanation.lane_context.lane)?.label })
             ),
             scoreBarContent: utilityBar(item.final_utility),
             scoreSummary: item.final_utility.toFixed(2),
+            quantityLabel: item.source_lane && item.source_lane !== "score_review" ? `Rank in ${laneLabel}` : "Appeal",
+            quantityValue: item.source_lane && item.source_lane !== "score_review" ? item.final_utility.toFixed(2) : `${item.appeal >= 0 ? "+" : ""}${item.appeal.toFixed(2)}`,
             scoreContent: React.createElement(
               React.Fragment,
               null,
-              React.createElement(ScoreNode, { name: "appeal", value: item.appeal }),
-              React.createElement(ScoreNode, { name: "current_fit", value: item.current_fit }),
-              React.createElement(ScoreNode, { name: "confidence", value: item.confidence }),
-              React.createElement(ScoreNode, { name: "components", value: item.components }),
-              React.createElement(ScoreNode, { name: "diversity_penalties", value: item.penalties }),
-              React.createElement(ScoreNode, { name: "diversity_bonuses", value: item.bonuses })
+              React.createElement(AppealHero, { appeal: item.appeal }),
+              React.createElement(ScoreBreakdown, { rows: [
+                { label: "Content similarity", value: (item.components?.content?.value ?? 0), unit: "similarity" },
+                { label: "Performer match", value: (item.components?.performer_identity?.value ?? 0) + (item.components?.performer_similarity?.value ?? 0), unit: "similarity" },
+                { label: "Studio appeal", value: (item.components?.studio?.value ?? 0), unit: "appeal" },
+                { label: "Direct feedback", value: (item.components?.direct?.value ?? 0), unit: "appeal" },
+                { label: "Right-now fit", value: item.current_fit, unit: "signed" },
+                { label: "Confidence", value: item.confidence, unit: "percent" },
+              ] }),
+              explanation && explanation.scores && explanation.scores.rank && item.source_lane && React.createElement(LaneCallout, { laneContext: { lane: item.source_lane, rank: explanation.scores.rank.value }, laneLabel })
             ),
           }),
           React.createElement(Feedback, { item, onRemove, onThumbDown })
@@ -2600,7 +2773,8 @@
         "td",
         null,
         item.current_model && scene && !explanation && React.createElement(Button, { size: "sm", variant: "link", onClick: explain }, "Why this now?"),
-        explanation && React.createElement("span", null, explanation.summary),
+        explanation && explanation.summary && React.createElement("span", null, explanation.summary),
+        explanation && explanation.reasons && React.createElement(EvidenceRows, { reasons: explanation.reasons }),
         error && React.createElement("small", { className: "text-danger" }, error)
       )
     );
@@ -3070,7 +3244,10 @@
         items.map((item) => {
           const entity = entities.get(String(item.entity_id));
           if (!entity) return null;
-          const body = React.createElement("div", { className: "curator-card-body" }, entityType === "scene" && React.createElement(LocalRatingPanel, { sceneId: item.entity_id }), React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, { evidenceContent: React.createElement("p", { className: "curator-explanation" }, relationshipChips(item)), scoreBarContent: utilityBar(item.rank_score), scoreSummary: item.rank_score.toFixed(2), scoreContent: React.createElement("p", null, `Similarity ${item.similarity.toFixed(2)} · predicted appeal ${item.appeal.toFixed(2)}`) })));
+          const body = React.createElement("div", { className: "curator-card-body" }, entityType === "scene" && React.createElement(LocalRatingPanel, { sceneId: item.entity_id }), React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, { evidenceContent: React.createElement("p", { className: "curator-explanation" }, relationshipChips(item)), scoreBarContent: utilityBar(item.rank_score), scoreSummary: item.rank_score.toFixed(2), quantityLabel: "Similarity", quantityValue: item.rank_score.toFixed(2), scoreContent: React.createElement(React.Fragment, null, React.createElement(AppealHero, { appeal: item.appeal }), React.createElement(ScoreBreakdown, { rows: [
+                { label: "Content similarity", value: item.similarity, unit: "similarity" },
+                { label: "Appeal", value: item.appeal, unit: "signed" },
+              ] })) })));
           if (entityType === "performer") return React.createElement("article", { key: item.entity_id, className: "curator-card" }, React.createElement(PerformerCard, { performer: entity }), body);
           const feedbackItem = { ...item, scene_id: item.entity_id, impression_id: result.impression_id };
           function rememberOrigin(event) {
@@ -4856,7 +5033,7 @@
           { className: "curator-view-copy" },
           React.createElement("h1", null, laneByValue.has(lane) ? "Recommendations" : laneOption.label),
           React.createElement("p", null, laneOption.description),
-          laneByValue.has(lane) && React.createElement("p", null, "The colored corner icon identifies the source lane; Score is ranking utility, not a probability."),
+          laneByValue.has(lane) && React.createElement("p", null, "The colored corner icon identifies the source lane. Each card shows the scene's intrinsic Appeal plus its rank within this lane's qualified, ordered population — the rank is a percentile, not a probability."),
           laneByValue.has(lane) && slate && React.createElement(
             "p",
             { className: "curator-view-stats" },

--- a/tests/core/test_backend_slice8_explanation_v2.py
+++ b/tests/core/test_backend_slice8_explanation_v2.py
@@ -16,9 +16,9 @@ from pathlib import Path
 import pytest
 
 from curator.core import core_binary
+from tests.core.compare import assert_equivalent
 from tests.core.test_backend import PLUGIN_DIR, _with_db_path, payload, run_backend
 from tests.core.test_backend_slice1 import make_model_sidecar
-from tests.core.compare import assert_equivalent
 
 
 @pytest.fixture(scope="module")

--- a/tests/core/test_backend_slice8_explanation_v2.py
+++ b/tests/core/test_backend_slice8_explanation_v2.py
@@ -1,0 +1,113 @@
+"""Differential gate for the apiSchemaVersion 2 explanation payload.
+
+The Go core and the Python oracle must emit byte-identical v2 explanation
+payloads (structure exactly, floats within the shared 1e-9 tolerance), and the
+payload must carry the versioned shape: apiSchemaVersion 2, summary,
+components[], reasons[], lane_context{}, scores{appeal,current_fit,confidence,
+rank}, and evidence_fingerprint{}.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+
+from curator.core import core_binary
+from tests.core.test_backend import PLUGIN_DIR, _with_db_path, payload, run_backend
+from tests.core.test_backend_slice1 import make_model_sidecar
+from tests.core.compare import assert_equivalent
+
+
+@pytest.fixture(scope="module")
+def stub_stash() -> str:
+    from http.server import HTTPServer
+
+    from tests.core.test_backend import _StubStash
+
+    server = HTTPServer(("127.0.0.1", 0), _StubStash)
+    import threading
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    yield f"http://127.0.0.1:{server.server_port}"
+    server.shutdown()
+
+
+@pytest.fixture(scope="module")
+def model_sidecar(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    path = tmp_path_factory.mktemp("model-sidecar-v2") / "curator.sqlite3"
+    make_model_sidecar(path)
+    return path
+
+V2_FIELDS = (
+    "apiSchemaVersion",
+    "summary",
+    "components",
+    "reasons",
+    "lane_context",
+    "scores",
+    "evidence_fingerprint",
+)
+
+
+@pytest.fixture(scope="module")
+def binary() -> Path:
+    path = core_binary()
+    if path is None:
+        pytest.skip("curator-core binary not built; run scripts/verify core")
+    return path
+
+
+def _run_both(binary: Path, raw: bytes, same_path: Path, tmp_path: Path) -> tuple[dict, dict]:
+    outputs: list[dict] = []
+    for name, runner in (("py", None), ("go", Path(binary))):
+        run_dir = tmp_path / f"run-{name}"
+        shutil.rmtree(run_dir, ignore_errors=True)
+        run_dir.mkdir()
+        db = run_dir / same_path.name
+        shutil.copy2(same_path, db)
+        derived_src = same_path.parent / f"{same_path.stem}-derived"
+        derived_dst = run_dir / f"{db.stem}-derived"
+        if derived_src.is_dir():
+            shutil.copytree(derived_src, derived_dst)
+        try:
+            result = run_backend(runner, PLUGIN_DIR, _with_db_path(raw, db))
+        finally:
+            shutil.rmtree(run_dir, ignore_errors=True)
+        assert result.returncode == 0, result.stdout
+        outputs.append(json.loads(result.stdout)["output"])
+    return outputs[0], outputs[1]
+
+
+def _assert_v2_shape(payload: dict) -> None:
+    assert payload["apiSchemaVersion"] == 2
+    assert isinstance(payload["summary"], str) and payload["summary"]
+    assert isinstance(payload["components"], list) and payload["components"]
+    assert isinstance(payload["reasons"], list) and payload["reasons"]
+    assert isinstance(payload["lane_context"], dict)
+    assert set(payload["scores"]) == {"appeal", "current_fit", "confidence", "rank"}
+    for key in ("appeal", "current_fit", "confidence", "rank"):
+        assert set(payload["scores"][key]) == {"value", "unit"}
+    assert "axes" in payload["evidence_fingerprint"]
+    assert set(payload["evidence_fingerprint"]["axes"]) == {
+        "content",
+        "performers",
+        "studios",
+        "similar_scenes",
+        "direct_history",
+        "metadata_coverage",
+    }
+
+
+@pytest.mark.parametrize("scene_id", ["recent-good", "old-good", "disliked", "unusual"])
+def test_explanation_v2_byte_identical(
+    model_sidecar: Path, binary: Path, stub_stash: str, tmp_path: Path, scene_id: str
+) -> None:
+    raw = payload("get_explanation", model_sidecar, stub_stash, scene_id=scene_id)
+    py_out, go_out = _run_both(binary, raw, model_sidecar, tmp_path)
+    _assert_v2_shape(py_out)
+    _assert_v2_shape(go_out)
+    assert_equivalent(py_out, go_out)

--- a/tests/core/test_backend_slice8_explanation_v2.py
+++ b/tests/core/test_backend_slice8_explanation_v2.py
@@ -42,6 +42,7 @@ def model_sidecar(tmp_path_factory: pytest.TempPathFactory) -> Path:
     make_model_sidecar(path)
     return path
 
+
 V2_FIELDS = (
     "apiSchemaVersion",
     "summary",

--- a/tests/explanations/test_breakdown.py
+++ b/tests/explanations/test_breakdown.py
@@ -1,0 +1,133 @@
+"""Unit tests for the apiSchemaVersion 2 explanation payload builder."""
+
+from __future__ import annotations
+
+import sqlite3
+
+from curator.api import CuratorAPI
+from curator.model import PreferenceModelBuilder
+from tests.model.test_builder import REFERENCE_MS, _database
+
+
+def _build(tmp_path) -> tuple[sqlite3.Connection, CuratorAPI]:
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    return connection, CuratorAPI(connection)
+
+
+def test_v2_payload_has_exact_shape(tmp_path) -> None:
+    connection, api = _build(tmp_path)
+    try:
+        payload = api.explanation("recent-good")
+        assert payload["apiSchemaVersion"] == 2
+        assert isinstance(payload["summary"], str) and payload["summary"]
+        assert isinstance(payload["components"], list)
+        assert payload["components"]
+        assert isinstance(payload["reasons"], list)
+        assert payload["reasons"]
+        assert isinstance(payload["lane_context"], dict)
+        assert isinstance(payload["scores"], dict)
+        assert set(payload["scores"]) == {"appeal", "current_fit", "confidence", "rank"}
+        assert isinstance(payload["evidence_fingerprint"], dict)
+        assert "axes" in payload["evidence_fingerprint"]
+    finally:
+        connection.close()
+
+
+def test_v2_components_are_named_scaled_rows_with_units(tmp_path) -> None:
+    connection, api = _build(tmp_path)
+    try:
+        payload = api.explanation("recent-good")
+        rows = payload["components"]
+        assert {row["key"] for row in rows} == {
+            "content_similarity",
+            "performer_match",
+            "studio_appeal",
+            "direct_feedback",
+            "right_now_fit",
+            "confidence",
+        }
+        for row in rows:
+            assert row["label"]
+            assert row["unit"] in {"similarity", "appeal", "percent"}
+            assert -1.0 <= row["value"] <= 1.0
+        # Novelty is NOT a model component — it must never appear.
+        assert not any("novelty" in row["key"] for row in rows)
+    finally:
+        connection.close()
+
+
+def test_v2_evidence_fingerprint_has_six_fixed_axes(tmp_path) -> None:
+    connection, api = _build(tmp_path)
+    try:
+        payload = api.explanation("recent-good")
+        axes = payload["evidence_fingerprint"]["axes"]
+        assert set(axes) == {
+            "content",
+            "performers",
+            "studios",
+            "similar_scenes",
+            "direct_history",
+            "metadata_coverage",
+        }
+        for key, axis in axes.items():
+            assert 0.0 <= axis["strength"] <= 1.0
+            assert axis["tone"] in {"support", "caution", "neutral"}
+            assert isinstance(axis["present"], bool)
+        # Metadata coverage is always neutral, not a preference axis.
+        assert axes["metadata_coverage"]["tone"] == "neutral"
+        assert axes["metadata_coverage"]["present"] is True
+    finally:
+        connection.close()
+
+
+def test_v2_scores_carry_units(tmp_path) -> None:
+    connection, api = _build(tmp_path)
+    try:
+        payload = api.explanation("recent-good")
+        scores = payload["scores"]
+        assert scores["appeal"]["unit"] == "signed"
+        assert scores["current_fit"]["unit"] == "signed"
+        assert scores["confidence"]["unit"] == "percent"
+        assert scores["rank"]["unit"] == "percent"
+        assert -1.0 <= scores["appeal"]["value"] <= 1.0
+        assert 0.0 <= scores["confidence"]["value"] <= 1.0
+    finally:
+        connection.close()
+
+
+def test_v2_lane_context_is_typed_union_when_lane_exists(tmp_path) -> None:
+    connection, api = _build(tmp_path)
+    try:
+        # old-good qualifies for the revisit lane.
+        payload = api.explanation("old-good")
+        context = payload["lane_context"]
+        assert context["lane"] == "revisit"
+        assert context["intent"] == "revisit"
+        assert context["subtype"] is None
+        assert "facets" in context
+        assert "durable_signals" in context["facets"]
+        # A scene with no lane gets an empty (not fabricated) lane_context.
+        payload = api.explanation("unlabeled")
+        assert payload["lane_context"] == {}
+    finally:
+        connection.close()
+
+
+def test_v2_reasons_are_backend_ranked_support_first(tmp_path) -> None:
+    connection, api = _build(tmp_path)
+    try:
+        payload = api.explanation("recent-good")
+        reasons = payload["reasons"]
+        assert reasons
+        # The first reason must be a support (positive-direction) fact.
+        assert reasons[0]["direction"] == "positive"
+        # Supports are ordered by descending signed strength.
+        directions = [reason["direction"] for reason in reasons]
+        first_negative = next(
+            (index for index, direction in enumerate(directions) if direction == "negative"),
+            len(directions),
+        )
+        assert all(d == "positive" for d in directions[:first_negative])
+    finally:
+        connection.close()

--- a/tests/explanations/test_breakdown.py
+++ b/tests/explanations/test_breakdown.py
@@ -70,7 +70,7 @@ def test_v2_evidence_fingerprint_has_six_fixed_axes(tmp_path) -> None:
             "direct_history",
             "metadata_coverage",
         }
-        for key, axis in axes.items():
+        for _key, axis in axes.items():
             assert 0.0 <= axis["strength"] <= 1.0
             assert axis["tone"] in {"support", "caution", "neutral"}
             assert isinstance(axis["present"], bool)

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -957,11 +957,18 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     assert '"Explaining…"' in source
     assert 'React.createElement("summary", null, scoreBarContent ? "Score breakdown" :' in source
     # The RecommendationCard header is pinned: Appeal plus the lane rank label.
-    assert 'quantityLabel: item.source_lane && item.source_lane !== "score_review" ? `Rank in ${laneLabel}` : "Appeal"' in source
-    assert 'quantityValue: item.source_lane && item.source_lane !== "score_review" ? item.final_utility.toFixed(2) : `${item.appeal >= 0 ? "+" : ""}${item.appeal.toFixed(2)}`' in source
+    assert (
+        'quantityLabel: item.source_lane && item.source_lane !== "score_review" '
+        '? `Rank in ${laneLabel}` : "Appeal"' in source
+    )
+    assert (
+        'quantityValue: item.source_lane && item.source_lane !== "score_review" '
+        '? item.final_utility.toFixed(2) : `${item.appeal >= 0 ? "+" : ""}'
+        "${item.appeal.toFixed(2)}`" in source
+    )
     # The ExternalCard header migrates from the bare "Score · x" to a labeled
     # Match/Similarity quantity.
-    assert "const quantityLabel = isMatch ? \"Match\" : \"Similarity\";" in source
+    assert 'const quantityLabel = isMatch ? "Match" : "Similarity";' in source
     assert "quantityLabel, quantityValue: item.score.toFixed(2)" in source
     # The SimilarityPanel header pins Similarity + Appeal.
     assert 'quantityLabel: "Similarity", quantityValue: item.rank_score.toFixed(2)' in source
@@ -972,7 +979,10 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     assert "function EvidenceRows({ reasons })" in source
     assert "function LaneCallout({ laneContext, laneLabel })" in source
     assert "function FingerprintRadar({ fingerprint })" in source
-    assert "explanation && explanation.evidence_fingerprint && React.createElement(FingerprintRadar" in source
+    assert (
+        "explanation && explanation.evidence_fingerprint && React.createElement(FingerprintRadar"
+        in source
+    )
     assert "scoreSummary: item.final_utility.toFixed(2)" in source
     assert "scoreSummary: item.score.toFixed(2)" in source
     assert "scoreSummary: item.rank_score.toFixed(2)" in source
@@ -982,7 +992,10 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     assert "className: `${type}-card-image`" in source
     assert 'className: "card-section-title"' in source
     assert "Curator never deletes media; tagging is reversible" in source
-    assert "Each card shows the scene's intrinsic Appeal plus its rank within this lane's qualified, ordered population" in source
+    assert (
+        "Each card shows the scene's intrinsic Appeal plus its rank within "
+        "this lane's qualified, ordered population" in source
+    )
     assert '"appeal.performer_identity": "Performer match"' in source
     assert '"appeal.content_neighbor": "Similar content"' in source
     assert '"appeal.performer_similar": "Similar performer profile"' in source
@@ -1000,7 +1013,9 @@ def test_legacy_partial_explanation_falls_back_without_fabricating_appeal() -> N
     # The card's explanation state handles a legacy string payload and a v2
     # object payload (the ternary branches), never assuming a field exists.
     assert 'typeof item.explanation === "string"' in source
-    assert "{ summary: item.explanation, supporting_reasons: item.supporting_reasons || [] }" in source
+    assert (
+        "{ summary: item.explanation, supporting_reasons: item.supporting_reasons || [] }" in source
+    )
     # The renderers tolerate missing v2 fields without fabricating Appeal.
     assert "explanation && explanation.reasons && React.createElement(EvidenceRows" in source
     assert "explanation && explanation.lane_context && explanation.lane_context.lane" in source

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -944,18 +944,35 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     assert 'className: "image-thumbnail"' in source
     assert 'className: "tag-item tag-link badge badge-secondary"' in source
     # RecommendationCard, ExternalCard, and SimilarityPanel's library-match
-    # grid share the "Why this?"/"Score" <details> shell via EvidenceScore;
-    # the shell markup lives once in its definition, content stays
-    # per-caller (async explain-on-toggle vs static text).
+    # grid share the "Why this?"/"<quantity>" <details> shell via
+    # EvidenceScore; the shell markup lives once in its definition, content
+    # stays per-caller (async explain-on-toggle vs static text). The quantity
+    # label is caller-supplied so no card shows a bare blended "Score".
     assert "function EvidenceScore({ evidenceProps, evidenceContent," in source
-    assert "scoreBarContent, scoreSummary, scoreContent })" in source
+    assert "scoreBarContent, scoreSummary, scoreContent, quantityLabel, quantityValue })" in source
     assert 'React.createElement("summary", null, "Why this?")' in source
     assert 'className: "curator-evidence", ...evidenceProps' in source
     assert "evidenceProps: { onToggle: explain }" in source
     assert 'operation({ operation: "get_explanation", scene_id: item.scene_id }, 60000)' in source
     assert '"Explaining…"' in source
     assert 'React.createElement("summary", null, scoreBarContent ? "Score breakdown" :' in source
-    assert "`Score · ${scoreSummary}`)" in source
+    # The RecommendationCard header is pinned: Appeal plus the lane rank label.
+    assert 'quantityLabel: item.source_lane && item.source_lane !== "score_review" ? `Rank in ${laneLabel}` : "Appeal"' in source
+    assert 'quantityValue: item.source_lane && item.source_lane !== "score_review" ? item.final_utility.toFixed(2) : `${item.appeal >= 0 ? "+" : ""}${item.appeal.toFixed(2)}`' in source
+    # The ExternalCard header migrates from the bare "Score · x" to a labeled
+    # Match/Similarity quantity.
+    assert "const quantityLabel = isMatch ? \"Match\" : \"Similarity\";" in source
+    assert "quantityLabel, quantityValue: item.score.toFixed(2)" in source
+    # The SimilarityPanel header pins Similarity + Appeal.
+    assert 'quantityLabel: "Similarity", quantityValue: item.rank_score.toFixed(2)' in source
+    # Shared renderers: named breakdown rows, the signed Appeal hero, the
+    # backend-ranked evidence rows, and the lane callout.
+    assert "function AppealHero({ appeal })" in source
+    assert "function ScoreBreakdown({ rows })" in source
+    assert "function EvidenceRows({ reasons })" in source
+    assert "function LaneCallout({ laneContext, laneLabel })" in source
+    assert "function FingerprintRadar({ fingerprint })" in source
+    assert "explanation && explanation.evidence_fingerprint && React.createElement(FingerprintRadar" in source
     assert "scoreSummary: item.final_utility.toFixed(2)" in source
     assert "scoreSummary: item.score.toFixed(2)" in source
     assert "scoreSummary: item.rank_score.toFixed(2)" in source
@@ -965,10 +982,32 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     assert "className: `${type}-card-image`" in source
     assert 'className: "card-section-title"' in source
     assert "Curator never deletes media; tagging is reversible" in source
-    assert "Score is ranking utility, not a probability" in source
+    assert "Each card shows the scene's intrinsic Appeal plus its rank within this lane's qualified, ordered population" in source
     assert '"appeal.performer_identity": "Performer match"' in source
     assert '"appeal.content_neighbor": "Similar content"' in source
+    assert '"appeal.performer_similar": "Similar performer profile"' in source
+    assert '"eligibility.lane": "Eligible for this lane"' in source
     assert "Wildcard items are selected outside preference-derived seeds" in source
+
+
+def test_legacy_partial_explanation_falls_back_without_fabricating_appeal() -> None:
+    """Legacy/partial explanation payloads render truthfully without fabricating
+    Appeal evidence: the RecommendationCard's state init tolerates a plain
+    string `item.explanation` (the old embedded summary) and the v2 renderers
+    no-op on missing reason/rank fields rather than inventing numbers."""
+    source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
+
+    # The card's explanation state handles a legacy string payload and a v2
+    # object payload (the ternary branches), never assuming a field exists.
+    assert 'typeof item.explanation === "string"' in source
+    assert "{ summary: item.explanation, supporting_reasons: item.supporting_reasons || [] }" in source
+    # The renderers tolerate missing v2 fields without fabricating Appeal.
+    assert "explanation && explanation.reasons && React.createElement(EvidenceRows" in source
+    assert "explanation && explanation.lane_context && explanation.lane_context.lane" in source
+    # Appeal always comes from the model score on the slate item (truthful),
+    # never invented by a legacy/partial explanation payload.
+    assert "React.createElement(AppealHero, { appeal: item.appeal })" in source
+    assert "React.createElement(AppealHero, { appeal: item.appeal })," in source
 
 
 def test_external_card_actions_are_a_named_shared_component() -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -103,7 +103,12 @@ def test_slate_api_defers_explanations_until_requested(
     )
     explanation = CuratorAPI(connection).explanation(str(result["items"][0]["scene_id"]))
     assert explanation["summary"]
-    assert explanation["supporting_reasons"]
+    assert explanation["reasons"]
+    assert explanation["apiSchemaVersion"] == 2
+    assert "scores" in explanation
+    assert "evidence_fingerprint" in explanation
+    assert "lane_context" in explanation
+    assert "components" in explanation
     assert (
         connection.execute(
             "SELECT count(*) FROM impression WHERE impression_id='api-impression'"


### PR DESCRIPTION
# Issue 119 + 122 — score presentation overhaul (Phase A frontend + Phase B backend schema)

Read both issues fully: issue://mrx-31415/stash-curator/119 (the 2026-08-18 comment is the operative design: appeal hero, conversational summary, evidence fingerprint radar, evidence rows, lane callout, technical details, versioned schema) and issue://mrx-31415/stash-curator/122 (the original + the rollout comment: Phase A frontend-only, Phase B backend explanation schema with apiSchemaVersion bump + differential gates).

You own the frontend + explanation backend for this change: plugin/stash-curator.js (cards, ScoreNode/disclosure, explanation renderers, nav labels, history), core/explanations*.go, the Python oracle mirror (curator/model/builder.py explanation payload / wherever get_explanation and the classification payload are built), and the differential tests (tests/core/test_backend_slice*.py, tests/plugin/test_runtime.py). All other agents have finished their waves before you start.

## Phase A — frontend semantics + renderers
1. Never a bare "Score": every card shows two separately-labeled quantities — intrinsic **Appeal** (`model_scene_score.appeal`, signed, −1..1, lane/surface-invariant) and the surface's relative quantity: lane utility labeled "Rank in <Lane>" (percentile within the qualified, ordered population for the source lane, before slate diversity/dedup; use display_lane/source_lane — For You cards show the source-lane rank) shown only where a lane exists. Similar shows `Similarity` + `Appeal`; Expand shows `Match` + `found via` provenance. Migrate the lane copy at stash-curator.js:2679.
2. Replace ScoreNode's raw float tree (stash-curator.js:437-461) with named, scaled rows: content similarity, performer match, studio appeal, direct feedback, novelty, right-now fit, confidence — each a visible 0..1 bar and real unit (Appeal −1..1 signed; Similarity/Match/rank 0..1; confidence %). Novelty is NOT a model component — show it only in lane context, labeled "relative to your library".
3. Pin the new headers in tests/plugin/test_runtime.py (the RecommendationCard final_utility header is currently unpinned; the ExternalCard `Score · x.toFixed(2)` pin must be migrated to the new labeled headers).
4. Evidence rows: up to three backend-ranked material facts, direction-aware (Supports/Cautions/Context), material caution shown when present, never force a negative row; low confidence is context not dislike. Lane callout separate from Appeal evidence.

## Phase B — backend versioned schema (Go + Python oracle, differential)
1. Emit the exact versioned payload:
   `{apiSchemaVersion: 2, summary, components[], reasons[], lane_context{}, scores: {appeal, current_fit, confidence, rank}, evidence_fingerprint{}}`
   — backend owns fact ranking, materiality, units, deterministic summary templates, reason semantics (codes from core/explanations.go). apiSchemaVersion bump + Python-mirror differential gates (tests/core). Materiality thresholds are mirrored module constants in Go + Python, NOT frontend rules or config-backed inputs.
2. Evidence fingerprint radar data: fixed axes Content / Performers / Studios / Similar scenes / Direct history / Metadata coverage; backend-normalized 0..1 visual strengths; missing families marked "No evidence" (not zero). Metadata coverage is neutral (usable resolved evidence coverage), not a preference axis; overall confidence is a separate labeled ring.
3. Render the radar only when the versioned payload has the required fixed-family data. Similar, Expand/Hunt, remote results, and legacy history fall back to story/rows WITHOUT fabricating Appeal evidence (progressive disclosure; legacy/partial payloads tolerated with the truthful frontend fallback).
4. Keep old history semantics: old Discover/Adventure snapshots stay historical, not relabeled as Stretch/Blind Spots. History keeps both "Shown then" and "Why this now?" as separate explanations.
5. lane_context is a discriminated union per lane (Stretch, Blind Spots, Dormant, Revisit, Best Bets) with lane-specific facets/entities and intent evidence; model evidence (components) stays separate from lane_context.

## Constraints
- Differential gates: Go == Python structure, floats rel 1e-9. Any backend payload change must be mirrored exactly; the gate tests you add must pass with the built binary (run scripts/build_core.sh first).
- SFW Switch card contract untouched (card chrome only, controls outside card-section).
- No new frontend dependencies.
- No schema/migration changes unless the payload schema itself requires versioning — apiSchemaVersion lives in the payload, not SQLite.

## Acceptance
- No card surface shows a bare blended "Score" anymore; both quantities labeled per surface.
- New headers pinned in test_runtime.py; runtime string tests pass.
- Backend emits apiSchemaVersion 2 payloads with evidence_fingerprint; differential tests (Go vs Python oracle) byte-identical for the new payload.
- Legacy/partial payloads render without fabricating appeal (fallback covered by a test).
- `cd core && go build ./... && go vet ./... && go test ./...` passes; your targeted differential + runtime tests pass. NEVER run `scripts/verify full`.

## Report
Files changed per phase; the apiSchemaVersion 2 payload shape as shipped; new/changed tests + results; anything left for a later phase.