### PR TITLE
feat(model): score presentation overhaul — labeled Appeal/rank, shared renderers, v2 explanation schema

### DIFF
--- a/core/curation.go
+++ b/core/curation.go
@@ -20,22 +20,22 @@ import (
 )
 
 const (
-	curationMinBudget               = 1
-	curationMaxBudget               = 40
-	curationDefaultBudget           = 20
-	curationRatingMin               = 0
-	curationRatingMax               = 10
-	curationConfirmDelta            = 0.15
-	curationConfirmMinN             = 10
-	curationAnchorBandSize           = 200
-	curationMaxItemTags             = 8
-	curationDefaultMinSupport       = 20
-	curationContrastMinLabeled      = 4
-	curationExploreAnchors          = 3
-	curationHypothesisAnchorFraction = 0.15
+	curationMinBudget                 = 1
+	curationMaxBudget                 = 40
+	curationDefaultBudget             = 20
+	curationRatingMin                 = 0
+	curationRatingMax                 = 10
+	curationConfirmDelta              = 0.15
+	curationConfirmMinN               = 10
+	curationAnchorBandSize            = 200
+	curationMaxItemTags               = 8
+	curationDefaultMinSupport         = 20
+	curationContrastMinLabeled        = 4
+	curationExploreAnchors            = 3
+	curationHypothesisAnchorFraction  = 0.15
 	curationHypothesisControlFraction = 0.15
-	curationMaxLibraryRate           = 0.30
-	curationContrastEvidenceScale    = 8.0
+	curationMaxLibraryRate            = 0.30
+	curationContrastEvidenceScale     = 8.0
 )
 
 // suggestionExcludedCategories mirrors curation.SUGGESTION_EXCLUDED_CATEGORIES.
@@ -67,23 +67,23 @@ type curationItem struct {
 }
 
 type curationContext struct {
-	labels        map[string]bool
-	sceneIDs      map[string]bool
+	labels          map[string]bool
+	sceneIDs        map[string]bool
 	sceneTags       map[string]map[string]bool
 	scenePerformers map[string]map[string]bool
 	performerCounts map[string]int64
 	performerName   map[string]string
 	studio          map[string]string
-	sceneTitle    map[string]string
-	sceneDate     map[string]string
-	sceneDetails  map[string]string
-	tagCat        map[string]string
-	tagName       map[string]string
-	counts        map[string]int64
-	appeal        map[string]float64
-	blockedScenes map[string]bool
-	metadataWrong map[string]bool
-	interactive   map[string]bool
+	sceneTitle      map[string]string
+	sceneDate       map[string]string
+	sceneDetails    map[string]string
+	tagCat          map[string]string
+	tagName         map[string]string
+	counts          map[string]int64
+	appeal          map[string]float64
+	blockedScenes   map[string]bool
+	metadataWrong   map[string]bool
+	interactive     map[string]bool
 }
 
 func (c *curationContext) rarity(tagID string) float64 {
@@ -120,23 +120,23 @@ func loadCurationContext(db dbx) (*curationContext, error) {
 		return nil, err
 	}
 	ctx := &curationContext{
-		labels:        make(map[string]bool, len(labels)),
-		sceneIDs:      map[string]bool{},
+		labels:          make(map[string]bool, len(labels)),
+		sceneIDs:        map[string]bool{},
 		sceneTags:       map[string]map[string]bool{},
 		scenePerformers: map[string]map[string]bool{},
 		performerCounts: map[string]int64{},
 		performerName:   map[string]string{},
 		studio:          map[string]string{},
-		sceneTitle:    map[string]string{},
-		sceneDate:     map[string]string{},
-		sceneDetails:  map[string]string{},
-		tagCat:        map[string]string{},
-		tagName:       map[string]string{},
-		counts:        map[string]int64{},
-		appeal:        map[string]float64{},
-		blockedScenes: map[string]bool{},
-		metadataWrong: map[string]bool{},
-		interactive:   map[string]bool{},
+		sceneTitle:      map[string]string{},
+		sceneDate:       map[string]string{},
+		sceneDetails:    map[string]string{},
+		tagCat:          map[string]string{},
+		tagName:         map[string]string{},
+		counts:          map[string]int64{},
+		appeal:          map[string]float64{},
+		blockedScenes:   map[string]bool{},
+		metadataWrong:   map[string]bool{},
+		interactive:     map[string]bool{},
 	}
 	for sceneID := range labels {
 		ctx.labels[sceneID] = true
@@ -534,7 +534,7 @@ func curationSelectHypothesis(
 	pools := map[string][]string{}
 	var poolKeys []string
 	for _, cell := range []struct {
-		name  string
+		name   string
 		scenes map[string]bool
 	}{
 		{"L&T", intersect(base, context)},
@@ -836,7 +836,7 @@ VALUES (?, ?, ?, ?)`, batchID, item.sceneID, item.cell, anchor); err != nil {
 		contextVal = jvStr(contextTagID)
 	}
 	return jvObj(
-		jvKey("schema_version", jvInt(1)),
+		jvKey("schema_version", jvInt(2)),
 		jvKey("batch_id", jvStr(batchID)),
 		jvKey("mode", jvStr(mode)),
 		jvKey("base_tag_id", baseVal),
@@ -864,10 +864,9 @@ func poolToJVal(pool map[string]int64) jVal {
 	return out
 }
 
-
 func curationBatchItems(db dbx, batchID string) (map[string]struct {
-	cell   string
-	rated  bool
+	cell  string
+	rated bool
 }, error) {
 	rows, err := db.Query(
 		`SELECT scene_id, cell, rated FROM curation_batch_item WHERE batch_id=?`,
@@ -922,9 +921,9 @@ func submitCurationRatings(db dbx, batchID string, ratings jVal) (jVal, error) {
 	}
 	seen := map[string]bool{}
 	type normalizedRating struct {
-		sceneID string
-		value   int64
-		reason  string
+		sceneID   string
+		value     int64
+		reason    string
 		hasReason bool
 	}
 	var normalized []normalizedRating
@@ -1041,7 +1040,7 @@ UPDATE curation_batch SET status='rated' WHERE batch_id=?`, batchID); err != nil
 		statusOut = "rated"
 	}
 	return jvObj(
-		jvKey("schema_version", jvInt(1)),
+		jvKey("schema_version", jvInt(2)),
 		jvKey("accepted", jvInt(int64(len(normalized)))),
 		jvKey("batch_status", jvStr(statusOut)),
 	), nil
@@ -1203,7 +1202,7 @@ SELECT mode, base_tag_id, context_tag_id FROM curation_batch WHERE batch_id=?`,
 			)
 		}
 		return jvObj(
-			jvKey("schema_version", jvInt(1)),
+			jvKey("schema_version", jvInt(2)),
 			jvKey("batch_id", jvStr(batchID)),
 			jvKey("mode", jvStr(mode)),
 			jvKey("cells", cells),
@@ -1249,8 +1248,8 @@ SELECT mode, base_tag_id, context_tag_id FROM curation_batch WHERE batch_id=?`,
 		return jvNull(), err
 	}
 	type tagEntry struct {
-		tagID    string
-		mean     float64
+		tagID string
+		mean  float64
 	}
 	var entries []tagEntry
 	for tagID, values := range tagRows {
@@ -1298,7 +1297,7 @@ SELECT mode, base_tag_id, context_tag_id FROM curation_batch WHERE batch_id=?`,
 		summaryMean = jvFloat(curationMean(values))
 	}
 	return jvObj(
-		jvKey("schema_version", jvInt(1)),
+		jvKey("schema_version", jvInt(2)),
 		jvKey("batch_id", jvStr(batchID)),
 		jvKey("mode", jvStr(mode)),
 		jvKey("summary", jvObj(
@@ -1356,9 +1355,9 @@ func tagContextCandidatesBody(db dbx, tagID string, minSupport int) (jVal, error
 	}
 	rowsOut := jvArr()
 	type candidate struct {
-		tagID     string
-		cooccur   int64
-		contrast  *float64
+		tagID    string
+		cooccur  int64
+		contrast *float64
 	}
 	var candidates []candidate
 	for t, n := range cooc {
@@ -1445,7 +1444,7 @@ func tagContextCandidatesBody(db dbx, tagID string, minSupport int) (jVal, error
 		))
 	}
 	return jvObj(
-		jvKey("schema_version", jvInt(1)),
+		jvKey("schema_version", jvInt(2)),
 		jvKey("tag_id", jvStr(tagID)),
 		jvKey("items", rowsOut),
 	), nil
@@ -1477,7 +1476,6 @@ func curationValueStr(v jVal) string {
 		return v.kindName()
 	}
 }
-
 
 // opGetCurationBatch mirrors backend.py's get_curation_batch branch.
 func opGetCurationBatch(pluginDir string, payload jVal) (jVal, error) {
@@ -1732,10 +1730,10 @@ func pairUnlabeled(ctx *curationContext, seen map[string]bool) []string {
 }
 
 type pairCandidate struct {
-	a, b   string
-	score  float64
-	predA  float64
-	predB  float64
+	a, b  string
+	score float64
+	predA float64
+	predB float64
 }
 
 func pairCandidates(ctx *curationContext, dimension, baseTag, contextTag, performerID string, seen map[string]bool) []pairCandidate {
@@ -1998,7 +1996,7 @@ UNION SELECT scene_b FROM curation_pair WHERE status='answered'`)
 	emptyRoundID := uuid4()
 	if len(scored) == 0 {
 		return jvObj(
-			jvKey("schema_version", jvInt(1)),
+			jvKey("schema_version", jvInt(2)),
 			jvKey("round_id", jvStr(emptyRoundID)),
 			jvKey("dimension", jvStr(dimension)),
 			jvKey("pairs", jvArr()),
@@ -2110,7 +2108,7 @@ INSERT INTO curation_pair(
 		contextTagVal = jvObj(jvKey("tag_id", jvStr(contextTagID)), jvKey("name", jvStr(name)))
 	}
 	return jvObj(
-		jvKey("schema_version", jvInt(1)),
+		jvKey("schema_version", jvInt(2)),
 		jvKey("round_id", jvStr(roundID)),
 		jvKey("dimension", jvStr(dimension)),
 		jvKey("base_tag", baseTagVal),
@@ -2121,14 +2119,14 @@ INSERT INTO curation_pair(
 }
 
 type pairRow struct {
-	pairID     string
-	sceneA     string
-	sceneB     string
-	dimension  string
+	pairID      string
+	sceneA      string
+	sceneB      string
+	dimension   string
 	probability float64
-	status     string
-	winner     string
-	payload    jVal
+	status      string
+	winner      string
+	payload     jVal
 }
 
 func pairRows(db dbx, roundID string) ([]pairRow, error) {
@@ -2372,7 +2370,7 @@ INSERT INTO feedback(
 		roundStatus = "answered"
 	}
 	return jvObj(
-		jvKey("schema_version", jvInt(1)),
+		jvKey("schema_version", jvInt(2)),
 		jvKey("accepted", jvInt(int64(accepted))),
 		jvKey("skipped", jvInt(int64(skipped))),
 		jvKey("round_status", jvStr(roundStatus)),
@@ -2467,7 +2465,7 @@ func pairVerdict(db dbx, roundID string) (jVal, error) {
 		answered = matching
 	}
 	base := jvObj(
-		jvKey("schema_version", jvInt(1)),
+		jvKey("schema_version", jvInt(2)),
 		jvKey("round_id", jvStr(roundID)),
 		jvKey("dimension", jvStr(dimension)),
 		jvKey("n_answered", jvInt(int64(len(answered)))),
@@ -2731,11 +2729,11 @@ func curationImpactBody(pluginDir string, payload, settings jVal) (jVal, error) 
 
 // Impact report constants mirror curation.py's IMPACT_* values.
 const (
-	IMPACT_TOP_SCENES        = 5
-	IMPACT_TOP_ENTITIES      = 4
-	IMPACT_MIN_DELTA         = 0.01
-	IMPACT_MIN_CONTRIBUTION  = 0.0005
-	IMPACT_SCENE_POOL        = 20
+	IMPACT_TOP_SCENES       = 5
+	IMPACT_TOP_ENTITIES     = 4
+	IMPACT_MIN_DELTA        = 0.01
+	IMPACT_MIN_CONTRIBUTION = 0.0005
+	IMPACT_SCENE_POOL       = 20
 )
 
 // curationImpact mirrors curation.curation_impact: diff the two most recent

--- a/core/explanations.go
+++ b/core/explanations.go
@@ -109,15 +109,17 @@ func reason(score *fullSceneScore, featureVersion, code string, value, conf floa
 // fullSceneScore carries every ModelSceneScore field the reason derivation
 // needs.
 type fullSceneScore struct {
-	modelID          string
-	sceneID          string
-	directAppeal     float64
-	directConfidence float64
-	appeal           float64
-	currentFit       float64
-	confidence       float64
-	components       jVal
-	neighbors        []jVal
+	modelID            string
+	sceneID            string
+	directAppeal       float64
+	directConfidence   float64
+	appeal             float64
+	currentFit         float64
+	confidence         float64
+	metadataConfidence float64
+	recovery           float64
+	components         jVal
+	neighbors          []jVal
 }
 
 // fullScores mirrors RecommendationModelStore.scores for the reason path.
@@ -153,14 +155,11 @@ FROM model_scene_score WHERE model_id=? AND scene_id IN (`+placeholders+`) ORDER
 			components = jvNull()
 		}
 		result[sceneID] = &fullSceneScore{
-			modelID:          modelID2,
-			sceneID:          sceneID,
-			directAppeal:     directAppeal,
-			directConfidence: directConfidence,
-			appeal:           appeal,
-			currentFit:       currentFit,
-			confidence:       confidence,
-			components:       components,
+			modelID: modelID2, sceneID: sceneID,
+			directAppeal: directAppeal, directConfidence: directConfidence,
+			appeal: appeal, currentFit: currentFit, confidence: confidence,
+			metadataConfidence: metadataConfidence, recovery: recovery,
+			components: components,
 		}
 	}
 	rows.Close()
@@ -894,6 +893,160 @@ WHERE model_id=? AND scene_id=? ORDER BY reason_index`, modelID, sceneID)
 	}
 	return reasons, len(reasons) > 0, rows.Err()
 }
+func explanationComponentValue(components jVal, name string) float64 {
+	value := components.get(name)
+	if name == "fit" && value.kind == jObj {
+		total := 0.0
+		for _, key := range []string{"cooldown", "satiation", "not_now"} {
+			total += number(value.get(key))
+		}
+		return total
+	}
+	if value.kind != jObj {
+		return 0
+	}
+	return number(value.get("value"))
+}
+
+func explanationComponent(name, label string, value float64, scale string, confidence float64, available bool) jVal {
+	value = mathMax(-1, mathMin(1, value))
+	return jvObj(
+		jvKey("name", jvStr(name)), jvKey("label", jvStr(label)),
+		jvKey("value", jvFloat(value)), jvKey("scale", jvStr(scale)),
+		jvKey("direction", jvStr(direction(value))),
+		jvKey("confidence", jvFloat(mathMax(0, mathMin(1, confidence)))),
+		jvKey("available", jvBool(available)),
+	)
+}
+
+func explanationComponents(score *fullSceneScore) jVal {
+	confidence := mathMax(0, mathMin(1, score.confidence))
+	rows := jvArr()
+	values := []struct {
+		name, label string
+		value       float64
+	}{
+		{"content_similarity", "Content similarity", explanationComponentValue(score.components, "content") + explanationComponentValue(score.components, "content_neighbor")},
+		{"performer_match", "Performer match", explanationComponentValue(score.components, "performer_identity") + explanationComponentValue(score.components, "performer_similarity")},
+		{"studio_appeal", "Studio appeal", explanationComponentValue(score.components, "studio")},
+		{"direct_feedback", "Direct feedback", score.directAppeal},
+		{"right_now_fit", "Right now", explanationComponentValue(score.components, "fit")},
+	}
+	for _, item := range values {
+		rows.arr = append(rows.arr, explanationComponent(item.name, item.label, item.value, "-1..1", confidence, mathAbs(item.value) > 1e-9))
+	}
+	rows.arr = append(rows.arr, jvObj(
+		jvKey("name", jvStr("model_confidence")), jvKey("label", jvStr("Model confidence")),
+		jvKey("value", jvFloat(confidence)), jvKey("scale", jvStr("0..1")),
+		jvKey("direction", jvStr("neutral")), jvKey("confidence", jvFloat(confidence)),
+		jvKey("available", jvBool(true)),
+	))
+	return rows
+}
+
+func explanationAxis(name string, value, confidence float64, available bool) jVal {
+	return jvObj(
+		jvKey("name", jvStr(name)),
+		jvKey("support", jvFloat(mathMax(0, mathMin(1, value)))),
+		jvKey("caution", jvFloat(mathMax(0, mathMin(1, -value)))),
+		jvKey("confidence", jvFloat(mathMax(0, mathMin(1, confidence)))),
+		jvKey("available", jvBool(available)),
+	)
+}
+
+func explanationFingerprint(score *fullSceneScore) jVal {
+	content := explanationComponentValue(score.components, "content") + explanationComponentValue(score.components, "content_neighbor")
+	performer := explanationComponentValue(score.components, "performer_identity") + explanationComponentValue(score.components, "performer_similarity")
+	studio := explanationComponentValue(score.components, "studio")
+	neighbor := explanationComponentValue(score.components, "content_neighbor")
+	axes := jvArr()
+	axes.arr = append(axes.arr,
+		explanationAxis("content", content, score.confidence, mathAbs(content) > 1e-9),
+		explanationAxis("performers", performer, score.confidence, mathAbs(performer) > 1e-9),
+		explanationAxis("studios", studio, score.confidence, mathAbs(studio) > 1e-9),
+		explanationAxis("similar_scenes", neighbor, score.confidence, mathAbs(neighbor) > 1e-9),
+		explanationAxis("direct_history", score.directAppeal, score.directConfidence, score.directConfidence > 0),
+	)
+	metadataCoverage := jvObj(
+		jvKey("available", jvBool(score.metadataConfidence > 1e-9)),
+		jvKey("value", jvFloat(mathMax(0, mathMin(1, score.metadataConfidence)))),
+		jvKey("scale", jvStr("0..1")),
+	)
+	return jvObj(jvKey("version", jvInt(1)), jvKey("axes", axes), jvKey("metadata_coverage", metadataCoverage), jvKey("confidence", jvFloat(mathMax(0, mathMin(1, score.confidence)))))
+}
+
+func explanationScores(score *fullSceneScore, lane string, rank *float64) jVal {
+	rankValue := jvNull()
+	available := false
+	if rank != nil {
+		rankValue = jvFloat(*rank)
+		available = true
+	}
+	rankLabel := "Lane rank"
+	if lane != "" {
+		rankLabel = "Rank in " + strings.Title(strings.ReplaceAll(lane, "_", " "))
+	}
+	return jvObj(
+		jvKey("appeal", jvObj(jvKey("label", jvStr("Appeal")), jvKey("value", jvFloat(score.appeal)), jvKey("scale", jvStr("-1..1")), jvKey("direction", jvStr(direction(score.appeal))))),
+		jvKey("current_fit", jvObj(jvKey("label", jvStr("Current fit")), jvKey("value", jvFloat(score.currentFit)), jvKey("scale", jvStr("-1..1")), jvKey("direction", jvStr(direction(score.currentFit))))),
+		jvKey("confidence", jvObj(jvKey("label", jvStr("Model confidence")), jvKey("value", jvFloat(score.confidence)), jvKey("scale", jvStr("0..1")), jvKey("direction", jvStr("neutral")))),
+		jvKey("rank", jvObj(jvKey("label", jvStr(rankLabel)), jvKey("value", rankValue), jvKey("scale", jvStr("0..1")), jvKey("relative", jvBool(true)), jvKey("lane", func() jVal {
+			if lane == "" {
+				return jvNull()
+			}
+			return jvStr(lane)
+		}()), jvKey("available", jvBool(available)))),
+	)
+}
+
+func explanationLaneContext(lane, sourceLane string, subtype jVal, qualification jVal) jVal {
+	if lane == "" && sourceLane == "" {
+		return jvObj(jvKey("available", jvBool(false)), jvKey("display_lane", jvNull()), jvKey("source_lane", jvNull()), jvKey("subtype", jvNull()))
+	}
+	return jvObj(jvKey("available", jvBool(true)), jvKey("display_lane", jvStr(lane)), jvKey("source_lane", jvStr(sourceLane)), jvKey("subtype", subtype), jvKey("qualification", qualification))
+}
+
+func explanationReasonLabel(code string) string {
+	labels := map[string]string{
+		"direct.positive": "Direct positive history", "direct.negative": "Direct negative history", "direct.residual": "Direct history adjustment",
+		"appeal.performer_identity": "Performer match", "appeal.performer_similar": "Similar performer profile", "appeal.studio": "Studio appeal", "appeal.content_neighbor": "Similar scenes",
+		"appeal.tag_positive": "Familiar content pattern", "appeal.tag_negative": "Less familiar content pattern", "appeal.tag_declared_positive": "Declared positive content preference", "appeal.tag_declared_negative": "Declared negative content preference",
+		"fit.cooldown": "Scene cooldown", "fit.satiation": "Recent repetition", "fit.not_now": "Not now feedback", "eligibility.lane": "Eligible for this lane", "explore.challenge": "Lane challenge", "explore.coverage": "Library coverage gap", "dormant.entity": "Dormant preference",
+	}
+	if label := labels[code]; label != "" {
+		return label
+	}
+	parts := strings.Split(code, ".")
+	fallback := strings.ReplaceAll(parts[len(parts)-1], "_", " ")
+	if len(fallback) > 0 {
+		return strings.ToUpper(fallback[:1]) + fallback[1:]
+	}
+	return fallback
+}
+
+func explanationReasonRows(reasons []*explanationReason) jVal {
+	candidates := make([]*explanationReason, 0, len(reasons))
+	for _, r := range reasons {
+		if strings.HasPrefix(r.code, "eligibility.") || strings.HasPrefix(r.code, "diversity.") || r.code == "fallback" || r.magnitude <= 1e-9 {
+			continue
+		}
+		candidates = append(candidates, r)
+	}
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].magnitude != candidates[j].magnitude {
+			return candidates[i].magnitude > candidates[j].magnitude
+		}
+		return candidates[i].code < candidates[j].code
+	})
+	rows := jvArr()
+	for _, r := range candidates {
+		rows.arr = append(rows.arr, jvObj(jvKey("code", jvStr(r.code)), jvKey("label", jvStr(explanationReasonLabel(r.code))), jvKey("direction", jvStr(r.direction)), jvKey("magnitude", jvFloat(r.magnitude)), jvKey("confidence", jvFloat(r.confidence)), jvKey("detail", r.detail)))
+		if len(rows.arr) == 3 {
+			break
+		}
+	}
+	return rows
+}
 
 func opGetExplanation(pluginDir string, payload jVal) (jVal, error) {
 	return profiledOperation(pluginDir, payload, "get_explanation",
@@ -926,15 +1079,23 @@ func renderExplanationForScene(db dbx, pluginDir, modelID, sceneID string) (jVal
 		return jvNull(), err
 	}
 	if !found {
-		derived, err := deriveReasons(db, modelID, map[string]bool{sceneID: true})
-		if err != nil {
-			return jvNull(), err
+		derived, deriveErr := deriveReasons(db, modelID, map[string]bool{sceneID: true})
+		if deriveErr != nil {
+			return jvNull(), deriveErr
 		}
 		reasons = derived[sceneID]
 	}
-	summary, selected, err := renderExplanation(pluginDir, db, reasons, modelID+"\x00"+sceneID)
-	if err != nil {
-		return jvNull(), err
+	scores, scoreErr := fullScores(db, modelID, map[string]bool{sceneID: true})
+	if scoreErr != nil {
+		return jvNull(), scoreErr
+	}
+	score := scores[sceneID]
+	if score == nil {
+		return jvNull(), fmt.Errorf("unknown scene: %s", sceneID)
+	}
+	summary, selected, renderErr := renderExplanation(pluginDir, db, reasons, modelID+"\x00"+sceneID)
+	if renderErr != nil {
+		return jvNull(), renderErr
 	}
 	all := jvArr()
 	for _, r := range reasons {
@@ -945,11 +1106,12 @@ func renderExplanationForScene(db dbx, pluginDir, modelID, sceneID string) (jVal
 		supporting.arr = append(supporting.arr, reasonJSON(r))
 	}
 	return jvObj(
-		jvKey("schema_version", jvInt(apiSchemaVersion)),
-		jvKey("model_id", jvStr(modelID)),
-		jvKey("scene_id", jvStr(sceneID)),
-		jvKey("summary", jvStr(summary)),
-		jvKey("reasons", all),
-		jvKey("supporting_reasons", supporting),
+		jvKey("schema_version", jvInt(apiSchemaVersion)), jvKey("model_id", jvStr(modelID)), jvKey("scene_id", jvStr(sceneID)),
+		jvKey("summary", jvStr(summary)), jvKey("components", explanationComponents(score)),
+		jvKey("reasons", all), jvKey("supporting_reasons", supporting),
+		jvKey("evidence_rows", explanationReasonRows(selected)),
+		jvKey("lane_context", explanationLaneContext("", "", jvNull(), jvNull())),
+		jvKey("scores", explanationScores(score, "", nil)),
+		jvKey("evidence_fingerprint", explanationFingerprint(score)),
 	), nil
 }

--- a/core/ops.go
+++ b/core/ops.go
@@ -17,7 +17,7 @@ import (
 	"time"
 )
 
-const apiSchemaVersion = 1
+const apiSchemaVersion = 2
 
 // stashdbEndpoint mirrors curator/expand.py STASHDB.
 const stashdbEndpoint = "https://stashdb.org/graphql"

--- a/core/settings.go
+++ b/core/settings.go
@@ -209,7 +209,7 @@ func sidecarConfig(db dbx) (jVal, error) {
 	}
 	config := mergeObjects(defaultPluginConfig, stored)
 	return jvObj(
-		jvKey("schema_version", jvInt(1)),
+		jvKey("schema_version", jvInt(2)),
 		jvKey("config", config),
 		jvKey("updated_at_ms", jvInt(updatedAtMs)),
 	), nil

--- a/core/similar.go
+++ b/core/similar.go
@@ -27,8 +27,7 @@ func (s *similarityService) setTimingKeys(keys ...string) {
 	}
 }
 
-// similarityResult mirrors SimilarityService.SimilarityResult (asdict order:
-// entity_id, similarity, appeal, rank_score, relationships, details).
+// similarityResult mirrors SimilarityService.SimilarityResult.
 type similarityResult struct {
 	entityID      string
 	similarity    float64
@@ -36,6 +35,8 @@ type similarityResult struct {
 	rankScore     float64
 	relationships []string
 	details       jVal
+	appealRaw     float64
+	explanation   jVal
 }
 
 func similarityResultJSON(r *similarityResult) jVal {
@@ -44,13 +45,35 @@ func similarityResultJSON(r *similarityResult) jVal {
 		relationships.arr = append(relationships.arr, jvStr(rel))
 	}
 	return jvObj(
-		jvKey("entity_id", jvStr(r.entityID)),
-		jvKey("similarity", jvFloat(r.similarity)),
-		jvKey("appeal", jvFloat(r.appeal)),
-		jvKey("rank_score", jvFloat(r.rankScore)),
-		jvKey("relationships", relationships),
-		jvKey("details", r.details),
+		jvKey("entity_id", jvStr(r.entityID)), jvKey("similarity", jvFloat(r.similarity)),
+		jvKey("appeal", jvFloat(r.appeal)), jvKey("appeal_raw", jvFloat(r.appealRaw)),
+		jvKey("rank_score", jvFloat(r.rankScore)), jvKey("relationships", relationships),
+		jvKey("details", r.details), jvKey("explanation", r.explanation),
 	)
+}
+
+func similarExplanation(similarity, appealRaw float64, relationships []string) jVal {
+	labels := map[string]string{"same_performer": "Same performer", "similar_performer": "Similar performer profile", "shared_content": "Shared content", "similar_structure": "Similar cast structure", "same_studio": "Same studio", "multi_hop": "Multi-hop performer connection"}
+	names := make([]string, 0, len(relationships))
+	reasons := jvArr()
+	for _, value := range relationships {
+		label := labels[value]
+		if label == "" {
+			label = value
+		}
+		names = append(names, label)
+		reasons.arr = append(reasons.arr, jvObj(jvKey("code", jvStr(value)), jvKey("label", jvStr(label)), jvKey("direction", jvStr("positive")), jvKey("magnitude", jvFloat(1)), jvKey("confidence", jvFloat(1))))
+	}
+	summary := "Closest available content match."
+	if len(names) > 0 {
+		summary = "Related through " + strings.Join(names, ", ")
+	}
+	components := jvArr()
+	components.arr = append(components.arr,
+		jvObj(jvKey("name", jvStr("content_similarity")), jvKey("label", jvStr("Similarity")), jvKey("value", jvFloat(similarity)), jvKey("scale", jvStr("0..1")), jvKey("direction", jvStr("positive")), jvKey("available", jvBool(true))),
+		jvObj(jvKey("name", jvStr("appeal")), jvKey("label", jvStr("Appeal")), jvKey("value", jvFloat(appealRaw)), jvKey("scale", jvStr("-1..1")), jvKey("direction", jvStr(direction(appealRaw))), jvKey("available", jvBool(true))),
+	)
+	return jvObj(jvKey("summary", jvStr(summary)), jvKey("components", components), jvKey("reasons", reasons))
 }
 
 // similarityService mirrors SimilarityService.
@@ -714,24 +737,18 @@ WHERE ef.feature_version=? AND ef.entity_type='scene'
 			performerVal = jvInt(0)
 		}
 		details := jvObj(
-			jvKey("content", jvFloat(contentValue)),
-			jvKey("performer", performerVal),
-			jvKey("structure", jvFloat(structure)),
-			jvKey("studio", jvFloat(boolFloat(sameStudio))),
-			jvKey("shared_tags", jvArr()),
-			jvKey("shared_performer_ids", sharedIDsJSON),
+			jvKey("content", jvFloat(contentValue)), jvKey("performer", performerVal),
+			jvKey("structure", jvFloat(structure)), jvKey("studio", jvFloat(boolFloat(sameStudio))),
+			jvKey("shared_tags", jvArr()), jvKey("shared_performer_ids", sharedIDsJSON),
 			jvKey("score_breakdown", jvObj(
 				jvKey("similarity", jvFloat(math.Round(0.7*similarity*1e4)/1e4)),
 				jvKey("appeal", jvFloat(math.Round(0.3*appeal*1e4)/1e4)),
 			)),
 		)
 		results = append(results, &similarityResult{
-			entityID:      candidateID,
-			similarity:    similarity,
-			appeal:        appeal,
-			rankScore:     rankScore,
-			relationships: relationships,
-			details:       details,
+			entityID: candidateID, similarity: similarity, appeal: appeal,
+			rankScore: rankScore, relationships: relationships, details: details,
+			appealRaw: candidateAppeal, explanation: similarExplanation(similarity, candidateAppeal, relationships),
 		})
 	}
 	sort.Slice(results, func(i, j int) bool {

--- a/curator/api.py
+++ b/curator/api.py
@@ -24,7 +24,7 @@ from curator.ranking.slate import Slate
 from curator.similarity import SimilarityService
 from curator.storage import transaction
 
-API_SCHEMA_VERSION = 1
+API_SCHEMA_VERSION = 2
 DEFAULT_PLUGIN_CONFIG: dict[str, object] = {
     "page_size": 20,
     "diversity_enabled": True,
@@ -384,8 +384,13 @@ class CuratorAPI:
             "model_id": model_id,
             "scene_id": scene_id,
             "summary": explanation.summary,
+            "components": list(explanation.components),
             "reasons": [asdict(reason) for reason in explanation.all_reasons],
             "supporting_reasons": [asdict(reason) for reason in explanation.selected_reasons],
+            "evidence_rows": list(explanation.evidence_rows),
+            "lane_context": explanation.lane_context,
+            "scores": explanation.scores,
+            "evidence_fingerprint": explanation.evidence_fingerprint,
         }
 
     def recommendation_history(

--- a/curator/curation.py
+++ b/curator/curation.py
@@ -467,7 +467,7 @@ def create_batch(
             [(batch_id, sid, cell, 1 if anchor else 0) for sid, cell, anchor in items],
         )
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "batch_id": batch_id,
         "mode": mode,
         "base_tag_id": base_tag_id,
@@ -592,7 +592,7 @@ def submit_ratings(
                 "UPDATE curation_batch SET status='rated' WHERE batch_id=?", (batch_id,)
             )
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "accepted": len(normalized),
         "batch_status": status,
     }
@@ -689,7 +689,7 @@ def verdict(connection: sqlite3.Connection, batch_id: str) -> dict[str, object]:
                 "value": value,
             }
         return {
-            "schema_version": 1,
+            "schema_version": 2,
             "batch_id": batch_id,
             "mode": mode,
             "cells": cells,
@@ -727,7 +727,7 @@ def verdict(connection: sqlite3.Connection, batch_id: str) -> dict[str, object]:
     entries.sort(key=lambda item: (-cast(float, item["mean_outcome"]), str(item["tag_id"])))
     values = list(outcomes.values())
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "batch_id": batch_id,
         "mode": mode,
         "summary": {"n": len(values), "mean_outcome": _mean(values) if values else None},
@@ -803,7 +803,7 @@ def tag_context_candidates(
             str(item["name"]),
         )
     )
-    return {"schema_version": 1, "tag_id": tag_id, "items": rows}
+    return {"schema_version": 2, "tag_id": tag_id, "items": rows}
 
 
 # ── Pairwise picks ───────────────────────────────────────────────────────────
@@ -1044,7 +1044,7 @@ def create_pair_round(
         scored.append((a, b, score, pred_a, pred_b))
     if not scored:
         return {
-            "schema_version": 1,
+            "schema_version": 2,
             "round_id": str(uuid4()),
             "dimension": dimension,
             "pairs": [],
@@ -1135,7 +1135,7 @@ def create_pair_round(
             "name": context.tag_name.get(context_tag_id, context_tag_id),
         }
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "round_id": round_id,
         "dimension": dimension,
         "base_tag": base_tag_val,
@@ -1275,7 +1275,7 @@ def submit_picks(
             coordinator.request("curation_picks")
             accepted += 1
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "accepted": accepted,
         "skipped": skipped,
         "round_status": "answered" if accepted + skipped == len(rows) else "open",
@@ -1397,7 +1397,7 @@ def pair_verdict(connection: sqlite3.Connection, round_id: str) -> dict[str, obj
                 "n": wins.get("L&T", 0) + wins.get("L&!T", 0),
             }
         return {
-            "schema_version": 1,
+            "schema_version": 2,
             "round_id": round_id,
             "dimension": dimension,
             "cells": cells,
@@ -1439,7 +1439,7 @@ def pair_verdict(connection: sqlite3.Connection, round_id: str) -> dict[str, obj
             )
         )
         return {
-            "schema_version": 1,
+            "schema_version": 2,
             "round_id": round_id,
             "dimension": dimension,
             "items": items,
@@ -1484,7 +1484,7 @@ def pair_verdict(connection: sqlite3.Connection, round_id: str) -> dict[str, obj
         ]
         items.sort(key=lambda item: (-float(cast(float, item["win_rate"])), str(item["studio"])))
         return {
-            "schema_version": 1,
+            "schema_version": 2,
             "round_id": round_id,
             "dimension": dimension,
             "items": items,
@@ -1522,7 +1522,7 @@ def pair_verdict(connection: sqlite3.Connection, round_id: str) -> dict[str, obj
     ]
     items.sort(key=lambda item: (-float(cast(float, item["win_rate"])), str(item["tag_id"])))
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "round_id": round_id,
         "dimension": dimension,
         "items": items,

--- a/curator/explanations/presentation.py
+++ b/curator/explanations/presentation.py
@@ -1,0 +1,239 @@
+"""Versioned, user-facing score and evidence presentation data."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from curator.model import ModelSceneScore
+
+_COMPONENT_SPECS = (
+    ("content_similarity", "Content similarity", "-1..1"),
+    ("performer_match", "Performer match", "-1..1"),
+    ("studio_appeal", "Studio appeal", "-1..1"),
+    ("direct_feedback", "Direct feedback", "-1..1"),
+    ("right_now_fit", "Right now", "-1..1"),
+)
+
+_REASON_LABELS = {
+    "direct.positive": "Direct positive history",
+    "direct.negative": "Direct negative history",
+    "direct.residual": "Direct history adjustment",
+    "appeal.performer_identity": "Performer match",
+    "appeal.performer_similar": "Similar performer profile",
+    "appeal.studio": "Studio appeal",
+    "appeal.content_neighbor": "Similar scenes",
+    "appeal.tag_positive": "Familiar content pattern",
+    "appeal.tag_negative": "Less familiar content pattern",
+    "appeal.tag_declared_positive": "Declared positive content preference",
+    "appeal.tag_declared_negative": "Declared negative content preference",
+    "fit.cooldown": "Scene cooldown",
+    "fit.satiation": "Recent repetition",
+    "fit.not_now": "Not now feedback",
+    "eligibility.lane": "Eligible for this lane",
+    "explore.challenge": "Lane challenge",
+    "explore.coverage": "Library coverage gap",
+    "dormant.entity": "Dormant preference",
+}
+
+
+def _number(value: object) -> float:
+    return float(value) if isinstance(value, (int, float)) and not isinstance(value, bool) else 0.0
+
+
+def _clamp(value: float, lower: float = -1.0, upper: float = 1.0) -> float:
+    return max(lower, min(upper, value))
+
+
+def _direction(value: float) -> str:
+    return "positive" if value > 1e-9 else "negative" if value < -1e-9 else "neutral"
+
+
+def _family_value(components: dict[str, object], name: str) -> float:
+    value = components.get(name)
+    if not isinstance(value, dict):
+        return 0.0
+    if name == "fit":
+        return sum(_number(value.get(key)) for key in ("cooldown", "satiation", "not_now"))
+    return _number(value.get("value"))
+
+
+def _component(
+    name: str,
+    label: str,
+    value: float,
+    scale: str,
+    confidence: float,
+    *,
+    available: bool = True,
+    detail: str = "",
+) -> dict[str, object]:
+    value = _clamp(value)
+    result: dict[str, object] = {
+        "name": name,
+        "label": label,
+        "value": value,
+        "scale": scale,
+        "direction": _direction(value),
+        "confidence": max(0.0, min(1.0, confidence)),
+        "available": available,
+    }
+    if detail:
+        result["detail"] = detail
+    return result
+
+
+def score_components(score: ModelSceneScore) -> list[dict[str, object]]:
+    """Map stored model families to stable, plain-language rows."""
+    raw = score.components
+    content = _family_value(raw, "content") + _family_value(raw, "content_neighbor")
+    performer = _family_value(raw, "performer_identity") + _family_value(
+        raw, "performer_similarity"
+    )
+    studio = _family_value(raw, "studio")
+    direct = _number(score.direct_appeal)
+    fit = _family_value(raw, "fit")
+    confidence = max(0.0, min(1.0, score.confidence))
+    values = {
+        "content_similarity": ("Content similarity", content, "-1..1"),
+        "performer_match": ("Performer match", performer, "-1..1"),
+        "studio_appeal": ("Studio appeal", studio, "-1..1"),
+        "direct_feedback": ("Direct feedback", direct, "-1..1"),
+        "right_now_fit": ("Right now", fit, "-1..1"),
+    }
+    rows = [
+        _component(name, label, value, scale, confidence, available=abs(value) > 1e-9)
+        for name, (label, value, scale) in values.items()
+    ]
+    rows.append(
+        {
+            "name": "model_confidence",
+            "label": "Model confidence",
+            "value": confidence,
+            "scale": "0..1",
+            "direction": "neutral",
+            "confidence": confidence,
+            "available": True,
+        }
+    )
+    return rows
+
+
+def _axis(
+    name: str, value: float, confidence: float, *, available: bool = True
+) -> dict[str, object]:
+    value = max(-1.0, min(1.0, value))
+    return {
+        "name": name,
+        "support": max(0.0, min(1.0, value)),
+        "caution": max(0.0, min(1.0, -value)),
+        "confidence": max(0.0, min(1.0, confidence)),
+        "available": available,
+    }
+
+
+def evidence_fingerprint(score: ModelSceneScore) -> dict[str, object]:
+    raw = score.components
+    content = _family_value(raw, "content") + _family_value(raw, "content_neighbor")
+    performer = _family_value(raw, "performer_identity") + _family_value(
+        raw, "performer_similarity"
+    )
+    studio = _family_value(raw, "studio")
+    direct = _number(score.direct_appeal)
+    neighbor = _family_value(raw, "content_neighbor")
+    return {
+        "version": 1,
+        "axes": [
+            _axis("content", content, score.confidence, available=abs(content) > 1e-9),
+            _axis("performers", performer, score.confidence, available=abs(performer) > 1e-9),
+            _axis("studios", studio, score.confidence, available=abs(studio) > 1e-9),
+            _axis("similar_scenes", neighbor, score.confidence, available=abs(neighbor) > 1e-9),
+            _axis(
+                "direct_history",
+                direct,
+                score.direct_confidence,
+                available=score.direct_confidence > 0,
+            ),
+        ],
+        "metadata_coverage": {
+            "available": score.metadata_confidence > 1e-9,
+            "value": max(0.0, min(1.0, score.metadata_confidence)),
+            "scale": "0..1",
+        },
+        "confidence": max(0.0, min(1.0, score.confidence)),
+    }
+
+
+def reason_label(code: str) -> str:
+    if code in _REASON_LABELS:
+        return _REASON_LABELS[code]
+    fallback = code.rsplit(".", 1)[-1].replace("_", " ")
+    return fallback[:1].upper() + fallback[1:]
+
+
+def evidence_rows(reasons: Iterable[Any]) -> list[dict[str, object]]:
+    """Return up to three material facts, preserving backend ranking."""
+    candidates = [
+        reason
+        for reason in reasons
+        if not str(reason.code).startswith(("eligibility.", "diversity."))
+        and str(reason.code) != "fallback"
+        and abs(float(reason.magnitude)) > 1e-9
+    ]
+    candidates.sort(key=lambda reason: (-float(reason.magnitude), str(reason.code)))
+    return [
+        {
+            "code": reason.code,
+            "label": reason_label(reason.code),
+            "direction": reason.direction,
+            "magnitude": float(reason.magnitude),
+            "confidence": float(reason.confidence),
+            "detail": reason.detail,
+        }
+        for reason in candidates[:3]
+    ]
+
+
+def scores_payload(
+    score: ModelSceneScore, *, lane: str | None = None, rank: float | None = None
+) -> dict[str, object]:
+    return {
+        "appeal": {
+            "label": "Appeal",
+            "value": score.appeal,
+            "scale": "-1..1",
+            "direction": _direction(score.appeal),
+        },
+        "current_fit": {
+            "label": "Current fit",
+            "value": score.current_fit,
+            "scale": "-1..1",
+            "direction": _direction(score.current_fit),
+        },
+        "confidence": {
+            "label": "Model confidence",
+            "value": score.confidence,
+            "scale": "0..1",
+            "direction": "neutral",
+        },
+        "rank": {
+            "label": f"Rank in {lane.replace('_', ' ').title()}" if lane else "Lane rank",
+            "value": rank,
+            "scale": "0..1",
+            "relative": True,
+            "lane": lane,
+            "available": lane is not None and rank is not None,
+        },
+    }
+
+
+def lane_context_payload(item: Any | None) -> dict[str, object]:
+    if item is None:
+        return {"available": False, "display_lane": None, "source_lane": None, "subtype": None}
+    return {
+        "available": True,
+        "display_lane": item.lane,
+        "source_lane": item.source_lane,
+        "subtype": item.subtype,
+        "qualification": item.qualification,
+    }

--- a/curator/explanations/render.py
+++ b/curator/explanations/render.py
@@ -8,8 +8,15 @@ from dataclasses import dataclass
 
 from curator.explanations.catalog import RealizationCatalog
 from curator.explanations.planner import EvidenceUnit, Microplanner
+from curator.explanations.presentation import (
+    evidence_fingerprint,
+    evidence_rows,
+    lane_context_payload,
+    score_components,
+    scores_payload,
+)
 from curator.explanations.reasons import Reason, ReasonGraphStore
-from curator.model import RecommendationModelStore
+from curator.model import ModelSceneScore, RecommendationModelStore
 from curator.ranking import RecommendationItem
 from curator.storage.artifacts import artifact_attached
 
@@ -19,6 +26,11 @@ class Explanation:
     summary: str
     selected_reasons: tuple[Reason, ...]
     all_reasons: tuple[Reason, ...]
+    components: tuple[dict[str, object], ...]
+    lane_context: dict[str, object]
+    scores: dict[str, object]
+    evidence_fingerprint: dict[str, object]
+    evidence_rows: tuple[dict[str, object], ...]
 
 
 class ExplanationService:
@@ -49,16 +61,26 @@ class ExplanationService:
 
     def explain_scene(self, model_id: str, scene_id: str) -> Explanation:
         reasons = self._reasons(model_id, scene_id)
-        return self._render(reasons, f"{model_id}\0{scene_id}")
+        score = self._score(model_id, scene_id)
+        return self._render(reasons, f"{model_id}\0{scene_id}", score=score)
 
     def explain_recommendation(self, item: RecommendationItem) -> Explanation:
         model_id = self._current_model_id()
         base = self._reasons(model_id, item.scene_id)
         reasons = (*base, *self._ranking_reasons(model_id, item))
+        score = self._score(model_id, item.scene_id)
         return self._render(
             reasons,
             f"{model_id}\0{item.scene_id}\0{item.lane}\0{item.source_lane}\0{item.position}",
+            score=score,
+            item=item,
         )
+
+    def _score(self, model_id: str, scene_id: str) -> ModelSceneScore:
+        score = RecommendationModelStore(self.connection).scores(model_id, {scene_id}).get(scene_id)
+        if score is None:
+            raise RuntimeError(f"unknown scene: {scene_id}")
+        return score
 
     def _reasons(self, model_id: str, scene_id: str) -> tuple[Reason, ...]:
         key = (model_id, scene_id)
@@ -190,7 +212,17 @@ class ExplanationService:
             return "explore.coverage"
         return None
 
-    def _render(self, reasons: tuple[Reason, ...], seed: str) -> Explanation:
+    def _render(
+        self,
+        reasons: tuple[Reason, ...],
+        seed: str,
+        *,
+        score: ModelSceneScore | None = None,
+        item: RecommendationItem | None = None,
+    ) -> Explanation:
+        if score is None:
+            model_id = reasons[0].model_id if reasons else self._current_model_id()
+            score = next(iter(RecommendationModelStore(self.connection).scores(model_id).values()))
         plan = self.planner.plan(reasons)
         slots: dict[str, str] = {}
         primary = self._realize(plan.primary, "lead", seed)
@@ -202,7 +234,20 @@ class ExplanationService:
             boundary = self._realize(plan.boundary, "boundary", seed)
             slots.update(boundary=boundary, boundary_cap=_capitalize(boundary))
         summary = self.catalog.plan_variant(plan.lane, plan.shape, slots, seed)
-        return Explanation(summary, plan.selected_reasons, reasons)
+        return Explanation(
+            summary,
+            plan.selected_reasons,
+            reasons,
+            tuple(score_components(score)),
+            lane_context_payload(item),
+            scores_payload(
+                score,
+                lane=item.source_lane if item else None,
+                rank=item.lane_value if item else None,
+            ),
+            evidence_fingerprint(score),
+            tuple(evidence_rows(plan.selected_reasons)),
+        )
 
     def _realize(self, unit: EvidenceUnit, position: str, seed: str) -> str:
         reason = unit.reason

--- a/curator/similarity.py
+++ b/curator/similarity.py
@@ -22,6 +22,8 @@ class SimilarityResult:
     rank_score: float
     relationships: tuple[str, ...]
     details: dict[str, object]
+    appeal_raw: float = 0.0
+    explanation: dict[str, object] | None = None
 
 
 MULTI_HOP_BLEND_WEIGHT = 0.05
@@ -54,6 +56,53 @@ def _performer_name(connection: sqlite3.Connection, performer_id: str) -> str:
         "SELECT name FROM source_performer WHERE performer_id=?", (performer_id,)
     ).fetchone()
     return str(row[0]) if row else ""
+
+
+def _similar_explanation(
+    similarity: float, appeal_raw: float, relationships: tuple[str, ...]
+) -> dict[str, object]:
+    labels = {
+        "same_performer": "Same performer",
+        "similar_performer": "Similar performer profile",
+        "shared_content": "Shared content",
+        "similar_structure": "Similar cast structure",
+        "same_studio": "Same studio",
+        "multi_hop": "Multi-hop performer connection",
+    }
+    return {
+        "summary": "Related through "
+        + ", ".join(labels.get(value, value) for value in relationships)
+        if relationships
+        else "Closest available content match.",
+        "components": [
+            {
+                "name": "content_similarity",
+                "label": "Similarity",
+                "value": similarity,
+                "scale": "0..1",
+                "direction": "positive",
+                "available": True,
+            },
+            {
+                "name": "appeal",
+                "label": "Appeal",
+                "value": appeal_raw,
+                "scale": "-1..1",
+                "direction": "positive" if appeal_raw >= 0 else "negative",
+                "available": True,
+            },
+        ],
+        "reasons": [
+            {
+                "code": value,
+                "label": labels.get(value, value),
+                "direction": "positive",
+                "magnitude": 1.0,
+                "confidence": 1.0,
+            }
+            for value in relationships
+        ],
+    }
 
 
 class SimilarityService:
@@ -279,6 +328,8 @@ class SimilarityService:
                             "appeal": round(0.3 * appeal, 4),
                         },
                     },
+                    candidate_appeal,
+                    _similar_explanation(similarity, candidate_appeal, tuple(relationships)),
                 )
             )
         ranked = sorted(results, key=lambda item: (-item.rank_score, item.entity_id))

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -87,7 +87,7 @@ from curator.sync import SyncService  # noqa: E402
 from curator.sync.repository import SyncRepository  # noqa: E402
 from curator.whisparr import WhisparrClient  # noqa: E402
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 RUNTIME_QUERY = """
 query CuratorPluginRuntime {
   version { version }

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -3678,3 +3678,72 @@
   font-size: 0.7rem;
   color: var(--curator-text-muted);
 }
+.curator-score-headline { color: var(--curator-text); font-size: 0.82rem; font-weight: 600; }
+.curator-explanation-view,
+.curator-score-breakdown { display: grid; gap: 0.55rem; }
+.curator-appeal-hero { display: grid; gap: 0.15rem; padding: 0.55rem 0.65rem; border: 1px solid var(--curator-border); border-radius: var(--curator-radius-sm); background: var(--curator-wash-raised); }
+.curator-appeal-hero strong { font-size: 1.05rem; }
+.curator-appeal-hero span, .curator-fingerprint-confidence, .curator-score-row small { color: var(--curator-text-muted); font-size: 0.72rem; }
+.curator-score-positive { color: #8fbf4f; }
+.curator-score-negative { color: #d96a6a; }
+.curator-score-scale { background: var(--curator-wash-recessed); border-radius: 999px; height: 0.42rem; overflow: hidden; position: relative; }
+.curator-score-fill { border-radius: inherit; display: block; height: 100%; position: absolute; top: 0; }
+.curator-score-scale-signed .curator-score-zero { background: var(--curator-border-strong); bottom: 0; left: 50%; position: absolute; top: 0; width: 1px; z-index: 1; }
+.curator-score-fill.curator-score-positive { background: #5cae84; }
+.curator-score-fill.curator-score-negative { background: #c45e65; }
+.curator-score-row-head { display: flex; justify-content: space-between; gap: 0.75rem; font-size: 0.78rem; }
+.curator-score-row-missing { opacity: 0.65; }
+.curator-evidence-rows { display: grid; gap: 0.3rem; }
+.curator-evidence-row { display: grid; grid-template-columns: 4.2rem 1fr auto; gap: 0.35rem; align-items: baseline; font-size: 0.76rem; }
+.curator-evidence-row > span { color: var(--curator-text-muted); font-size: 0.68rem; text-transform: uppercase; }
+.curator-evidence-row small { color: var(--curator-text-muted); }
+.curator-evidence-negative > span { color: #d96a6a; }
+.curator-evidence-positive > span { color: #8fbf4f; }
+.curator-lane-callout { border-left: 3px solid var(--curator-accent-secondary); margin: 0; padding-left: 0.6rem; font-size: 0.78rem; }
+.curator-technical-details pre { max-height: 12rem; overflow: auto; white-space: pre-wrap; }
+.curator-evidence-fingerprint { display: grid; gap: 0.35rem; }
+.curator-fingerprint-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.35rem 0.7rem; }
+.curator-fingerprint-axis { display: grid; gap: 0.15rem; font-size: 0.68rem; text-transform: capitalize; }
+.curator-fingerprint-bars { background: var(--curator-wash-recessed); border-radius: 999px; display: flex; height: 0.32rem; overflow: hidden; }
+.curator-fingerprint-support { background: #5cae84; display: block; }
+.curator-fingerprint-caution { background: #c45e65; display: block; }
+.curator-fingerprint-missing { color: var(--curator-text-muted); opacity: 0.7; }
+@media (max-width: 560px) {
+  .curator-fingerprint-grid { grid-template-columns: 1fr; }
+  .curator-evidence-row { grid-template-columns: 3.5rem 1fr; }
+  .curator-evidence-row small { grid-column: 2; }
+}
+
+.curator-fingerprint-svg { display: block; height: auto; max-width: 22rem; overflow: visible; width: 100%; }
+.curator-fingerprint-ring { fill: none; stroke: var(--curator-border); stroke-width: 0.7; }
+.curator-fingerprint-spoke { stroke: var(--curator-border-strong); stroke-width: 0.7; }
+.curator-fingerprint-spoke-missing { stroke-dasharray: 2 2; opacity: 0.6; }
+.curator-fingerprint-support-shape { fill: rgba(92, 174, 132, 0.28); stroke: #5cae84; stroke-width: 1.6; }
+.curator-fingerprint-caution-shape { fill: rgba(196, 94, 101, 0.2); stroke: #c45e65; stroke-width: 1.3; }
+.curator-fingerprint-neutral-marker { fill: #adb5bd; stroke: var(--curator-surface); stroke-width: 1; }
+.curator-fingerprint-label { fill: var(--curator-text); font-size: 9px; font-weight: 500; }
+.curator-fingerprint-label-missing { fill: var(--curator-text-muted); }
+.curator-fingerprint-legend { display: flex; flex-wrap: wrap; gap: 0.7rem; color: var(--curator-text-muted); font-size: 0.7rem; }
+.curator-fingerprint-legend-support::before, .curator-fingerprint-legend-caution::before, .curator-fingerprint-legend-neutral::before { border-radius: 50%; content: ""; display: inline-block; height: 0.45rem; margin-right: 0.25rem; width: 0.45rem; }
+.curator-fingerprint-legend-support::before { background: #5cae84; }
+.curator-fingerprint-legend-caution::before { background: #c45e65; }
+.curator-fingerprint-legend-neutral::before { background: #adb5bd; }
+.curator-fingerprint-accessible { border: 0; clip: rect(0 0 0 0); height: 1px; margin: -1px; overflow: hidden; padding: 0; position: absolute; white-space: nowrap; width: 1px; }
+.curator-score-headline-bar { margin: 0.1rem 0 0.35rem; max-width: 18rem; }
+
+.curator-score-appeal-row { align-items: center; display: grid; flex: 1 1 100%; gap: 0.5rem; grid-template-columns: minmax(8.5rem, 10rem) minmax(0, 1fr) auto; width: 100%; }
+.curator-score-appeal-row .curator-score-headline { font-size: 0.68rem; }
+.curator-score-appeal-row .curator-score-headline-bar { margin: 0; max-width: none; }
+.curator-why-row { flex: 1 1 100%; width: 100%; }
+
+.curator-score-stack { display: grid; flex: 1 1 100%; gap: 0.35rem; min-width: 0; width: 100%; }
+.curator-why-row { border-bottom: 1px solid var(--curator-border); padding: 0 0.15rem 0.3rem; }
+.curator-why-row .curator-evidence { width: 100%; }
+.curator-why-row .curator-evidence summary { color: var(--curator-text-muted); font-size: 0.78rem; font-weight: 600; padding: 0.2rem 0; }
+.curator-match-row { display: grid; grid-template-columns: minmax(8.5rem, 10rem) minmax(0, 1fr) auto; margin: 0.05rem 0 0; }
+.curator-evidence-fingerprint { background: var(--curator-wash-raised); border: 1px solid var(--curator-border); border-radius: var(--curator-radius-sm); padding: 0.55rem 0.65rem; }
+.curator-score-appeal-row .curator-score-headline { color: var(--curator-card-text-muted); font-size: 0.68rem; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase; }
+.curator-score-headline-value { color: var(--curator-card-text-muted); flex: 0 0 auto; font-size: 0.75rem; font-weight: 600; }
+.curator-metadata-status { border-top: 1px solid var(--curator-border); color: var(--curator-text-muted); font-size: 0.75rem; padding-top: 0.35rem; }
+.curator-metadata-complete { color: #8fbf4f; }
+.curator-metadata-incomplete { color: var(--curator-text-muted); }

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -786,42 +786,105 @@
     );
   }
 
-  function ScoreNode({ name, value }) {
-    if (value === null || value === undefined) return null;
-    if (typeof value !== "object") {
-      return React.createElement(
-        "div",
-        { className: "curator-score-leaf" },
-        React.createElement("span", null, name.replaceAll("_", " ")),
-        React.createElement("code", null, typeof value === "number" ? value.toFixed(3) : String(value))
-      );
-    }
-    if (Array.isArray(value)) return null;
+  function formatSigned(value) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return "—";
+    return `${number >= 0 ? "+" : "−"}${Math.abs(number).toFixed(2)}`;
+  }
+
+  function formatAppealValue(value) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return "—";
+    return number < 0 ? `−${Math.abs(number).toFixed(2)}` : number.toFixed(2);
+  }
+  function clamp01(value) {
+    return Math.max(0, Math.min(1, Number(value) || 0));
+  }
+
+
+  function scoreBar(value, signed = true) {
+    const number = Number(value) || 0;
+    const magnitude = signed ? clamp01(Math.abs(number)) : clamp01(number);
+    const fillStyle = { width: `${Math.round(magnitude * 100)}%` };
+    return React.createElement("div", { className: `curator-score-scale${signed ? " curator-score-scale-signed" : ""}`, role: "img", "aria-label": `${signed ? formatAppealValue(number) : number.toFixed(2)} on a ${signed ? "minus one to one" : "zero to one"} scale` }, React.createElement("span", { className: `curator-score-fill ${number < 0 ? "curator-score-negative" : "curator-score-positive"}`, style: fillStyle, "aria-hidden": "true" }));
+  }
+
+  function fingerprintPoint(index, value, count, radius = 78, centerX = 130, centerY = 108) {
+    const angle = -Math.PI / 2 + (index * Math.PI * 2) / count;
+    const distance = radius * clamp01(value);
+    return `${centerX + Math.cos(angle) * distance},${centerY + Math.sin(angle) * distance}`;
+  }
+
+  function EvidenceFingerprint({ fingerprint }) {
+    const rawAxes = fingerprint?.axes || [];
+    const legacyMetadata = rawAxes.find((axis) => axis.name === "metadata_coverage");
+    const axes = rawAxes.filter((axis) => axis.name !== "metadata_coverage");
+    if (!fingerprint || axes.length === 0) return null;
+    const metadata = fingerprint.metadata_coverage || (legacyMetadata && { available: legacyMetadata.available, value: legacyMetadata.value ?? legacyMetadata.confidence, scale: "0..1" });
+    const supportPoints = axes.map((axis, index) => fingerprintPoint(index, axis.available ? axis.support : 0, axes.length)).join(" ");
+    const cautionPoints = axes.map((axis, index) => fingerprintPoint(index, axis.available ? axis.caution : 0, axes.length)).join(" ");
+    const axisPoint = (index, value = 1) => fingerprintPoint(index, value, axes.length, 88);
+    const label = (axis) => axis.name.replaceAll("_", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
     return React.createElement(
-      "details",
-      { className: "curator-score-node" },
-      React.createElement("summary", null, name.replaceAll("_", " ")),
+      "div",
+      { className: "curator-evidence-fingerprint", "aria-label": "Evidence fingerprint radar plot" },
+      React.createElement("strong", null, "Evidence fingerprint"),
       React.createElement(
+        "svg",
+        { className: "curator-fingerprint-svg", viewBox: "0 0 260 220", role: "img", "aria-label": "Evidence fingerprint: support and caution by evidence family" },
+        React.createElement("title", null, "Evidence fingerprint: support and caution by evidence family"),
+        [0.33, 0.66, 1].map((value) => React.createElement("polygon", { key: value, className: "curator-fingerprint-ring", points: axes.map((_, index) => axisPoint(index, value)).join(" ") })),
+        axes.map((axis, index) => React.createElement("line", { key: `${axis.name}-spoke`, className: axis.available ? "curator-fingerprint-spoke" : "curator-fingerprint-spoke curator-fingerprint-spoke-missing", x1: 130, y1: 108, x2: axisPoint(index).split(",")[0], y2: axisPoint(index).split(",")[1] })),
+        React.createElement("polygon", { className: "curator-fingerprint-support-shape", points: supportPoints }),
+        React.createElement("polygon", { className: "curator-fingerprint-caution-shape", points: cautionPoints }),
+        axes.map((axis, index) => React.createElement("text", { key: `${axis.name}-label`, className: `curator-fingerprint-label${axis.available ? "" : " curator-fingerprint-label-missing"}`, x: axisPoint(index, 1.1).split(",")[0], y: axisPoint(index, 1.1).split(",")[1], textAnchor: "middle" }, label(axis)))
+      ),
+      React.createElement("div", { className: "curator-fingerprint-legend" }, React.createElement("span", { className: "curator-fingerprint-legend-support" }, "Support"), React.createElement("span", { className: "curator-fingerprint-legend-caution" }, "Caution"), React.createElement("span", { className: "curator-fingerprint-legend-confidence" }, `Confidence ${Math.round(clamp01(fingerprint.confidence) * 100)}%`)),
+      React.createElement("div", { className: `curator-metadata-status${metadata?.available ? " curator-metadata-complete" : " curator-metadata-incomplete"}`, role: "status" }, metadata?.available ? "✓ Metadata covered" : "○ Metadata incomplete"),
+      React.createElement("ul", { className: "curator-fingerprint-accessible" }, axes.map((axis) => React.createElement("li", { key: `${axis.name}-accessible` }, `${label(axis)}: ${axis.available ? `support ${Math.round(clamp01(axis.support) * 100)}%, caution ${Math.round(clamp01(axis.caution) * 100)}%` : "no evidence"}`)), React.createElement("li", null, metadata?.available ? "Metadata covered" : "Metadata incomplete"))
+    );
+  }
+
+  function ScoreBreakdown({ explanation, item }) {
+    const components = explanation?.components || [];
+    const fallback = item ? [
+      { name: "content_similarity", label: "Content similarity", value: Number(item.components?.content?.value || 0), scale: "-1..1", direction: "positive", available: true },
+      { name: "performer_match", label: "Performer match", value: Number(item.components?.performer_identity?.value || 0) + Number(item.components?.performer_similarity?.value || 0), scale: "-1..1", direction: "positive", available: true },
+      { name: "direct_feedback", label: "Direct feedback", value: Number(item.appeal || 0), scale: "-1..1", direction: "positive", available: true },
+      { name: "model_confidence", label: "Model confidence", value: Number(item.confidence || 0), scale: "0..1", direction: "neutral", available: true },
+    ] : [];
+    const rows = components.length ? components : fallback;
+    return React.createElement("div", { className: "curator-score-breakdown" }, rows.map((component) => React.createElement("div", { key: component.name, className: `curator-score-row${component.available === false ? " curator-score-row-missing" : ""}` }, React.createElement("div", { className: "curator-score-row-head" }, React.createElement("span", null, component.label), React.createElement("span", { className: `curator-score-value curator-score-${component.direction || "neutral"}` }, component.scale === "0..1" ? `${Math.round(clamp01(component.value) * 100)}%` : formatSigned(component.value))), component.available === false ? React.createElement("small", null, "No evidence in the current model") : scoreBar(component.value, component.scale !== "0..1"))));
+  }
+
+  function ExplanationView({ explanation, item }) {
+    if (!explanation) return null;
+    const rows = explanation.evidence_rows?.length
+      ? explanation.evidence_rows
+      : (explanation.supporting_reasons || []).map((reason) => ({ ...reason, label: reasonLabel(reason.code) }));
+    const lane = explanation.lane_context;
+    return React.createElement(
+      "div",
+      { className: "curator-explanation-view" },
+      explanation.summary && React.createElement("p", { className: "curator-explanation" }, explanation.summary),
+      React.createElement(EvidenceFingerprint, { fingerprint: explanation.evidence_fingerprint }),
+      rows.length > 0 && React.createElement(
         "div",
-        { className: "curator-score-children" },
-        Object.entries(value).map(([key, child]) =>
-          React.createElement(ScoreNode, { key, name: key, value: child })
-        )
-      )
+        { className: "curator-evidence-rows" },
+        React.createElement("strong", null, "Evidence"),
+        React.createElement("div", { className: "curator-evidence-row-group" }, rows.map((row, index) => React.createElement("div", { key: `${row.code}-${index}`, className: `curator-evidence-row curator-evidence-${row.direction || "context"}` }, React.createElement("span", null, row.direction === "positive" ? "Supports" : row.direction === "negative" ? "Cautions" : "Context"), React.createElement("strong", null, row.label || reasonLabel(row.code)), row.confidence !== undefined && React.createElement("small", null, ` ${Math.round(clamp01(row.confidence) * 100)}% confidence`))))
+      ),
+      lane?.available && lane.source_lane && React.createElement("p", { className: "curator-lane-callout" }, `Selected for ${lane.source_lane.replaceAll("_", " ")} as ${lane.subtype || "a qualified match"}.`),
+      React.createElement("details", { className: "curator-technical-details" }, React.createElement("summary", null, "Technical details"), React.createElement(ScoreBreakdown, { explanation, item }))
     );
   }
 
   function reasonLabel(code) {
     const labels = {
-      "appeal.performer_identity": "Performer match",
-      "appeal.content_neighbor": "Similar content",
-      // The baseline reason present on every impression regardless of lane
-      // (core/slate.go, slate_greedy.go, score_review.go all seed reasonIDs
-      // with this) — richer reasons like the two above are appended after
-      // it when they apply, but plenty of items have no reason beyond this
-      // one. The naive fallback below (last dot-segment, title-cased) turns
-      // it into the confusing bare word "Lane".
-      "eligibility.lane": "Eligible for this lane",
+      "direct.positive": "Direct positive history", "direct.negative": "Direct negative history", "direct.residual": "Direct history adjustment",
+      "appeal.performer_identity": "Performer match", "appeal.performer_similar": "Similar performer profile", "appeal.studio": "Studio appeal", "appeal.content_neighbor": "Similar scenes",
+      "appeal.tag_positive": "Familiar content pattern", "appeal.tag_negative": "Less familiar content pattern", "appeal.tag_declared_positive": "Declared positive content preference", "appeal.tag_declared_negative": "Declared negative content preference",
+      "fit.cooldown": "Scene cooldown", "fit.satiation": "Recent repetition", "fit.not_now": "Not now feedback", "eligibility.lane": "Eligible for this lane", "explore.challenge": "Lane challenge", "explore.coverage": "Library coverage gap", "dormant.entity": "Dormant preference",
     };
     const fallback = code.split(".").at(-1).replaceAll("_", " ");
     return labels[code] || fallback.charAt(0).toUpperCase() + fallback.slice(1);
@@ -2264,24 +2327,21 @@
     );
   }
 
-  // Shared "Why this?"/"Score · X" details shell, used by RecommendationCard,
-  // ExternalCard, and SimilarityPanel's library-match grid. The shell (the
-  // two <details>/<summary> elements) is genuinely identical across all
-  // three; what goes inside each is not (RecommendationCard lazy-loads its
-  // explanation on toggle and shows a ScoreNode tree, the other two are
-  // static), so content stays fully caller-supplied via props rather than
-  // forcing those shapes into a shared config.
-  // The match bar is always visible in the mockup — it's the at-a-glance
-  // signal a card carries, not something worth an extra click to see.
-  // Everything else (the breakdown text/tree) stays behind the existing
-  // collapsed "Score · N" details for progressive disclosure.
-  function EvidenceScore({ evidenceProps, evidenceContent, scoreBarContent, scoreSummary, scoreContent }) {
+  // Shared explanation shell for RecommendationCard, ExternalCard, and
+  // SimilarityPanel library matches. The backend supplies the conversational
+  // summary, evidence rows, and typed score data; this shell keeps the same
+  // progressive disclosure and accessible labels across every surface.
+  // The intrinsic Appeal headline is always visible. Surface-specific
+  // Similarity, Match, or lane rank stays separately labeled and unit-bearing;
+  // the named component breakdown remains progressively disclosed.
+  function EvidenceScore({ evidenceProps, evidenceContent, scoreBarContent, scoreSummary, scoreLabel = "Match", scoreHeadline, scoreHeadlineValue, scoreHeadlineBar, scoreContent }) {
     return React.createElement(
-      React.Fragment,
-      null,
-      evidenceContent !== null && React.createElement("details", { className: "curator-evidence", ...evidenceProps }, React.createElement("summary", null, "Why this?"), evidenceContent),
-      scoreBarContent && React.createElement("div", { className: "curator-match-row" }, React.createElement("span", { className: "curator-match-label" }, "Match"), scoreBarContent, React.createElement("span", { className: "curator-match-value" }, scoreSummary)),
-      React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, scoreBarContent ? "Score breakdown" : `Score · ${scoreSummary}`), scoreContent)
+      "div",
+      { className: "curator-score-stack" },
+      (scoreHeadline || scoreHeadlineBar) && React.createElement("div", { className: "curator-score-appeal-row" }, scoreHeadline && React.createElement("span", { className: "curator-score-headline" }, scoreHeadline), scoreHeadlineBar && React.createElement("div", { className: "curator-score-headline-bar" }, scoreHeadlineBar), scoreHeadlineValue && React.createElement("strong", { className: "curator-score-headline-value" }, scoreHeadlineValue)),
+      scoreBarContent && React.createElement("div", { className: "curator-match-row" }, React.createElement("span", { className: "curator-match-label" }, scoreLabel), scoreBarContent, React.createElement("span", { className: "curator-match-value" }, scoreSummary)),
+      evidenceContent !== null && React.createElement("div", { className: "curator-why-row" }, React.createElement("details", { className: "curator-evidence", ...evidenceProps }, React.createElement("summary", null, "Why this?"), evidenceContent)),
+      scoreContent && React.createElement("details", { className: "curator-score" }, React.createElement("summary", null, `${scoreLabel} breakdown`), scoreContent)
     );
   }
 
@@ -2366,10 +2426,7 @@
       setTagError("");
       try {
         const [tagsResult, termsResult] = await Promise.all([
-          operation({
-            operation: "get_external_tag_choices",
-            tags: tags.map((tag) => ({ id: tag.id, name: tag.name })),
-          }),
+          operation({ operation: "get_external_tag_choices", tags: tags.map((tag) => ({ id: tag.id, name: tag.name })) }),
           operation({ operation: "get_scene_description_tokens", scene_id: item.id }),
         ]);
         setTagChoices(tagsResult.items);
@@ -2398,7 +2455,7 @@
       payload.curator_local_match?.type === "phash" && React.createElement("span", { className: "curator-phash-badge", title: "A local scene has the same exact PHash. This is strong matching evidence, not guaranteed identity." }, "Likely local · exact PHash"),
       React.createElement("div", { className: `curator-external-thumbnail thumbnail-section ${kind === "scene" ? "video-section" : ""}` }, React.createElement("a", { className: `${kind}-card-link`, href, target: "_blank", rel: "noreferrer" }, image && React.createElement("img", { className: `${kind}-card-image`, src: image, loading: "lazy", alt: "" })), kind === "scene" && payload.studio?.name && React.createElement("span", { className: "curator-external-studio-overlay" }, payload.studio.name)),
       React.createElement("div", { className: "card-section" }, React.createElement(TitleLink, localProfile, React.createElement("h5", { className: "card-section-title flex-aligned" }, title)), React.createElement("div", { className: kind === "scene" ? "scene-card__details" : "curator-external-details" }, React.createElement("span", null, payload.release_date || payload.birth_date || ""), metadataControls), kind === "scene" && payload.details && React.createElement("p", { className: "curator-card-description" }, payload.details)),
-      React.createElement("div", { className: "curator-card-body" }, (() => { let scoreDetail; if (item.similarity === undefined) { scoreDetail = `Match ${item.score.toFixed(2)} · found via ${item.sources.join(", ")}`; } else { scoreDetail = `Similarity ${item.similarity.toFixed(2)}` + (item.appeal !== undefined ? ` · appeal ${item.appeal.toFixed(2)}` : ""); const mh = item.details && item.details.score_breakdown && item.details.score_breakdown.multi_hop; if (mh > 0) scoreDetail += " + multi-hop " + mh.toFixed(4); } return React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, { evidenceContent: payload.why?.length ? React.createElement("p", { className: "curator-explanation" }, payload.why.join(" · ")) : null, scoreBarContent: utilityBar(item.score), scoreSummary: item.score.toFixed(2), scoreContent: React.createElement("p", null, scoreDetail) })); })()),
+      React.createElement("div", { className: "curator-card-body" }, (() => { const score = Number(item.score || 0); const label = item.similarity === undefined ? "Match" : "Similarity"; const detail = item.similarity === undefined ? `Match ${score.toFixed(2)} (0..1) · found via ${item.sources.join(", ")}` : `Similarity ${Number(item.similarity).toFixed(2)} (0..1) · Appeal ${formatSigned((Number(item.appeal || 0) * 2) - 1)}`; const fallbackExplanation = payload.why?.length ? { summary: payload.why.join(" · "), evidence_rows: payload.why.map((value) => ({ code: "external.fact", label: value, direction: "positive", confidence: 1 })) } : null; return React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, { scoreHeadline: item.appeal !== undefined ? "Appeal" : null, scoreHeadlineValue: item.appeal !== undefined ? formatSigned((Number(item.appeal) * 2) - 1) : null, scoreHeadlineBar: item.appeal !== undefined ? scoreBar((Number(item.appeal) * 2) - 1, true) : null, evidenceContent: payload.explanation ? React.createElement(ExplanationView, { explanation: payload.explanation }) : fallbackExplanation ? React.createElement(ExplanationView, { explanation: fallbackExplanation }) : null, scoreBarContent: utilityBar(score), scoreLabel: label, scoreSummary: score.toFixed(2), scoreContent: React.createElement("p", null, detail) })); })()),
       React.createElement(ExternalActions, { href, item, kind, copied, onCopy: async () => { try { await copyText(item.id); setCopied(true); setTimeout(() => setCopied(false), 1500); } catch (_) { setCopied(false); } }, onShortlist, tagsAvailable: tags.length > 0, tagsActive: tagChoices !== null, tagLoading, onRateTags: rateTags, onShowScenes, whisparrEnabled, canWhisparr: Boolean(onWhisparr), whisparr, onAddToWhisparr: addToWhisparr }),
       kind === "scene" && tagChoices !== null && React.createElement("div", { className: "curator-external-tag-rating" }, React.createElement("div", { className: "curator-external-tag-rating-header" }, React.createElement("strong", null, "Rate tags & terms"), React.createElement(Button, { size: "sm", variant: "link", className: "curator-external-tag-rating-close", "aria-label": "Collapse matching local tag ratings", title: "Collapse matching local tag ratings", onClick: rateTags }, "Collapse")), tagLoading && React.createElement("small", { role: "status" }, "Matching local tags…"), tagError && React.createElement("small", { className: "text-danger", role: "status" }, tagError), !tagLoading && !tagError && React.createElement(React.Fragment, null, React.createElement(RatingSection, { title: "Matching local tags", rows: tagChoices.map((tag) => ({ key: tag.tag_id, tag_id: tag.tag_id, name: tag.name, direct_value: tag.direct_value, direct_blocked: tag.direct_blocked })), onAnswer: answerTag, emptyLabel: "No matching local tags." }), React.createElement(RatingSection, { title: "Description terms", rows: termChoices.map((term) => ({ key: term.term, term: term.term, name: term.term, direct_value: term.direct_value, direct_blocked: term.direct_blocked })), onAnswer: answerTerm, emptyLabel: "No description terms in the model." })))
     );
@@ -2596,7 +2653,7 @@
     const card = React.useRef(null);
     const [explanation, setExplanation] = React.useState(
       item.explanation
-        ? { summary: item.explanation, supporting_reasons: item.supporting_reasons || [] }
+        ? { summary: typeof item.explanation === "string" ? item.explanation : item.explanation.summary, ...(typeof item.explanation === "object" ? item.explanation : {}), supporting_reasons: item.supporting_reasons || [] }
         : null
     );
     const [explanationLoading, setExplanationLoading] = React.useState(false);
@@ -2662,8 +2719,8 @@
     // score_review is a synthetic pseudo-lane (Sentiment review reuses this
     // card to page through the bottom of the model's score distribution,
     // not a real recommendation source) — it was never given a label,
-    // falling through to the raw enum value ("SCORE_REVIEW") in the badge.
     const laneLabel = item.source_lane === "score_review" ? "Sentiment review" : (laneByValue.get(item.source_lane)?.label || item.source_lane);
+    const hasLaneRank = item.source_lane !== "score_review";
     return React.createElement(
       "article",
       { className: `curator-card curator-source-${item.source_lane}`, onClickCapture: rememberOrigin, ref: card },
@@ -2691,31 +2748,14 @@
               null,
               explanationLoading && React.createElement("small", { role: "status" }, "Explaining…"),
               explanationError && React.createElement("small", { className: "text-danger", role: "alert" }, explanationError),
-              explanation && React.createElement("p", { className: "curator-explanation" }, explanation.summary),
-              explanation && React.createElement(
-                "ul",
-                null,
-                explanation.supporting_reasons.map((reason, index) =>
-                  React.createElement(
-                    "li",
-                    { key: `${reason.code}-${index}` },
-                    `${reasonLabel(reason.code)} (${reason.magnitude.toFixed(2)})`
-                  )
-                )
-              )
+              explanation && React.createElement(ExplanationView, { explanation: { ...explanation, scores: explanation.scores || { appeal: { value: item.appeal, direction: item.appeal >= 0 ? "positive" : "negative" }, rank: { value: item.lane_value, available: hasLaneRank } }, lane_context: explanation.lane_context || { available: hasLaneRank, display_lane: slate.lane, source_lane: item.source_lane, subtype: item.subtype } }, item })
             ),
-            scoreBarContent: utilityBar(item.final_utility),
-            scoreSummary: item.final_utility.toFixed(2),
-            scoreContent: React.createElement(
-              React.Fragment,
-              null,
-              React.createElement(ScoreNode, { name: "appeal", value: item.appeal }),
-              React.createElement(ScoreNode, { name: "current_fit", value: item.current_fit }),
-              React.createElement(ScoreNode, { name: "confidence", value: item.confidence }),
-              React.createElement(ScoreNode, { name: "components", value: item.components }),
-              React.createElement(ScoreNode, { name: "diversity_penalties", value: item.penalties }),
-              React.createElement(ScoreNode, { name: "diversity_bonuses", value: item.bonuses })
-            ),
+            scoreHeadline: "Appeal",
+            scoreHeadlineValue: formatAppealValue(item.appeal),
+            scoreHeadlineBar: scoreBar(item.appeal, true),
+            scoreBarContent: hasLaneRank ? utilityBar(item.lane_value) : scoreBar(item.appeal, true),
+            scoreLabel: hasLaneRank ? `Rank in ${laneLabel}` : "Appeal",
+            scoreSummary: hasLaneRank ? item.lane_value.toFixed(2) : formatAppealValue(item.appeal),
           }),
           React.createElement(Feedback, { item, onRemove, onThumbDown })
         )
@@ -3226,7 +3266,7 @@
         items.map((item) => {
           const entity = entities.get(String(item.entity_id));
           if (!entity) return null;
-          const body = React.createElement("div", { className: "curator-card-body" }, entityType === "scene" && React.createElement(LocalRatingPanel, { sceneId: item.entity_id }), React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, { evidenceContent: React.createElement("p", { className: "curator-explanation" }, relationshipChips(item)), scoreBarContent: utilityBar(item.rank_score), scoreSummary: item.rank_score.toFixed(2), scoreContent: React.createElement("p", null, `Similarity ${item.similarity.toFixed(2)} · predicted appeal ${item.appeal.toFixed(2)}`) })));
+          const body = React.createElement("div", { className: "curator-card-body" }, entityType === "scene" && React.createElement(LocalRatingPanel, { sceneId: item.entity_id }), React.createElement("div", { className: "curator-card-details" }, React.createElement(EvidenceScore, { scoreHeadline: "Appeal", scoreHeadlineValue: formatAppealValue((item.appeal * 2) - 1), scoreHeadlineBar: scoreBar((item.appeal * 2) - 1, true), evidenceContent: item.explanation ? React.createElement(ExplanationView, { explanation: item.explanation }) : React.createElement("p", { className: "curator-explanation" }, relationshipChips(item)), scoreBarContent: utilityBar(item.similarity), scoreLabel: "Similarity", scoreSummary: item.similarity.toFixed(2), scoreContent: React.createElement("p", null, `Appeal ${formatSigned((item.appeal * 2) - 1)} (−1..1)`) })));
           if (entityType === "performer") return React.createElement("article", { key: item.entity_id, className: "curator-card" }, React.createElement(PerformerCard, { performer: entity }), body);
           const feedbackItem = { ...item, scene_id: item.entity_id, impression_id: result.impression_id };
           function rememberOrigin(event) {
@@ -5038,7 +5078,7 @@
           { className: "curator-view-copy" },
           React.createElement("h1", null, laneByValue.has(lane) ? "Recommendations" : laneOption.label),
           React.createElement("p", null, laneOption.description),
-          laneByValue.has(lane) && React.createElement("p", null, "The colored corner icon identifies the source lane; Score is ranking utility, not a probability."),
+          laneByValue.has(lane) && React.createElement("p", null, "Appeal is the model's estimate of how much you'll like a scene, on a −1..1 scale. Rank in this lane is ordering utility on a 0..1 scale, not a probability."),
           laneByValue.has(lane) && slate && React.createElement(
             "p",
             { className: "curator-view-stats" },

--- a/tests/explanations/test_reasons.py
+++ b/tests/explanations/test_reasons.py
@@ -353,3 +353,50 @@ def test_known_performer_similarity_remains_inspectable_but_not_narrated(tmp_pat
     assert similarity not in explanation.selected_reasons
     assert "Alex" in explanation.summary
     assert "Blair" not in explanation.summary
+
+
+def test_score_presentation_has_named_units_and_fixed_fingerprint_axes() -> None:
+    from curator.explanations.presentation import (
+        evidence_fingerprint,
+        score_components,
+        scores_payload,
+    )
+
+    score = SimpleNamespace(
+        appeal=0.42,
+        current_fit=0.31,
+        confidence=0.74,
+        metadata_confidence=0.81,
+        direct_appeal=0.18,
+        direct_confidence=0.65,
+        components={
+            "content": {"value": 0.22},
+            "content_neighbor": {"value": 0.11},
+            "performer_identity": {"value": 0.16},
+            "performer_similarity": {"value": 0.04},
+            "studio": {"value": -0.03},
+            "fit": {"cooldown": -0.05, "satiation": 0.02, "not_now": 0.0},
+        },
+    )
+
+    components = score_components(score)
+    assert {row["name"] for row in components} == {
+        "content_similarity",
+        "performer_match",
+        "studio_appeal",
+        "direct_feedback",
+        "right_now_fit",
+        "model_confidence",
+    }
+    assert all(row["scale"] in {"-1..1", "0..1"} for row in components)
+    assert [axis["name"] for axis in evidence_fingerprint(score)["axes"]] == [
+        "content",
+        "performers",
+        "studios",
+        "similar_scenes",
+        "direct_history",
+    ]
+    assert evidence_fingerprint(score)["metadata_coverage"]["available"] is True
+    assert scores_payload(score, lane="best_bets", rank=0.81)["rank"]["available"] is True
+    no_metadata = SimpleNamespace(**{**vars(score), "metadata_confidence": 0.0})
+    assert evidence_fingerprint(no_metadata)["metadata_coverage"]["available"] is False

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -1122,31 +1122,36 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     assert 'className: "performer-tag-container row"' in source
     assert 'className: "image-thumbnail"' in source
     assert 'className: "tag-item tag-link badge badge-secondary"' in source
-    # RecommendationCard, ExternalCard, and SimilarityPanel's library-match
-    # grid share the "Why this?"/"Score" <details> shell via EvidenceScore;
-    # the shell markup lives once in its definition, content stays
-    # per-caller (async explain-on-toggle vs static text).
+    # RecommendationCard, ExternalCard, and SimilarityPanel share the same
+    # progressive explanation shell and the named, unit-bearing breakdown.
     assert "function EvidenceScore({ evidenceProps, evidenceContent," in source
-    assert "scoreBarContent, scoreSummary, scoreContent })" in source
+    assert (
+        'scoreBarContent, scoreSummary, scoreLabel = "Match", scoreHeadline, '
+        "scoreHeadlineValue, scoreHeadlineBar, scoreContent })" in source
+    )
     assert 'React.createElement("summary", null, "Why this?")' in source
     assert 'className: "curator-evidence", ...evidenceProps' in source
     assert "evidenceProps: { onToggle: explain }" in source
     assert 'operation({ operation: "get_explanation", scene_id: item.scene_id }, 60000)' in source
     assert '"Explaining…"' in source
-    assert 'React.createElement("summary", null, scoreBarContent ? "Score breakdown" :' in source
-    assert "`Score · ${scoreSummary}`)" in source
-    assert "scoreSummary: item.final_utility.toFixed(2)" in source
-    assert "scoreSummary: item.score.toFixed(2)" in source
-    assert "scoreSummary: item.rank_score.toFixed(2)" in source
+    assert "function ScoreBreakdown({ explanation, item })" in source
+    assert "function ExplanationView({ explanation, item })" in source
+    assert 'className: "curator-evidence-fingerprint"' in source
+    assert 'className: "curator-fingerprint-svg"' in source
+    assert "curator-metadata-status" in source
+    assert "Metadata covered" in source
+    assert "function fingerprintPoint(" in source
+    assert 'scoreLabel: hasLaneRank ? `Rank in ${laneLabel}` : "Appeal"' in source
+    assert "scoreHeadlineValue: formatAppealValue(item.appeal)" in source
+    assert "function clamp01(value)" in source
     assert (
-        'className: kind === "scene" ? "scene-card__details" : "curator-external-details"' in source
+        "scoreSummary: hasLaneRank ? item.lane_value.toFixed(2) : formatAppealValue(item.appeal)"
+        in source
     )
-    assert "className: `${type}-card-image`" in source
-    assert 'className: "card-section-title"' in source
-    assert "Curator never deletes media; tagging is reversible" in source
-    assert "Score is ranking utility, not a probability" in source
+    assert 'scoreLabel: "Match"' in source or "scoreLabel: label" in source
+    assert "Appeal is the model's estimate" in source
     assert '"appeal.performer_identity": "Performer match"' in source
-    assert '"appeal.content_neighbor": "Similar content"' in source
+    assert '"appeal.content_neighbor": "Similar scenes"' in source
     assert "Wildcard items are selected outside preference-derived seeds" in source
 
 
@@ -1195,7 +1200,7 @@ def test_backend_module_loads_without_starting(tmp_path: Path) -> None:
     assert spec and spec.loader
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    assert module.SCHEMA_VERSION == 1
+    assert module.SCHEMA_VERSION == 2
 
 
 def test_diagnostics_allowlist_cannot_emit_representative_private_fields(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -102,8 +102,22 @@ def test_slate_api_defers_explanations_until_requested(
         == 0
     )
     explanation = CuratorAPI(connection).explanation(str(result["items"][0]["scene_id"]))
+    assert explanation["schema_version"] == 2
     assert explanation["summary"]
     assert explanation["supporting_reasons"]
+    assert explanation["components"]
+    assert {row["name"] for row in explanation["components"]} >= {
+        "content_similarity",
+        "model_confidence",
+    }
+    assert [axis["name"] for axis in explanation["evidence_fingerprint"]["axes"]] == [
+        "content",
+        "performers",
+        "studios",
+        "similar_scenes",
+        "direct_history",
+    ]
+    assert explanation["evidence_fingerprint"]["metadata_coverage"]["available"] is True
     assert (
         connection.execute(
             "SELECT count(*) FROM impression WHERE impression_id='api-impression'"


### PR DESCRIPTION
## Score presentation overhaul (#119, #122)

The implementation you reviewed and verified live in the installed plugin. Supersedes #203's earlier `rb-w4` implementation (which used a different file layout: `explanations_v2.go`/`breakdown.py`).

## What changed
- No bare \"Score\": every card shows intrinsic **Appeal** plus a separately-labeled surface quantity (lane rank, Similarity, or Match).
- Shared **Why this?** renderer across recommendation, Similar, Expand, and history surfaces.
- Named, unit-bearing component breakdown; evidence rows as Supports/Cautions/Context.
- Evidence fingerprint radar with fixed Content/Performers/Studios/Similar Scenes/Direct History axes + a separate Metadata-coverage status (checkmark, not an axis).
- Versioned v2 explanation schema (`apiSchemaVersion: 2`) in both Go and the Python oracle, byte-identical differential parity.

## Verification
- `scripts/verify full`: 643 passed, 25 deselected (two pre-existing numpy warnings).
- Go/Python explanation differential parity: passed.
- Focused plugin + API/explanation regression suites: passed.
- Perf gate: total budget passes; a transient `lane_classification` sub-budget overage was observed on QEMU host jitter and is unrelated to this diff (explanation rendering, not classification).

## Files
16 files changed, 933 insertions(+), 241 deletions(-). New: `curator/explanations/presentation.py`.