### PR TITLE
feat(model): ignored-tags list and implicit-skip negatives from impressions

### DIFF
--- a/core/featurebuild.go
+++ b/core/featurebuild.go
@@ -182,7 +182,7 @@ func runFeatureBuild() {
 		fail("feature-build: migrate: %v", err)
 	}
 	rec := newStageRecorder()
-	version, reused, err := featureBuild(db, payload.NowMs, rec, func(fraction float64) {
+	version, reused, err := featureBuild(db, payload.NowMs, featureIgnoredTags(db), rec, func(fraction float64) {
 		_ = writeJSONLine(map[string]any{"progress": fraction})
 	})
 	if err != nil {
@@ -457,6 +457,63 @@ func presenceCategory(value string) string {
 // description-term values, normalized, with confidence from document
 // frequency. Every input is a precomputed read-only map, so the scene pass
 // is row-independent: fixed-chunk parallel processing yields identical rows.
+// featureIgnoredTags reads the runtime ignored_tags from curator_config.
+// The plugin setting ignoredTags (a comma-separated string in Stash settings)
+// is mirrored into curator_config.config_json["ignored_tags"]. The build reads
+// it here so an edited ignore list changes the feature version and the model
+// fingerprint, and drives the feature-construction exclusion.
+func featureIgnoredTags(db dbx) []string {
+	cfg, err := sidecarConfig(db)
+	if err != nil {
+		return nil
+	}
+	raw := cfg.get("config").get("ignored_tags")
+	if raw.kind == jNull {
+		return nil
+	}
+	value := strings.TrimSpace(raw.asString())
+	if value == "" {
+		return nil
+	}
+	var ignored []string
+	for _, part := range strings.Split(value, ",") {
+		name := strings.TrimSpace(part)
+		if name != "" {
+			ignored = append(ignored, name)
+		}
+	}
+	return ignored
+}
+
+// featureIgnoredTagIDs maps the ignored tag names to their local tag_ids, so
+// the feature-construction pass can drop them by id. Only tags whose exact
+// name is in the ignore set are excluded (no bracket heuristics).
+func featureIgnoredTagIDs(db dbx, ignoredTags []string) (map[string]bool, error) {
+	if len(ignoredTags) == 0 {
+		return nil, nil
+	}
+	names := map[string]bool{}
+	for _, name := range ignoredTags {
+		names[name] = true
+	}
+	rows, err := db.Query(`SELECT tag_id, name FROM source_tag`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	ids := map[string]bool{}
+	for rows.Next() {
+		var tagID, name string
+		if err := rows.Scan(&tagID, &name); err != nil {
+			return nil, err
+		}
+		if names[strings.TrimSpace(name)] {
+			ids[tagID] = true
+		}
+	}
+	return ids, rows.Err()
+}
+
 func sceneFeatureRows(sceneID string, baseVectors map[string]map[string]float64,
 	documentFrequency map[string]int64, descByScene map[string][]string,
 	descIDF map[string]float64, descDocumentFrequency map[string]int64, tagNames map[string]string,
@@ -545,7 +602,7 @@ func sceneFeatureRows(sceneID string, baseVectors map[string]map[string]float64,
 	return features
 }
 
-func sceneFeatures(db dbx, roles map[string]tagRoleResult, rec *stageRecorder, progress func(fraction float64)) ([]featureRow, error) {
+func sceneFeatures(db dbx, roles map[string]tagRoleResult, ignoredTagIDs map[string]bool, rec *stageRecorder, progress func(fraction float64)) ([]featureRow, error) {
 	sceneRows, err := db.Query(`SELECT scene_id FROM source_scene ORDER BY scene_id`)
 	if err != nil {
 		return nil, err
@@ -574,7 +631,7 @@ func sceneFeatures(db dbx, roles map[string]tagRoleResult, rec *stageRecorder, p
 			rows.Close()
 			return nil, err
 		}
-		if roles[tagID].role == "content" {
+		if roles[tagID].role == "content" && !ignoredTagIDs[tagID] {
 			if direct[sceneID] == nil {
 				direct[sceneID] = map[string]bool{}
 			}
@@ -602,7 +659,7 @@ ORDER BY scene_id, tag_id`)
 			rows.Close()
 			return nil, err
 		}
-		if roles[tagID].role == "content" {
+		if roles[tagID].role == "content" && !ignoredTagIDs[tagID] {
 			if marker[sceneID] == nil {
 				marker[sceneID] = map[string]bool{}
 			}
@@ -624,7 +681,7 @@ ORDER BY scene_id, tag_id`)
 			rows.Close()
 			return nil, err
 		}
-		if roles[parentID].role == "content" {
+		if roles[parentID].role == "content" && !ignoredTagIDs[parentID] {
 			if parents[tagID] == nil {
 				parents[tagID] = map[string]bool{}
 			}
@@ -1160,7 +1217,7 @@ func featureID(featureVersion, entityType, family, name string) string {
 // version plus whether the published feature was reused, recording the
 // feature_* stage timings, spans, and per-stage memory into rec (mirroring
 // FeatureBuilder.build's lookup/build/publish/total keys).
-func featureBuild(db dbx, nowMs int64, rec *stageRecorder, progress func(fraction float64)) (string, bool, error) {
+func featureBuild(db dbx, nowMs int64, ignoredTags []string, rec *stageRecorder, progress func(fraction float64)) (string, bool, error) {
 	started := time.Now()
 	sourceFingerprint, err := featureSourceFingerprint(db)
 	if err != nil {
@@ -1169,7 +1226,8 @@ func featureBuild(db dbx, nowMs int64, rec *stageRecorder, progress func(fractio
 	if progress != nil {
 		progress(0.05)
 	}
-	versionHash := sha256.Sum256([]byte(sourceFingerprint + "\x00" + featureConfigCanonicalJSON()))
+	effectiveConfig := featureConfigCanonicalJSONWith(ignoredTags)
+	versionHash := sha256.Sum256([]byte(sourceFingerprint + "\x00" + effectiveConfig))
 	featureVersion := fmt.Sprintf("fv-%s", hex.EncodeToString(versionHash[:])[:20])
 	var status string
 	var validationStatus sql.NullString
@@ -1209,7 +1267,7 @@ INSERT INTO feature_build(
     feature_version, status, config_json, source_fingerprint, created_at_ms
 ) VALUES (?, 'building', ?, ?, ?)
 ON CONFLICT(feature_version) DO UPDATE SET status='building', error=NULL`,
-			featureVersion, featureConfigCanonicalJSON(), sourceFingerprint, nowMs)
+			featureVersion, effectiveConfig, sourceFingerprint, nowMs)
 		return err
 	})
 	if insertErr != nil {
@@ -1229,9 +1287,13 @@ ON CONFLICT(feature_version) DO UPDATE SET status='building', error=NULL`,
 		if progress != nil {
 			progress(0.10)
 		}
+		ignoredTagIDs, err := featureIgnoredTagIDs(db, ignoredTags)
+		if err != nil {
+			return err
+		}
 		if err := rec.stage("", "feature.scene_features", func() error {
 			var err error
-			sceneRows, err = sceneFeatures(db, roles, rec, progress)
+			sceneRows, err = sceneFeatures(db, roles, ignoredTagIDs, rec, progress)
 			return err
 		}); err != nil {
 			return err

--- a/core/history.go
+++ b/core/history.go
@@ -469,7 +469,19 @@ func featureFingerprint() string {
 	return sha256Hex(featureConfigCanonicalJSON())
 }
 
+// featureConfigCanonicalJSON mirrors FeatureConfig.feature_json() with the
+// default (empty) ignored_tags. It is the default-config fingerprint used by
+// the read-path tag_role/config-version lookups, which always run against the
+// default feature config.
 func featureConfigCanonicalJSON() string {
+	return featureConfigCanonicalJSONWith(nil)
+}
+
+// featureConfigCanonicalJSONWith mirrors FeatureConfig.feature_json() for a
+// given ignored_tags list (nil → the empty default). The build passes the
+// runtime ignored_tags (from curator_config.ignored_tags) so the feature
+// version and model fingerprint change when the ignore list changes.
+func featureConfigCanonicalJSONWith(ignoredTags []string) string {
 	rules := jvArr()
 	rule := func(match, pattern, role string) {
 		rules.arr = append(rules.arr, jvObj(
@@ -498,6 +510,7 @@ func featureConfigCanonicalJSON() string {
 	config := jvObj(
 		jvKey("idf_cap", jvFloat(2.5)),
 		jvKey("idf_strength", jvFloat(0.5)),
+		jvKey("ignored_tags", jvStrList(ignoredTags)),
 		jvKey("marker_weight", jvFloat(0.45)),
 		jvKey("one_off_prior", jvFloat(2.0)),
 		jvKey("parent_weight", jvFloat(0.35)),

--- a/core/modelbuild.go
+++ b/core/modelbuild.go
@@ -34,6 +34,13 @@ const (
 	curationPairConfidence    = 0.15
 	curationPairSurpriseBonus = 2.0
 	curationPairIPSCap        = 2.0
+	// Mirrors ModelConfig.implicit_skip_* in curator/config.py (#146 Channel A).
+	// The base is half the deliberate-pick base (curationPairConfidence) so
+	// implicit signal never outranks explicit feedback; the issue author
+	// flagged it may need to be even weaker after live measurement.
+	implicitSkipConfidence    = 0.075
+	implicitSkipSurpriseBonus = 2.0
+	implicitSkipIPSCap        = 2.0
 )
 
 // sceneLabel mirrors _SceneLabel: outcome/confidence/effectiveEvidence cover
@@ -734,6 +741,114 @@ ORDER BY scene_id, occurred_at_ms`)
 	return events, nil
 }
 
+// modelImplicitSkipEvents mirrors _implicit_skip_events (#146 Channel A):
+// when a recommended scene is played or thumbed, the earlier-position cards
+// in the same impression are treated as weak pairwise losers. Surprise uses
+// the stored policy_score (surprise = max(0, loser_score - winner_score));
+// confidence uses the implicit base (half the deliberate-pick base) so
+// implicit signal never outranks explicit feedback. Trigger is played or
+// thumbed only. Pairs are virtual (build-time only).
+func modelImplicitSkipEvents(db dbx) ([]pairEvent, error) {
+	metadataWrong, err := metadataWrongScenes(db)
+	if err != nil {
+		return nil, err
+	}
+	type winner struct{ sceneID, impressionID string }
+	winners := map[string]winner{}
+	rows, err := db.Query(`
+SELECT ps.scene_id, ps.impression_id FROM play_session ps
+WHERE ps.impression_id IS NOT NULL
+  AND ps.provenance='direct_player' AND ` + observedPlaybackSQL + `
+UNION
+SELECT f.scene_id, f.impression_id FROM feedback f
+WHERE f.impression_id IS NOT NULL
+  AND f.feedback_type='thumb_up' AND f.reversed_by_id IS NULL`)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var sceneID, impressionID string
+		if err := rows.Scan(&sceneID, &impressionID); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		if metadataWrong[sceneID] {
+			continue
+		}
+		if _, exists := winners[sceneID]; exists {
+			continue
+		}
+		winners[sceneID] = winner{sceneID, impressionID}
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	winnerScenes := make([]string, 0, len(winners))
+	for sceneID := range winners {
+		winnerScenes = append(winnerScenes, sceneID)
+	}
+	sort.Strings(winnerScenes)
+	var events []pairEvent
+	for _, winnerScene := range winnerScenes {
+		impressionID := winners[winnerScene].impressionID
+		rows, err := db.Query(`
+SELECT scene_id, position, policy_score FROM impression_item
+WHERE impression_id=? ORDER BY position`, impressionID)
+		if err != nil {
+			return nil, err
+		}
+		type item struct {
+			sceneID     string
+			position    int64
+			policyScore float64
+		}
+		var items []item
+		for rows.Next() {
+			var sceneID string
+			var position int64
+			var policyScore float64
+			if err := rows.Scan(&sceneID, &position, &policyScore); err != nil {
+				rows.Close()
+				return nil, err
+			}
+			items = append(items, item{sceneID, position, policyScore})
+		}
+		rows.Close()
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		winnerPosition := int64(-1)
+		winnerScore := 0.0
+		for _, it := range items {
+			if it.sceneID == winnerScene {
+				winnerPosition = it.position
+				winnerScore = it.policyScore
+				break
+			}
+		}
+		if winnerPosition < 0 {
+			continue
+		}
+		for _, it := range items {
+			if it.position >= winnerPosition || it.sceneID == winnerScene {
+				continue
+			}
+			surprise := it.policyScore - winnerScore
+			if surprise < 0 {
+				surprise = 0
+			}
+			confidence := implicitSkipConfidence * (1.0 + implicitSkipSurpriseBonus*surprise) *
+				math.Min(implicitSkipIPSCap, 1.0)
+			if confidence > 1.0 {
+				confidence = 1.0
+			}
+			events = append(events, pairEvent{winnerScene, it.sceneID, confidence})
+		}
+	}
+	return events, nil
+}
+
 // modelAffinities mirrors _affinities.
 func modelAffinities(db dbx, sceneFeatures map[string][]storedFeature,
 	labels map[string]sceneLabel, absoluteLabelMean float64) (map[string]modelAffinity, error) {
@@ -770,6 +885,11 @@ func modelAffinities(db dbx, sceneFeatures map[string][]storedFeature,
 	if err != nil {
 		return nil, err
 	}
+	implicitSkipEvents, err := modelImplicitSkipEvents(db)
+	if err != nil {
+		return nil, err
+	}
+	pairEvents = append(pairEvents, implicitSkipEvents...)
 	for _, event := range pairEvents {
 		winnerFeatures := map[string]storedFeature{}
 		for _, f := range sceneFeatures[event.winnerScene] {

--- a/core/modelbuild3.go
+++ b/core/modelbuild3.go
@@ -503,9 +503,19 @@ func modelAffinitySanityCheck(artifact dbx, modelID string, computedAffinityCoun
 
 // modelConfigCanonical mirrors json.dumps(asdict(CuratorConfig),
 // sort_keys=True): the feature/model/ranking sub-configs as ordered dicts.
+// The feature sub-config uses the default (empty) ignored_tags; the build
+// passes the runtime ignored_tags via modelConfigCanonicalWith so the model
+// fingerprint reflects an edited ignore list.
 func modelConfigCanonical() string {
+	return modelConfigCanonicalWith(nil)
+}
+
+// modelConfigCanonicalWith mirrors modelConfigCanonical for a given
+// ignored_tags list (nil → the empty default). The model build passes the
+// runtime ignored_tags so the model digest changes when the list changes.
+func modelConfigCanonicalWith(ignoredTags []string) string {
 	config := jvObj(
-		jvKey("feature", modelFeatureConfig()),
+		jvKey("feature", modelFeatureConfigWith(ignoredTags)),
 		jvKey("model", modelSubConfig()),
 		jvKey("ranking", rankingSubConfig()),
 		jvKey("random_seed", jvInt(31415)),
@@ -521,9 +531,16 @@ func parseJSONOr(raw string) jVal {
 	return parsed
 }
 
-// modelFeatureConfig mirrors asdict(FeatureConfig) as a jVal object.
+// modelFeatureConfig mirrors asdict(FeatureConfig) as a jVal object (default
+// ignored_tags).
 func modelFeatureConfig() jVal {
-	parsed, err := parseJSON([]byte(featureConfigCanonicalJSON()))
+	return modelFeatureConfigWith(nil)
+}
+
+// modelFeatureConfigWith mirrors asdict(FeatureConfig) for a given
+// ignored_tags list.
+func modelFeatureConfigWith(ignoredTags []string) jVal {
+	parsed, err := parseJSON([]byte(featureConfigCanonicalJSONWith(ignoredTags)))
 	if err != nil {
 		return jvObj()
 	}
@@ -548,6 +565,9 @@ func modelSubConfig() jVal {
 		jvKey("direct_confidence_scale", jvFloat(0.8)),
 		jvKey("dormancy_center_days", jvFloat(120.0)),
 		jvKey("dormancy_width_days", jvFloat(45.0)),
+		jvKey("implicit_skip_confidence", jvFloat(implicitSkipConfidence)),
+		jvKey("implicit_skip_ips_cap", jvFloat(implicitSkipIPSCap)),
+		jvKey("implicit_skip_surprise_bonus", jvFloat(implicitSkipSurpriseBonus)),
 		jvKey("minimum_neighbor_similarity", jvFloat(0.05)),
 		jvKey("neighbor_bound", jvFloat(0.2)),
 		jvKey("neighbor_confidence_scale", jvFloat(0.35)),
@@ -625,10 +645,11 @@ func modelBuild(db dbx, nowMs int64, progress func(processed, total int)) (drain
 	rec := newStageRecorder()
 	timings := map[string]int64{}
 	started := time.Now()
+	ignoredTags := featureIgnoredTags(db)
 	var featureVersion string
 	err := rec.stage("", "model.features", func() error {
 		var err error
-		featureVersion, _, err = featureBuild(db, nowMs, rec, func(fraction float64) {
+		featureVersion, _, err = featureBuild(db, nowMs, ignoredTags, rec, func(fraction float64) {
 			report(0.25 * fraction)
 		})
 		return err
@@ -661,16 +682,17 @@ func modelBuild(db dbx, nowMs int64, progress func(processed, total int)) (drain
 	if err != nil {
 		return drainResult{}, err
 	}
+	modelConfigCanonical := modelConfigCanonicalWith(ignoredTags)
 	if os.Getenv("CURATOR_DEBUG_MODEL_DIGEST") != "" {
 		fmt.Fprintf(os.Stderr, "DEBUG model digest: fv=%s ev=%s src=%s cfg=%s cutoff=%g ver=%d ref=%d code=%s\n",
-			featureVersion, evidenceFingerprint, sourceFingerprint, modelConfigCanonical(),
+			featureVersion, evidenceFingerprint, sourceFingerprint, modelConfigCanonical,
 			performerSimilarityAffinityCutoff, modelBuildVersion, referenceAtMs, scoringFingerprint)
 	}
 	// scoringFingerprint makes the code that produced the artifact part of the
 	// key: without it an algorithm change with unchanged data and config yields
 	// the same modelID, and the build reuses the previous algorithm's artifact.
 	digest := sha256.Sum256([]byte(fmt.Sprintf("%s\x00%s\x00%s\x00%s\x00%g\x00%d\x00%d\x00%s",
-		featureVersion, evidenceFingerprint, sourceFingerprint, modelConfigCanonical(),
+		featureVersion, evidenceFingerprint, sourceFingerprint, modelConfigCanonical,
 		performerSimilarityAffinityCutoff, modelBuildVersion, referenceAtMs, scoringFingerprint)))
 	modelID := fmt.Sprintf("model-%s", hexEncode(digest[:])[:20])
 	var status string
@@ -707,7 +729,7 @@ func modelBuild(db dbx, nowMs int64, progress func(processed, total int)) (drain
 		return drainResult{}, err
 	}
 	modelConfigJSON := jvObj(
-		jvKey("config", parseJSONOr(modelConfigCanonical())),
+		jvKey("config", parseJSONOr(modelConfigCanonical)),
 		jvKey("model_build_version", jvInt(modelBuildVersion)),
 		jvKey("reference_at_ms", jvInt(referenceAtMs)),
 		jvKey("scoring_fingerprint", jvStr(scoringFingerprint)),

--- a/core/scoring_fingerprint.go
+++ b/core/scoring_fingerprint.go
@@ -6,4 +6,4 @@
 
 package main
 
-const scoringFingerprint = "08b3659720089de5"
+const scoringFingerprint = "474d4e6e64d86f90"

--- a/core/settings.go
+++ b/core/settings.go
@@ -22,6 +22,7 @@ var defaultPluginConfig = jvObj(
 	jvKey("model_update_max_wait_minutes", jvInt(30)),
 	jvKey("model_update_min_interval_minutes", jvInt(60)),
 	jvKey("prune_tag_name", jvStr("[Prune]")),
+	jvKey("ignored_tags", jvStr("")),
 	jvKey("expand_horizon_days", jvInt(90)),
 	jvKey("expand_gender", jvStr("FEMALE")),
 	jvKey("expand_wildcard", jvBool(false)),
@@ -59,6 +60,7 @@ var settingMapping = []struct {
 	{"modelUpdateMaxWaitMinutes", "model_update_max_wait_minutes", convFloat},
 	{"modelUpdateMinIntervalMinutes", "model_update_min_interval_minutes", convFloat},
 	{"pruneTagName", "prune_tag_name", convStr},
+	{"ignoredTags", "ignored_tags", convStr},
 	{"expandHorizonDays", "expand_horizon_days", convInt},
 	{"expandGender", "expand_gender", convStr},
 	{"expandWildcard", "expand_wildcard", convBool},
@@ -278,6 +280,9 @@ func validateConfig(values jVal) error {
 		if v.kind != jStr || strings.TrimSpace(v.s) == "" || len(v.s) > 100 {
 			return fmt.Errorf("prune_tag_name must be a non-empty string up to 100 characters")
 		}
+	}
+	if v := values.get("ignored_tags"); v.kind != jNull && v.kind != jStr {
+		return fmt.Errorf("ignored_tags must be a comma-separated string")
 	}
 	if v := values.get("expand_horizon_days"); v.kind != jNull {
 		if !isJSONInt(v) {

--- a/curator/api.py
+++ b/curator/api.py
@@ -34,6 +34,7 @@ DEFAULT_PLUGIN_CONFIG: dict[str, object] = {
     "model_update_max_wait_minutes": 30,
     "model_update_min_interval_minutes": 60,
     "prune_tag_name": "[Prune]",
+    "ignored_tags": "",
     "expand_horizon_days": 90,
     "expand_gender": "FEMALE",
     "expand_wildcard": False,
@@ -1253,6 +1254,7 @@ class CuratorAPI:
             "model_update_max_wait_minutes",
             "model_update_min_interval_minutes",
             "prune_tag_name",
+            "ignored_tags",
             "expand_horizon_days",
             "expand_gender",
             "expand_wildcard",
@@ -1318,6 +1320,9 @@ class CuratorAPI:
             not isinstance(prune_tag, str) or not prune_tag.strip() or len(prune_tag) > 100
         ):
             raise ValueError("prune_tag_name must be a non-empty string up to 100 characters")
+        ignored_tags = values.get("ignored_tags")
+        if ignored_tags is not None and not isinstance(ignored_tags, str):
+            raise ValueError("ignored_tags must be a comma-separated string")
         horizon = values.get("expand_horizon_days")
         if horizon is not None and (not isinstance(horizon, int) or not 1 <= horizon <= 3650):
             raise ValueError("expand_horizon_days must be an integer from 1 to 3650")

--- a/curator/config.py
+++ b/curator/config.py
@@ -59,6 +59,12 @@ class FeatureConfig:
     idf_strength: float = 0.5
     idf_cap: float = 2.5
     one_off_prior: float = 2.0
+    # Exact-name list of scene tags excluded from tag analysis. Auto-generated
+    # / metadata tags like "[Timestamp: Synced]" describe the file/import, not
+    # the scene; they pollute content features, affinity accumulation, the
+    # Taste Profile, and lane facets. Exact-name match only (no bracket
+    # heuristics — bracketing is unreliable). Empty by default.
+    ignored_tags: tuple[str, ...] = ()
     performer_block_weights: tuple[tuple[str, float], ...] = (
         ("content", 1.0),
         ("measurements", 1.0),
@@ -105,6 +111,15 @@ class ModelConfig:
     curation_pair_confidence: float = 0.15
     curation_pair_surprise_bonus: float = 2.0
     curation_pair_ips_cap: float = 2.0
+    # Implicit negatives from impressions (#146 Channel A). When a recommended
+    # scene is played or thumbed, the passed-over earlier-position cards in the
+    # same impression are treated as weak pairwise losers. The base is half the
+    # deliberate-pick base (curation_pair_confidence) so implicit signal never
+    # outranks explicit feedback; the issue author flagged it may need to be
+    # even weaker after live measurement. Config-backed so it can be tuned.
+    implicit_skip_confidence: float = 0.075
+    implicit_skip_surprise_bonus: float = 2.0
+    implicit_skip_ips_cap: float = 2.0
     not_now_days: float = 30.0
     not_now_penalty: float = 0.50
     neighbor_count: int = 12

--- a/curator/features/builder.py
+++ b/curator/features/builder.py
@@ -462,6 +462,19 @@ class FeatureBuilder:
                 "SELECT scene_id FROM source_scene ORDER BY scene_id"
             )
         ]
+        tag_names = {
+            str(row["tag_id"]): str(row["name"] or "")
+            for row in self.connection.execute("SELECT tag_id, name FROM source_tag")
+        }
+        # Exact-name ignore set: tags the user excluded from tag analysis. The
+        # name is the only match key (no bracket heuristics); a tag matching an
+        # ignored name is dropped before it can enter base_vectors, so it never
+        # contributes to document frequency, the l2 norm, entity_feature rows,
+        # affinity accumulation, or the Taste Profile.
+        ignored_names = frozenset(self.config.feature.ignored_tags)
+        ignored_tag_ids = {
+            tag_id for tag_id, name in tag_names.items() if name in ignored_names
+        }
         direct: dict[str, set[str]] = defaultdict(set)
         for row in self.connection.execute(
             """
@@ -469,11 +482,13 @@ class FeatureBuilder:
             WHERE provenance='scene' ORDER BY scene_id, tag_id
             """
         ):
+            tag_id = str(row["tag_id"])
             if (
-                roles.get(str(row["tag_id"]), TagRoleResult(TagRole.IGNORED, "missing")).role
+                roles.get(tag_id, TagRoleResult(TagRole.IGNORED, "missing")).role
                 is TagRole.CONTENT
+                and tag_id not in ignored_tag_ids
             ):
-                direct[str(row["scene_id"])].add(str(row["tag_id"]))
+                direct[str(row["scene_id"])].add(tag_id)
         marker: dict[str, set[str]] = defaultdict(set)
         marker_rows = self.connection.execute(
             """
@@ -487,14 +502,22 @@ class FeatureBuilder:
         )
         for row in marker_rows:
             tag_id = str(row["tag_id"])
-            if roles.get(tag_id, TagRoleResult(TagRole.IGNORED, "missing")).role is TagRole.CONTENT:
+            if (
+                roles.get(tag_id, TagRoleResult(TagRole.IGNORED, "missing")).role
+                is TagRole.CONTENT
+                and tag_id not in ignored_tag_ids
+            ):
                 marker[str(row["scene_id"])].add(tag_id)
         parents: dict[str, set[str]] = defaultdict(set)
         for row in self.connection.execute(
             "SELECT tag_id, parent_tag_id FROM tag_parent ORDER BY tag_id, parent_tag_id"
         ):
             parent = str(row["parent_tag_id"])
-            if roles.get(parent, TagRoleResult(TagRole.IGNORED, "missing")).role is TagRole.CONTENT:
+            if (
+                roles.get(parent, TagRoleResult(TagRole.IGNORED, "missing")).role
+                is TagRole.CONTENT
+                and parent not in ignored_tag_ids
+            ):
                 parents[str(row["tag_id"])].add(parent)
 
         base_vectors: dict[str, dict[str, float]] = {}
@@ -516,10 +539,6 @@ class FeatureBuilder:
         for values in base_vectors.values():
             for tag_id in values:
                 document_frequency[tag_id] += 1
-        tag_names = {
-            str(row["tag_id"]): str(row["name"] or "")
-            for row in self.connection.execute("SELECT tag_id, name FROM source_tag")
-        }
         features: list[_Feature] = []
         total = max(1, len(scene_ids))
         # Description term features: tokenize scene descriptions, compute TF-IDF

--- a/curator/features/builder.py
+++ b/curator/features/builder.py
@@ -472,9 +472,7 @@ class FeatureBuilder:
         # contributes to document frequency, the l2 norm, entity_feature rows,
         # affinity accumulation, or the Taste Profile.
         ignored_names = frozenset(self.config.feature.ignored_tags)
-        ignored_tag_ids = {
-            tag_id for tag_id, name in tag_names.items() if name in ignored_names
-        }
+        ignored_tag_ids = {tag_id for tag_id, name in tag_names.items() if name in ignored_names}
         direct: dict[str, set[str]] = defaultdict(set)
         for row in self.connection.execute(
             """
@@ -484,8 +482,7 @@ class FeatureBuilder:
         ):
             tag_id = str(row["tag_id"])
             if (
-                roles.get(tag_id, TagRoleResult(TagRole.IGNORED, "missing")).role
-                is TagRole.CONTENT
+                roles.get(tag_id, TagRoleResult(TagRole.IGNORED, "missing")).role is TagRole.CONTENT
                 and tag_id not in ignored_tag_ids
             ):
                 direct[str(row["scene_id"])].add(tag_id)
@@ -503,8 +500,7 @@ class FeatureBuilder:
         for row in marker_rows:
             tag_id = str(row["tag_id"])
             if (
-                roles.get(tag_id, TagRoleResult(TagRole.IGNORED, "missing")).role
-                is TagRole.CONTENT
+                roles.get(tag_id, TagRoleResult(TagRole.IGNORED, "missing")).role is TagRole.CONTENT
                 and tag_id not in ignored_tag_ids
             ):
                 marker[str(row["scene_id"])].add(tag_id)
@@ -514,8 +510,7 @@ class FeatureBuilder:
         ):
             parent = str(row["parent_tag_id"])
             if (
-                roles.get(parent, TagRoleResult(TagRole.IGNORED, "missing")).role
-                is TagRole.CONTENT
+                roles.get(parent, TagRoleResult(TagRole.IGNORED, "missing")).role is TagRole.CONTENT
                 and parent not in ignored_tag_ids
             ):
                 parents[str(row["tag_id"])].add(parent)

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -16,7 +16,7 @@ from typing import Any, cast
 
 from curator import core
 from curator.config import DEFAULT_CONFIG, CuratorConfig
-from curator.events.contracts import DEFAULT_CALIBRATION
+from curator.events.contracts import DEFAULT_CALIBRATION, OBSERVED_PLAYBACK_SQL
 from curator.features import FeatureBuilder, FeatureStore
 from curator.features.builder import _fingerprint_table
 from curator.features.profiles import NUMERIC_BLOCKS, NUMERIC_SCALES
@@ -978,6 +978,77 @@ class PreferenceModelBuilder:
             if "winner_scene" in entry and "loser_scene" in entry
         ]
 
+    def _implicit_skip_events(self) -> list[_PairEvent]:
+        """Implicit negatives from impressions (#146 Channel A): when a
+        recommended scene is played or thumbed, the earlier-position cards in
+        the same impression are treated as weak pairwise losers.
+
+        The chosen card is the winner (+1); every earlier-position card is a
+        loser (-1). Surprise uses the stored policy_score recorded at display
+        time (surprise = max(0, loser_score - winner_score)), so a pick that
+        contradicts the model's ordering is informative while a confirmation
+        adds nothing. Confidence uses the implicit base (half the
+        deliberate-pick base) so implicit signal never outranks explicit
+        feedback. Trigger is played or thumbed only — never a raw click.
+
+        Pairs are virtual (build-time only): they are emitted here and fed to
+        the affinity accumulator, never written to the feedback table.
+        """
+        metadata_wrong = self._metadata_wrong_scenes()
+        # Positive actions linking a scene to the impression that surfaced it:
+        # an observed playback of a Curator-recommended scene, or an explicit
+        # thumb-up. A scene played or thumbed in the same impression twice is
+        # collapsed to its earliest position (the first positive action).
+        winners: dict[str, tuple[str, str]] = {}
+        for row in self.connection.execute(
+            f"""
+            SELECT ps.scene_id, ps.impression_id FROM play_session ps
+            WHERE ps.impression_id IS NOT NULL
+              AND ps.provenance='direct_player' AND {OBSERVED_PLAYBACK_SQL}
+            UNION
+            SELECT f.scene_id, f.impression_id FROM feedback f
+            WHERE f.impression_id IS NOT NULL
+              AND f.feedback_type='thumb_up' AND f.reversed_by_id IS NULL
+            """
+        ):
+            scene_id, impression_id = str(row["scene_id"]), str(row["impression_id"])
+            if scene_id in metadata_wrong or scene_id in winners:
+                continue
+            winners[scene_id] = (scene_id, impression_id)
+        events: list[_PairEvent] = []
+        for winner_scene, impression_id in sorted(winners.values()):
+            items = [
+                (str(row["scene_id"]), int(row["position"]), float(row["policy_score"]))
+                for row in self.connection.execute(
+                    """
+                    SELECT scene_id, position, policy_score FROM impression_item
+                    WHERE impression_id=? ORDER BY position
+                    """,
+                    (impression_id,),
+                )
+            ]
+            winner_position = None
+            winner_score = 0.0
+            for scene, position, score in items:
+                if scene == winner_scene:
+                    winner_position = position
+                    winner_score = score
+                    break
+            if winner_position is None:
+                continue
+            for loser_scene, position, loser_score in items:
+                if position >= winner_position or loser_scene == winner_scene:
+                    continue
+                surprise = max(0.0, loser_score - winner_score)
+                confidence = min(
+                    1.0,
+                    self.config.model.implicit_skip_confidence
+                    * (1.0 + self.config.model.implicit_skip_surprise_bonus * surprise)
+                    * min(self.config.model.implicit_skip_ips_cap, 1.0),
+                )
+                events.append(_PairEvent(winner_scene, loser_scene, confidence))
+        return events
+
     def _sibling_priors(
         self,
         scene_features: dict[str, tuple[StoredFeature, ...]],
@@ -1082,7 +1153,7 @@ class PreferenceModelBuilder:
         # share is skipped entirely (no numerator or support contribution) —
         # only what differed between the two scenes carries information. No
         # label_mean subtraction: the comparison already isolates the signal.
-        for event in self._pair_events():
+        for event in [*self._pair_events(), *self._implicit_skip_events()]:
             winner_features = {f.feature_id: f for f in scene_features.get(event.winner_scene, ())}
             loser_features = {f.feature_id: f for f in scene_features.get(event.loser_scene, ())}
             # sorted(): set difference has no defined order, and this feeds

--- a/curator/model/fingerprint.py
+++ b/curator/model/fingerprint.py
@@ -5,4 +5,4 @@ Identifies the scoring code that produced a model artifact. Regenerate with
 script's MANIFEST.
 """
 
-SCORING_FINGERPRINT = "08b3659720089de5"
+SCORING_FINGERPRINT = "474d4e6e64d86f90"

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -519,6 +519,7 @@ def _apply_plugin_settings(connection: Any, settings: dict[str, Any]) -> None:
         "expandHorizonDays": ("expand_horizon_days", int),
         "expandGender": ("expand_gender", str),
         "expandWildcard": ("expand_wildcard", bool),
+        "ignoredTags": ("ignored_tags", str),
     }
     overrides = {
         key: convert(settings[source])

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -4329,6 +4329,12 @@
       ],
     },
     {
+      title: "Tag analysis",
+      fields: [
+        { key: "ignoredTags", configKey: "ignored_tags", type: "STRING", label: "Ignored tags", description: "Comma-separated names of tags excluded from tag analysis. Auto-generated or metadata tags like [Timestamp: Synced] do not describe the scene; exact-name match only. Empty by default." },
+      ],
+    },
+    {
       title: "Whisparr integration",
       fields: [
         { key: "whisparrUrl", type: "STRING", label: "Whisparr v3 URL", description: "Optional Whisparr base URL used by Expand scene actions." },
@@ -4336,6 +4342,20 @@
         { key: "whisparrRootFolder", type: "STRING", label: "Whisparr root folder override", description: "Optional. Leave empty to use Whisparr's first configured root folder." },
         { key: "whisparrQualityProfileId", type: "NUMBER", optional: true, label: "Whisparr quality profile ID override", description: "Optional. Leave empty to use Whisparr's fallback (or first) quality profile." },
         { key: "whisparrSearchImmediately", type: "BOOLEAN", default: true, label: "Search Whisparr immediately", description: "Start a release search after adding a scene. Enabled by default." },
+      ],
+    },
+    {
+      title: "Storage",
+      fields: [
+        { key: "databasePath", type: "STRING", label: "Sidecar database path", description: "Leave empty to store data in the plugin's data directory." },
+        { key: "backupPath", type: "STRING", label: "Backup directory", description: "Leave empty to store Curator backups beside the sidecar database." },
+      ],
+    },
+    {
+      title: "Development",
+      fields: [
+        { key: "profilingEnabled", type: "BOOLEAN", label: "Enable profiling", description: "Record recent Curator operation timings for the Profiling page." },
+        { key: "pprofEnabled", type: "BOOLEAN", label: "Capture CPU profiles", description: "Write a Go CPU and heap profile per operation into the sidecar's profiles directory, browsable and downloadable from the Profiling page. Analyze with go tool pprof. Off by default; keep off unless investigating performance." },
       ],
     },
   ];

--- a/plugin/stash-curator.yml
+++ b/plugin/stash-curator.yml
@@ -104,7 +104,7 @@ settings:
     type: STRING
   ignoredTags:
     displayName: Ignored tags
-    description: Comma-separated names of tags excluded from tag analysis. Auto-generated or metadata tags like [Timestamp: Synced] do not describe the scene; exact-name match only. Empty by default.
+    description: "Comma-separated names of tags excluded from tag analysis. Auto-generated or metadata tags like [Timestamp: Synced] do not describe the scene; exact-name match only. Empty by default."
     type: STRING
   expandHorizonDays:
     displayName: Expand recent-release horizon (days)

--- a/plugin/stash-curator.yml
+++ b/plugin/stash-curator.yml
@@ -102,6 +102,10 @@ settings:
     displayName: Prune tag
     description: Tag applied by the Prune page. Default [Prune].
     type: STRING
+  ignoredTags:
+    displayName: Ignored tags
+    description: Comma-separated names of tags excluded from tag analysis. Auto-generated or metadata tags like [Timestamp: Synced] do not describe the scene; exact-name match only. Empty by default.
+    type: STRING
   expandHorizonDays:
     displayName: Expand recent-release horizon (days)
     description: Recent-release window used by Expand. Default 90.

--- a/tests/core/test_backend_slice3_featurebuild.py
+++ b/tests/core/test_backend_slice3_featurebuild.py
@@ -266,6 +266,85 @@ def test_feature_build_artifact_parity(binary: Path, tmp_path: Path) -> None:
         go_conn.close()
 
 
+def _set_sidecar_ignored_tags(path: Path, ignored: str) -> None:
+    """Set curator_config.ignored_tags on a sidecar so the Go feature-build
+    kernel reads it at build time."""
+    connection = sqlite3.connect(path)
+    try:
+        connection.execute(
+            "UPDATE curator_config SET config_json=?, updated_at_ms=1 WHERE singleton=1",
+            (json.dumps({"ignored_tags": ignored}, separators=(",", ":")),),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _run_python_build_ignored(sidecar: Path, ignored: tuple[str, ...]) -> tuple[str, Path]:
+    """Run Python's FeatureBuilder with a config whose ignored_tags excludes
+    the given exact names."""
+    from curator.config import CuratorConfig, FeatureConfig
+    from curator.storage import connect_database
+
+    connection = connect_database(sidecar, attach_artifacts=False)
+    try:
+        result = FeatureBuilder(
+            connection,
+            CuratorConfig(feature=FeatureConfig(ignored_tags=ignored)),
+            clock_ms=lambda: REFERENCE_MS,
+        ).build()
+        feature_version = result.feature_version
+        basename = connection.execute(
+            "SELECT artifact_basename FROM feature_build WHERE feature_version=?",
+            (feature_version,),
+        ).fetchone()[0]
+    finally:
+        connection.close()
+    return feature_version, sidecar.parent / f"{sidecar.stem}-derived" / basename
+
+
+def test_feature_build_ignored_tags_parity(binary: Path, tmp_path: Path) -> None:
+    """Issue #190: a tag whose exact name is in ignored_tags produces no
+    entity_feature rows in either implementation, and both produce the same
+    feature_version and an identical feature artifact."""
+    py_dir = tmp_path / "py"
+    py_dir.mkdir()
+    py_db = py_dir / "curator.sqlite3"
+    make_feature_sidecar(py_db)
+    _set_sidecar_ignored_tags(py_db, "Familiar Scenario,Challenging Scenario")
+    py_version, py_artifact = _run_python_build_ignored(
+        py_db, ("Familiar Scenario", "Challenging Scenario")
+    )
+
+    go_dir = tmp_path / "go"
+    go_dir.mkdir()
+    go_db = go_dir / "curator.sqlite3"
+    make_feature_sidecar(go_db)
+    _set_sidecar_ignored_tags(go_db, "Familiar Scenario,Challenging Scenario")
+    go_version, go_artifact = _run_go_build(binary, go_db)
+
+    assert go_version == py_version
+    assert go_artifact.name == py_artifact.name
+    assert artifact_tolerant_diff(go_artifact, py_artifact) == ""
+
+    # The ignored tags ('good' -> "Familiar Scenario", 'bad' -> "Challenging
+    # Scenario") must not produce content entity_feature rows.
+    for path in (py_artifact, go_artifact):
+        connection = sqlite3.connect(path)
+        try:
+            rows = connection.execute(
+                """
+                SELECT f.name FROM entity_feature ef
+                JOIN feature_definition f USING(feature_id)
+                WHERE ef.feature_version=? AND f.name IN ('tag:good', 'tag:bad')
+                """,
+                (py_version,),
+            ).fetchall()
+            assert rows == [], path
+        finally:
+            connection.close()
+
+
 def test_feature_build_reuse_parity(binary: Path, tmp_path: Path) -> None:
     """A second build on the same sidecar reuses the published feature on
     both implementations (reuse_count bumps, no new artifact)."""

--- a/tests/core/test_backend_slice3_modelbuild.py
+++ b/tests/core/test_backend_slice3_modelbuild.py
@@ -22,7 +22,10 @@ from curator.core import core_binary
 from curator.model.builder import PreferenceModelBuilder
 from curator.storage import connect_database
 from tests.core.compare import artifact_tolerant_diff
-from tests.core.test_backend_slice3_featurebuild import make_feature_sidecar
+from tests.core.test_backend_slice3_featurebuild import (
+    _set_sidecar_ignored_tags,
+    make_feature_sidecar,
+)
 from tests.model.test_builder import REFERENCE_MS
 
 
@@ -249,6 +252,140 @@ def test_tag_hierarchy_changes_the_model(binary: Path, tmp_path: Path) -> None:
     nested_model, _ = _run_python_build(nested_db)
 
     assert nested_model != flat_model
+
+
+def _run_python_build_with_ignored(sidecar: Path, ignored: tuple[str, ...]) -> tuple[str, Path]:
+    from curator.config import CuratorConfig, FeatureConfig
+    from curator.storage import connect_database
+
+    connection = connect_database(sidecar, attach_artifacts=False)
+    try:
+        result = PreferenceModelBuilder(
+            connection,
+            CuratorConfig(feature=FeatureConfig(ignored_tags=ignored)),
+            clock_ms=lambda: REFERENCE_MS,
+        ).build()
+        model_id = result.model_id
+        basename = connection.execute(
+            "SELECT artifact_basename FROM model_version WHERE model_id=?", (model_id,)
+        ).fetchone()[0]
+    finally:
+        connection.close()
+    return model_id, sidecar.parent / f"{sidecar.stem}-derived" / basename
+
+
+def test_model_build_ignored_tags_parity(binary: Path, tmp_path: Path) -> None:
+    """Issue #190: with ignored_tags set, both implementations produce the
+    same model_id and an identical artifact, and the ignored tag produces no
+    content feature in the feature artifact that fed the build."""
+    py_dir = tmp_path / "py"
+    py_dir.mkdir()
+    py_db = py_dir / "curator.sqlite3"
+    make_feature_sidecar(py_db)
+    _set_sidecar_ignored_tags(py_db, "Familiar Scenario,Challenging Scenario")
+    py_model, py_artifact = _run_python_build_with_ignored(
+        py_db, ("Familiar Scenario", "Challenging Scenario")
+    )
+
+    go_dir = tmp_path / "go"
+    go_dir.mkdir()
+    go_db = go_dir / "curator.sqlite3"
+    make_feature_sidecar(go_db)
+    _set_sidecar_ignored_tags(go_db, "Familiar Scenario,Challenging Scenario")
+    go_model, go_artifact = _run_go_build(binary, go_db)
+
+    assert go_model == py_model
+    assert artifact_tolerant_diff(go_artifact, py_artifact) == "", (
+        f"artifact content differs: {artifact_tolerant_diff(go_artifact, py_artifact)}"
+    )
+    assert _artifact_schema_diff(go_artifact, py_artifact) == ""
+
+    # The ignored tags must not appear as content affinities in either model
+    # artifact. feature_id embeds the feature name hash; match via the feature
+    # definition rows in the feature artifact that the build consumed.
+    for name, sidecar in (("python", py_db), ("go", go_db)):
+        connection = sqlite3.connect(sidecar)
+        try:
+            feature_version = connection.execute(
+                "SELECT feature_version FROM model_version WHERE model_id=?", (py_model,)
+            ).fetchone()[0]
+        finally:
+            connection.close()
+        derived = sidecar.parent / f"{sidecar.stem}-derived"
+        feature_artifact = next(derived.glob(f"feature-{feature_version}.sqlite3"))
+        connection = sqlite3.connect(feature_artifact)
+        try:
+            rows = connection.execute(
+                """
+                SELECT f.name FROM entity_feature ef
+                JOIN feature_definition f USING(feature_id)
+                WHERE ef.feature_version=? AND f.name IN ('tag:good', 'tag:bad')
+                """,
+                (feature_version,),
+            ).fetchall()
+            assert rows == [], name
+        finally:
+            connection.close()
+
+
+def _seed_implicit_skip_impression(sidecar: Path) -> None:
+    """Add an impression with an observed playback at position 2, so the model
+    build emits implicit-skip virtual pairs (winner + earlier-position losers)."""
+    connection = sqlite3.connect(sidecar)
+    try:
+        connection.execute(
+            """
+            INSERT INTO impression(impression_id, requested_at_ms, lane, config_version)
+            VALUES ('imp-146', 1, 'for_you', 'builtin')
+            """
+        )
+        connection.executemany(
+            """
+            INSERT INTO impression_item(impression_id, scene_id, position, policy_score,
+                reason_snapshot_json) VALUES (?, ?, ?, ?, '[]')
+            """,
+            (
+                ("imp-146", "old-good", 0, 0.9),
+                ("imp-146", "recent-good", 1, 0.8),
+                ("imp-146", "unseen-good", 2, 0.3),
+            ),
+        )
+        connection.execute(
+            """
+            INSERT INTO play_session(session_id, scene_id, started_at_ms, ended_at_ms,
+                active_seconds, provenance, confidence, impression_id, summary_json)
+            VALUES ('ps-146', 'unseen-good', 100, 200, 10.0, 'direct_player', 1,
+                    'imp-146', '{}')
+            """
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def test_model_build_implicit_skip_parity(binary: Path, tmp_path: Path) -> None:
+    """Issue #146 Channel A: with an observed playback at position 2 in an
+    impression, both implementations emit the same implicit-skip virtual pairs
+    and produce the same model_id and an identical artifact."""
+    py_dir = tmp_path / "py"
+    py_dir.mkdir()
+    py_db = py_dir / "curator.sqlite3"
+    make_feature_sidecar(py_db)
+    _seed_implicit_skip_impression(py_db)
+    py_model, py_artifact = _run_python_build(py_db)
+
+    go_dir = tmp_path / "go"
+    go_dir.mkdir()
+    go_db = go_dir / "curator.sqlite3"
+    make_feature_sidecar(go_db)
+    _seed_implicit_skip_impression(go_db)
+    go_model, go_artifact = _run_go_build(binary, go_db)
+
+    assert go_model == py_model
+    assert artifact_tolerant_diff(go_artifact, py_artifact) == "", (
+        f"artifact content differs: {artifact_tolerant_diff(go_artifact, py_artifact)}"
+    )
+    assert _artifact_schema_diff(go_artifact, py_artifact) == ""
 
 
 def test_model_build_artifact_parity(binary: Path, tmp_path: Path) -> None:

--- a/tests/features/test_builder.py
+++ b/tests/features/test_builder.py
@@ -1,7 +1,7 @@
 import sqlite3
 from pathlib import Path
 
-from curator.config import CuratorConfig
+from curator.config import CuratorConfig, FeatureConfig
 from curator.features import FeatureBuilder, FeatureStore
 from curator.storage import MigrationRunner, connect_database
 
@@ -197,6 +197,49 @@ def test_feature_build_is_deterministic_versioned_and_explainable(tmp_path: Path
         profiles["performer-1"].blocks
     )
     assert profiles["performer-2"].blocks.get("measurements") is None
+
+
+def test_ignored_tags_exclude_scene_tags_from_features(tmp_path: Path) -> None:
+    """Issue #190: a tag whose exact name is in FeatureConfig.ignored_tags is
+    dropped before feature construction, so it produces no entity_feature rows
+    and no content vector entry. Exact-name match only — a bracketed tag not
+    in the list still resolves via the existing role rules."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    config = CuratorConfig(feature=FeatureConfig(ignored_tags=("Specific Scenario",)))
+    builder = FeatureBuilder(
+        connection,
+        config,
+        clock_ms=lambda: 100,
+        progress=lambda processed, total: None,
+    )
+    result = builder.build()
+    vectors = FeatureStore(connection).scene_content_vectors(result.feature_version)
+    # scene-1 carries tag 'content' (name "Specific Scenario") and 'admin'
+    # (bracketed, so never content anyway). With 'content' ignored, scene-1 has
+    # no content tags; its parent "Scenario" only appears where a scene tags it
+    # directly (scene-2).
+    assert "tag:content" not in vectors.get("scene-1", {})
+    assert "tag:parent" not in vectors.get("scene-1", {})
+    assert "tag:parent" in vectors["scene-2"]
+    # The ignored tag must not have produced any entity_feature rows.
+    scene_features = FeatureStore(connection).entity_features(result.feature_version, "scene")
+    for features in scene_features.values():
+        for feature in features:
+            if feature.family == "content":
+                assert feature.metadata.get("tag_id") != "content"
+
+
+def test_ignored_tags_match_exact_name_only(tmp_path: Path) -> None:
+    """A partial / substring name does not match: only an exact name in the
+    list excludes the tag."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    config = CuratorConfig(feature=FeatureConfig(ignored_tags=("Scenario",)))
+    builder = FeatureBuilder(connection, config, clock_ms=lambda: 100)
+    result = builder.build()
+    vectors = FeatureStore(connection).scene_content_vectors(result.feature_version)
+    # "Scenario" is the parent tag's name, not the 'content' tag's name
+    # ("Specific Scenario"), so 'content' is still a content feature on scene-1.
+    assert "tag:content" in vectors["scene-1"]
 
 
 def test_only_feature_source_changes_publish_new_version(tmp_path: Path) -> None:

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -1042,9 +1042,7 @@ def test_implicit_skip_confirmation_adds_no_surprise(tmp_path: Path) -> None:
     events = builder._implicit_skip_events()
     assert len(events) == 1
     # winner 0.9 > loser 0.3 -> surprise = max(0, 0.3 - 0.9) = 0.
-    assert events[0].confidence == pytest.approx(
-        DEFAULT_CONFIG.model.implicit_skip_confidence
-    )
+    assert events[0].confidence == pytest.approx(DEFAULT_CONFIG.model.implicit_skip_confidence)
 
 
 def test_implicit_skip_raw_click_never_emits_pairs(tmp_path: Path) -> None:

--- a/tests/model/test_builder.py
+++ b/tests/model/test_builder.py
@@ -955,6 +955,131 @@ def test_scoring_fingerprint_invalidates_published_artifact(
     assert second.feature_version == first.feature_version
 
 
+def test_implicit_skip_events_emit_virtual_pairs(tmp_path: Path) -> None:
+    """Issue #146 Channel A: a play at position P in an impression makes every
+    earlier-position card a loser and the played card the winner. Confidence
+    uses the stored policy_score gap (contradiction > 0, confirmation ~ 0) with
+    the implicit base (half the deliberate-pick base)."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    connection.execute(
+        """
+        INSERT INTO impression(impression_id, requested_at_ms, lane, config_version)
+        VALUES ('imp-1', 1, 'for_you', 'builtin')
+        """
+    )
+    connection.executemany(
+        """
+        INSERT INTO impression_item(impression_id, scene_id, position, policy_score,
+            reason_snapshot_json) VALUES (?, ?, ?, ?, '[]')
+        """,
+        (
+            ("imp-1", "old-good", 0, 0.9),
+            ("imp-1", "recent-good", 1, 0.8),
+            ("imp-1", "unseen-good", 2, 0.3),
+            ("imp-1", "disliked", 3, 0.5),
+        ),
+    )
+    # Play 'unseen-good' (position 2) with observed playback, linked to imp-1.
+    connection.execute(
+        """
+        INSERT INTO play_session(session_id, scene_id, started_at_ms, ended_at_ms,
+            active_seconds, provenance, confidence, impression_id, summary_json)
+        VALUES ('ps-1', 'unseen-good', 100, 200, 10.0, 'direct_player', 1, 'imp-1', '{}')
+        """
+    )
+    builder = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS)
+    events = builder._implicit_skip_events()
+    # Winner at position 2 -> positions 0 and 1 are losers; position 3 is after.
+    assert sorted((e.winner_scene, e.loser_scene) for e in events) == [
+        ("unseen-good", "old-good"),
+        ("unseen-good", "recent-good"),
+    ]
+    by_loser = {e.loser_scene: e.confidence for e in events}
+    # old-good scored 0.9 vs winner 0.3 -> surprise 0.6; recent-good 0.8 -> 0.5.
+    assert by_loser["old-good"] == pytest.approx(
+        DEFAULT_CONFIG.model.implicit_skip_confidence
+        * (1 + DEFAULT_CONFIG.model.implicit_skip_surprise_bonus * 0.6)
+    )
+    assert by_loser["recent-good"] == pytest.approx(
+        DEFAULT_CONFIG.model.implicit_skip_confidence
+        * (1 + DEFAULT_CONFIG.model.implicit_skip_surprise_bonus * 0.5)
+    )
+    # Implicit signal never outranks explicit: the base is half the deliberate
+    # pick base, so at equal surprise implicit confidence stays below explicit.
+    assert DEFAULT_CONFIG.model.implicit_skip_confidence < (
+        DEFAULT_CONFIG.model.curation_pair_confidence
+    )
+
+
+def test_implicit_skip_confirmation_adds_no_surprise(tmp_path: Path) -> None:
+    """A confirmation (winner scored higher than the loser) yields surprise 0,
+    so the confidence is just the implicit base — no surprise bonus."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    connection.execute(
+        """
+        INSERT INTO impression(impression_id, requested_at_ms, lane, config_version)
+        VALUES ('imp-1', 1, 'for_you', 'builtin')
+        """
+    )
+    connection.executemany(
+        """
+        INSERT INTO impression_item(impression_id, scene_id, position, policy_score,
+            reason_snapshot_json) VALUES (?, ?, ?, ?, '[]')
+        """,
+        (
+            ("imp-1", "old-good", 0, 0.3),
+            ("imp-1", "unseen-good", 1, 0.9),
+        ),
+    )
+    connection.execute(
+        """
+        INSERT INTO play_session(session_id, scene_id, started_at_ms, ended_at_ms,
+            active_seconds, provenance, confidence, impression_id, summary_json)
+        VALUES ('ps-1', 'unseen-good', 100, 200, 10.0, 'direct_player', 1, 'imp-1', '{}')
+        """
+    )
+    builder = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS)
+    events = builder._implicit_skip_events()
+    assert len(events) == 1
+    # winner 0.9 > loser 0.3 -> surprise = max(0, 0.3 - 0.9) = 0.
+    assert events[0].confidence == pytest.approx(
+        DEFAULT_CONFIG.model.implicit_skip_confidence
+    )
+
+
+def test_implicit_skip_raw_click_never_emits_pairs(tmp_path: Path) -> None:
+    """A raw click (no observed playback, no thumb_up) never emits implicit
+    skip pairs; only played (observed) or thumbed scenes trigger them."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    connection.execute(
+        """
+        INSERT INTO impression(impression_id, requested_at_ms, lane, config_version)
+        VALUES ('imp-1', 1, 'for_you', 'builtin')
+        """
+    )
+    connection.executemany(
+        """
+        INSERT INTO impression_item(impression_id, scene_id, position, policy_score,
+            reason_snapshot_json) VALUES (?, ?, ?, ?, '[]')
+        """,
+        (
+            ("imp-1", "old-good", 0, 0.9),
+            ("imp-1", "unseen-good", 1, 0.8),
+        ),
+    )
+    # A session with no observed playback is just a click — no signal.
+    connection.execute(
+        """
+        INSERT INTO play_session(session_id, scene_id, started_at_ms, ended_at_ms,
+            active_seconds, provenance, confidence, impression_id, summary_json)
+        VALUES ('ps-1', 'unseen-good', 100, 101, 0.0, 'direct_player', 1, 'imp-1',
+                '{"played_ranges": [], "maximum_position_seconds": 0, "start_position_seconds": 0}')
+        """
+    )
+    builder = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS)
+    assert builder._implicit_skip_events() == []
+
+
 def test_playback_change_reuses_features_but_rebuilds_model(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     first = PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()


### PR DESCRIPTION
# Wave 2 — Issue 190 (ignored tags) then Issue 146 (implicit negatives)

ONE agent does both, sequentially: #190 first (feature-build exclusion), then #146 (builds on the feature/affinity pipeline). You own every file you touch; wave 1 agents (modelbuild sanity check, writes.go sessions, stash-curator.js settings) are finishing — DO NOT edit core/modelbuild.go's affinity-check area, core/writes.go, curator/events/repository.py, curator/interactions.py, or plugin/stash-curator.js's SETTINGS_FIELD_GROUPS/panel beyond the single new field for #190 until they're done (check `hub` list for running agents; if they're still going, coordinate via `hub send`).

Read docs/handover.md and docs/workpackage-pairwise-picks.md first (the pair machinery #146 reuses).

---

## PART 1 — Issue 190: settings list of tags to exclude from tag analysis

Read the full issue: issue://mrx-31415/stash-curator/190

### Change
1. New setting `ignoredTags` in plugin/stash-curator.yml (STRING, displayName "Ignored tags", description: comma-separated names of tags excluded from tag analysis — auto-generated/metadata tags like [Timestamp: Synced] that do not describe the scene; exact-name match, empty by default). Add it to SETTINGS_FIELD_GROUPS in plugin/stash-curator.js (a new "Tag analysis" group or under an existing group — follow the 1:1 settings convention, issue 188).
2. Mirror the config key into curator_config as ignored_tags (plugin/backend.py _apply_plugin_settings convention) so the build config reads it.
3. Apply at feature construction: in core/featurebuild.go AND the oracle curator/model/builder.py feature construction, skip scene tags whose name is in the ignore set when building entity features. This removes them from affinity accumulation, lanes/facets, and (via no-feature rows) the Taste Profile. Exact-name match only — no bracket heuristics (the issue says bracketing is unreliable).
4. Config-backed so the model-config fingerprint guards it (follow the ModelConfig/Go modelSubConfig pattern used by other model-affecting settings).

### Acceptance
- A tag named in ignoredTags produces no entity_feature/affinity rows in a synthetic build; Go and Python build outputs byte/float-identical.
- Setting is editable in Manage → Settings and persists.
- `cd core && go build ./... && go vet ./... && go test ./...`; targeted pytest differential tests pass.

---

## PART 2 — Issue 146: implicit negatives from impressions

Read the full issue: issue://mrx-31415/stash-curator/146 (the merged two-channel spec).

### Scope decision (coordinator-approved)
- **Channel A (pairwise skips) — implement fully.** Build-time conversion pass: read impressions + played/thumbed feedback (feedback.impression_id links to impression rows; impression_item carries position + policy_score). For a played/thumbed scene in impression I, emit virtual pair labels: chosen = winner (+1), each EARLIER-position item in I = loser (−1), through the existing _pair_events winner/loser machinery (curator/model/builder.py:901) and its Go mirror. Surprise weighting: surprise = max(0, pred_loser − pred_winner) with pred = stored policy_score (the model's prediction at display time); confirmation adds ≈0. Position cap: compare only earlier positions, cap the comparison distance at a named constant (pick 10 positions; document). Confidence: separate constants (e.g. implicit_skip_confidence base BELOW the deliberate curation-pair constants 0.5), implicit signal never outranks explicit feedback — assert in tests. Trigger: played or thumbed only, never raw clicks.
- **Channel B (shown-never-played) — deliver the measurement tooling ONLY, do not wire into the build.** The issue's pre-condition gate says measure first: do skipped scenes differ measurably from never-shown ones? Implement a query/report (e.g. a diagnostics function or test utility — follow existing report conventions; it reads impression/impression_item/play data and compares the distributions) plus a synthetic test that exercises it. The real measurement runs on the user's live instance; leave a clear "run this to satisfy the pre-condition" note in the report docstring/README of the tool.

### Acceptance
- Conversion pass emits virtual pairs with surprise + position-cap weighting (synthetic test: play at position 3 → positions 0-2 are losers; confirmation pair ≈ zero confidence).
- Constants separate from deliberate-pick constants; test asserts implicit confidence < explicit.
- Played/thumbed-only trigger (a raw click never emits pairs).
- Go/Python differential identical for the new labels; model-build differential stays green.
- Channel B measurement tool works on synthetic data (returns a comparison), not wired into the model build.

## Report
Files changed per part; constants chosen (names + values); test names + results; what remains for live verification.