### PR TITLE
ci: run integration tests concurrently and cache Playwright browsers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,11 +63,6 @@ jobs:
         with:
           go-version: "1.26"
           cache-dependency-path: core/go.sum
-      - name: Vet and test
-        working-directory: core
-        run: |
-          go vet ./...
-          go test ./...
       - name: Install uv and Python
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
@@ -82,7 +77,6 @@ jobs:
   integration:
     name: Integration (Playwright)
     runs-on: ubuntu-latest
-    needs: quality
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -113,10 +107,17 @@ jobs:
             build-${{ runner.os }}-
       - name: Install dependencies
         run: uv sync --locked --group integration
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          # Playwright is pinned in uv.lock (1.62.0); an exact-hash key means the
+          # browser download is skipped on cache hit and busted only when the lock
+          # actually changes. No loose restore-key: a mismatched browser version
+          # would force a re-download anyway.
+          key: playwright-${{ runner.os }}-${{ hashFiles('uv.lock') }}
       - name: Install Playwright browsers
         run: uv run playwright install chromium --with-deps
-      - name: Build plugin
-        run: uv run --frozen python scripts/build_plugin.py
       - name: Run integration tests
         run: scripts/verify integration
       - uses: actions/upload-artifact@v7


### PR DESCRIPTION
## What

Speed up CI by getting the integration job off the `quality` job's critical path and cutting its fixed overhead.

- **Drop `needs: quality` on `integration`.** The job consumes none of `quality`'s output — it does its own checkout, toolchain setup, dependency install, and plugin build (`scripts/verify integration` builds the zip itself). So `needs: quality` only serialized the two: the workflow now waits for the slower of {quality, core, integration} instead of quality + integration in series.
- **Cache Playwright's Chromium.** New `Cache Playwright browsers` step keyed on `~/.cache/ms-playwright` + `hashFiles('uv.lock')` (Playwright is pinned, 1.62.0). Skips the ~150MB browser download on cache hit.
- **Drop the redundant `Build plugin` step.** `scripts/verify integration` builds the archive as its first action.
- **Drop the duplicate `Vet and test` step in the `core` job.** `scripts/verify core` -> `core_build_and_check` already runs `go vet ./...` and `go test ./...`.

## Verification

- `ci.yml` parses (PyYAML `safe_load`); `integration` reports no `needs`.
- `git diff --check` clean.
- Removed steps audited against `scripts/verify` to confirm each check still runs exactly once (not zero).

## Tradeoff

Removing `needs: quality` means a PR whose `quality` job fails fast also burns the integration job (~5–9 min, Docker Stash + plugin build) before CI reports failure. This is the accepted cost of the speedup; a `concurrency` `cancel-in-progress: true` group would recoup most of it on re-pushed PRs but is not included here (single-run neutral, and it is its own behavioral choice).

Optional follow-ups intentionally not included: `pytest-xdist` for the Playwright suite (shared-Stash across concurrent browsers is flaky) and collapsing the separate `core` job (its `tests/core` differential gate already runs under `quality`'s `verify full`).
