### PR TITLE
fix(plugin): preserve plugins.settings map on single-field saves

### DIFF
--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -4486,7 +4486,10 @@
       setSavingKeys((current) => new Set(current).add(field.key));
       setFieldErrors((current) => ({ ...current, [field.key]: "" }));
       try {
-        await configurePlugin({ [field.key]: value });
+        // Stash's configurePlugin REPLACES the stored plugins.settings map
+        // (config.go's set() deletes before writing), so a single-key payload
+        // would wipe every other setting. Send the full map we already hold.
+        await configurePlugin({ ...raw, [field.key]: value });
         if (field.configKey) {
           const data = await operation({ operation: "get_config" });
           cachedConfigUpdatedAtMs = data.updated_at_ms;
@@ -4838,7 +4841,10 @@
       setDiversitySaving(true);
       setError("");
       try {
-        await configurePlugin({ diversityDisabled: !nextEnabled });
+        // Same replace-semantics guard as saveField: spread the stored map so
+        // toggling variety cannot erase the other plugins.settings keys.
+        const raw = await getPluginSettings();
+        await configurePlugin({ ...raw, diversityDisabled: !nextEnabled });
         const data = await operation({ operation: "get_config" });
         clearSlateCache();
         cachedConfigUpdatedAtMs = data.updated_at_ms;

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -692,7 +692,11 @@ def test_recommendation_variety_toggle_updates_native_setting_and_cache() -> Non
     source = (Path(__file__).parents[2] / "plugin" / "stash-curator.js").read_text(encoding="utf-8")
 
     assert 'configurePlugin(plugin_id: "stash-curator", input: $input)' in source
-    assert "await configurePlugin({ diversityDisabled: !nextEnabled });" in source
+    # The toggle must spread the stored map: Stash's configurePlugin replaces
+    # the whole plugins.settings entry, so a single-key payload would wipe
+    # every other setting the panel had saved.
+    assert "const raw = await getPluginSettings();" in source
+    assert "await configurePlugin({ ...raw, diversityDisabled: !nextEnabled });" in source
     assert "configUpdatedAtMs: cachedConfigUpdatedAtMs" in source
     assert "laneByValue.has(lane) && diversityEnabled !== null" in source
     assert '"aria-pressed": diversityEnabled' in source
@@ -739,10 +743,10 @@ def test_settings_panel_reads_and_saves_every_configured_field() -> None:
     )
     assert 'payload.data.configuration.plugins["stash-curator"] || {}' in source
 
-    # One configurePlugin call per field, on change, matching the
-    # toggleDiversity precedent this panel reuses for the diversity toggle
-    # instead of re-implementing its cache-busting side effects.
-    assert "await configurePlugin({ [field.key]: value });" in source
+    # One configurePlugin call per field, on change — spreading the stored
+    # map so a single-field save cannot wipe the other settings (Stash's
+    # ConfigurePlugin replaces the entire plugins.settings entry).
+    assert "await configurePlugin({ ...raw, [field.key]: value });" in source
 
     # Every setting the issue calls out as in scope for v1 is represented,
     # with the config-backed ones mapped to their curator_config key and the


### PR DESCRIPTION
## What

Settings saved from Curator's **Manage → Settings** panel — and the recommendation-variety toggle on Curate — called Stash's `configurePlugin` mutation with a **single-key payload** (`{ key: value }`). Stash's `ConfigurePlugin` **replaces the entire** `plugins.settings.<plugin_id>` **map** (its `config.set` deletes the key before writing), so every save wiped every other stored setting.

The loss was partly masked: Curator's sidecar mirror merges rather than replaces, so mirrored fields kept showing their old values in Curator's own panel, while Stash's native plugin-settings page — and every non-mirrored field (Whisparr, storage, profiling) — fell back to defaults. Installing a new build (local or from the index) was the moment the wipe became visible.

## Fix

Both save paths now spread the currently stored map before applying the change, matching how Stash's own settings UI saves:

- `saveField` → `configurePlugin({ ...raw, [field.key]: value })`, where `raw` is the full map already loaded via `getPluginSettings()`
- variety toggle → fetches the current settings, then `configurePlugin({ ...raw, diversityDisabled: ... })`

## Verification

- Reproduced against a real Stash (v0.31.1): a single-key `configurePlugin` left only that key in the stored map; the spread payload preserved the full map.
- `scripts/verify changed` green: compiled-core build + vet/test, differential gate (232 passed), `node --check`, `git diff --check`.