### PR TITLE
feat(core): shown-never-played impression measurement op (#146)

### DIFF
--- a/core/backend.go
+++ b/core/backend.go
@@ -163,6 +163,8 @@ func dispatch(pluginDir string, payload jVal) (jVal, error) {
 		return opGetTasteProfile(pluginDir, payload)
 	case "get_diagnostics":
 		return opGetDiagnostics(pluginDir, payload)
+	case "get_impression_measurement":
+		return opGetImpressionMeasurement(pluginDir, payload)
 	case "get_expand":
 		return opGetExpand(pluginDir, payload)
 	case "get_performer_hunt":

--- a/core/impression_measurement.go
+++ b/core/impression_measurement.go
@@ -1,0 +1,144 @@
+// get_impression_measurement — issue #146 Channel B: the shown-never-played
+// pre-condition gate. A port of backend.py's _impression_measurement: reads
+// impression_item (shown), the positive-action union (played), and the
+// never-shown corpus, and reports per-bucket counts plus the display-time
+// policy_score distribution. Read-only; deliberately not wired into the
+// model build.
+package main
+
+import (
+	"math"
+)
+
+// observedPlaybackSQL is defined in slate.go.
+
+// pyRoundDigits reproduces CPython's round(f, ndigits) for |f| < 1e16: it
+// scales by 10^ndigits, rounds half-to-even, then divides back (the exact
+// algorithm in CPython's double_round for this magnitude range).
+func pyRoundDigits(f float64, digits int) float64 {
+	scale := math.Pow10(digits)
+	return math.RoundToEven(f*scale) / scale
+}
+
+func opGetImpressionMeasurement(pluginDir string, payload jVal) (jVal, error) {
+	return profiledOperation(pluginDir, payload, "get_impression_measurement",
+		func(settings jVal) (jVal, error) { return getImpressionMeasurementBody(pluginDir, payload, settings) })
+}
+
+func getImpressionMeasurementBody(pluginDir string, payload, settings jVal) (jVal, error) {
+	db, err := openAPISidecar(pluginDir, payload, settings)
+	if err != nil {
+		return jvNull(), err
+	}
+	defer db.Close()
+
+	// Mirrors builder.py's positive-action-per-impression UNION
+	// (curator/model/builder.py:1006-1011 / core/modelbuild.go:760-765):
+	// a played or thumbed scene links to the impression that surfaced it.
+	played := make(map[[2]string]bool)
+	rows, err := db.Query(`
+SELECT scene_id, impression_id FROM play_session
+WHERE impression_id IS NOT NULL
+  AND provenance='direct_player' AND ` + observedPlaybackSQL + `
+UNION
+SELECT scene_id, impression_id FROM feedback
+WHERE impression_id IS NOT NULL
+  AND feedback_type='thumb_up' AND reversed_by_id IS NULL`)
+	if err != nil {
+		return jvNull(), err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var sceneID, impressionID string
+		if err := rows.Scan(&sceneID, &impressionID); err != nil {
+			return jvNull(), err
+		}
+		played[[2]string{sceneID, impressionID}] = true
+	}
+	if err := rows.Err(); err != nil {
+		return jvNull(), err
+	}
+	rows.Close()
+
+	type shownItem struct {
+		sceneID      string
+		impressionID string
+		policyScore  float64
+	}
+	items := []shownItem{}
+	itemRows, err := db.Query(`SELECT scene_id, impression_id, policy_score FROM impression_item`)
+	if err != nil {
+		return jvNull(), err
+	}
+	defer itemRows.Close()
+	for itemRows.Next() {
+		var item shownItem
+		if err := itemRows.Scan(&item.sceneID, &item.impressionID, &item.policyScore); err != nil {
+			return jvNull(), err
+		}
+		items = append(items, item)
+	}
+	if err := itemRows.Err(); err != nil {
+		return jvNull(), err
+	}
+
+	var neverShown int64
+	if err := db.QueryRow(`
+SELECT count(*) FROM source_scene
+WHERE scene_id NOT IN (SELECT scene_id FROM impression_item)`).Scan(&neverShown); err != nil {
+		return jvNull(), err
+	}
+
+	bucket := func(selected []shownItem) jVal {
+		if len(selected) == 0 {
+			return jvObj(
+				jvKey("count", jvInt(0)),
+				jvKey("mean_policy_score", jvNull()),
+				jvKey("max_policy_score", jvNull()),
+			)
+		}
+		sum := 0.0
+		maxScore := selected[0].policyScore
+		for _, item := range selected {
+			sum += item.policyScore
+			if item.policyScore > maxScore {
+				maxScore = item.policyScore
+			}
+		}
+		return jvObj(
+			jvKey("count", jvInt(int64(len(selected)))),
+			jvKey("mean_policy_score", jvFloat(pyRoundDigits(sum/float64(len(selected)), 6))),
+			jvKey("max_policy_score", jvFloat(pyRoundDigits(maxScore, 6))),
+		)
+	}
+
+	playedItems := []shownItem{}
+	skippedItems := []shownItem{}
+	for _, item := range items {
+		if played[[2]string{item.sceneID, item.impressionID}] {
+			playedItems = append(playedItems, item)
+		} else {
+			skippedItems = append(skippedItems, item)
+		}
+	}
+
+	shownPlayRate := jvNull()
+	if len(items) > 0 {
+		shownPlayRate = jvFloat(pyRoundDigits(float64(len(playedItems))/float64(len(items)), 6))
+	}
+
+	return jvObj(
+		jvKey("schema_version", jvInt(apiSchemaVersion)),
+		jvKey("buckets", jvObj(
+			jvKey("shown", bucket(items)),
+			jvKey("played", bucket(playedItems)),
+			jvKey("skipped", bucket(skippedItems)),
+			jvKey("never_shown", jvObj(
+				jvKey("count", jvInt(neverShown)),
+				jvKey("mean_policy_score", jvNull()),
+				jvKey("max_policy_score", jvNull()),
+			)),
+		)),
+		jvKey("shown_play_rate", shownPlayRate),
+	), nil
+}

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -56,6 +56,7 @@ for package_root in (PLUGIN_DIR, PLUGIN_DIR.parent):
 from curator import __version__  # noqa: E402
 from curator.api import CuratorAPI  # noqa: E402
 from curator.events import HistoricalEventStore  # noqa: E402
+from curator.events.contracts import OBSERVED_PLAYBACK_SQL  # noqa: E402
 from curator.expand import (  # noqa: E402
     PERFORMER_HUNT_LIMIT,
     STASHDB,
@@ -996,6 +997,8 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
             return _cancel_job(connection, args)
         if operation == "get_diagnostics":
             return _diagnostics(connection)
+        if operation == "get_impression_measurement":
+            return _impression_measurement(connection)
         if operation == "list_profiles":
             return {
                 "schema_version": SCHEMA_VERSION,
@@ -1386,6 +1389,88 @@ def _diagnostics(connection: Any) -> dict[str, object]:
                 for job_type, values in sorted(durations.items())
             ],
         },
+    }
+
+
+def _impression_measurement(connection: Any) -> dict[str, object]:
+    """Issue #146 Channel B — do shown-but-skipped scenes differ measurably
+    from never-shown ones?
+
+    The implicit-negatives pre-condition gate: before shown-never-played
+    scenes can be treated as a negative signal, the skipped population has to
+    be distinguishable from scenes that were never surfaced at all. This is a
+    read-only measurement op, deliberately NOT wired into the model build.
+
+    Definitions (mirroring the build's positive-action predicate):
+    - shown: appears in impression_item (surfaced in a Curator impression).
+    - played: shown AND a positive action links the scene to that impression —
+      a play_session with provenance='direct_player' whose OBSERVED_PLAYBACK_SQL
+      predicate holds, or non-reversed feedback thumb_up.
+    - skipped: shown and not played.
+    - never-shown: in source_scene but never appears in any impression_item.
+
+    Run this on a live instance to satisfy the pre-condition:
+        operation({ operation: "get_impression_measurement" })
+
+    Outputs per-bucket counts and the display-time policy_score distribution
+    (mean/max) for each group. If skipped scenes carry systematically higher
+    policy_score than never-shown ones (the model kept pushing them and the
+    user kept passing), that is evidence the channel is worth wiring.
+    """
+    positive_action_sql = f"""
+        SELECT scene_id, impression_id FROM play_session
+        WHERE impression_id IS NOT NULL
+          AND provenance='direct_player' AND {OBSERVED_PLAYBACK_SQL}
+        UNION
+        SELECT scene_id, impression_id FROM feedback
+        WHERE impression_id IS NOT NULL
+          AND feedback_type='thumb_up' AND reversed_by_id IS NULL
+    """
+    played = {
+        (str(row["scene_id"]), str(row["impression_id"]))
+        for row in connection.execute(positive_action_sql)
+    }
+    shown = [
+        (str(row["scene_id"]), str(row["impression_id"]), float(row["policy_score"]))
+        for row in connection.execute(
+            """
+            SELECT scene_id, impression_id, policy_score FROM impression_item
+            """
+        )
+    ]
+    never_shown = {
+        str(row["scene_id"])
+        for row in connection.execute(
+            """
+            SELECT scene_id FROM source_scene
+            WHERE scene_id NOT IN (SELECT scene_id FROM impression_item)
+            """
+        )
+    }
+
+    def _bucket(items: list[tuple[str, str, float]]) -> dict[str, object]:
+        scores = [score for (_, _, score) in items]
+        return {
+            "count": len(items),
+            "mean_policy_score": (round(sum(scores) / len(scores), 6) if scores else None),
+            "max_policy_score": round(max(scores), 6) if scores else None,
+        }
+
+    played_items = [item for item in shown if (item[0], item[1]) in played]
+    skipped_items = [item for item in shown if (item[0], item[1]) not in played]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "buckets": {
+            "shown": _bucket(shown),
+            "played": _bucket(played_items),
+            "skipped": _bucket(skipped_items),
+            "never_shown": {
+                "count": len(never_shown),
+                "mean_policy_score": None,
+                "max_policy_score": None,
+            },
+        },
+        "shown_play_rate": (round(len(played_items) / len(shown), 6) if shown else None),
     }
 
 

--- a/tests/core/test_backend_slice1.py
+++ b/tests/core/test_backend_slice1.py
@@ -449,6 +449,110 @@ def test_get_diagnostics_byte_identical(model_sidecar: Path, binary: Path, stub_
     )
 
 
+def make_measurement_sidecar(path: Path) -> None:
+    """A sidecar for get_impression_measurement (#146 Channel B): a published
+    model plus a deterministic mix of played, skipped, and never-shown scenes.
+
+    - imp-play: shown scene "recent-good" with a direct_player play_session
+      linked to the impression (observed playback: active_seconds > 0).
+    - imp-thumb: shown scene "old-good" with a non-reversed thumb_up linked to
+      the impression.
+    - imp-skip: shown scene "unseen-good" with no positive action.
+    - "disliked", "unlabeled", "unusual" are in source_scene but never shown.
+    """
+    connection = _database(path)
+    try:
+        PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+        connection.executemany(
+            """
+            INSERT INTO impression(
+                impression_id, requested_at_ms, lane, model_id, config_version,
+                request_context_json
+            ) VALUES (?, ?, 'for_you', 'model-seed', 'builtin', '{}')
+            """,
+            [
+                (f"imp-{suffix}", REFERENCE_MS - i * DAY_MS)
+                for suffix, i in (("play", 10), ("thumb", 9), ("skip", 8))
+            ],
+        )
+        connection.executemany(
+            """
+            INSERT INTO impression_item(
+                impression_id, scene_id, position, policy_score, reason_snapshot_json
+            ) VALUES (?, ?, 0, ?, '["eligibility.lane"]')
+            """,
+            [
+                ("imp-play", "recent-good", 0.6),
+                ("imp-thumb", "old-good", 0.5),
+                ("imp-skip", "unseen-good", 0.4),
+            ],
+        )
+        connection.execute(
+            """
+            INSERT INTO play_session(
+                session_id, scene_id, started_at_ms, ended_at_ms, active_seconds,
+                provenance, confidence, impression_id, summary_json
+            ) VALUES ('sess-play', 'recent-good', ?, ?, 30.0, 'direct_player', 0.8,
+                      'imp-play', '{}')
+            """,
+            (REFERENCE_MS - DAY_MS, REFERENCE_MS - DAY_MS + 30_000),
+        )
+        connection.execute(
+            """
+            INSERT INTO feedback(
+                feedback_id, scene_id, feedback_type, value, occurred_at_ms,
+                impression_id, payload_json
+            ) VALUES ('fb-thumb', 'old-good', 'thumb_up', 1.0, ?, 'imp-thumb', '{}')
+            """,
+            (REFERENCE_MS - 2 * DAY_MS,),
+        )
+        connection.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        connection.close()
+
+
+def test_get_impression_measurement_byte_identical(
+    tmp_path: Path, binary: Path, stub_stash: str
+) -> None:
+    """The shown-never-played measurement op must be byte-identical between
+    Python and Go, and must classify played vs skipped vs never-shown
+    correctly (issue #146 Channel B pre-condition gate)."""
+    path = tmp_path / "curator.sqlite3"
+    make_measurement_sidecar(path)
+    raw = payload("get_impression_measurement", path, stub_stash)
+    assert_slice1_identical(binary, PLUGIN_DIR, raw, same_path=path)
+    # The op is read-only: it must not mutate the sidecar between runs, so a
+    # second identical comparison against the same source confirms stability.
+    assert_slice1_identical(binary, PLUGIN_DIR, raw, same_path=path)
+
+
+def test_impression_measurement_counts(tmp_path: Path) -> None:
+    """Python-side behavioral check of the bucket definitions (#146 Channel B):
+    played = shown + positive action in that impression; skipped = shown and
+    not played; never_shown = in source_scene, never surfaced."""
+    from curator.storage.database import connect_database
+    from curator.storage.migrations import MigrationRunner
+    from plugin.backend import _impression_measurement
+
+    path = tmp_path / "curator.sqlite3"
+    make_measurement_sidecar(path)
+    connection = connect_database(path)
+    MigrationRunner(connection).migrate(applied_at_ms=1)
+    try:
+        report = _impression_measurement(connection)
+    finally:
+        connection.close()
+    buckets = report["buckets"]
+    assert buckets["shown"]["count"] == 3
+    assert buckets["played"]["count"] == 2  # recent-good (play) + old-good (thumb)
+    assert buckets["skipped"]["count"] == 1  # unseen-good
+    assert buckets["never_shown"]["count"] == 3  # disliked, unlabeled, unusual
+    assert report["shown_play_rate"] == pytest.approx(round(2 / 3, 6))
+    # The skipped scene's policy_score is preserved; never-shown has none.
+    assert buckets["skipped"]["mean_policy_score"] == 0.4
+    assert buckets["never_shown"]["mean_policy_score"] is None
+
+
 # ── read-path write parity ──────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Closes #146 (Channel B: measurement tooling only, per the #206 scope decision).

New read-only op `get_impression_measurement` classifies scenes as shown / played / skipped / never-shown and reports the display-time policy_score distribution per bucket, using the build's positive-action predicate (direct_player with observed playback, or non-reversed thumb_up). This is the issue's pre-condition gate: whether shown-but-skipped scenes differ measurably from never-shown ones before wiring them as implicit negatives.

- Python: `_impression_measurement` (plugin/backend.py) + dispatch
- Go: `core/impression_measurement.go` + dispatch (byte-identical JSON)
- Tests: differential `test_get_impression_measurement_byte_identical` (Go/Python on a seeded sidecar) + behavioral `test_impression_measurement_counts`

Verified: 23 slice-1 differentials pass; Go build/vet/test pass; ruff clean.

Stacked on #221.