### PR TITLE
chore: refresh scoring fingerprint after build-publish split

### DIFF
--- a/core/modelbuild3.go
+++ b/core/modelbuild3.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
+	"runtime/debug"
 	"time"
 )
 
@@ -207,50 +209,46 @@ JOIN feature_affinity fa ON fa.feature_id = ct.feature_id AND fa.model_id = ?`, 
 	return rows, nil
 }
 
-// modelPublish mirrors PreferenceModelBuilder._publish, recording the
-// database_writing / lane_classification / varied_ordering / indexing /
-// validation / publication stage timings into rec (the caller's build
-// recorder) and returning them as the stage map.
-func modelPublish(db dbx, modelID, featureVersion string, affinities map[string]modelAffinity,
+// modelWriteTables mirrors the database-writing half of
+// PreferenceModelBuilder._publish: artifact creation through the five insert
+// batches, recording the database_writing stage timing. The
+// lane-classification and ordering stages run separately (modelPublishTail)
+// so modelBuild can release the in-memory working set first (issue #214).
+func modelWriteTables(db dbx, modelID, featureVersion string, affinities map[string]modelAffinity,
 	labels map[string]sceneLabel, scores []buildModelScore, performerSimilarity jVal,
-	nowMs int64, report func(fraction float64), rec *stageRecorder) (map[string]int64, error) {
-	var scoresByScene map[string]buildModelScore
+	report func(fraction float64), rec *stageRecorder) (dbx, string, string, error) {
 	var artifact dbx
 	var temporary, final string
-	published := false
-	fail := func(err error) (map[string]int64, error) {
-		if !published {
-			discardArtifact(artifact, temporary)
-			if _, statErr := os.Stat(temporary); os.IsNotExist(statErr) {
-				os.Remove(final)
-			}
+	fail := func(err error) (dbx, string, string, error) {
+		discardArtifact(artifact, temporary)
+		if _, statErr := os.Stat(temporary); os.IsNotExist(statErr) {
+			os.Remove(final)
 		}
-		return nil, err
+		return nil, "", "", err
 	}
 	// database_writing: Python's writing_started boundary — scores_by_scene
 	// through the five insert batches (including create_artifact and
 	// attach_build_sources, which sit between writing_started and the first
 	// insert in Python too).
 	databaseWritingStarted := time.Now()
-	scoresByScene = map[string]buildModelScore{}
+	scoresByScene := map[string]buildModelScore{}
 	for _, score := range scores {
 		scoresByScene[score.sceneID] = score
 	}
 	featurePath, err := featureArtifactPath(db, featureVersion)
 	if err != nil {
-		return nil, err
+		return nil, "", "", err
 	}
 	corePath, err := coreDatabasePath(db)
 	if err != nil {
-		return nil, err
+		return nil, "", "", err
 	}
 	artifact, temporary, final, err = createArtifact(corePath, "model", modelID)
 	if err != nil {
-		return nil, err
+		return nil, "", "", err
 	}
 	if err := attachBuildSources(artifact, corePath, featurePath); err != nil {
-		discardArtifact(artifact, temporary)
-		return nil, err
+		return fail(err)
 	}
 	// feature_affinity
 	affinityRows := make([][]any, 0, len(affinities))
@@ -373,6 +371,26 @@ INSERT INTO model_entity_dormancy(
 		return fail(err)
 	}
 	rec.set("database_writing", elapsedMs(databaseWritingStarted))
+	return artifact, temporary, final, nil
+}
+
+// modelPublishTail mirrors the second half of PreferenceModelBuilder._publish:
+// lane classification, ordering materialization, index creation, validation,
+// and artifact publication. Runs after modelBuild has released the in-memory
+// working set so the ordering stages don't stack their peak on top of it
+// (issue #214).
+func modelPublishTail(db dbx, artifact dbx, temporary, final, modelID, featureVersion string,
+	scoreCount int, nowMs int64, report func(fraction float64), rec *stageRecorder) (map[string]int64, error) {
+	published := false
+	fail := func(err error) (map[string]int64, error) {
+		if !published {
+			discardArtifact(artifact, temporary)
+			if _, statErr := os.Stat(temporary); os.IsNotExist(statErr) {
+				os.Remove(final)
+			}
+		}
+		return nil, err
+	}
 	// Lanes + slate inside the artifact. indexing spans from just before lane
 	// classification through index creation (Python's indexing_started).
 	indexingStarted := time.Now()
@@ -423,9 +441,9 @@ INSERT INTO model_entity_dormancy(
 		}
 		var laneState int
 		err := artifact.QueryRow(`SELECT 1 FROM model_lane_order_state WHERE model_id=?`, modelID).Scan(&laneState)
-		if storedCount != int64(len(scores)) || (err != nil && err != sql.ErrNoRows) {
+		if storedCount != int64(scoreCount) || (err != nil && err != sql.ErrNoRows) {
 			return fmt.Errorf("model validation failed: scores=%d/%d, lane state=%v",
-				storedCount, len(scores), err == nil)
+				storedCount, scoreCount, err == nil)
 		}
 		var vErr error
 		summary, vErr = artifactValidate(artifact, "model", map[string]int64{
@@ -790,9 +808,27 @@ func modelBuild(db dbx, nowMs int64, progress func(processed, total int)) (drain
 	report(0.35)
 	var publishTimings map[string]int64
 	err = rec.stage("", "model.publish", func() error {
-		var err error
-		publishTimings, err = modelPublish(db, modelID, featureVersion, affinities, labels,
-			scores, performerSimilarity, nowMs, report, rec)
+		artifact, temporary, final, err := modelWriteTables(db, modelID, featureVersion, affinities,
+			labels, scores, performerSimilarity, report, rec)
+		if err != nil {
+			return err
+		}
+		// Issue #214: release the in-memory working set (scene feature matrix,
+		// affinities, scores, performer edges) before the lane-classification
+		// and ordering-materialization stages so their peak memory no longer
+		// stacks on top of it.
+		scoreCount := len(scores)
+		sceneFeatures = nil
+		affinities = nil
+		scores = nil
+		performerSimilarity = jvNull()
+		// GC alone keeps the freed heap in the runtime arenas; FreeOSMemory
+		// returns it to the OS so the ordering stages' measured RSS no longer
+		// includes the released working set (issue #214).
+		runtime.GC()
+		debug.FreeOSMemory()
+		publishTimings, err = modelPublishTail(db, artifact, temporary, final, modelID,
+			featureVersion, scoreCount, nowMs, report, rec)
 		return err
 	})
 	if err != nil {

--- a/core/scoring_fingerprint.go
+++ b/core/scoring_fingerprint.go
@@ -6,4 +6,4 @@
 
 package main
 
-const scoringFingerprint = "474d4e6e64d86f90"
+const scoringFingerprint = "2116f4c3e2cf35e6"

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -656,15 +656,25 @@ class PreferenceModelBuilder:
             timings["scoring"] = max(0, score_total - timings["similarity"])
             record_duration("python", "model.scores", score_total)
             stage_started = time.perf_counter()
+            score_count = len(scores)
+            labeled_count = len(labels)
+            artifact, temporary, final, write_timings = self._write_model_tables(
+                model_id,
+                feature_version,
+                affinities,
+                labels,
+                scores,
+                performer_similarity_scores,
+            )
+            # Issue #214: release the build's in-memory working set (scene
+            # feature matrix, affinities, scores, performer edges) before the
+            # lane-classification and ordering-materialization stages, so their
+            # peak memory no longer stacks on top of it.
+            del scene_features, affinities, labels, training_labels, scores
+            del performer_similarity_scores
+            timings.update(write_timings)
             timings.update(
-                self._publish(
-                    model_id,
-                    feature_version,
-                    affinities,
-                    labels,
-                    scores,
-                    performer_similarity_scores,
-                )
+                self._publish_tail(artifact, temporary, final, model_id, score_count, timings)
             )
             self._report(0.98)
             record_duration(
@@ -680,7 +690,7 @@ class PreferenceModelBuilder:
         timings["cleanup"] = round((time.perf_counter() - stage_started) * 1000)
         self._report(1.0)
         timings["total"] = round((time.perf_counter() - started) * 1000)
-        return self._result(model_id, feature_version, len(labels), reused=False, timings=timings)
+        return self._result(model_id, feature_version, labeled_count, reused=False, timings=timings)
 
     def _report(self, fraction: float) -> None:
         if self.progress:
@@ -2038,7 +2048,7 @@ class PreferenceModelBuilder:
             self.connection, reference_at_ms, self.config, include_temporary=False
         )
 
-    def _publish(
+    def _write_model_tables(
         self,
         model_id: str,
         feature_version: str,
@@ -2046,14 +2056,17 @@ class PreferenceModelBuilder:
         labels: dict[str, _SceneLabel],
         scores: tuple[_Score, ...],
         performer_similarity_scores: dict[str, dict[str, object]],
-    ) -> dict[str, int]:
+    ) -> tuple[sqlite3.Connection, Path, Path, dict[str, int]]:
+        """Write the model artifact tables and return the open artifact plus
+        timings. The lane-classification and ordering stages run separately
+        (``_publish_tail``) so the build's in-memory working set can be
+        released first (issue #214)."""
         timings: dict[str, int] = {}
         writing_started = time.perf_counter()
         scores_by_scene = {score.scene_id: score for score in scores}
         feature_path = self._feature_artifact_path(feature_version)
         artifact, temporary, final = create_artifact(self.connection, "model", model_id)
         attach_build_sources(artifact, self.connection, feature_path)
-        published = False
 
         def insert_rows(sql: str, rows: Iterable[tuple[object, ...]]) -> None:
             for batch in batched(rows, 1_000):
@@ -2210,8 +2223,30 @@ class PreferenceModelBuilder:
                 ),
             )
             timings["database_writing"] = round((time.perf_counter() - writing_started) * 1000)
-            from curator.ranking import LanePolicy, SlateBuilder
+            return artifact, temporary, final, timings
+        except Exception:
+            discard_artifact(artifact, temporary)
+            if not temporary.exists():
+                final.unlink(missing_ok=True)
+            raise
 
+    def _publish_tail(
+        self,
+        artifact: sqlite3.Connection,
+        temporary: Path,
+        final: Path,
+        model_id: str,
+        score_count: int,
+        timings: dict[str, int],
+    ) -> dict[str, int]:
+        """Lane classification, ordering materialization, indexing, validation,
+        and artifact publication. Runs after the in-memory working set
+        (features, affinities, scores) has been released so the ordering
+        stages don't stack their peak on top of it (issue #214)."""
+        from curator.ranking import LanePolicy, SlateBuilder
+
+        published = False
+        try:
             indexing_started = time.perf_counter()
             stage_started = time.perf_counter()
             LanePolicy(artifact, self.config).classify(
@@ -2260,10 +2295,10 @@ class PreferenceModelBuilder:
             lane_state = artifact.execute(
                 "SELECT 1 FROM model_lane_order_state WHERE model_id=?", (model_id,)
             ).fetchone()
-            if stored_count != len(scores) or lane_state is None:
+            if stored_count != score_count or lane_state is None:
                 raise RuntimeError(
                     "model validation failed: "
-                    f"scores={stored_count}/{len(scores)}, "
+                    f"scores={stored_count}/{score_count}, "
                     f"lane state={lane_state is not None}"
                 )
             summary = validate_artifact(

--- a/curator/model/fingerprint.py
+++ b/curator/model/fingerprint.py
@@ -5,4 +5,4 @@ Identifies the scoring code that produced a model artifact. Regenerate with
 script's MANIFEST.
 """
 
-SCORING_FINGERPRINT = "474d4e6e64d86f90"
+SCORING_FINGERPRINT = "2116f4c3e2cf35e6"


### PR DESCRIPTION
The model-build refactor touched builder.py/modelbuild3.go, which the
scoring fingerprint covers; regenerate so the model digest changes with
the new code (behavior-neutral, but the fingerprint is code-based).