### PR TITLE
fix(rank): make 'Rank in <lane>' relative to the lane's best

### DIFF
--- a/core/slate.go
+++ b/core/slate.go
@@ -413,6 +413,37 @@ func recommend(db dbx, modelID, lane string, count int64, diversityEnabled bool,
 
 func isFinite(f float64) bool { return !math.IsInf(f, 0) && !math.IsNaN(f) }
 
+// laneValueMaxes returns the per-lane max lane_value from model_scene_lane,
+// used to make the displayed "Rank in <lane>" relative to the lane's best
+// (issue #212).
+func laneValueMaxes(db dbx, modelID string) (map[string]float64, error) {
+	rows, err := db.Query(`SELECT lane, MAX(lane_value) FROM model_scene_lane WHERE model_id=? GROUP BY lane`, modelID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := map[string]float64{}
+	for rows.Next() {
+		var lane string
+		var maxValue float64
+		if err := rows.Scan(&lane, &maxValue); err != nil {
+			return nil, err
+		}
+		result[lane] = maxValue
+	}
+	return result, rows.Err()
+}
+
+// rankValue normalizes a lane value against the lane's best so the top of the
+// lane reads 1.00 (issue #212). Lanes without a positive max (including the
+// score_review pseudo-lane) keep their raw value.
+func rankValue(laneValue, laneMax float64) float64 {
+	if laneMax <= 0 {
+		return laneValue
+	}
+	return laneValue / laneMax
+}
+
 // loadMaterializedSlate mirrors SlateBuilder._load_materialized_slate. The
 // second return value is false when the model has no materialized lanes.
 // sceneFilter, when non-nil, additionally gates each row (get_slate's
@@ -514,6 +545,13 @@ func loadMaterializedSlate(db dbx, modelID, lane string, count int64, diversityE
 	if err != nil {
 		return builtSlate{}, false, err
 	}
+	// The displayed "Rank in <lane>" is relative to the lane's best (issue
+	// #212): normalize each item's lane_value by its source lane's max so the
+	// top of every lane reads 1.00.
+	laneMaxes, err := laneValueMaxes(db, modelID)
+	if err != nil {
+		return builtSlate{}, false, err
+	}
 	items := make([]*recommendationItem, 0, len(selectedRows))
 	for position, row := range selectedRows {
 		sceneID := row.sceneID
@@ -561,7 +599,7 @@ func loadMaterializedSlate(db dbx, modelID, lane string, count int64, diversityE
 			appeal:        score.appeal,
 			currentFit:    currentFit,
 			confidence:    score.confidence,
-			laneValue:     classification.laneValue,
+			laneValue:     rankValue(classification.laneValue, laneMaxes[row.sourceLane]),
 			finalUtility:  row.utility - liveCooldown[sceneID],
 			penalties:     penaltiesCopy,
 			bonuses:       bonuses,

--- a/core/slate_greedy.go
+++ b/core/slate_greedy.go
@@ -463,6 +463,12 @@ WHERE provenance='direct_player' GROUP BY scene_id`)
 	if err != nil {
 		return builtSlate{}, err
 	}
+	// The displayed "Rank in <lane>" is relative to the lane's best (issue
+	// #212) — see loadMaterializedSlate.
+	laneMaxes, err := laneValueMaxes(db, modelID)
+	if err != nil {
+		return builtSlate{}, err
+	}
 	items := make([]*recommendationItem, 0, len(selected))
 	items = append(items, prefixItems...)
 	for offset, chosen := range newSelected {
@@ -491,7 +497,7 @@ WHERE provenance='direct_player' GROUP BY scene_id`)
 			appeal:        score.appeal,
 			currentFit:    currentFit,
 			confidence:    score.confidence,
-			laneValue:     chosen.laneValue,
+			laneValue:     rankValue(chosen.laneValue, laneMaxes[chosen.lane]),
 			finalUtility:  util.final,
 			penalties:     util.penalties,
 			bonuses:       util.bonuses,

--- a/curator/ranking/slate.py
+++ b/curator/ranking/slate.py
@@ -99,6 +99,30 @@ def _dormant_entity(classification: LaneClassification) -> str | None:
     return str(entity_id) if entity_id else None
 
 
+def _lane_value_maxes(connection: sqlite3.Connection, model_id: str) -> dict[str, float]:
+    """Per-lane max lane_value from the artifact, used to make the displayed
+    "Rank in <lane>" relative to the lane's best (issue #212)."""
+    return {
+        str(row["lane"]): float(row["max_lane_value"])
+        for row in connection.execute(
+            """
+            SELECT lane, MAX(lane_value) AS max_lane_value
+            FROM model_scene_lane WHERE model_id=? GROUP BY lane
+            """,
+            (model_id,),
+        )
+    }
+
+
+def _rank_value(lane_value: float, lane_max: float | None) -> float:
+    """Normalize a lane value against the lane's best so the top of the lane
+    reads 1.00. Lanes without a positive max (including the score_review
+    pseudo-lane) keep their raw value."""
+    if lane_max is None or lane_max <= 0:
+        return lane_value
+    return lane_value / lane_max
+
+
 @dataclass(frozen=True)
 class _Candidate:
     classification: LaneClassification
@@ -797,6 +821,9 @@ class SlateBuilder:
         scores = RecommendationModelStore(self.connection).scores(
             model_id, {candidate.classification.scene_id for candidate in new_selected}
         )
+        # The displayed "Rank in <lane>" is relative to the lane's best
+        # (issue #212) — see _load_materialized_slate.
+        lane_maxes = _lane_value_maxes(self.connection, model_id)
         items = list(prefix_items)
         selected_items = zip(new_selected, selected_utilities, strict=True)
         for position, (chosen, utility) in enumerate(selected_items, start=len(prefix_items)):
@@ -813,7 +840,10 @@ class SlateBuilder:
                     score.appeal,
                     self._live_fit.get(score.scene_id, score.current_fit),
                     score.confidence,
-                    chosen.classification.lane_value,
+                    _rank_value(
+                        chosen.classification.lane_value,
+                        lane_maxes.get(chosen.classification.lane),
+                    ),
                     utility[0],
                     utility[1],
                     utility[2],
@@ -913,6 +943,10 @@ class SlateBuilder:
                 )
                 classifications[(classification.scene_id, classification.lane)] = classification
         self._live_fit, self._live_cooldown = self._live_current_fit(model_id, direct_plays, now_ms)
+        # The displayed "Rank in <lane>" is relative to the lane's best
+        # (issue #212): normalize each item's lane_value by its source lane's
+        # max, so the top of every lane reads 1.00.
+        lane_maxes = _lane_value_maxes(self.connection, model_id)
         items = []
         for position, row in enumerate(selected_rows):
             scene_id = str(row["scene_id"])
@@ -944,7 +978,7 @@ class SlateBuilder:
                     score.appeal,
                     self._live_fit.get(scene_id, score.current_fit),
                     score.confidence,
-                    classification.lane_value,
+                    _rank_value(classification.lane_value, lane_maxes.get(source_lane)),
                     float(row["utility"]) - penalties["live_cooldown"],
                     penalties,
                     bonuses,

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -4916,7 +4916,7 @@
           { className: "curator-view-copy" },
           React.createElement("h1", null, laneByValue.has(lane) ? "Recommendations" : laneOption.label),
           React.createElement("p", null, laneOption.description),
-          laneByValue.has(lane) && React.createElement("p", null, "Appeal is the model's estimate of how much you'll like a scene, on a −1..1 scale. Rank in this lane is ordering utility on a 0..1 scale, not a probability."),
+          laneByValue.has(lane) && React.createElement("p", null, "Appeal is the model's estimate of how much you'll like a scene, on a −1..1 scale. Rank in this lane is relative to the lane's best — 1.00 is the top of the lane, so it measures ordering utility, not probability. A scene can rank high while its appeal is moderate: rank includes recency and cooldown, appeal is how much you'd like it now."),
           laneByValue.has(lane) && slate && React.createElement(
             "p",
             { className: "curator-view-stats" },

--- a/tests/ranking/test_slate.py
+++ b/tests/ranking/test_slate.py
@@ -622,6 +622,28 @@ def test_materialize_reports_each_lane_ordering(tmp_path: Path) -> None:
     } == {"for_you"}
 
 
+def test_rank_in_lane_is_relative_to_lane_best(tmp_path: Path) -> None:
+    """Issue #212: the displayed "Rank in <lane>" is the scene's lane value
+    relative to the lane's best — the top of the lane reads 1.00 — not the
+    raw absolute utility."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    LanePolicy(connection).classify("model")
+    builder = SlateBuilder(connection)
+    builder.materialize("model")
+    slate = builder.recommend("best_bets", 4)
+    raw = {
+        item.scene_id: item.lane_value
+        for item in LanePolicy(connection).load("model", lanes={"best_bets"})
+    }
+    lane_max = max(raw.values())
+    assert lane_max > 0
+    for item in slate.items:
+        assert item.lane_value == pytest.approx(raw[item.scene_id] / lane_max)
+    # The top of the lane reads 1.00; everything else is relative to it.
+    assert max(item.lane_value for item in slate.items) == pytest.approx(1.0)
+    assert all(0.0 < item.lane_value <= 1.0 for item in slate.items)
+
+
 def test_queried_score_first_lanes_match_full_materialized_order(tmp_path: Path) -> None:
     connection = _database(tmp_path / "curator.sqlite3")
     classifications = LanePolicy(connection).classify("model")


### PR DESCRIPTION
The card labeled lane_value as "Rank in <lane>", implying a relative
measure, but the value was the raw absolute utility: revisit's
lane_value = direct_appeal * direct_confidence * recovery + 0.25 *
current_fit has no defined maximum of 1, so the lane's best scene could
read 0.58. Best bets' blend is the same kind of absolute utility.

Normalize in the slate read path (Go and Python identically): each
item's lane_value is divided by its source lane's max lane_value, so the
top of every lane reads 1.00 and lower scenes are relative to it.
The artifact and model outputs are unchanged (normalization is read-side
only); score_review items (no lane) keep their raw value.

The recommendation-lane caption now explains the semantics and why a
scene can rank high while its appeal is moderate (rank includes recency
and cooldown; appeal is the blended liking estimate).

Closes #212