### PR TITLE
feat(similar): lane-style 'why this' — labeled evidence rows and component breakdown

### DIFF
--- a/core/similar.go
+++ b/core/similar.go
@@ -52,10 +52,11 @@ func similarityResultJSON(r *similarityResult) jVal {
 	)
 }
 
-func similarExplanation(similarity, appealRaw float64, relationships []string) jVal {
+func similarExplanation(similarity, contentValue, performerValue, structure float64, sameStudio bool, appealRaw float64, relationships []string) jVal {
 	labels := map[string]string{"same_performer": "Same performer", "similar_performer": "Similar performer profile", "shared_content": "Shared content", "similar_structure": "Similar cast structure", "same_studio": "Same studio", "multi_hop": "Multi-hop performer connection"}
 	names := make([]string, 0, len(relationships))
 	reasons := jvArr()
+	evidenceRows := jvArr()
 	for _, value := range relationships {
 		label := labels[value]
 		if label == "" {
@@ -63,17 +64,26 @@ func similarExplanation(similarity, appealRaw float64, relationships []string) j
 		}
 		names = append(names, label)
 		reasons.arr = append(reasons.arr, jvObj(jvKey("code", jvStr(value)), jvKey("label", jvStr(label)), jvKey("direction", jvStr("positive")), jvKey("magnitude", jvFloat(1)), jvKey("confidence", jvFloat(1))))
+		evidenceRows.arr = append(evidenceRows.arr, jvObj(jvKey("code", jvStr(value)), jvKey("label", jvStr(label)), jvKey("direction", jvStr("positive")), jvKey("magnitude", jvFloat(1)), jvKey("confidence", jvFloat(1)), jvKey("detail", jvStr(""))))
 	}
 	summary := "Closest available content match."
 	if len(names) > 0 {
 		summary = "Related through " + strings.Join(names, ", ")
 	}
+	studioValue := 0.0
+	if sameStudio {
+		studioValue = 1.0
+	}
 	components := jvArr()
 	components.arr = append(components.arr,
-		jvObj(jvKey("name", jvStr("content_similarity")), jvKey("label", jvStr("Similarity")), jvKey("value", jvFloat(similarity)), jvKey("scale", jvStr("0..1")), jvKey("direction", jvStr("positive")), jvKey("available", jvBool(true))),
+		jvObj(jvKey("name", jvStr("similarity")), jvKey("label", jvStr("Similarity")), jvKey("value", jvFloat(similarity)), jvKey("scale", jvStr("0..1")), jvKey("direction", jvStr("positive")), jvKey("available", jvBool(true))),
+		jvObj(jvKey("name", jvStr("content_similarity")), jvKey("label", jvStr("Content similarity")), jvKey("value", jvFloat(contentValue)), jvKey("scale", jvStr("0..1")), jvKey("direction", jvStr("positive")), jvKey("available", jvBool(true))),
+		jvObj(jvKey("name", jvStr("performer_match")), jvKey("label", jvStr("Performer match")), jvKey("value", jvFloat(performerValue)), jvKey("scale", jvStr("0..1")), jvKey("direction", jvStr("positive")), jvKey("available", jvBool(true))),
+		jvObj(jvKey("name", jvStr("cast_structure")), jvKey("label", jvStr("Cast structure")), jvKey("value", jvFloat(structure)), jvKey("scale", jvStr("0..1")), jvKey("direction", jvStr("positive")), jvKey("available", jvBool(true))),
+		jvObj(jvKey("name", jvStr("studio_match")), jvKey("label", jvStr("Studio match")), jvKey("value", jvFloat(studioValue)), jvKey("scale", jvStr("0..1")), jvKey("direction", jvStr("positive")), jvKey("available", jvBool(true))),
 		jvObj(jvKey("name", jvStr("appeal")), jvKey("label", jvStr("Appeal")), jvKey("value", jvFloat(appealRaw)), jvKey("scale", jvStr("-1..1")), jvKey("direction", jvStr(direction(appealRaw))), jvKey("available", jvBool(true))),
 	)
-	return jvObj(jvKey("summary", jvStr(summary)), jvKey("components", components), jvKey("reasons", reasons))
+	return jvObj(jvKey("summary", jvStr(summary)), jvKey("components", components), jvKey("reasons", reasons), jvKey("evidence_rows", evidenceRows))
 }
 
 // similarityService mirrors SimilarityService.
@@ -748,7 +758,8 @@ WHERE ef.feature_version=? AND ef.entity_type='scene'
 		results = append(results, &similarityResult{
 			entityID: candidateID, similarity: similarity, appeal: appeal,
 			rankScore: rankScore, relationships: relationships, details: details,
-			appealRaw: candidateAppeal, explanation: similarExplanation(similarity, candidateAppeal, relationships),
+			appealRaw: candidateAppeal,
+			explanation: similarExplanation(similarity, contentValue, performerValue, structure, sameStudio, candidateAppeal, relationships),
 		})
 	}
 	sort.Slice(results, func(i, j int) bool {

--- a/curator/similarity.py
+++ b/curator/similarity.py
@@ -59,7 +59,13 @@ def _performer_name(connection: sqlite3.Connection, performer_id: str) -> str:
 
 
 def _similar_explanation(
-    similarity: float, appeal_raw: float, relationships: tuple[str, ...]
+    similarity: float,
+    content_value: float,
+    performer_value: float,
+    structure: float,
+    same_studio: bool,
+    appeal_raw: float,
+    relationships: tuple[str, ...],
 ) -> dict[str, object]:
     labels = {
         "same_performer": "Same performer",
@@ -76,9 +82,41 @@ def _similar_explanation(
         else "Closest available content match.",
         "components": [
             {
-                "name": "content_similarity",
+                "name": "similarity",
                 "label": "Similarity",
                 "value": similarity,
+                "scale": "0..1",
+                "direction": "positive",
+                "available": True,
+            },
+            {
+                "name": "content_similarity",
+                "label": "Content similarity",
+                "value": content_value,
+                "scale": "0..1",
+                "direction": "positive",
+                "available": True,
+            },
+            {
+                "name": "performer_match",
+                "label": "Performer match",
+                "value": performer_value,
+                "scale": "0..1",
+                "direction": "positive",
+                "available": True,
+            },
+            {
+                "name": "cast_structure",
+                "label": "Cast structure",
+                "value": structure,
+                "scale": "0..1",
+                "direction": "positive",
+                "available": True,
+            },
+            {
+                "name": "studio_match",
+                "label": "Studio match",
+                "value": float(same_studio),
                 "scale": "0..1",
                 "direction": "positive",
                 "available": True,
@@ -99,6 +137,17 @@ def _similar_explanation(
                 "direction": "positive",
                 "magnitude": 1.0,
                 "confidence": 1.0,
+            }
+            for value in relationships
+        ],
+        "evidence_rows": [
+            {
+                "code": value,
+                "label": labels.get(value, value),
+                "direction": "positive",
+                "magnitude": 1.0,
+                "confidence": 1.0,
+                "detail": "",
             }
             for value in relationships
         ],
@@ -329,7 +378,15 @@ class SimilarityService:
                         },
                     },
                     candidate_appeal,
-                    _similar_explanation(similarity, candidate_appeal, tuple(relationships)),
+                    _similar_explanation(
+                        similarity,
+                        content_value,
+                        performer_value,
+                        structure,
+                        same_studio,
+                        candidate_appeal,
+                        tuple(relationships),
+                    ),
                 )
             )
         ranked = sorted(results, key=lambda item: (-item.rank_score, item.entity_id))

--- a/tests/model/test_multi_hop.py
+++ b/tests/model/test_multi_hop.py
@@ -244,6 +244,32 @@ def _affinities_from_store(connection: sqlite3.Connection, model_id: str) -> dic
     return affinities
 
 
+def test_similar_explanation_has_lane_style_evidence_rows(tmp_path: Path) -> None:
+    """Issue #217: Similar's "Why this?" carries the same plain-language
+    evidence rows and labeled component breakdown as the recommendation
+    lanes — not just a bare Similarity/Appeal float pair."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    results = SimilarityService(connection).scenes("old-good", 20)
+    assert results
+    item = results[0]
+    explanation = item.explanation
+    assert explanation is not None
+    assert set(explanation) == {"summary", "components", "reasons", "evidence_rows"}
+    # One labeled, positive evidence row per relationship.
+    assert [row["code"] for row in explanation["evidence_rows"]] == list(item.relationships)
+    for row in explanation["evidence_rows"]:
+        assert row["direction"] == "positive"
+        assert row["confidence"] == 1.0
+        assert row["label"]
+    # The family breakdown uses the lanes' component language.
+    labels = [component["label"] for component in explanation["components"]]
+    assert "Similarity" in labels
+    assert "Content similarity" in labels
+    assert "Performer match" in labels
+    assert "Appeal" in labels
+
+
 def test_similarity_annotates_multi_hop_when_reachable(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
Similar cards showed a vague Similarity 0.71 · Appeal 0.4 pair whose
"Why this?" broke down into only two bare numbers. Port the
recommendation-lane explanation schema to the Similar explanation
(Go core and Python oracle identically):

- evidence_rows: one labeled, positive row per relationship (Same
  performer, Shared content, Same studio, ...), the same shape the
  lanes' Evidence section renders, so ExplanationView now shows the
  relationships as plain-language evidence.
- components: the lane-style family breakdown — Similarity (composite),
  Content similarity, Performer match, Cast structure, Studio match,
  Appeal — replacing the bare Similarity/Appeal pair in the Technical
  details section.

The kernel outputs and the card headline are unchanged; this is
presentation payload only.

Closes #217