### PR TITLE
feat(hunt): search StashDB performers not in the local library

### DIFF
--- a/core/backend.go
+++ b/core/backend.go
@@ -167,6 +167,8 @@ func dispatch(pluginDir string, payload jVal) (jVal, error) {
 		return opGetExpand(pluginDir, payload)
 	case "get_performer_hunt":
 		return opGetPerformerHunt(pluginDir, payload)
+	case "get_stashdb_performer_search":
+		return opGetStashdbPerformerSearch(pluginDir, payload)
 	case "get_external_similar":
 		return opGetExternalSimilar(pluginDir, payload)
 	case "send_whisparr":

--- a/core/expand_ops.go
+++ b/core/expand_ops.go
@@ -289,6 +289,48 @@ func sortNewestKey(item jVal) newestKey {
 	return newestKey{date: date, score: pythonFloatOr(item.get("score"), 0)}
 }
 
+// opGetStashdbPerformerSearch — name search over StashDB performers for the
+// Performer Hunt picker (issue #218): lets the user hunt scenes for a
+// performer that is not in the local library.
+func opGetStashdbPerformerSearch(pluginDir string, payload jVal) (jVal, error) {
+	return profiledOperation(pluginDir, payload, "get_stashdb_performer_search",
+		func(settings jVal) (jVal, error) { return getStashdbPerformerSearchBody(pluginDir, payload, settings) })
+}
+
+func getStashdbPerformerSearchBody(pluginDir string, payload, settings jVal) (jVal, error) {
+	args := payload.get("args")
+	query := argsString(args, "query", "")
+	limit := argsInt(args, "limit", 8)
+	if limit < 1 || limit > 50 {
+		limit = 8
+	}
+	clientURL, apiKey, err := stashdbClient(payload)
+	if err != nil {
+		return jvNull(), err
+	}
+	search := jvObj(
+		jvKey("page", jvInt(1)),
+		jvKey("per_page", jvInt(limit)),
+		jvKey("names", jvObj(jvKey("value", jvStr(query)), jvKey("modifier", jvStr("INCLUDES")))),
+	)
+	data, err := stashdbQuery(clientURL, apiKey, stashdbPerformerSearchQuery, jvObj(jvKey("input", search)))
+	if err != nil {
+		return jvNull(), err
+	}
+	items := jvArr()
+	for _, performer := range data.get("queryPerformers").get("performers").arr {
+		items.arr = append(items.arr, jvObj(
+			jvKey("id", performer.get("id")),
+			jvKey("name", performer.get("name")),
+			jvKey("aliases", performer.get("aliases")),
+			jvKey("disambiguation", performer.get("disambiguation")),
+			jvKey("scene_count", performer.get("scene_count")),
+			jvKey("images", performer.get("images")),
+		))
+	}
+	return jvObj(jvKey("items", items)), nil
+}
+
 // opGetPerformerHunt mirrors backend.py's _profiled-wrapped get_performer_hunt.
 func opGetPerformerHunt(pluginDir string, payload jVal) (jVal, error) {
 	return profiledOperation(pluginDir, payload, "get_performer_hunt",

--- a/core/graphql.go
+++ b/core/graphql.go
@@ -111,6 +111,16 @@ query CuratorSimilarPerformers($input: PerformerQueryInput!) {
   }
 }
 `
+const stashdbPerformerSearchQuery = `
+query CuratorPerformerSearch($input: PerformerQueryInput!) {
+  queryPerformers(input: $input) {
+    performers {
+      id name aliases disambiguation scene_count
+      images { url width height }
+    }
+  }
+}
+`
 
 // graphqlOperationName mirrors curator.graphql.client._operation_name.
 func graphqlOperationName(document string) string {

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -89,6 +89,17 @@ query CuratorSimilarPerformers($input: PerformerQueryInput!) {
 }
 """
 
+PERFORMER_SEARCH = """
+query CuratorPerformerSearch($input: PerformerQueryInput!) {
+  queryPerformers(input: $input) {
+    performers {
+      id name aliases disambiguation scene_count
+      images { url width height }
+    }
+  }
+}
+"""
+
 
 def normalize_phash(value: object) -> str | None:
     normalized = str(value or "").strip().casefold()
@@ -441,6 +452,37 @@ class ExpandService:
                 " AND external_id=?",
                 ((float(item["score"]), str(item["id"])) for item in performers),
             )
+
+    def stashdb_performer_search(
+        self, client: GraphQLClient, query: str, *, limit: int = 8
+    ) -> dict[str, object]:
+        """Name search over StashDB performers for the Performer Hunt picker
+        (issue #218): lets the user hunt scenes for a performer that is not in
+        the local library."""
+        limit = max(1, min(50, limit))
+        data = client.execute(
+            PERFORMER_SEARCH,
+            {
+                "input": {
+                    "page": 1,
+                    "per_page": limit,
+                    "names": {"value": query, "modifier": "INCLUDES"},
+                }
+            },
+        )["queryPerformers"]["performers"]
+        return {
+            "items": [
+                {
+                    "id": performer["id"],
+                    "name": performer["name"],
+                    "aliases": performer.get("aliases", []),
+                    "disambiguation": performer.get("disambiguation"),
+                    "scene_count": performer.get("scene_count"),
+                    "images": performer.get("images", []),
+                }
+                for performer in data
+            ]
+        }
 
     def performer_hunt(
         self,

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -764,6 +764,12 @@ def _api(payload: dict[str, Any], operation: str, settings: dict[str, Any]) -> d
                 include_tags=_string_list(args.get("include_tags")),
                 exclude_tags=_string_list(args.get("exclude_tags")),
             )
+        if operation == "get_stashdb_performer_search":
+            return ExpandService(connection).stashdb_performer_search(
+                _stashdb(payload),
+                str(args.get("query") or ""),
+                limit=int(args.get("limit") or 8),
+            )
         if operation == "get_shortlist":
             config = api.config()["config"]
             assert isinstance(config, dict)

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2119,6 +2119,23 @@
   color: var(--curator-text);
 }
 
+.curator-toolbar-check {
+  align-items: center;
+  background: var(--curator-surface-raised);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius-sm);
+  display: inline-flex;
+  gap: 0.35rem;
+  height: 2.15rem;
+  margin: 0;
+  padding: 0 0.55rem;
+  white-space: nowrap;
+}
+
+.curator-toolbar-check input {
+  margin: 0;
+}
+
 .curator-shortlist-tab {
   border-left: 1px solid var(--curator-border);
   margin-left: 0.35rem;

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2721,27 +2721,50 @@
     );
   }
 
-  function FilterTokens({ kind, label, values, onChange, disabled = false }) {
+  function FilterTokens({ kind, label, values, onChange, disabled = false, external = false }) {
     const [query, setQuery] = React.useState("");
+    const [externalResults, setExternalResults] = React.useState([]);
     const variables = { filter: { q: query, per_page: 8 } };
     const tags = GQL.useFindTagsQuery({ variables, skip: kind !== "tag" || !query || disabled });
     const studios = GQL.useFindStudiosQuery({ variables, skip: kind !== "studio" || !query || disabled });
-    const performers = GQL.useFindPerformersQuery({ variables, skip: kind !== "performer" || !query || disabled });
-    const options = kind === "tag"
-      ? tags.data?.findTags?.tags || []
-      : kind === "studio"
-        ? studios.data?.findStudios?.studios || []
-        : performers.data?.findPerformers?.performers || [];
+    const performers = GQL.useFindPerformersQuery({ variables, skip: kind !== "performer" || external || !query || disabled });
+    // Issue #218: external mode searches StashDB performers by name (debounced)
+    // so the local completion path never hits the network per keystroke.
+    React.useEffect(() => {
+      if (kind !== "performer" || !external || !query || disabled) {
+        setExternalResults([]);
+        return undefined;
+      }
+      let active = true;
+      const timer = setTimeout(() => {
+        operation({ operation: "get_stashdb_performer_search", query, limit: 8 }).then(
+          (result) => { if (active) setExternalResults(result.items || []); },
+          () => { if (active) setExternalResults([]); }
+        );
+      }, 300);
+      return () => { active = false; clearTimeout(timer); };
+    }, [kind, external, query, disabled]);
+    const options = external && kind === "performer"
+      ? externalResults.map((item) => ({ ...item, external: true }))
+      : kind === "tag"
+        ? tags.data?.findTags?.tags || []
+        : kind === "studio"
+          ? studios.data?.findStudios?.studios || []
+          : performers.data?.findPerformers?.performers || [];
     function add(item) {
       if (!values.some((value) => String(value.id) === String(item.id))) onChange([...values, item]);
       setQuery("");
+    }
+    function optionLabel(item) {
+      if (!external || kind !== "performer" || !item.disambiguation) return item.name;
+      return `${item.name} (${item.disambiguation})`;
     }
     return React.createElement(
       "label",
       { className: "curator-token-filter" },
       React.createElement("span", null, label),
       React.createElement("div", { className: "curator-token-input" }, values.map((item) => React.createElement("button", { key: item.id, type: "button", title: `Remove ${item.name}`, onClick: () => onChange(values.filter((value) => value.id !== item.id)) }, item.name, " ×")), disabled ? null : React.createElement("input", { value: query, onChange: (event) => setQuery(event.target.value), onKeyDown: (event) => { if (event.key === "Enter" && options.length > 0) { event.preventDefault(); add(options[0]); } }, placeholder: values.length ? "Add…" : `Search ${label.toLowerCase()}…` })),
-      query && options.length > 0 && React.createElement("div", { className: "curator-token-options" }, options.map((item) => React.createElement("button", { key: item.id, type: "button", onClick: () => add(item) }, item.name)))
+      query && options.length > 0 && React.createElement("div", { className: "curator-token-options" }, options.map((item) => React.createElement("button", { key: item.id, type: "button", onClick: () => add(item) }, optionLabel(item))))
     );
   }
 
@@ -3246,6 +3269,7 @@
         performer: null,
         huntView: "unlinked",
         huntSort: "date",
+        huntExternal: false,
         includeTags: initialFilters.includeTags || [],
         excludeTags: initialFilters.excludeTags || [],
         hidePhashMatches: initialFilters.hidePhashMatches !== false,
@@ -3262,6 +3286,7 @@
         },
         huntView: urlStringField("hunt_view", "unlinked", (value) => ["all", "linked", "unlinked"].includes(value)),
         huntSort: urlStringField("hunt_sort", "date", (value) => ["date", "score"].includes(value)),
+        huntExternal: urlBoolField("hunt_ext", false),
         includeTags: urlListField("hunt_include_tags", initialFilters.includeTags || []),
         excludeTags: urlListField("hunt_exclude_tags", initialFilters.excludeTags || []),
         hidePhashMatches: urlBoolField("hunt_hide_phash", initialFilters.hidePhashMatches !== false),
@@ -3303,7 +3328,7 @@
       },
     }, [huntOnly, initialFilters]);
     const [urlState, updateUrl] = useUrlState(expandSpec);
-    const { entityType, sort, performerId, favoriteOnly, gender, includeTags, excludeTags, performers, studios, minimumScore, hidePhashMatches, page, performer: huntPerformer, huntView, huntSort } = urlState;
+    const { entityType, sort, performerId, favoriteOnly, gender, includeTags, excludeTags, performers, studios, minimumScore, hidePhashMatches, page, performer: huntPerformer, huntView, huntSort, huntExternal } = urlState;
     const [filtersOpen, setFiltersOpen] = React.useState(false);
     const [filterVersion, setFilterVersion] = React.useState(0);
     const [data, setData] = React.useState(null);
@@ -3428,7 +3453,11 @@
       entityType === "hunt" && React.createElement(
         "div",
         { className: "curator-hunt-controls" },
-        React.createElement(FilterTokens, { kind: "performer", label: huntPerformer?.external ? "External performer on StashDB" : "Local performer with a StashDB link", values: huntPerformer ? [huntPerformer] : [], onChange: selectHuntPerformer, disabled: Boolean(huntPerformer?.external) }),
+        // Issue #218: search StashDB performers directly instead of only
+        // local performers linked to StashDB. Local stays the default and
+        // the checkbox keeps completions off the network until enabled.
+        React.createElement("label", { className: "curator-toolbar-check" }, React.createElement("input", { type: "checkbox", checked: huntExternal, onChange: (event) => updateUrl((s) => ({ ...s, page: 1, performer: null, huntExternal: event.target.checked })) }), " Search StashDB"),
+        React.createElement(FilterTokens, { kind: "performer", label: huntPerformer?.external ? "External performer on StashDB" : "Local performer with a StashDB link", values: huntPerformer ? [huntPerformer] : [], onChange: selectHuntPerformer, disabled: Boolean(huntPerformer?.external), external: huntExternal }),
         data?.ready && React.createElement("div", { className: "btn-group", role: "group", "aria-label": "Performer Hunt view" }, [["all", `All ${huntCounts.all}`], ["linked", `In library ${huntCounts.linked}`], ["unlinked", `Not linked locally ${huntCounts.unlinked}`]].map(([value, label]) => React.createElement(Button, { key: value, size: "sm", variant: huntView === value ? "primary" : "secondary", onClick: () => updateUrl((s) => ({ ...s, page: 1, huntView: value })) }, label))),
         data?.ready && React.createElement("label", { className: "curator-toolbar-select" }, React.createElement(FontAwesomeIcon, { icon: faSortAmountDown }), React.createElement("select", { value: huntSort, onChange: (event) => updateUrl((s) => ({ ...s, page: 1, huntSort: event.target.value })), "aria-label": "Sort Performer Hunt results" }, React.createElement("option", { value: "date" }, "Release date"), React.createElement("option", { value: "score" }, "Preference score")))
       ),

--- a/tests/core/test_backend_slice2.py
+++ b/tests/core/test_backend_slice2.py
@@ -324,6 +324,23 @@ class _StubExpand(BaseHTTPRequestHandler):
             if input_data.get("performed_with"):
                 pool = [p for p in pool if p["id"] in {"ext-p1", "ext-p3"}]
             return {"data": {"queryPerformers": {"performers": pool}}}
+        if operation == "CuratorPerformerSearch":
+            input_data = json.loads(body)["variables"]["input"]
+            names = input_data.get("names", {})
+            needle = str(names.get("value", "")).casefold()
+            pool = [
+                {
+                    "id": performer["id"],
+                    "name": performer["name"],
+                    "aliases": performer.get("aliases", []),
+                    "disambiguation": performer.get("disambiguation"),
+                    "scene_count": performer.get("scene_count"),
+                    "images": performer.get("images", []),
+                }
+                for performer in STASHDB_PERFORMER_POOL
+                if not needle or needle in str(performer["name"]).casefold()
+            ]
+            return {"data": {"queryPerformers": {"performers": pool}}}
         return {"errors": [{"message": f"no stub for {operation}"}]}
 
     @staticmethod
@@ -335,6 +352,7 @@ class _StubExpand(BaseHTTPRequestHandler):
             "CuratorExternalLinks",
             "CuratorExpandScenes",
             "CuratorSimilarPerformers",
+            "CuratorPerformerSearch",
         ):
             if name in body:
                 return name
@@ -736,6 +754,19 @@ def test_get_performer_hunt_unlinked_byte_identical(
     # p3 has no StashDB link in the stub; both backends must raise the same
     # "selected performer is not linked to StashDB" error.
     raw = payload("get_performer_hunt", expand_sidecar, stub_stash, performer_id="p3")
+    assert_slice2_identical(binary, PLUGIN_DIR, raw, expand_sidecar, stub_stash)
+
+
+def test_get_stashdb_performer_search_byte_identical(
+    expand_sidecar: Path, binary: Path, stub_stash: str
+) -> None:
+    """Issue #218: the StashDB performer name search (Performer Hunt picker)
+    answers identically on both backends, including the not-found case."""
+    raw = payload("get_stashdb_performer_search", expand_sidecar, stub_stash, query="Performer")
+    assert_slice2_identical(binary, PLUGIN_DIR, raw, expand_sidecar, stub_stash)
+    raw = payload(
+        "get_stashdb_performer_search", expand_sidecar, stub_stash, query="Nobody Named This"
+    )
     assert_slice2_identical(binary, PLUGIN_DIR, raw, expand_sidecar, stub_stash)
 
 

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -818,6 +818,11 @@ def test_plugin_performer_hunt_keeps_results_and_reuses_external_cards() -> None
 
     assert 'operation: "get_performer_hunt"' in source
     assert 'value: "hunt"' in source
+    # Issue #218: the picker can search StashDB performers directly; the
+    # checkbox keeps local completions off the network.
+    assert 'operation: "get_stashdb_performer_search"' in source
+    assert '" Search StashDB"' in source
+    assert "external: huntExternal" in source
     assert "icon: faCrosshairs" in source
     assert 'initialType: "hunt", huntOnly: true' in source
     assert '["all", `All ${huntCounts.all}`]' in source


### PR DESCRIPTION
Performer Hunt could only start from a local performer linked to StashDB;
the backend's expandPerformerHunt already accepted a non-local StashDB id
(the isLocal=false path), but there was no way to find one by name.

- New op get_stashdb_performer_search (Go core + Python oracle): name
  search over StashDB's queryPerformers, returning id, name, aliases,
  disambiguation, scene_count, images.
- Hunt picker gains a "Search StashDB" checkbox (URL state hunt_ext,
  default off): when enabled the performer token search queries the new
  op (debounced 300 ms) instead of local Stash, so local completions
  never hit the network. Results show disambiguation and select as
  external performers; the existing external-hunt flow handles the rest.
- Differential test (stub CuratorPerformerSearch, hit + miss cases) and
  runtime guards.

Closes #218