### PR TITLE
fix(sentiment): stop rendering Appeal twice in review cards

### DIFF
--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2597,9 +2597,12 @@
             scoreHeadline: "Appeal",
             scoreHeadlineValue: formatAppealValue(item.appeal),
             scoreHeadlineBar: scoreBar(item.appeal, true),
-            scoreBarContent: hasLaneRank ? utilityBar(item.lane_value) : scoreBar(item.appeal, true),
-            scoreLabel: hasLaneRank ? `Rank in ${laneLabel}` : "Appeal",
-            scoreSummary: hasLaneRank ? item.lane_value.toFixed(2) : formatAppealValue(item.appeal),
+            // Issue #210: score_review has no lane rank — rendering the
+            // second "Appeal" row would duplicate the headline row, so it is
+            // dropped for the pseudo-lane.
+            scoreBarContent: hasLaneRank ? utilityBar(item.lane_value) : null,
+            scoreLabel: hasLaneRank ? `Rank in ${laneLabel}` : null,
+            scoreSummary: hasLaneRank ? item.lane_value.toFixed(2) : null,
           }),
           React.createElement(Feedback, { item, onRemove, onThumbDown })
         )

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -1000,13 +1000,12 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     assert "curator-metadata-status" in source
     assert "Metadata covered" in source
     assert "function fingerprintPoint(" in source
-    assert 'scoreLabel: hasLaneRank ? `Rank in ${laneLabel}` : "Appeal"' in source
+    assert "scoreLabel: hasLaneRank ? `Rank in ${laneLabel}` : null" in source
     assert "scoreHeadlineValue: formatAppealValue(item.appeal)" in source
     assert "function clamp01(value)" in source
-    assert (
-        "scoreSummary: hasLaneRank ? item.lane_value.toFixed(2) : formatAppealValue(item.appeal)"
-        in source
-    )
+    # Issue #210: score_review cards drop the duplicate second "Appeal" row.
+    assert "scoreBarContent: hasLaneRank ? utilityBar(item.lane_value) : null" in source
+    assert "scoreSummary: hasLaneRank ? item.lane_value.toFixed(2) : null" in source
     assert 'scoreLabel: "Match"' in source or "scoreLabel: label" in source
     assert "Appeal is the model's estimate" in source
     assert '"appeal.performer_identity": "Performer match"' in source


### PR DESCRIPTION
Sentiment review reuses RecommendationCard with the score_review
pseudo-lane, which has no lane rank. hasLaneRank=false made EvidenceScore
render the always-visible "Appeal" headline row AND a second identical
"Appeal" label/bar/value row (the fallback that real lanes replace with
"Rank in <lane>").

The second row is now null for the pseudo-lane, so each review card shows
Appeal exactly once.

Closes #210