### PR TITLE
feat(tasks): worker status header, grouped progress, collapsible completed section

### DIFF
--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -1682,6 +1682,143 @@
   line-height: 1;
 }
 
+/* Manage → Tasks panel (issue #211): worker status header, grouped job
+   sections, and per-job progress/summary rows. */
+.curator-tasks-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.curator-worker-status {
+  align-items: center;
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius-sm);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.6rem;
+  padding: 0.55rem 0.7rem;
+}
+
+.curator-worker-status-dot {
+  border-radius: 50%;
+  height: 0.6rem;
+  width: 0.6rem;
+}
+
+.curator-worker-status-running .curator-worker-status-dot {
+  background: var(--success, #198754);
+  box-shadow: 0 0 0 3px rgba(25, 135, 84, 0.15);
+}
+
+.curator-worker-status-idle .curator-worker-status-dot {
+  background: var(--curator-text-muted);
+}
+
+.curator-worker-status span:not(.curator-worker-status-dot) {
+  color: var(--curator-text-muted);
+  font-size: 0.82rem;
+}
+
+.curator-tasks-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.curator-tasks-section-title {
+  font-size: 0.85rem;
+  margin: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--curator-text-muted);
+}
+
+.curator-tasks-completed summary {
+  color: var(--curator-text-muted);
+  cursor: pointer;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.curator-tasks-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.curator-task {
+  background: var(--curator-surface-raised);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.55rem 0.7rem;
+}
+
+.curator-task-head {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 0.6rem;
+}
+
+.curator-task-state {
+  border-radius: var(--curator-radius-sm);
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.1rem 0.45rem;
+  text-transform: uppercase;
+}
+
+.curator-task-state-running {
+  background: rgba(13, 110, 253, 0.15);
+  color: #0d6efd;
+}
+
+.curator-task-state-queued {
+  background: rgba(108, 117, 125, 0.15);
+  color: var(--curator-text-muted);
+}
+
+.curator-task-state-complete {
+  background: rgba(25, 135, 84, 0.15);
+  color: #198754;
+}
+
+.curator-task-state-failed {
+  background: rgba(220, 53, 69, 0.15);
+  color: #dc3545;
+}
+
+.curator-task-state-cancelled {
+  background: rgba(108, 117, 125, 0.15);
+  color: var(--curator-text-muted);
+}
+
+.curator-task-time {
+  color: var(--curator-text-muted);
+  font-size: 0.78rem;
+  margin-left: auto;
+}
+
+.curator-task-meta {
+  color: var(--curator-text-muted);
+  font-size: 0.82rem;
+}
+
+.curator-task-error {
+  color: #dc3545;
+  display: block;
+  margin-top: 0.2rem;
+  white-space: pre-wrap;
+}
+
 .curator-header-message {
   background: var(--curator-surface);
   border: 1px solid var(--curator-border);

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -3723,7 +3723,7 @@
   function TasksPanel() {
     const [jobs, setJobs] = React.useState([]);
     const [error, setError] = React.useState("");
-    const [running, setRunning] = React.useState("");
+    const [starting, setStarting] = React.useState("");
     const [message, setMessage] = React.useState("");
     function refresh() {
       operation({ operation: "get_job_status" }).then(
@@ -3736,8 +3736,66 @@
       const timer = setInterval(refresh, 5000);
       return () => clearInterval(timer);
     }, []);
+    const active = jobs.filter((job) => job.state === "queued" || job.state === "running");
+    const finished = jobs.filter((job) => job.state !== "queued" && job.state !== "running");
+    const running = active.length > 0;
+    const last = jobs[0];
+    function durationMs(job) {
+      const end = typeof job.finished_at_ms === "number" ? job.finished_at_ms : Date.now();
+      const start = typeof job.started_at_ms === "number" ? job.started_at_ms : end;
+      return Math.max(0, end - start);
+    }
+    function formatDuration(ms) {
+      const seconds = Math.round(ms / 1000);
+      if (seconds < 60) return `${seconds}s`;
+      const minutes = Math.floor(seconds / 60);
+      if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+      return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+    }
+    function summaryLine(job) {
+      const summary = job.summary || {};
+      const scenes = typeof summary.scene_count === "number" ? `${summary.scene_count} scenes` : "";
+      if (job.job_type === "build" || job.job_type === "update-model" || job.job_type === "sync-build" || job.job_type === "full-sync-build") {
+        return scenes ? `Model built · ${scenes}` : "Model built";
+      }
+      if (job.job_type === "backup") return "Backup created";
+      if (job.job_type === "compact") return "Compaction finished";
+      if (job.job_type === "expand-refresh") return "StashDB candidates refreshed";
+      if (job.job_type === "sync-plays") return "Play history synced";
+      return scenes || "Done";
+    }
+    function taskRow(job) {
+      const label = TASK_MODE_LABELS[job.job_type] || job.job_type;
+      const pct = typeof job.progress === "number" ? Math.max(0, Math.min(job.progress, 1)) : null;
+      const stateLabel = job.state === "complete" ? "Done" : job.state === "running" ? "Running" : job.state.charAt(0).toUpperCase() + job.state.slice(1);
+      return React.createElement(
+        "li",
+        { key: job.job_id, className: `curator-task curator-task-${job.state}` },
+        React.createElement(
+          "div",
+          { className: "curator-task-head" },
+          React.createElement("strong", null, label),
+          React.createElement("span", { className: `curator-task-state curator-task-state-${job.state}` }, stateLabel),
+          React.createElement("span", { className: "curator-task-time" }, job.state === "running" ? `started ${formatTimeAgo(job.started_at_ms)}` : `took ${formatDuration(durationMs(job))}`)
+        ),
+        (job.state === "running" || job.state === "queued") && React.createElement(
+          "div",
+          { className: "curator-task-progress-track" },
+          React.createElement("span", { className: "curator-task-progress-fill", style: pct !== null ? { width: `${Math.round(pct * 100)}%` } : undefined })
+        ),
+        React.createElement(
+          "div",
+          { className: "curator-task-meta" },
+          (job.state === "running" || job.state === "queued")
+            ? (pct !== null ? `${Math.round(pct * 100)}%` : job.state === "running" ? "Working" : "Queued")
+            : summaryLine(job),
+          job.error && React.createElement("span", { className: "curator-task-error" }, job.error)
+        )
+      );
+    }
+
     async function start(taskName) {
-      setRunning(taskName);
+      setStarting(taskName);
       setMessage("");
       try {
         await runTask(taskName);
@@ -3746,7 +3804,7 @@
       } catch (failure) {
         setMessage(failure.message);
       } finally {
-        setRunning("");
+        setStarting("");
       }
     }
     return React.createElement(
@@ -3758,38 +3816,32 @@
         "div",
         { className: "curator-tasks-runnow" },
         React.createElement("span", null, "Run now"),
-        React.createElement(Button, { size: "sm", variant: "primary", disabled: Boolean(running), onClick: () => start("Sync and build recommendations") }, running === "Sync and build recommendations" ? "Starting…" : "Sync and build recommendations")
+        React.createElement(Button, { size: "sm", variant: "primary", disabled: Boolean(starting), onClick: () => start("Sync and build recommendations") }, starting === "Sync and build recommendations" ? "Starting…" : "Sync and build recommendations")
       ),
       message && React.createElement("p", { className: "curator-header-message", role: "status" }, message),
-      jobs.length === 0 && !error && React.createElement("p", { role: "status" }, "No tasks yet."),
       React.createElement(
-        "ul",
-        { className: "curator-tasks-list" },
-        jobs.map((job) => {
-          const label = TASK_MODE_LABELS[job.job_type] || job.job_type;
-          const pct = typeof job.progress === "number" ? Math.max(0, Math.min(job.progress, 1)) : null;
-          return React.createElement(
-            "li",
-            { key: job.job_id, className: `curator-task curator-task-${job.state}` },
-            React.createElement(
-              "div",
-              { className: "curator-task-head" },
-              React.createElement("strong", null, label),
-              React.createElement("span", { className: "curator-task-state" }, job.state)
-            ),
-            React.createElement(
-              "div",
-              { className: "curator-task-progress-track" },
-              React.createElement("span", { className: "curator-task-progress-fill", style: pct !== null ? { width: `${Math.round(pct * 100)}%` } : undefined })
-            ),
-            React.createElement(
-              "div",
-              { className: "curator-task-meta" },
-              pct !== null ? `${Math.round(pct * 100)}%` : job.state === "running" ? "Working" : job.state,
-              job.error && React.createElement("span", { className: "curator-task-error" }, job.error)
-            )
-          );
-        })
+        "div",
+        { className: `curator-worker-status curator-worker-status-${running ? "running" : "idle"}` },
+        React.createElement("span", { className: "curator-worker-status-dot", "aria-hidden": "true" }),
+        React.createElement("strong", null, running ? "Worker running" : "Worker idle"),
+        running
+          ? `${active.length} task${active.length === 1 ? "" : "s"} active`
+          : last
+            ? `Last task: ${TASK_MODE_LABELS[last.job_type] || last.job_type} · ${formatTimeAgo(last.finished_at_ms || last.started_at_ms)}`
+            : "No tasks yet"
+      ),
+      jobs.length === 0 && !error && React.createElement("p", { role: "status" }, "No tasks yet."),
+      active.length > 0 && React.createElement(
+        "section",
+        { className: "curator-tasks-section" },
+        React.createElement("h4", { className: "curator-tasks-section-title" }, "Active"),
+        React.createElement("ul", { className: "curator-tasks-list" }, active.map(taskRow))
+      ),
+      finished.length > 0 && React.createElement(
+        "details",
+        { className: "curator-tasks-completed", open: active.length === 0 },
+        React.createElement("summary", null, `Completed (${finished.length})`),
+        React.createElement("ul", { className: "curator-tasks-list" }, finished.map(taskRow))
       )
     );
   }

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -1377,6 +1377,14 @@ def test_task_indicator_and_compact_external_tag_rating_are_shared_ui_contracts(
     assert "tasks: () => React.createElement(TasksPanel)" in source
     assert "Manage → Tasks" in source
     assert "curator-tasks-list" in source
+    # Issue #211: worker status header and a collapsible Completed section.
+    assert "curator-worker-status" in source
+    assert "curator-worker-status-dot" in source
+    assert "Worker running" in source
+    assert "Worker idle" in source
+    assert 'className: "curator-tasks-completed"' in source
+    assert "Completed (" in source
+    assert "curator-task-state-" in source
     assert "Querying StashDB" not in source
     assert 'className: "curator-loading", role: "status"' in source
     assert 'className: "curator-progress"' not in source


### PR DESCRIPTION
Manage → Tasks was a flat, unstyled list of curator_job rows with no
worker state, no result summaries, and finished jobs mixed in with active
ones.

- Worker status header: running/idle dot with active-task count, or the
  last finished task and when it ran.
- Active jobs (queued/running) render first with a progress bar and
  percentage; completed jobs move into a collapsible "Completed (N)"
  section, each with a state badge, duration, and a plain-language result
  summary (model scene count, backup/compact/refresh outcome) plus the
  error text for failures.
- Styled with the panel's existing surface tokens (issue #211).

Live per-stage logs are future work: the worker heartbeat only writes a
progress float today (no stage column), so the redesign surfaces what the
job status payload already provides.

Closes #211