### PR TITLE
style(why): give the 'Why this?' prose lead the section's visual language

### DIFF
--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -3569,6 +3569,18 @@
 .curator-explanation-view,
 .curator-score-breakdown { display: grid; gap: 0.55rem; }
 .curator-appeal-hero { display: grid; gap: 0.15rem; padding: 0.55rem 0.65rem; border: 1px solid var(--curator-border); border-radius: var(--curator-radius-sm); background: var(--curator-wash-raised); }
+/* Issue #213: the prose lead in "Why this?" gets the section's visual
+   language instead of bare body text. */
+.curator-explanation-view > .curator-explanation {
+  background: var(--curator-wash-raised);
+  border-left: 3px solid var(--curator-accent-secondary);
+  border-radius: var(--curator-radius-sm);
+  color: var(--curator-text);
+  font-size: 0.88rem;
+  line-height: 1.5;
+  margin: 0;
+  padding: 0.5rem 0.65rem;
+}
 .curator-appeal-hero strong { font-size: 1.05rem; }
 .curator-appeal-hero span, .curator-fingerprint-confidence, .curator-score-row small { color: var(--curator-text-muted); font-size: 0.72rem; }
 .curator-score-positive { color: #8fbf4f; }

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -997,6 +997,10 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     assert "function ExplanationView({ explanation, item })" in source
     assert 'className: "curator-evidence-fingerprint"' in source
     assert 'className: "curator-fingerprint-svg"' in source
+    # Issue #213: the prose lead in "Why this?" is styled to match the section.
+    css = (Path(__file__).parents[2] / "plugin" / "stash-curator.css").read_text(encoding="utf-8")
+    assert ".curator-explanation-view > .curator-explanation" in css
+    assert "border-left: 3px solid var(--curator-accent-secondary)" in css
     assert "curator-metadata-status" in source
     assert "Metadata covered" in source
     assert "function fingerprintPoint(" in source


### PR DESCRIPTION
The explanation summary rendered as a bare body paragraph while the rest
of the section (fingerprint, evidence rows, score bars) is designed.
Style the lead with the section's tokens — raised wash background,
accent-secondary left border, radius and padding — so the prose reads as
part of the explanation rather than unstyled text (issue #213).

Scoped to .curator-explanation-view > .curator-explanation, so the
shared .curator-explanation fallback chips elsewhere are untouched.

Closes #213