### PR TITLE
fix(similar): contain performer cards in their grid cell

### DIFF
--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2574,8 +2574,31 @@
   background: var(--curator-card-surface);
   border: 0;
   margin: 0;
+  max-width: 100%;
   padding-bottom: 0;
   width: 100%;
+}
+
+/* Issue #215: Similar performer cards must never bleed horizontally out of
+   their grid cell. Stash's native performer-card internals (Bootstrap .row
+   negative margins, fixed-width thumbnails, nowrap name rows) can force the
+   card wider than its column, so contain the card and its rows and zero the
+   row gutters. */
+.curator-card > .performer-card .row,
+.curator-card > .performer-card .card-section,
+.curator-card > .performer-card .performer-card-image {
+  margin-left: 0;
+  margin-right: 0;
+  max-width: 100%;
+}
+
+.curator-card > .performer-card .card-section-title,
+.curator-card > .performer-card .performer-card-name {
+  overflow-wrap: anywhere;
+}
+
+.curator-grid > * {
+  min-width: 0;
 }
 
 .curator-more {

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -1335,6 +1335,10 @@ def test_task_indicator_and_compact_external_tag_rating_are_shared_ui_contracts(
         in source
     )
     assert "curator-task-indicator-done" in css
+    # Issue #215: similar performer cards are contained in their grid cell.
+    assert ".curator-card > .performer-card .row" in css
+    assert ".curator-grid > * {" in css
+    assert "min-width: 0;" in css
     assert "health?.active_jobs" in source
     assert "?view=manage&section=tasks" in source
     assert "curatorTaskStage(job)" in source


### PR DESCRIPTION
Similar performer cards could overlap horizontally: Stash's native
performer-card internals (Bootstrap .row negative gutters, fixed-width
thumbnails, nowrap name rows) can force the card wider than its column.

- Contain the card and its rows (max-width 100%), zero the .row gutters,
  and allow long names to wrap instead of stretching the card.
- Defensive min-width: 0 on grid children so no card escapes its track.

Closes #215