### PR TITLE
fix(rank): scale the score bar to 1.0 so rank 1.00 renders full

### DIFF
--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -1913,18 +1913,18 @@
   // segmented bar would need — an earlier version tried a segmented bar
   // keyed off item.details.score_breakdown and it silently rendered empty
   // for real Similar-panel results, since that field isn't populated there.
-  // A single clamped fill is the one thing guaranteed to have real data.
-  // Utility/appeal is usually in [0, 1], but bonuses (e.g. uncovered-content)
-  // can push final_utility modestly above 1.0 — clamping the fill to 1.0
-  // made every overflowing score (1.15, 1.16, 1.17, ...) render at the same
-  // ~100% width as a plain 0.95, erasing the difference. Scale against a
-  // slightly wider ceiling so that range is visible; anything that still
-  // exceeds the ceiling gets a distinct "off the chart" treatment rather
-  // than silently pinning to 100% again.
-  const UTILITY_BAR_CEILING = 1.2;
+  // A single clamped fill renders every surface's headline score on its
+  // documented 0..1 scale: the lane rank is normalized to the lane's best
+  // (issue #226 — the top of every lane reads 1.00), Similarity is a 0..1
+  // match score, and Prune's appeal is −1..1 with negatives clamped to an
+  // empty bar. The previous 1.2 ceiling existed for raw final_utility, which
+  // bonuses could push above 1.0 — no current caller passes it (the rank
+  // surface now receives the normalized lane_value). Anything that still
+  // exceeds 1.0 gets a distinct "off the chart" treatment rather than
+  // silently pinning to 100% again.
   function utilityBar(value) {
-    const clipped = value > UTILITY_BAR_CEILING;
-    const pct = Math.round((Math.min(UTILITY_BAR_CEILING, Math.max(0, value)) / UTILITY_BAR_CEILING) * 100);
+    const clipped = value > 1;
+    const pct = Math.round(clamp01(value) * 100);
     return React.createElement("div", { className: "curator-score-bar" },
       React.createElement("span", { className: `curator-score-bar-seg curator-score-app${clipped ? " curator-score-bar-clipped" : ""}`, style: { width: pct + "%" }, title: `Utility ${value.toFixed(3)}` })
     );

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -1043,6 +1043,12 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     # Issue #210: score_review cards drop the duplicate second "Appeal" row.
     assert "scoreBarContent: hasLaneRank ? utilityBar(item.lane_value) : null" in source
     assert "scoreSummary: hasLaneRank ? item.lane_value.toFixed(2) : null" in source
+    # Issue #237: the bar scales to 1.0, so the lane's best — normalized to
+    # 1.00 by #226 — renders a full bar. The old 1.2 ceiling (raw final
+    # utility, no longer passed anywhere) is gone.
+    assert "function utilityBar(value) {" in source
+    assert "const pct = Math.round(clamp01(value) * 100);" in source
+    assert "UTILITY_BAR_CEILING" not in source
     assert 'scoreLabel: "Match"' in source or "scoreLabel: label" in source
     assert "Appeal is the model's estimate" in source
     assert '"appeal.performer_identity": "Performer match"' in source


### PR DESCRIPTION
Closes #237

After #226 normalized the displayed lane_value to the lane's best (1.00 = top of lane), utilityBar still divided by its old 1.2 ceiling (added for raw final_utility with bonuses), so rank 1.00 rendered an 83% bar next to a '1.00' label.

No current caller passes raw final_utility (rank surface receives the normalized lane_value; Similarity is a documented 0..1 score; Prune appeal is −1..1), so the ceiling is dead weight: scale to 1.0, keep the 'off the chart' treatment for values above 1.0. Negatives still clamp to an empty bar.