### PR TITLE
feat(find): render Find sections as lane-style cards with tightened copy

### DIFF
--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -500,33 +500,14 @@
 }
 
 /* ---------- Find switcher (Similar / Expand / Performer Hunt inner tabs) ---------- */
+/* Reuses the lane-card classes from the recommendation lane switcher above;
+   the container matches the lane switcher's scrollable layout. */
 .curator-find-switcher {
   display: flex;
-  gap: 0.4rem;
+  gap: 0.6rem;
   margin: 0.35rem 0 0.8rem;
-}
-
-.curator-find-tab {
-  align-items: center;
-  background: var(--curator-surface);
-  border: 1px solid var(--curator-border);
-  border-radius: var(--curator-radius-sm);
-  color: var(--curator-text);
-  cursor: pointer;
-  display: inline-flex;
-  font-size: 0.8rem;
-  gap: 0.4rem;
-  padding: 0.35rem 0.7rem;
-}
-
-.curator-find-tab:hover {
-  border-color: var(--curator-border-strong);
-}
-
-.curator-find-tab[aria-pressed="true"] {
-  background: color-mix(in srgb, var(--curator-accent) 14%, var(--curator-surface));
-  border-color: var(--curator-accent);
-  color: var(--curator-text);
+  overflow-x: auto;
+  padding-bottom: 0.2rem;
 }
 
 /* ---------- Manage shell (two-pane list + detail) ---------- */

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -66,19 +66,19 @@
       value: "similar",
       label: "Similar",
       icon: faClone,
-      description: "Choose a scene or performer, then compare preference-aware matches from your Library or StashDB.",
+      description: "Preference-aware matches from your library or StashDB.",
     },
     {
       value: "expand",
       label: "Expand",
       icon: faGlobe,
-      description: "External metadata candidates scored locally. Wildcard items are selected outside preference-derived seeds.",
+      description: "External metadata candidates, scored locally.",
     },
     {
       value: "hunt",
       label: "Performer Hunt",
       icon: faCrosshairs,
-      description: "Find scenes listed for a performer on StashDB and compare them with exact links in your library.",
+      description: "StashDB performers and their scenes, checked against your library.",
     },
     {
       value: "taste",
@@ -4787,13 +4787,15 @@
           {
             key: section.value,
             type: "button",
-            className: "curator-find-tab",
+            className: "curator-lane-card",
+            style: { "--lc": `var(--curator-hue-${section.value})` },
             "aria-pressed": lane === section.value,
             onClick: () => openView(section.value),
             title: section.description,
           },
-          React.createElement(FontAwesomeIcon, { icon: section.icon }),
-          React.createElement("span", null, section.label)
+          React.createElement("span", { className: "curator-lane-card-icon" }, React.createElement(FontAwesomeIcon, { icon: section.icon })),
+          React.createElement("span", { className: "curator-lane-card-name" }, section.label),
+          React.createElement("span", { className: "curator-lane-card-desc" }, section.description)
         ))
       ),
       laneOption && lane !== "curate" && React.createElement(

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -4790,6 +4790,7 @@
             className: "curator-lane-card",
             style: { "--lc": `var(--curator-hue-${section.value})` },
             "aria-pressed": lane === section.value,
+            "aria-label": section.label,
             onClick: () => openView(section.value),
             title: section.description,
           },

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -420,7 +420,11 @@ def test_curator_tabs_update_browser_history() -> None:
     assert "FIND_SECTION_VALUES.has(lane)" in source
     assert "openView(FIND_SECTIONS[0].value)" in source
     assert 'className: "curator-find-switcher"' in source
-    assert 'className: "curator-find-tab"' in source
+    # Issue #240: Find sections render as lane-style cards (icon, name, short
+    # description) with the section's own hue, not small pills.
+    assert 'className: "curator-lane-card"' in source
+    assert "curator-lane-card-desc" in source
+    assert 'style: { "--lc": `var(--curator-hue-${section.value})` }' in source
     # Header order is Recommendations | Find | Curate (issue #239): Find sits
     # before the remaining primary items (Curate) rather than after them.
     expected_top_nav = "".join(
@@ -1060,7 +1064,7 @@ def test_custom_cards_follow_native_sfw_contract_and_explain_views() -> None:
     assert "Appeal is the model's estimate" in source
     assert '"appeal.performer_identity": "Performer match"' in source
     assert '"appeal.content_neighbor": "Similar scenes"' in source
-    assert "Wildcard items are selected outside preference-derived seeds" in source
+    assert "External metadata candidates, scored locally." in source
 
 
 def test_external_card_actions_are_a_named_shared_component() -> None:

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -425,6 +425,9 @@ def test_curator_tabs_update_browser_history() -> None:
     assert 'className: "curator-lane-card"' in source
     assert "curator-lane-card-desc" in source
     assert 'style: { "--lc": `var(--curator-hue-${section.value})` }' in source
+    # The description must stay out of the accessible name (aria-label = the
+    # section label), or substring lookups like "StashDB" match every card.
+    assert '"aria-label": section.label,' in source
     # Header order is Recommendations | Find | Curate (issue #239): Find sits
     # before the remaining primary items (Curate) rather than after them.
     expected_top_nav = "".join(


### PR DESCRIPTION
Closes #240

Find's inner tabs (Similar / Expand / Performer Hunt) now render as recommendation-lane-style cards: icon, name, and short description, each with its own hue (--curator-hue-similar/expand/hunt). The container matches the lane switcher's scrollable layout; the small pill classes are removed.

Card copy tightened (used by the cards, the header guidance, and nav tooltips):
- Similar: Preference-aware matches from your library or StashDB.
- Expand: External metadata candidates, scored locally.
- Hunt: StashDB performers and their scenes, checked against your library.