### PR TITLE
fix(plugin): V1 polish — card badges, lane help, settings toggle, Manage order; perf(core): cut build peak memory

### DIFF
--- a/core/featurebuild.go
+++ b/core/featurebuild.go
@@ -1465,9 +1465,8 @@ INSERT INTO feature_definition(
 ) VALUES (?, ?, ?, ?, 'feature_builder', ?)`, definitionRows); err != nil {
 				return err
 			}
-			sortedFeatures := append([]featureRow(nil), features...)
-			sort.SliceStable(sortedFeatures, func(i, j int) bool {
-				a, b := sortedFeatures[i], sortedFeatures[j]
+			sort.SliceStable(features, func(i, j int) bool {
+				a, b := features[i], features[j]
 				if a.entityType != b.entityType {
 					return a.entityType < b.entityType
 				}
@@ -1479,34 +1478,68 @@ INSERT INTO feature_definition(
 				}
 				return a.name < b.name
 			})
-			featureRows := make([][]any, 0, len(sortedFeatures))
-			for _, feature := range sortedFeatures {
+			// Stream the row arrays in bounded chunks instead of materializing
+			// every row as []any up front: the build holds ~1.7M feature rows
+			// at production scale, and three full [][]any copies (featureRows,
+			// searchRows, plus the sortedFeatures copy removed above) stacked
+			// the feature_database_writing peak to ~2 GB. Chunking keeps the
+			// same per-statement batching and the exact same row order, so the
+			// differential gate (SELECT * per table, rowid order) is unchanged.
+			const publishRowChunk = 4000
+			featureRows := make([][]any, 0, publishRowChunk)
+			flushFeatureRows := func() error {
+				if len(featureRows) == 0 {
+					return nil
+				}
+				if err := execMultiRow(conn, `
+INSERT INTO entity_feature(
+    feature_version, entity_type, entity_id, feature_id, value, confidence
+) VALUES (?, ?, ?, ?, ?, ?)`, featureRows); err != nil {
+					return err
+				}
+				featureRows = featureRows[:0]
+				return nil
+			}
+			searchRows := make([][]any, 0, publishRowChunk)
+			flushSearchRows := func() error {
+				if len(searchRows) == 0 {
+					return nil
+				}
+				if err := execMultiRow(conn, `
+INSERT INTO scene_content_search(
+    feature_version, feature_id, scene_id, value
+) VALUES (?, ?, ?, ?)`, searchRows); err != nil {
+					return err
+				}
+				searchRows = searchRows[:0]
+				return nil
+			}
+			for _, feature := range features {
 				key := feature.entityType + "\x00" + feature.family + "\x00" + feature.name
 				featureRows = append(featureRows, []any{
 					featureVersion, feature.entityType, feature.entityID, definitions[key].featureID,
 					feature.value, feature.confidence,
 				})
+				if len(featureRows) >= publishRowChunk {
+					if err := flushFeatureRows(); err != nil {
+						return err
+					}
+				}
+				if feature.entityType == "scene" && feature.family == "content" {
+					searchRows = append(searchRows, []any{
+						featureVersion, definitions[key].featureID, feature.entityID, feature.value,
+					})
+					if len(searchRows) >= publishRowChunk {
+						if err := flushSearchRows(); err != nil {
+							return err
+						}
+					}
+				}
 			}
-			if err := execMultiRow(conn, `
-INSERT INTO entity_feature(
-    feature_version, entity_type, entity_id, feature_id, value, confidence
-) VALUES (?, ?, ?, ?, ?, ?)`, featureRows); err != nil {
+			if err := flushFeatureRows(); err != nil {
 				return err
 			}
-			searchRows := make([][]any, 0, len(sortedFeatures))
-			for _, feature := range sortedFeatures {
-				if feature.entityType != "scene" || feature.family != "content" {
-					continue
-				}
-				key := feature.entityType + "\x00" + feature.family + "\x00" + feature.name
-				searchRows = append(searchRows, []any{
-					featureVersion, definitions[key].featureID, feature.entityID, feature.value,
-				})
-			}
-			if err := execMultiRow(conn, `
-INSERT INTO scene_content_search(
-    feature_version, feature_id, scene_id, value
-) VALUES (?, ?, ?, ?)`, searchRows); err != nil {
+			if err := flushSearchRows(); err != nil {
 				return err
 			}
 			return nil

--- a/core/modelbuild3.go
+++ b/core/modelbuild3.go
@@ -231,9 +231,12 @@ func modelWriteTables(db dbx, modelID, featureVersion string, affinities map[str
 	// attach_build_sources, which sit between writing_started and the first
 	// insert in Python too).
 	databaseWritingStarted := time.Now()
-	scoresByScene := map[string]buildModelScore{}
-	for _, score := range scores {
-		scoresByScene[score.sceneID] = score
+	// Index by scene id rather than copying every buildModelScore struct
+	// (each carries jVal component/eligibility trees and a neighbor slice):
+	// the direct_scene_state loop only needs the score for labeled scenes.
+	scoreIndex := map[string]int{}
+	for i, score := range scores {
+		scoreIndex[score.sceneID] = i
 	}
 	featurePath, err := featureArtifactPath(db, featureVersion)
 	if err != nil {
@@ -280,14 +283,14 @@ INSERT INTO feature_affinity(
 	var stateRows [][]any
 	for _, sceneID := range sortedStringKeys(labels) {
 		label := labels[sceneID]
-		score, ok := scoresByScene[sceneID]
+		score, ok := scoreIndex[sceneID]
 		if !ok {
 			continue
 		}
 		stateRows = append(stateRows, []any{
 			modelID, sceneID, label.absoluteOutcome, label.absoluteEvidence,
 			directConfidenceOf(label.absoluteEvidence),
-			clampValue(label.absoluteOutcome-score.generalAppeal, -2, 2),
+			clampValue(label.absoluteOutcome-scores[score].generalAppeal, -2, 2),
 		})
 	}
 	if err := insertArtifactRows(artifact, `
@@ -300,8 +303,43 @@ INSERT INTO direct_scene_state(
 		report(0.81)
 	}
 	// model_scene_score
-	scoreRows := make([][]any, 0, len(scores))
-	neighborRows := make([][]any, 0)
+	// Stream the row arrays in bounded chunks: the combined score+neighbor
+	// rows are ~240k at production scale, and building every []any row up
+	// front stacked the database_writing peak to ~3 GB (each score row also
+	// marshals three JSON payloads). Chunking keeps the same per-batch
+	// statement shape and the exact same row order (scores slice order, then
+	// neighbor rank), so the differential gate is unchanged.
+	const scoreRowChunk = 2000
+	scoreRows := make([][]any, 0, scoreRowChunk)
+	neighborRows := make([][]any, 0, scoreRowChunk)
+	flushScoreRows := func() error {
+		if len(scoreRows) == 0 {
+			return nil
+		}
+		if err := insertArtifactRows(artifact, `
+INSERT INTO model_scene_score(
+    model_id, scene_id, general_appeal, direct_appeal, direct_confidence,
+    appeal, current_fit, confidence, metadata_confidence, recovery,
+    components_json, classification_json, eligibility_json
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, scoreRows); err != nil {
+			return err
+		}
+		scoreRows = scoreRows[:0]
+		return nil
+	}
+	flushNeighborRows := func() error {
+		if len(neighborRows) == 0 {
+			return nil
+		}
+		if err := insertArtifactRows(artifact, `
+INSERT INTO model_scene_neighbor(
+    model_id, scene_id, rank, neighbor_scene_id, similarity, weight, outcome
+) VALUES (?, ?, ?, ?, ?, ?, ?)`, neighborRows); err != nil {
+			return err
+		}
+		neighborRows = neighborRows[:0]
+		return nil
+	}
 	for _, score := range scores {
 		scoreRows = append(scoreRows, []any{
 			modelID, score.sceneID, score.generalAppeal, score.directAppeal,
@@ -311,6 +349,11 @@ INSERT INTO direct_scene_state(
 			classificationPayload(score.components).marshalSortedKeys(),
 			score.eligibility.marshalSortedKeys(),
 		})
+		if len(scoreRows) >= scoreRowChunk {
+			if err := flushScoreRows(); err != nil {
+				return fail(err)
+			}
+		}
 		for rank, neighbor := range score.neighbors {
 			neighborRows = append(neighborRows, []any{
 				modelID, score.sceneID, rank, neighbor.get("scene_id").asString(),
@@ -318,19 +361,16 @@ INSERT INTO direct_scene_state(
 				numberValue(neighbor.get("outcome")),
 			})
 		}
+		if len(neighborRows) >= scoreRowChunk {
+			if err := flushNeighborRows(); err != nil {
+				return fail(err)
+			}
+		}
 	}
-	if err := insertArtifactRows(artifact, `
-INSERT INTO model_scene_score(
-    model_id, scene_id, general_appeal, direct_appeal, direct_confidence,
-    appeal, current_fit, confidence, metadata_confidence, recovery,
-    components_json, classification_json, eligibility_json
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, scoreRows); err != nil {
+	if err := flushScoreRows(); err != nil {
 		return fail(err)
 	}
-	if err := insertArtifactRows(artifact, `
-INSERT INTO model_scene_neighbor(
-    model_id, scene_id, rank, neighbor_scene_id, similarity, weight, outcome
-) VALUES (?, ?, ?, ?, ?, ?, ?)`, neighborRows); err != nil {
+	if err := flushNeighborRows(); err != nil {
 		return fail(err)
 	}
 	if report != nil {
@@ -421,6 +461,12 @@ func modelPublishTail(db dbx, artifact dbx, temporary, final, modelID, featureVe
 	if report != nil {
 		report(0.94)
 	}
+	// materializeLanes held every greedy candidate with its content vector
+	// map; release that working set before index creation so sqlite_index_
+	// creation / indexing don't stack on top of it (the same
+	// GC+FreeOSMemory treatment modelBuild applies after modelWriteTables).
+	runtime.GC()
+	debug.FreeOSMemory()
 	if err := rec.stage("sqlite_index_creation", "model.sqlite_index_creation", func() error {
 		return artifactCreateIndexes(artifact, "model")
 	}); err != nil {

--- a/core/scoring_fingerprint.go
+++ b/core/scoring_fingerprint.go
@@ -6,4 +6,4 @@
 
 package main
 
-const scoringFingerprint = "2116f4c3e2cf35e6"
+const scoringFingerprint = "b5d0b5d7ac27e5e0"

--- a/curator/model/fingerprint.py
+++ b/curator/model/fingerprint.py
@@ -5,4 +5,4 @@ Identifies the scoring code that produced a model artifact. Regenerate with
 script's MANIFEST.
 """
 
-SCORING_FINGERPRINT = "2116f4c3e2cf35e6"
+SCORING_FINGERPRINT = "b5d0b5d7ac27e5e0"

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -384,6 +384,67 @@
   white-space: nowrap;
 }
 
+/* Question-mark disclosure for the Appeal/Rank explanation in the
+   recommendation lane guidance. The summary renders as a quiet circular
+   icon button; opening it shows the explanation as an inline popover. */
+.curator-view-help {
+  display: inline-block;
+  margin-left: 0.35rem;
+  position: relative;
+  vertical-align: middle;
+}
+
+.curator-view-help summary {
+  align-items: center;
+  border: 1px solid var(--curator-border-strong);
+  border-radius: 50%;
+  color: var(--curator-text-muted);
+  cursor: pointer;
+  display: inline-flex;
+  height: 1.15rem;
+  justify-content: center;
+  list-style: none;
+  transition: color 0.12s ease, border-color 0.12s ease;
+  width: 1.15rem;
+}
+
+.curator-view-help summary::-webkit-details-marker {
+  display: none;
+}
+
+.curator-view-help summary:hover {
+  border-color: var(--curator-text-muted);
+  color: var(--curator-text);
+}
+
+.curator-view-help summary svg {
+  font-size: 0.7rem;
+}
+
+.curator-view-help[open] summary {
+  border-color: var(--curator-accent);
+  color: var(--curator-accent);
+}
+
+.curator-view-help p {
+  background: var(--curator-surface-raised);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius);
+  box-shadow: var(--curator-shadow-md);
+  color: var(--curator-text-muted);
+  display: block;
+  font-size: 0.76rem;
+  left: 0;
+  line-height: 1.45;
+  margin: 0.35rem 0 0;
+  max-width: 24rem;
+  padding: 0.5rem 0.6rem;
+  position: absolute;
+  top: 100%;
+  z-index: 5;
+}
+
+
 .curator-navigation {
   align-items: stretch;
   display: flex;
@@ -715,7 +776,7 @@
   margin-top: 0.1rem;
 }
 
-.curator-record-row .btn {
+.curator-record-row .btn:not(.btn-primary) {
   color: var(--curator-accent);
   flex: none;
   font-weight: 700;
@@ -2078,7 +2139,7 @@
   border-radius: var(--curator-radius-sm);
   color: #fff;
   display: inline-flex;
-  font-size: calc(0.65rem * var(--curator-card-text-scale, 1));
+  font-size: calc(0.55rem * var(--curator-card-text-scale, 1));
   font-weight: 700;
   gap: calc(0.3rem * var(--curator-card-text-scale, 1));
   height: auto;

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -10,7 +10,7 @@
   const { Button, ButtonGroup, Nav } = libraries.Bootstrap;
   const { NavLink, useHistory, useLocation } = libraries.ReactRouterDOM;
   const { FontAwesomeIcon } = libraries.ReactFontAwesome;
-  const { faBalanceScale, faBed, faBroom, faBullseye, faChartLine, faCheckCircle, faClock, faClone, faCog, faCompass, faCopy, faCrosshairs, faDatabase, faDownload, faExpandArrowsAlt, faExternalLinkAlt, faEyeSlash, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faMoon, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSun, faSync, faTag, faThLarge, faThumbsDown, faThumbsUp, faUser, faVenus, faWrench, faXmark } = libraries.FontAwesomeSolid;
+  const { faBalanceScale, faBed, faBroom, faBullseye, faChartLine, faCheckCircle, faCircleQuestion, faClock, faClone, faCog, faCompass, faCopy, faCrosshairs, faDatabase, faDownload, faExpandArrowsAlt, faExternalLinkAlt, faEyeSlash, faFilm, faFilter, faGlobe, faHeart, faHistory, faList, faMoon, faPlay, faPlayCircle, faSearch, faSortAmountDown, faStar, faSun, faSync, faTag, faThLarge, faThumbsDown, faThumbsUp, faUser, faVenus, faWrench, faXmark } = libraries.FontAwesomeSolid;
   const componentTransforms = window.StashCuratorComponentTransforms ||= {};
 
   function transformComponentProps(name, props) {
@@ -81,13 +81,6 @@
       description: "StashDB performers and their scenes, checked against your library.",
     },
     {
-      value: "sentiment",
-      label: "Sentiment review",
-      icon: faBalanceScale,
-      maintenance: true,
-      description: "Review the model's sentiment estimates: least-appealing scenes first, with reasons and feedback on each card.",
-    },
-    {
       value: "feedback",
       label: "Feedback history",
       icon: faThumbsUp,
@@ -100,6 +93,13 @@
       icon: faHistory,
       maintenance: true,
       description: "Revisit qualified recommendations with the reasons recorded when each card appeared.",
+    },
+    {
+      value: "sentiment",
+      label: "Sentiment review",
+      icon: faBalanceScale,
+      maintenance: true,
+      description: "Review the model's sentiment estimates: least-appealing scenes first, with reasons and feedback on each card.",
     },
     {
       value: "prune",
@@ -116,18 +116,18 @@
       description: "Create, inspect, and safely restore Curator sidecar backups.",
     },
     {
+      value: "tasks",
+      label: "Tasks",
+      icon: faList,
+      maintenance: true,
+      description: "Live status of background Curator jobs: queue position, progress, and results.",
+    },
+    {
       value: "diagnostics",
       label: "Diagnostics",
       icon: faWrench,
       maintenance: true,
       description: "Preview and export a privacy-safe status report for bug reports.",
-    },
-    {
-      value: "profiling",
-      label: "Profiling",
-      icon: faChartLine,
-      maintenance: true,
-      description: "Inspect render and query performance profiles captured during development.",
     },
     {
       value: "settings",
@@ -137,11 +137,11 @@
       description: "Sync, discovery, prune, and Whisparr integration settings, without leaving Curator.",
     },
     {
-      value: "tasks",
-      label: "Tasks",
-      icon: faList,
+      value: "profiling",
+      label: "Profiling",
+      icon: faChartLine,
       maintenance: true,
-      description: "Live status of background Curator jobs: queue position, progress, and results.",
+      description: "Inspect render and query performance profiles captured during development.",
     },
   ];
   const PRIMARY_NAV_ITEMS = NAV_ITEMS.filter((item) => !item.maintenance);
@@ -157,7 +157,7 @@
     value: "manage",
     label: "Manage",
     icon: faWrench,
-    description: "Feedback history, sentiment review, recent recommendations, backups, diagnostics, prune queues, profiling, and settings.",
+    description: "Feedback history, recent recommendations, sentiment review, prune queues, backups, tasks, diagnostics, settings, and profiling.",
   };
   // Find groups the three "find new content" surfaces (Similar, Expand,
   // Performer Hunt) under one primary nav item with inner tabs (issue #192).
@@ -4873,7 +4873,16 @@
           { className: "curator-view-copy" },
           React.createElement("h1", null, laneByValue.has(lane) ? "Recommendations" : laneOption.label),
           React.createElement("p", null, laneOption.description),
-          laneByValue.has(lane) && React.createElement("p", null, "Appeal is the model's estimate of how much you'll like a scene, on a −1..1 scale. Rank in this lane is relative to the lane's best — 1.00 is the top of the lane, so it measures ordering utility, not probability. A scene can rank high while its appeal is moderate: rank includes recency and cooldown, appeal is how much you'd like it now."),
+          laneByValue.has(lane) && React.createElement(
+            "details",
+            { className: "curator-view-help" },
+            React.createElement(
+              "summary",
+              { "aria-label": "What do Appeal and Rank mean?", title: "What do Appeal and Rank mean?" },
+              React.createElement(FontAwesomeIcon, { icon: faCircleQuestion })
+            ),
+            React.createElement("p", null, "Appeal is the model's estimate of how much you'll like a scene, on a −1..1 scale. Rank in this lane is relative to the lane's best — 1.00 is the top of the lane, so it measures ordering utility, not probability. A scene can rank high while its appeal is moderate: rank includes recency and cooldown, appeal is how much you'd like it now.")
+          ),
           laneByValue.has(lane) && slate && React.createElement(
             "p",
             { className: "curator-view-stats" },


### PR DESCRIPTION
## Summary

Two commits — UI polish and a model-build memory pass — ahead of V1.

### UI (fix)
- Smaller card source badges (Best Bets / Discover / …): font 0.65rem → 0.55rem base.
- The lane Appeal/Rank explanation is now behind a question-mark disclosure instead of always-visible guidance copy.
- Fixed the Recommendation variety toggle in Settings rendering blue-on-blue when active (`.curator-record-row` color override now excludes `.btn-primary`).
- Manage sections reordered into review / data / system groups (Feedback history → Recently recommended → Sentiment review → Prune → Backups → Tasks → Diagnostics → Settings → Profiling); nav description updated to match.

### Perf / memory (perf)
Three changes cut the model build's peak RSS ~19% on the production-shape synthetic corpus (24k scenes, measured 4784.7 → 3855.5 MB):

- `featurePublish`: sort feature rows in place and stream `entity_feature` / `scene_content_search` inserts in bounded chunks instead of materializing three full `[][]any` copies of the ~1.7M-row set.
- `modelWriteTables`: replace the full `scoresByScene` struct-copy map with a scene-id index; stream score/neighbor rows in chunks.
- `modelPublishTail`: `runtime.GC` + `FreeOSMemory` after `materializeLanes`, so the ordering working set is returned before index creation (tail stages now run on a ~2 MB live heap instead of ~2.4 GB).

The scoring fingerprint was regenerated (code identity is part of the model digest).

## Verification
- `scripts/verify full`: 624 passed, 25 deselected (integration).
- Differential gate (Go binary vs numpy oracle): 222 passed — artifact rows byte-identical.
- Perf gate: 32.7 s vs 74.5 s baseline (2.5x budget).
- 49 plugin runtime tests, 132 model/ranking tests, `node --check` JS.

No issues referenced.
