### PR TITLE
fix(plugin): give card source badges more padding

### DIFF
--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2146,7 +2146,7 @@
   justify-content: center;
   left: 0.5rem;
   letter-spacing: 0.03em;
-  padding: calc(0.3rem * var(--curator-card-text-scale, 1)) calc(0.5rem * var(--curator-card-text-scale, 1));
+  padding: calc(0.32rem * var(--curator-card-text-scale, 1)) calc(0.6rem * var(--curator-card-text-scale, 1));
   position: absolute;
   top: 0.5rem;
   width: auto;


### PR DESCRIPTION
## Summary

After the 0.65 → 0.55rem badge font shrink, the lane-source badge text sat tight against the pill edge. Give it breathing room:

- horizontal padding 0.5 → 0.6rem
- vertical padding 0.3 → 0.32rem

Both stay scaled by `--curator-card-text-scale` as before; the pill grows slightly but stays proportionate to the smaller text.

## Verification

CSS-only change; `git diff --cached --check` clean. No tests pin badge padding.
