### PR TITLE
fix(plugin): badge font 0.625rem and unify score bar tracks

### DIFF
--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2139,7 +2139,7 @@
   border-radius: var(--curator-radius-sm);
   color: #fff;
   display: inline-flex;
-  font-size: calc(0.55rem * var(--curator-card-text-scale, 1));
+  font-size: calc(0.625rem * var(--curator-card-text-scale, 1));
   font-weight: 700;
   gap: calc(0.3rem * var(--curator-card-text-scale, 1));
   height: auto;
@@ -3020,7 +3020,10 @@
   border-radius: var(--curator-radius-sm);
   overflow: hidden;
   margin: 6px 0 4px;
-  background: var(--bs-secondary-bg, #333);
+  /* Same track token as .curator-score-scale so the Appeal and Rank bars
+     match in both themes: --bs-secondary-bg stays dark in Stash's own
+     chrome, so Curator's light-mode data-theme toggle never reached it. */
+  background: var(--curator-wash-recessed);
 }
 .curator-score-bar-seg {
   display: block;


### PR DESCRIPTION
## Summary

Two CSS fixes, verified locally in the Stash install before this PR:

- **Badge font 0.55 → 0.625rem** — the 0.65rem original was too large and 0.55rem/0.6rem too small after the badge padding grew; 0.625rem is the confirmed middle.
- **Unify score-bar tracks** — `.curator-score-bar` (Rank) used `var(--bs-secondary-bg, #333)`, a Bootstrap token that stays dark in Stash's own chrome, so the Rank bar never followed Curator's light-mode `data-theme` toggle. It now uses `var(--curator-wash-recessed)`, the same track token as the Appeal bar (`.curator-score-scale`), so both bars match and both render in light mode.

## Verification

- Local install to the Stash plugin dir, hash-verified against the built zip (md5 match).
- User confirmed 0.625rem reads right and both bars render in light mode.
- CSS-only; no tests pin these values.
