### PR TITLE
perf(core): speed up get_expand serve path 11x on live libraries

### DIFF
--- a/core/expand.go
+++ b/core/expand.go
@@ -737,21 +737,28 @@ func (s *expandService) blockedTagNameGroups() ([]map[string]bool, error) {
 	return equivalentTagNames(s.db, names)
 }
 
-// annotateLocalMatch mirrors ExpandService._annotate_local_match.
-func annotateLocalMatch(scene jVal, links jVal) jVal {
-	externalID := scene.get("id").asString()
-	sceneIDs := links.get("scene_ids")
-	localSceneID := ""
-	if v := sceneIDs.get(externalID); v.truthy() {
-		localSceneID = v.asString()
-	} else {
-		for _, pair := range links.get("scenes").obj {
-			if pair.val.asString() == externalID {
-				localSceneID = pair.key
-				break
-			}
-		}
+// sceneLinkMaps mirrors the scene_ids/scene_phashes lookups of
+// ExpandService._annotate_local_match as hash maps. The ordered jVal links
+// maps are built once per operation and the per-row annotation is O(1): the
+// insertion-ordered jVal lookups would otherwise linearly scan every linked
+// scene per candidate (a Python dict is a hash map, so the ported loop was
+// orders of magnitude slower on large libraries).
+func sceneLinkMaps(links jVal) (byExternalID, byPhash map[string]string) {
+	byExternalID = make(map[string]string)
+	for _, pair := range links.get("scene_ids").obj {
+		byExternalID[pair.key] = pair.val.asString()
 	}
+	byPhash = make(map[string]string)
+	for _, pair := range links.get("scene_phashes").obj {
+		byPhash[pair.key] = pair.val.asString()
+	}
+	return byExternalID, byPhash
+}
+
+// annotateLocalMatch mirrors ExpandService._annotate_local_match.
+func annotateLocalMatch(scene jVal, byExternalID, byPhash map[string]string) jVal {
+	externalID := scene.get("id").asString()
+	localSceneID := byExternalID[externalID]
 	matchType := ""
 	if localSceneID != "" {
 		matchType = "stashdb_id"
@@ -765,8 +772,8 @@ func annotateLocalMatch(scene jVal, links jVal) jVal {
 			if !ok {
 				continue
 			}
-			if v := links.get("scene_phashes").get(value); v.truthy() {
-				localSceneID = v.asString()
+			if localID, found := byPhash[value]; found {
+				localSceneID = localID
 				matchType = "phash"
 				break
 			}

--- a/core/expand_ops.go
+++ b/core/expand_ops.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"sort"
+	"sync"
 	"time"
 )
 
@@ -145,7 +146,10 @@ func expandResults(db dbx, entityType string, page int64, sortBy string, perform
 	if err != nil {
 		return jvNull(), err
 	}
-	rows := make([]jVal, 0)
+	var byExternalID, byPhash map[string]string
+	if links.kind == jObj {
+		byExternalID, byPhash = sceneLinkMaps(links)
+	}
 	entityRows, err := db.Query(`SELECT * FROM external_entity WHERE entity_type=? AND pool='candidate'`, entityType)
 	if err != nil {
 		return jvNull(), err
@@ -154,6 +158,18 @@ func expandResults(db dbx, entityType string, page int64, sortBy string, perform
 	if err != nil {
 		return jvNull(), err
 	}
+	// The candidate rows are materialized first so the parse/annotate/filter
+	// phase can run across all cores: each row's work is independent, and the
+	// outputs land in index-ordered slots, so the assembled rows are
+	// identical to the sequential loop (and the first payload error by row
+	// order is the one returned, matching the old behavior).
+	type expandRow struct {
+		externalID  string
+		score       float64
+		payloadJSON string
+		sourcesJSON string
+	}
+	materialized := make([]expandRow, 0)
 	for entityRows.Next() {
 		values := make([]any, len(columns))
 		scanned := make([]any, len(columns))
@@ -167,72 +183,115 @@ func expandResults(db dbx, entityType string, page int64, sortBy string, perform
 		for i, name := range columns {
 			row[name] = values[i]
 		}
-		score := asDBFloat(row["score"])
-		if score < minimumScore {
-			continue
-		}
-		payload, err := parseJSON([]byte(asDBString(row["payload_json"])))
-		if err != nil {
-			return jvNull(), err
-		}
-		// Issue #118: the stored annotation can be stale (the candidate was
-		// fetched before the local scene gained its StashDB id). Re-derive it
-		// against the current links map; the serve-time match is
-		// authoritative for the exclusion and for the served payload.
-		if links.kind == jObj && entityType == "scene" {
-			payload = annotateLocalMatch(payload, links)
-		}
-		matchType := payload.get("curator_local_match").get("type").asString()
-		if entityType == "scene" && (matchType == "stashdb_id" || (hidePhash && matchType == "phash")) {
-			continue
-		}
-		if performerID.kind != jNull && entityType == "scene" {
-			found := false
-			for _, item := range payload.get("performers").arr {
-				if item.get("performer").get("id").asString() == performerID.asString() {
-					found = true
-					break
-				}
-			}
-			if !found {
-				continue
-			}
-		}
-		if favoriteOnly && entityType == "scene" {
-			hasFavorite := false
-			for _, item := range payload.get("performers").arr {
-				if item.get("performer").get("curator_local").get("favorite").truthy() {
-					hasFavorite = true
-					break
-				}
-			}
-			if !hasFavorite {
-				continue
-			}
-		}
-		if gender != "" && !payloadMatchesGender(payload, entityType, gender) {
-			continue
-		}
-		if entityType == "scene" && !expandSceneMatches(payload, includeTags, excludeTags,
-			performerNames, studioNames, performerQuery, studioQuery,
-			includeGroups, excludeGroups, blockedGroups, blockedTerms) {
-			continue
-		}
-		sources, err := parseJSON([]byte(asDBString(row["sources_json"])))
-		if err != nil {
-			sources = jvArr()
-		}
-		rows = append(rows, jvObj(
-			jvKey("id", jvStr(asDBString(row["external_id"]))),
-			jvKey("score", jvFloat(score)),
-			jvKey("sources", sources),
-			jvKey("payload", payload),
-			jvKey("shortlisted", jvBool(shortlisted[asDBString(row["external_id"])])),
-		))
+		materialized = append(materialized, expandRow{
+			externalID:  asDBString(row["external_id"]),
+			score:       asDBFloat(row["score"]),
+			payloadJSON: asDBString(row["payload_json"]),
+			sourcesJSON: asDBString(row["sources_json"]),
+		})
 	}
 	entityRows.Close()
 	if err := entityRows.Err(); err != nil {
 		return jvNull(), err
+	}
+	results := make([]jVal, len(materialized))
+	errs := make([]error, len(materialized))
+	workers := nthreads(0)
+	if workers > len(materialized) {
+		workers = len(materialized)
+	}
+	if workers < 1 {
+		workers = 1
+	}
+	var wg sync.WaitGroup
+	jobCh := make(chan int)
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range jobCh {
+				row := materialized[i]
+				if row.score < minimumScore {
+					continue
+				}
+				payload, err := parseJSON([]byte(row.payloadJSON))
+				if err != nil {
+					errs[i] = err
+					continue
+				}
+				// Issue #118: the stored annotation can be stale (the
+				// candidate was fetched before the local scene gained its
+				// StashDB id). Re-derive it against the current links map;
+				// the serve-time match is authoritative for the exclusion and
+				// for the served payload.
+				if links.kind == jObj && entityType == "scene" {
+					payload = annotateLocalMatch(payload, byExternalID, byPhash)
+				}
+				matchType := payload.get("curator_local_match").get("type").asString()
+				if entityType == "scene" && (matchType == "stashdb_id" || (hidePhash && matchType == "phash")) {
+					continue
+				}
+				if performerID.kind != jNull && entityType == "scene" {
+					found := false
+					for _, item := range payload.get("performers").arr {
+						if item.get("performer").get("id").asString() == performerID.asString() {
+							found = true
+							break
+						}
+					}
+					if !found {
+						continue
+					}
+				}
+				if favoriteOnly && entityType == "scene" {
+					hasFavorite := false
+					for _, item := range payload.get("performers").arr {
+						if item.get("performer").get("curator_local").get("favorite").truthy() {
+							hasFavorite = true
+							break
+						}
+					}
+					if !hasFavorite {
+						continue
+					}
+				}
+				if gender != "" && !payloadMatchesGender(payload, entityType, gender) {
+					continue
+				}
+				if entityType == "scene" && !expandSceneMatches(payload, includeTags, excludeTags,
+					performerNames, studioNames, performerQuery, studioQuery,
+					includeGroups, excludeGroups, blockedGroups, blockedTerms) {
+					continue
+				}
+				sources, err := parseJSON([]byte(row.sourcesJSON))
+				if err != nil {
+					sources = jvArr()
+				}
+				results[i] = jvObj(
+					jvKey("id", jvStr(row.externalID)),
+					jvKey("score", jvFloat(row.score)),
+					jvKey("sources", sources),
+					jvKey("payload", payload),
+					jvKey("shortlisted", jvBool(shortlisted[row.externalID])),
+				)
+			}
+		}()
+	}
+	for i := range materialized {
+		jobCh <- i
+	}
+	close(jobCh)
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			return jvNull(), err
+		}
+	}
+	rows := make([]jVal, 0, len(results))
+	for _, result := range results {
+		if result.kind != jNull {
+			rows = append(rows, result)
+		}
 	}
 	if sortBy == "newest" && entityType == "scene" {
 		sort.SliceStable(rows, func(i, j int) bool {
@@ -424,8 +483,9 @@ func expandPerformerHunt(db dbx, clientURL, apiKey string, links jVal, performer
 		}
 	}
 	annotated := make([]jVal, 0, len(rows.order))
+	byExternalID, byPhash := sceneLinkMaps(links)
 	for _, id := range rows.order {
-		annotated = append(annotated, annotateLocalMatch(rows.m[id], links))
+		annotated = append(annotated, annotateLocalMatch(rows.m[id], byExternalID, byPhash))
 	}
 	service := newExpandService(db)
 	scenes, _, err := service.score(annotated, sources, modelID, featureVersion, links, jvStr(performerID))

--- a/core/expand_refresh.go
+++ b/core/expand_refresh.go
@@ -616,9 +616,10 @@ func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int
 	}
 	today := time.Now()
 	cutoff := today.AddDate(0, 0, -horizonDays).Format("2006-01-02")
+	byExternalID, byPhash := sceneLinkMaps(links)
 	var candidates []jVal
 	for _, row := range rows.list() {
-		candidate := annotateLocalMatch(row, links)
+		candidate := annotateLocalMatch(row, byExternalID, byPhash)
 		match := candidate.get("curator_local_match")
 		if match.get("type").asString() != "stashdb_id" &&
 			recentScene(candidate, cutoff) &&

--- a/core/expand_similar.go
+++ b/core/expand_similar.go
@@ -601,9 +601,10 @@ func expandTargetedSimilar(db dbx, clientURL, apiKey string, links jVal, entityT
 		timings.set("retrieval", jvInt(retrievalMs))
 		recordDurationMs(trace, "python", "external_similar.retrieval", retrievalMs)
 		stageStart := time.Now()
+		byExternalID, byPhash := sceneLinkMaps(links)
 		candidates := make([]jVal, 0)
 		for _, value := range rows.list() {
-			candidate := annotateLocalMatch(value, links)
+			candidate := annotateLocalMatch(value, byExternalID, byPhash)
 			matchType := candidate.get("curator_local_match").get("type").asString()
 			if !(includeOwned || matchType != "stashdb_id") {
 				continue

--- a/core/go.mod
+++ b/core/go.mod
@@ -5,3 +5,5 @@ go 1.26.5
 require github.com/mattn/go-sqlite3 v1.14.49
 
 require github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3
+
+require github.com/buger/jsonparser v1.1.1

--- a/core/go.sum
+++ b/core/go.sum
@@ -1,3 +1,5 @@
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3 h1:LMLX+LgTNWpfvCBdFebv6EsYotImrt/Ppc5cXIriCSo=
 github.com/google/pprof v0.0.0-20260802141513-ef3492d7dac3/go.mod h1:jl5iWTm0/hd5PjEYEOuwAJ57L/CibdZfrqZ5XA5GrCk=
 github.com/mattn/go-sqlite3 v1.14.49 h1:B8jBHC3xhxZgxztrgruTuLucebnULQnx4W7cF7SAE9w=

--- a/core/jsonv.go
+++ b/core/jsonv.go
@@ -11,14 +11,14 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"math"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/buger/jsonparser"
 )
 
 type jKind uint8
@@ -155,75 +155,108 @@ func deepEqual(a, b jVal) bool {
 }
 
 // parseJSON parses one JSON value, preserving object key order and number
-// tokens exactly as Python's json.loads consumes them.
+// tokens exactly as Python's json.loads consumes them. The decode uses
+// github.com/buger/jsonparser: a single-pass, allocation-light walk that
+// yields the same tree as the stdlib Token decoder (same key order, raw
+// number tokens, \uXXXX string decoding including surrogate pairs and
+// lone-surrogate replacement), measured ~3x faster on the expand payloads
+// and ~4x on the external-links cache document.
 func parseJSON(data []byte) (jVal, error) {
-	dec := json.NewDecoder(bytes.NewReader(data))
-	dec.UseNumber()
-	v, err := decodeValue(dec)
+	trimmed := bytes.TrimLeft(data, " \t\r\n")
+	if len(trimmed) == 0 {
+		return jVal{}, errors.New("unexpected end of JSON input")
+	}
+	vt := jsonparser.NotExist
+	switch trimmed[0] {
+	case '{':
+		vt = jsonparser.Object
+	case '[':
+		vt = jsonparser.Array
+	case '"':
+		vt = jsonparser.String
+	case 't', 'f':
+		vt = jsonparser.Boolean
+	case 'n':
+		vt = jsonparser.Null
+	default:
+		vt = jsonparser.Number
+	}
+	v, err := decodeValue(trimmed, vt)
 	if err != nil {
 		return jVal{}, err
 	}
-	// Reject trailing content after the value.
-	if _, err := dec.Token(); !errors.Is(err, io.EOF) {
-		if err == nil {
-			return jVal{}, errors.New("trailing data after JSON value")
-		}
+	// Reject trailing content after the value (jsonparser ignores it).
+	_, _, off, err := jsonparser.Get(trimmed)
+	if err != nil {
 		return jVal{}, err
+	}
+	if len(bytes.TrimLeft(trimmed[off:], " \t\r\n")) > 0 {
+		return jVal{}, errors.New("trailing data after JSON value")
 	}
 	return v, nil
 }
 
-func decodeValue(dec *json.Decoder) (jVal, error) {
-	tok, err := dec.Token()
-	if err != nil {
-		return jVal{}, err
-	}
-	switch t := tok.(type) {
-	case nil:
-		return jvNull(), nil
-	case bool:
-		return jvBool(t), nil
-	case json.Number:
-		return jvNum(string(t)), nil
-	case string:
-		return jvStr(t), nil
-	case json.Delim:
-		switch t {
-		case '{':
-			obj := jVal{kind: jObj}
-			for dec.More() {
-				keyTok, err := dec.Token()
-				if err != nil {
-					return jVal{}, err
-				}
-				key, ok := keyTok.(string)
-				if !ok {
-					return jVal{}, errors.New("object key is not a string")
-				}
-				val, err := decodeValue(dec)
-				if err != nil {
-					return jVal{}, err
-				}
-				obj.obj = append(obj.obj, jPair{key: key, val: val})
+// decodeValue parses one JSON value into a jVal. The iterators report the
+// ValueType of each child (string values arrive without their quotes), so
+// dispatch uses vt rather than the first byte; the top-level call derives vt
+// from the first byte after leading whitespace.
+func decodeValue(data []byte, vt jsonparser.ValueType) (jVal, error) {
+	switch vt {
+	case jsonparser.Object:
+		obj := jVal{kind: jObj}
+		err := jsonparser.ObjectEach(data, func(key, value []byte, childVt jsonparser.ValueType, _ int) error {
+			val, err := decodeValue(value, childVt)
+			if err != nil {
+				return err
 			}
-			if _, err := dec.Token(); err != nil { // consume '}'
-				return jVal{}, err
-			}
-			return obj, nil
-		case '[':
-			arr := jVal{kind: jArr}
-			for dec.More() {
-				val, err := decodeValue(dec)
-				if err != nil {
-					return jVal{}, err
-				}
-				arr.arr = append(arr.arr, val)
-			}
-			if _, err := dec.Token(); err != nil { // consume ']'
-				return jVal{}, err
-			}
-			return arr, nil
+			obj.obj = append(obj.obj, jPair{key: string(key), val: val})
+			return nil
+		})
+		if err != nil {
+			return jVal{}, err
 		}
+		return obj, nil
+	case jsonparser.Array:
+		arr := jVal{kind: jArr}
+		var walkErr error
+		_, err := jsonparser.ArrayEach(data, func(value []byte, childVt jsonparser.ValueType, _ int, err error) {
+			if err != nil {
+				if walkErr == nil {
+					walkErr = err
+				}
+				return
+			}
+			val, err := decodeValue(value, childVt)
+			if err != nil {
+				if walkErr == nil {
+					walkErr = err
+				}
+				return
+			}
+			arr.arr = append(arr.arr, val)
+		})
+		if err != nil {
+			return jVal{}, err
+		}
+		if walkErr != nil {
+			return jVal{}, walkErr
+		}
+		return arr, nil
+	case jsonparser.String:
+		s, err := jsonparser.ParseString(data)
+		if err != nil {
+			return jVal{}, err
+		}
+		return jvStr(s), nil
+	case jsonparser.Boolean:
+		if len(data) == 0 {
+			return jVal{}, errors.New("unexpected end of JSON input")
+		}
+		return jvBool(data[0] == 't'), nil
+	case jsonparser.Null:
+		return jvNull(), nil
+	case jsonparser.Number:
+		return jvNum(string(data)), nil
 	}
 	return jVal{}, errors.New("unexpected JSON token")
 }


### PR DESCRIPTION
## What

`get_expand` (the Expand browse op) took 31s on a live 23.9k-scene library. Root cause: the candidate scan re-derived the local-match annotation per row with linear lookups over the insertion-ordered `jVal` links maps — a Python dict is a hash map, so the Go port was O(library-size) per candidate row, including a dead fallback over the `scenes` map that can never succeed (both maps are built from the same rows). Cold per-op process made it unavoidable to redo every time.

## Changes

- `annotateLocalMatch` now uses O(1) Go hash maps (`sceneLinkMaps`) built once per operation; the dead `scenes` fallback is removed. Applied to all four paths (expand serve, performer hunt, refresh, external similar).
- The expandResults candidate scan materializes rows and runs parse/annotate/filter across all cores with index-ordered slots — deterministic, byte-identical output.
- `parseJSON` switched from the stdlib `Token` decoder to `buger/jsonparser` (~3x on expand payloads, ~4x on the external-links cache document). Trailing-data guard preserved (via `Get` offset); surrogate-pair and lone-surrogate handling verified identical to stdlib; duplicate-key behavior unchanged. Every op benefits from the faster links-cache parse.

## Verification

- Local repro (real payloads, 24k-entry links maps): 28.8s → 0.31s idle (~2.9s under load).
- Live install: 31.0s → 2.4–2.9s (steady-state, 3 runs).
- `scripts/verify full`: 624 tests pass, including the Go/Python byte-identity differential gates for all expand ops.
- Perf gate A/B vs the pre-change binary: no build-path regression (both pass; the new binary trips only a 7ms/508ms noise blip).