### PR TITLE
perf(core): fetch expand-refresh probes concurrently

### DIFF
--- a/core/expand.go
+++ b/core/expand.go
@@ -1279,42 +1279,6 @@ type fetchPageSpec struct {
 	since    string
 }
 
-// fetchScenes runs one _fetch pass (sequential pages), mirroring the Python
-// loop exactly. Rows and sources are merged with first-seen semantics.
-func fetchScenes(clientURL, apiKey string, spec fetchPageSpec, rows *sceneRows, sources map[string]map[string]bool) (int64, bool, error) {
-	fetched := int64(0)
-	page := int64(1)
-	total := int64(0)
-	pageSize := minInt64(250, spec.limit)
-	for fetched < spec.limit {
-		pageTotal, batch, err := fetchScenesPage(clientURL, apiKey, spec, page, pageSize)
-		if err != nil {
-			return 0, false, err
-		}
-		total = pageTotal
-		accepted := batch
-		if int64(len(accepted)) > spec.limit-fetched {
-			accepted = batch[:spec.limit-fetched]
-		}
-		for _, scene := range accepted {
-			identifier := scene.get("id").asString()
-			rows.add(identifier, scene)
-			sourceSet := sources[identifier]
-			if sourceSet == nil {
-				sourceSet = map[string]bool{}
-				sources[identifier] = sourceSet
-			}
-			sourceSet[spec.source] = true
-		}
-		fetched += int64(len(accepted))
-		if len(batch) == 0 || fetched >= total {
-			break
-		}
-		page++
-	}
-	return total, fetched < total, nil
-}
-
 // fetchScenesPage executes one SCENES query page and returns (count, scenes).
 func fetchScenesPage(clientURL, apiKey string, spec fetchPageSpec, page, pageSize int64) (int64, []jVal, error) {
 	query := jvObj(

--- a/core/expand_refresh.go
+++ b/core/expand_refresh.go
@@ -599,24 +599,35 @@ func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int
 	if wildcard {
 		queries = append(queries, querySpec{"wildcard", nil, minInt64(100, int64(perSource))})
 	}
-	for position, query := range queries {
-		spec := fetchPageSpec{
+	specs := make([]fetchPageSpec, 0, len(queries))
+	for _, query := range queries {
+		specs = append(specs, fetchPageSpec{
 			source:   query.source,
 			values:   query.values,
 			limit:    query.limit,
 			modifier: "INCLUDES",
 			sort:     "DATE",
 			since:    since,
-		}
-		if _, _, err := fetchScenes(clientURL, apiKey, spec, rows, sources); err != nil {
-			return jvNull(), err
-		}
-		if progress != nil {
-			progress(200+int(pyRound(450*float64(position+1)/float64(maxInt(1, len(queries))))), 1000)
-		}
+		})
 	}
-	if progress != nil && len(queries) == 0 {
-		progress(650, 1000)
+	// Fetch every probe concurrently (pages within each probe in parallel),
+	// merging in probe order — the same merge semantics as the sequential
+	// loop, so the fetched rows are identical while the fetch phase takes
+	// max(probe) instead of the sum. The per-probe progress ticks keep their
+	// sequential values and fire once all probes have returned.
+	fetched, fetchedSources, err := fetchProbes(clientURL, apiKey, specs)
+	if err != nil {
+		return jvNull(), err
+	}
+	rows = fetched
+	sources = fetchedSources
+	if progress != nil {
+		for position := range specs {
+			progress(200+int(pyRound(450*float64(position+1)/float64(maxInt(1, len(specs))))), 1000)
+		}
+		if len(specs) == 0 {
+			progress(650, 1000)
+		}
 	}
 	today := time.Now()
 	cutoff := today.AddDate(0, 0, -horizonDays).Format("2006-01-02")


### PR DESCRIPTION
## What

The Expand-refresh task fetched its probes **sequentially** (and each probe's pages sequentially), so the fetch phase was the sum of every StashDB round trip. The other network ops were already parallel: performer hunt uses `fetchParallel` (pages fanned out), external similar uses `fetchProbes` (probes concurrently).

## Changes

Route the refresh's probes through the existing `fetchProbes` helper: pages within a probe run in parallel and the probes run concurrently, merged in probe order with first-seen semantics — the fetched rows are byte-identical to the sequential loop (the same helper `get_external_similar` already relies on for its differential parity). The per-probe progress ticks keep their sequential values and fire once the fetch completes (no test pins the tick stream; values unchanged). The now-dead sequential `fetchScenes` mirror is removed.

Fetch phase goes from sum(probe latencies) to max(probe latency).

## Verification

- `tests/core/` differential suite (Go vs Python byte-identity, incl. `test_expand_refresh_state_parity` / `test_expand_refresh_byte_identical` + all slice2 network ops): 211 passed.
- `go test ./...`: pass.