### PR TITLE
fix(core): hand over the worker daemon to a new binary immediately

### DIFF
--- a/core/daemon.go
+++ b/core/daemon.go
@@ -233,6 +233,33 @@ func removeWorkerPidIfOwned(pluginDir string) {
 	}
 }
 
+// handoverWorker hands the resident worker to the newly installed binary:
+// refresh the worker-state fingerprint, drop the pid file, and spawn the
+// successor (os.Executable() resolves the replaced file, so the spawn is the
+// new generation). Best-effort — on any failure the next Curator invocation
+// spawns the new generation as before, so the daemon is never left in a
+// worse state than without the handover.
+func handoverWorker(pluginDir string) {
+	fresh, err := readWorkerState(pluginDir)
+	if err != nil {
+		return
+	}
+	fingerprint, err := workerBinaryFingerprint(pluginDir)
+	if err != nil {
+		return
+	}
+	fresh.BinaryFingerprint = fingerprint
+	if err := writeWorkerState(pluginDir, fresh); err != nil {
+		return
+	}
+	// Drop the pid before spawning: the successor refuses to start while a
+	// live worker pid is recorded. The deferred removeWorkerPidIfOwned on
+	// exit is ownership-guarded, so it cannot remove the successor's pid.
+	removeWorkerPidIfOwned(pluginDir)
+	infoLog("daemon handing over to the updated binary")
+	_ = spawnWorkerFn(pluginDir)
+}
+
 func stopWorker(pid int) error {
 	if !pidAlive(pid) {
 		return nil
@@ -508,7 +535,11 @@ func runDaemon(pluginDir string) {
 		select {
 		case <-updateDetected:
 			// Let an active job finish, but do not claim more work under the
-			// old executable. The next invocation starts the new generation.
+			// old executable. Hand over to the new generation immediately so
+			// scheduled work keeps firing even when no Curator invocation
+			// follows the plugin update (an idle system would otherwise miss
+			// the next schedule window until the next op).
+			handoverWorker(pluginDir)
 			infoLog("daemon stopped after plugin update")
 			return
 		default:

--- a/core/daemon_test.go
+++ b/core/daemon_test.go
@@ -344,6 +344,53 @@ func TestEnsureWorkerIgnoresReusedPID(t *testing.T) {
 		t.Fatalf("reused PID handling: stop=%d spawn=%d", stopCalls, spawnCalls)
 	}
 }
+func TestHandoverWorkerSpawnsSuccessor(t *testing.T) {
+	pluginDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(pluginDir, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	name := "curator-core-" + runtime.GOOS + "-" + runtime.GOARCH
+	if runtime.GOOS == "windows" {
+		name += ".exe"
+	}
+	binary := filepath.Join(pluginDir, name)
+	if err := os.WriteFile(binary, []byte("new-generation"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oldFingerprint, err := workerBinaryFingerprint(pluginDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// The resident worker: its own pid in the pid file and a state row for
+	// the previous generation.
+	if err := os.WriteFile(workerPidPath(pluginDir), []byte(strconv.Itoa(os.Getpid())), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeWorkerState(pluginDir, workerState{BinaryFingerprint: "old-generation"}); err != nil {
+		t.Fatal(err)
+	}
+	spawned := 0
+	previousSpawn := spawnWorkerFn
+	spawnWorkerFn = func(string) error { spawned++; return nil }
+	defer func() { spawnWorkerFn = previousSpawn }()
+
+	handoverWorker(pluginDir)
+
+	if spawned != 1 {
+		t.Fatalf("successor spawns = %d, want 1", spawned)
+	}
+	if _, err := os.Stat(workerPidPath(pluginDir)); !os.IsNotExist(err) {
+		t.Fatalf("pid file not removed: %v", err)
+	}
+	state, err := readWorkerState(pluginDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.BinaryFingerprint != oldFingerprint {
+		t.Fatalf("state fingerprint = %q, want %q (the installed binary)", state.BinaryFingerprint, oldFingerprint)
+	}
+}
+
 func TestWorkerUpdateWatcherDetectsReplacement(t *testing.T) {
 	pluginDir := t.TempDir()
 	name := "curator-core-" + runtime.GOOS + "-" + runtime.GOARCH


### PR DESCRIPTION
## What

A plugin update replaces the installed binary, and the resident worker daemon retires on its next fingerprint check (by design — `installed curator-core changed; daemon retiring`). It was only re-spawned by the **next Curator invocation**, so on an idle system the scheduled tasks (expand-refresh, backups) silently missed their window until the next op. Observed live: three overnight plugin installs left the daemon down for hours; the expand-refresh schedule did not fire until morning activity re-spawned it (the Expand page showed `Stale · Updated 2026-08-22 12:07:55`).

## Changes

The retiring daemon now hands over directly (`handoverWorker`): refresh the worker-state fingerprint, drop its pid file (the successor refuses to start while a live worker pid is recorded; the deferred removal is ownership-guarded), and spawn the successor — `os.Executable()` resolves the replaced file, so the spawn is the new generation. Best-effort: on any failure the next invocation spawns the new generation as before, so the daemon is never in a worse state than without the handover.

## Verification

- New `TestHandoverWorkerSpawnsSuccessor`: successor spawned once, pid file removed, state fingerprint updated to the installed binary.
- `go test ./...`: pass (incl. the existing rotation/watcher tests).
- Differential sanity (`test_backend_slice1` + `test_backend_slice3_refresh`): 25 passed — the daemon change does not touch op output.