### PR TITLE
perf(core): batch curation-impact feature reads; index blocked-term lookup

### DIFF
--- a/core/curation.go
+++ b/core/curation.go
@@ -1902,28 +1902,51 @@ func curationImpact(db dbx) (jVal, error) {
 		for _, e := range demotedPool {
 			sceneIDs = append(sceneIDs, e.id)
 		}
-		for _, sceneID := range sceneIDs {
+		// One batched query instead of one per scene: the pooled entity_id
+		// lookups were individual full scans of the artifact (entity_feature
+		// has no entity_id index and the predicate omits entity_type, so the
+		// PK prefix cannot narrow them), which dominated the op on large
+		// libraries. Contributors are sorted and truncated afterwards, so
+		// row order is irrelevant and the output is unchanged.
+		namesByScene := map[string][]string{}
+		if len(sceneIDs) > 0 {
+			marks := strings.TrimSuffix(strings.Repeat("?,", len(sceneIDs)), ",")
+			args := make([]any, 0, len(sceneIDs)+1)
+			args = append(args, newer.featureVersion)
+			for _, sceneID := range sceneIDs {
+				args = append(args, sceneID)
+			}
 			cr, err := fdb.Query(`
-				SELECT fd.name
+				SELECT ef.entity_id, fd.name
 				FROM entity_feature ef
 				JOIN feature_definition fd USING(feature_id)
-				WHERE ef.feature_version=? AND ef.entity_id=?`, newer.featureVersion, sceneID)
+				WHERE ef.feature_version=? AND ef.entity_id IN (`+marks+`)`, args...)
 			if err != nil {
 				fdb.Close()
 				return unavailable(), nil
 			}
+			for cr.Next() {
+				var sceneID, name string
+				if err := cr.Scan(&sceneID, &name); err != nil {
+					cr.Close()
+					fdb.Close()
+					return jvNull(), err
+				}
+				namesByScene[sceneID] = append(namesByScene[sceneID], name)
+			}
+			cr.Close()
+			if err := cr.Err(); err != nil {
+				fdb.Close()
+				return jvNull(), err
+			}
+		}
+		for _, sceneID := range sceneIDs {
 			var cands []contributor
 			directDelta := newDirect[sceneID] - oldDirect[sceneID]
 			if math.Abs(directDelta) > IMPACT_MIN_CONTRIBUTION {
 				cands = append(cands, contributor{kind: "direct", id: sceneID, name: "Your direct feedback", delta: directDelta})
 			}
-			for cr.Next() {
-				var name string
-				if err := cr.Scan(&name); err != nil {
-					cr.Close()
-					fdb.Close()
-					return jvNull(), err
-				}
+			for _, name := range namesByScene[sceneID] {
 				delta, ok := contributionDeltas[name]
 				if !ok {
 					continue
@@ -1945,11 +1968,6 @@ func curationImpact(db dbx) (jVal, error) {
 					}
 				}
 				cands = append(cands, c)
-			}
-			cr.Close()
-			if err := cr.Err(); err != nil {
-				fdb.Close()
-				return jvNull(), err
 			}
 			sort.Slice(cands, func(i, j int) bool {
 				ai, aj := math.Abs(cands[i].delta), math.Abs(cands[j].delta)

--- a/core/similar.go
+++ b/core/similar.go
@@ -591,10 +591,10 @@ WHERE model_id=? AND performer_id=? ORDER BY rank`, s.modelID, targetID)
 			args = append(args, "desc:"+term)
 		}
 		rows, err := s.db.Query(`SELECT DISTINCT ef.entity_id FROM entity_feature ef
-JOIN feature_definition fd ON fd.feature_id=ef.feature_id
 WHERE ef.feature_version=? AND ef.entity_type='scene'
-  AND fd.family='content'
-  AND fd.name IN (`+placeholders+`)`, args...)
+  AND ef.feature_id IN (
+    SELECT feature_id FROM feature_definition
+    WHERE family='content' AND name IN (`+placeholders+`))`, args...)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## What

Latest profiling (24h window) showed `get_curation_impact` at 11-17s per call (42s total across 3 calls) and `get_similar` spending 2 x 3.1s on `entity_feature` reads.

## Changes

1. **`get_curation_impact`** — ran one `entity_feature` query per pooled scene (40 scenes on the live library). Each is a full scan of the artifact table: the predicate omits `entity_type`, so the PK `(feature_version, entity_type, entity_id, feature_id)` cannot narrow it, and no `entity_id` index exists — measured ~360ms/query via the artifact (≈14s of the 11-17s op). Batched into one `entity_id IN (...)` query. Contributors are sorted and truncated afterwards, so row order is irrelevant — output byte-identical (the Python oracle's per-scene loop feeds the same sort).
2. **`get_similar` blocked-term lookup** — the query joined `feature_definition` and scanned the scene subtree; routing the name filter through a `feature_id` subquery uses the existing `entity_feature(feature_id)` index — measured 3.6s → 0.28s. Reachable only when blocked description terms exist (0 on the live host today, so this is latent).

The remaining `get_similar` cost (2 x ~2.8s `performerProfiles` — 397k rows) is inherent volume + cold page cache, not a query-shape bug.

## Verification

- `tests/core/` differential suite: 211 passed (incl. `test_backend_slice7_impact.py` byte-identity + slice2 network ops).
- `go test ./...`: pass. `tests/curation/test_impact.py`: pass.