### PR TITLE
perf(core): memoize curation coverage sort; fetch StashDB at max page size

### DIFF
--- a/core/curation.go
+++ b/core/curation.go
@@ -698,8 +698,17 @@ func mapEqual(a, b map[string]bool) bool {
 // per-scene cap.
 func orthogonalPairs(ctx *curationContext, budget int, seen map[string]bool) []pairCandidate {
 	unlabeled := pairUnlabeled(ctx, seen)
+	// sceneCoverage is a pure function of the scene; the sort comparator
+	// used to recompute it per comparison (O(n log n) calls, each building
+	// and sorting the scene's tag/performer lists), which dominated the op
+	// on large libraries. Precompute once — identical values, identical
+	// ordering, byte-identical output.
+	coverage := make(map[string]float64, len(unlabeled))
+	for _, sceneID := range unlabeled {
+		coverage[sceneID] = sceneCoverage(ctx, sceneID)
+	}
 	sort.Slice(unlabeled, func(i, j int) bool {
-		ci, cj := sceneCoverage(ctx, unlabeled[i]), sceneCoverage(ctx, unlabeled[j])
+		ci, cj := coverage[unlabeled[i]], coverage[unlabeled[j]]
 		if ci != cj {
 			return ci > cj
 		}

--- a/core/expand.go
+++ b/core/expand.go
@@ -1319,8 +1319,13 @@ func fetchScenesPage(clientURL, apiKey string, spec fetchPageSpec, page, pageSiz
 // stdlib worker pool: page 1 is fetched synchronously (its count fixes the
 // page count), the remaining pages run in parallel, and results merge in
 // page order so the output is identical to the sequential loop.
+// StashDB caps per_page at 500; fetching the maximum halves the round trips
+// for multi-page probes while the first-seen merge keeps the fetched rows
+// identical (pagination follows the same sort).
+const fetchPageSize = int64(500)
+
 func fetchParallel(clientURL, apiKey string, spec fetchPageSpec, rows *sceneRows, sources map[string]map[string]bool, workers int) (int64, bool, error) {
-	pageSize := minInt64(250, spec.limit)
+	pageSize := minInt64(fetchPageSize, spec.limit)
 	mergePage := func(pageTotal int64, accepted []jVal) {
 		for _, scene := range accepted {
 			identifier := scene.get("id").asString()


### PR DESCRIPTION
## What

Profiling pass on the ~6s methods (from the 24h trace window):

## Changes

1. **`get_curation_picks` (orthogonal)** — the round type in use (the live round is orthogonal). The candidate sort's comparator recomputed `sceneCoverage` per comparison: O(n log n) calls, each building and sorting the scene's tag/performer lists with rarity lookups. `sceneCoverage` is pure, so precompute it once per unlabeled scene — identical values, identical ordering, byte-identical output (the curation differential tests pin it). The other dimensions were already bounded by the `pairMaxCandidates` early exit.
2. **StashDB fetch page size 250 → 500** (StashDB's cap; the links fetch already uses 500). Halves the round trips for multi-page fetches — performer hunt (limit up to 1000) and expand refresh (per-source quotas). The first-seen merge keeps the fetched rows identical (pagination follows the same sort).

## Verification

- `go test ./...`: pass.
- `tests/curation/` + `test_backend_slice3_refresh.py` + `test_backend_slice2.py`: 45 passed (byte-identity gates incl. the orthogonal-picks parity).
- Full `tests/core/` suite run before commit: 211 passed.