### PR TITLE
perf(core): load only target performer profiles

### DIFF
--- a/core/expand_similar.go
+++ b/core/expand_similar.go
@@ -162,7 +162,11 @@ WHERE st.scene_id=? AND lower(t.name)='compilation' LIMIT 1`, entityID).Scan(&pr
 		}
 		var profiles map[string]*performerProfile
 		if featureVersion != "" {
-			profiles, err = performerProfilesAll(s.db, featureVersion)
+			targetProfileIDs := make(map[string]bool, len(targetPerformers))
+			for _, performerID := range targetPerformers {
+				targetProfileIDs[performerID] = true
+			}
+			profiles, err = performerProfilesForIDs(s.db, featureVersion, targetProfileIDs)
 			if err != nil {
 				return jvNull(), err
 			}
@@ -330,7 +334,7 @@ WHERE st.scene_id=? AND lower(t.name)='compilation' LIMIT 1`, entityID).Scan(&pr
 		}
 		var target *performerProfile
 		if featureVersion != "" {
-			profiles, err := performerProfilesAll(s.db, featureVersion)
+			profiles, err := performerProfilesForIDs(s.db, featureVersion, map[string]bool{entityID: true})
 			if err != nil {
 				return jvNull(), err
 			}
@@ -479,6 +483,7 @@ func whyForShared(tags jVal, shared map[string]bool, exactPerformer bool, perfor
 
 // profileMatchFull mirrors ExpandService._profile_match, also returning the
 // per-block similarities and weights for the why attributes.
+//
 //go:noinline
 func profileMatchFull(left, right *performerProfile, weights map[string]float64) (float64, float64, map[string]float64, map[string]float64) {
 	total, sims, used := performerSimilarity(left, right, weights)
@@ -659,7 +664,7 @@ func expandTargetedSimilar(db dbx, clientURL, apiKey string, links jVal, entityT
 		}
 		var target *performerProfile
 		if featureVersion != "" {
-			profiles, err := performerProfilesAll(db, featureVersion)
+			profiles, err := performerProfilesForIDs(db, featureVersion, map[string]bool{entityID: true})
 			if err != nil {
 				return jvNull(), err
 			}

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -947,7 +947,7 @@ class ExpandService:
                 ).fetchone()
             )
             profiles = (
-                FeatureStore(self.connection).performer_profiles(feature_version)
+                FeatureStore(self.connection).performer_profiles(feature_version, target_performers)
                 if feature_version
                 else {}
             )
@@ -1078,7 +1078,7 @@ class ExpandService:
         elif entity_type == "performer":
             feature_version = FeatureStore(self.connection).current_version()
             target = (
-                FeatureStore(self.connection).performer_profiles(feature_version).get(entity_id)
+                FeatureStore(self.connection).performer_profiles(feature_version, [entity_id]).get(entity_id)
                 if feature_version
                 else None
             )
@@ -1250,7 +1250,7 @@ class ExpandService:
             }:
                 ethnicity = ""
             target = (
-                FeatureStore(self.connection).performer_profiles(feature_version).get(entity_id)
+                FeatureStore(self.connection).performer_profiles(feature_version, [entity_id]).get(entity_id)
             )
             if target is not None:
                 target = self._with_age(target, target_row["birthdate"])

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -1142,7 +1142,8 @@ def test_external_similarity_loads_only_positive_anchor_profiles(
         value["tags"] == {"value": ["external-tag"], "modifier": "INCLUDES"}
         for value in tag_queries
     )
-    assert {"p1"} in requested
+    assert requested
+    assert all(value is not None and set(value) <= {"p1"} for value in requested)
 
 
 def test_targeted_scene_similar_probes_both_sorts_and_tight_tag_sets(


### PR DESCRIPTION
Reduces external-similar and performer-hunt work by loading only profiles for the requested target performers. Keeps the existing exact-ID SQL helper and Python/Go behavior aligned.\n\nTests: scripts/verify changed tests/test_expand.py