### PR TITLE
perf: skip external-link state query on cache hits

### DIFF
--- a/core/links.go
+++ b/core/links.go
@@ -66,7 +66,7 @@ func cachedExternalLinks(db dbx, state string) (jVal, bool, error) {
 	if err != nil {
 		return jvNull(), false, nil // JSONDecodeError -> None
 	}
-	if payload.get("state").asString() != state {
+	if state != "" && payload.get("state").asString() != state {
 		return jvNull(), false, nil
 	}
 	links := payload.get("links")
@@ -175,23 +175,21 @@ func fetchLinksPage(base string, headers map[string]string, page int64) linksPag
 }
 
 func externalLinksImpl(payload jVal, db dbx, refresh bool, progress func(processed, total int)) (jVal, error) {
-	// The state hash is computed whenever a cache row can be written — also
-	// on refresh — so the cache never stores an empty state and the next
-	// non-refresh op can reuse the row (mirrors _external_links, which
-	// computes the state whenever connection is not None).
 	state := ""
 	var err error
 	if db != nil {
-		state, err = externalLinksState(payload)
-		if err != nil {
-			return jvNull(), err
-		}
 		if !refresh {
-			if cached, ok, err := cachedExternalLinks(db, state); err != nil {
+			// ponytail: cache until explicit refresh; add TTL or entity-hook invalidation if
+			// newly linked entities must appear without a manual refresh.
+			if cached, ok, err := cachedExternalLinks(db, ""); err != nil {
 				return jvNull(), err
 			} else if ok {
 				return cached, nil
 			}
+		}
+		state, err = externalLinksState(payload)
+		if err != nil {
+			return jvNull(), err
 		}
 	}
 	base, headers := stashConnection(payload)

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -239,7 +239,7 @@ def _external_links_state(payload: dict[str, Any]) -> str:
 
 
 def _cached_external_links(
-    connection: sqlite3.Connection, state: str
+    connection: sqlite3.Connection, state: str | None
 ) -> dict[str, dict[str, str]] | None:
     row = connection.execute(
         "SELECT value FROM application_meta WHERE key=?", (EXTERNAL_LINKS_CACHE_KEY,)
@@ -250,7 +250,7 @@ def _cached_external_links(
         payload = json.loads(str(row[0]))
     except json.JSONDecodeError:
         return None
-    if payload.get("state") != state:
+    if state is not None and payload.get("state") != state:
         return None
     links = payload.get("links")
     return links if isinstance(links, dict) else None
@@ -271,11 +271,13 @@ def _external_links(
     walk (issue #110: the expand-refresh bar used to sit at 5% for the whole
     library walk).
     """
-    state = _external_links_state(payload) if connection is not None else ""
     if connection is not None and not refresh:
-        cached = _cached_external_links(connection, state)
+        # ponytail: cache until explicit refresh; add TTL or entity-hook invalidation if
+        # newly linked entities must appear without a manual refresh.
+        cached = _cached_external_links(connection, None)
         if cached is not None:
             return cached
+    state = _external_links_state(payload) if connection is not None else ""
     result: dict[str, dict[str, str]] = {
         "scenes": {},
         "scene_ids": {},

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -1599,7 +1599,7 @@ def test_backend_profiles_only_when_enabled_and_exposes_profile_api(
     assert module._api(payload, "clear_profiles", {"profilingEnabled": False})["deleted"] == 1
 
 
-def test_external_links_reuse_the_last_scan_until_stash_reports_a_change(
+def test_external_links_reuse_the_last_scan_until_explicit_refresh(
     tmp_path: Path,
 ) -> None:
     backend = Path(__file__).parents[2] / "plugin" / "backend.py"
@@ -1655,11 +1655,14 @@ def test_external_links_reuse_the_last_scan_until_stash_reports_a_change(
 
     state["updated_at"] = "2026-02-02T00:00:00Z"
     module._external_links({}, connection)
-    assert scanned == 3, "an edited library must invalidate the cache"
+    assert scanned == 2, "normal reads should not revalidate a cached library"
 
     state["count"] = 2
     module._external_links({}, connection)
-    assert scanned == 4, "an added or deleted link must invalidate the cache"
+    assert scanned == 2, "normal reads should not revalidate a cached library"
+
+    module._external_links({}, connection, refresh=True)
+    assert scanned == 3, "the refresh task must force a rescan after library changes"
 
 
 def test_every_user_visible_empty_and_error_message_is_defensive() -> None:


### PR DESCRIPTION
Avoids the normal Stash external-links state query when a cached map exists. Explicit refresh still recomputes state and walks the library, preserving a manual correctness path while removing the recurring network round trip from expand, similar, and hunt calls.\n\nTests: scripts/verify changed tests/plugin/test_runtime.py core/links.go; focused regression passed.