### PR TITLE
perf(core): merge performer entries by ordinal

### DIFF
--- a/core/content_test.go
+++ b/core/content_test.go
@@ -272,8 +272,7 @@ func TestPerformerPairHandComputed(t *testing.T) {
 		blocks: map[string]map[string]profileValue{"content": {"a": {value: 0.5, confidence: 0.5}}},
 		norms:  map[string]float64{"content": 0.5},
 	}
-	cacheProfileEntries(left)
-	cacheProfileEntries(right)
+	cacheProfileEntries(map[string]*performerProfile{"l": left, "r": right})
 	similarity, blocks := performerPair(left, right, []string{"content"}, weights, scales, numeric)
 	// dot = 0.5, norm product = 0.5, confidence = 0.5 -> cosine = 0.5.
 	if math.Abs(similarity-0.5) > 1e-12 {

--- a/core/performer.go
+++ b/core/performer.go
@@ -42,8 +42,9 @@ type profileValue struct {
 }
 
 type profileBlockEntry struct {
-	key   string
-	value profileValue
+	key     string
+	ordinal int
+	value   profileValue
 }
 
 type performerProfile struct {
@@ -88,16 +89,10 @@ func readProfiles(db *sql.DB, featureVersion string, numeric map[string]bool) (m
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	cacheProfileEntries(profiles)
 	for _, profile := range profiles {
 		profile.norms = make(map[string]float64, len(profile.blocks))
-		profile.sortedBlock = make(map[string][]profileBlockEntry, len(profile.blocks))
-		for block, values := range profile.blocks {
-			entries := make([]profileBlockEntry, 0, len(values))
-			for key, value := range values {
-				entries = append(entries, profileBlockEntry{key: key, value: value})
-			}
-			sort.Slice(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
-			profile.sortedBlock[block] = entries
+		for block, entries := range profile.sortedBlock {
 			if numeric[block] {
 				continue
 			}
@@ -111,18 +106,52 @@ func readProfiles(db *sql.DB, featureVersion string, numeric map[string]bool) (m
 	return profiles, nil
 }
 
-func cacheProfileEntries(profile *performerProfile) {
-	if profile.sortedBlock != nil {
+func cacheProfileEntries(profiles map[string]*performerProfile) {
+	complete := true
+	for _, profile := range profiles {
+		if len(profile.sortedBlock) != len(profile.blocks) {
+			complete = false
+			break
+		}
+	}
+	if complete {
 		return
 	}
-	profile.sortedBlock = make(map[string][]profileBlockEntry, len(profile.blocks))
-	for block, values := range profile.blocks {
-		entries := make([]profileBlockEntry, 0, len(values))
-		for key, value := range values {
-			entries = append(entries, profileBlockEntry{key: key, value: value})
+	blockNames := make(map[string]map[string]bool)
+	for _, profile := range profiles {
+		for block, values := range profile.blocks {
+			names := blockNames[block]
+			if names == nil {
+				names = make(map[string]bool)
+				blockNames[block] = names
+			}
+			for key := range values {
+				names[key] = true
+			}
 		}
-		sort.Slice(entries, func(i, j int) bool { return entries[i].key < entries[j].key })
-		profile.sortedBlock[block] = entries
+	}
+	ordinals := make(map[string]map[string]int, len(blockNames))
+	for block, names := range blockNames {
+		keys := make([]string, 0, len(names))
+		for key := range names {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		ordinals[block] = make(map[string]int, len(keys))
+		for ordinal, key := range keys {
+			ordinals[block][key] = ordinal
+		}
+	}
+	for _, profile := range profiles {
+		profile.sortedBlock = make(map[string][]profileBlockEntry, len(profile.blocks))
+		for block, values := range profile.blocks {
+			entries := make([]profileBlockEntry, 0, len(values))
+			for key, value := range values {
+				entries = append(entries, profileBlockEntry{key: key, ordinal: ordinals[block][key], value: value})
+			}
+			sort.Slice(entries, func(i, j int) bool { return entries[i].ordinal < entries[j].ordinal })
+			profile.sortedBlock[block] = entries
+		}
 	}
 }
 
@@ -178,9 +207,7 @@ func performerSimilarityScores(
 	profiles map[string]*performerProfile,
 	numeric map[string]bool,
 ) map[string]any {
-	for _, profile := range profiles {
-		cacheProfileEntries(profile)
-	}
+	cacheProfileEntries(profiles)
 	profileIDs := make([]string, 0, len(profiles))
 	for id := range profiles {
 		profileIDs = append(profileIDs, id)
@@ -291,11 +318,11 @@ func performerPair(
 			var total float64
 			count := 0
 			for i, j := 0, 0; i < len(leftEntries) && j < len(rightEntries); {
-				if leftEntries[i].key < rightEntries[j].key {
+				if leftEntries[i].ordinal < rightEntries[j].ordinal {
 					i++
 					continue
 				}
-				if leftEntries[i].key > rightEntries[j].key {
+				if leftEntries[i].ordinal > rightEntries[j].ordinal {
 					j++
 					continue
 				}
@@ -329,11 +356,11 @@ func performerPair(
 			var dot, confidenceSum float64
 			count := 0
 			for i, j := 0, 0; i < len(leftEntries) && j < len(rightEntries); {
-				if leftEntries[i].key < rightEntries[j].key {
+				if leftEntries[i].ordinal < rightEntries[j].ordinal {
 					i++
 					continue
 				}
-				if leftEntries[i].key > rightEntries[j].key {
+				if leftEntries[i].ordinal > rightEntries[j].ordinal {
 					j++
 					continue
 				}


### PR DESCRIPTION
## Summary
- assign each profile feature a deterministic lexical ordinal per block
- merge cached entries by ordinal instead of string comparison
- preserve the original lexical accumulation order and numeric-scale lookup

## Measured
On the profiled 24k-scene build, after #267:
- similarity stage: 38.9s → 35.5s (about 9%)
- performer CPU samples: 36.9s → 29.5s (-20%)
- the previous string-comparison hotspot is no longer present

## Validation
- go test . -count=1