### PR TITLE
perf(core): defer performer match details

### DIFF
--- a/core/content_test.go
+++ b/core/content_test.go
@@ -273,10 +273,14 @@ func TestPerformerPairHandComputed(t *testing.T) {
 		norms:  map[string]float64{"content": 0.5},
 	}
 	cacheProfileEntries(map[string]*performerProfile{"l": left, "r": right})
-	similarity, blocks := performerPair(left, right, []string{"content"}, weights, scales, numeric)
+	similarity, blocks := performerPair(left, right, []string{"content"}, weights, scales, numeric, true)
+	scoreOnly, noBlocks := performerPair(left, right, []string{"content"}, weights, scales, numeric, false)
 	// dot = 0.5, norm product = 0.5, confidence = 0.5 -> cosine = 0.5.
 	if math.Abs(similarity-0.5) > 1e-12 {
 		t.Fatalf("expected similarity 0.5, got %v", similarity)
+	}
+	if scoreOnly != similarity || noBlocks != nil {
+		t.Fatalf("score-only result = %v, %v", scoreOnly, noBlocks)
 	}
 	if !reflect.DeepEqual(blocks, map[string]float64{"content": 0.5}) {
 		t.Fatalf("unexpected blocks: %v", blocks)

--- a/core/performer.go
+++ b/core/performer.go
@@ -298,8 +298,11 @@ func performerPair(
 	globalBlocks []string,
 	weights, scales map[string]float64,
 	numeric map[string]bool,
+	withBlocks bool,
 ) (similarity float64, blocks map[string]float64) {
-	blocks = make(map[string]float64)
+	if withBlocks {
+		blocks = make(map[string]float64)
+	}
 	var numerator, denominator float64
 	cosineZero := false
 	for _, block := range globalBlocks {
@@ -389,7 +392,9 @@ func performerPair(
 		if used {
 			denominator += weight
 			numerator += blockValue * weight
-			blocks[block] = blockValue
+			if withBlocks {
+				blocks[block] = blockValue
+			}
 		}
 	}
 	if denominator <= 0 {
@@ -468,7 +473,7 @@ func performerForProfile(
 		if knownID == profile.id {
 			continue
 		}
-		similarity, blocks := performerPair(profile, profiles[knownID], globalBlocks, payload.BlockWeights, payload.NumericScales, numeric)
+		similarity, _ := performerPair(profile, profiles[knownID], globalBlocks, payload.BlockWeights, payload.NumericScales, numeric, false)
 		if math.IsNaN(similarity) || similarity <= 0 {
 			continue
 		}
@@ -478,7 +483,6 @@ func performerForProfile(
 			similarity: similarity,
 			affinity:   affinity[0],
 			confidence: affinity[1],
-			blocks:     blocks,
 		})
 	}
 	sort.Slice(candidates, func(i, j int) bool {
@@ -489,6 +493,10 @@ func performerForProfile(
 	})
 	if len(candidates) > 5 {
 		candidates = candidates[:5]
+	}
+	for i := range candidates {
+		_, candidates[i].blocks = performerPair(profile, profiles[candidates[i].id], globalBlocks,
+			payload.BlockWeights, payload.NumericScales, numeric, true)
 	}
 	var denominator float64
 	for _, c := range candidates {


### PR DESCRIPTION
## Summary
- score every performer pair without allocating match-detail maps
- recompute details only for the retained top-five matches
- preserve scores, ordering, and returned match details

## Measured
On the profiled 24k-scene build, after #268:
- similarity stage: 35.5s → 24.3s (-32%)
- performer CPU samples: 29.5s → 18.1s (-39%)
- performer allocation profile: 498MB; original baseline was 6.81GB before the cumulative performer optimizations

## Validation
- go test . -count=1