### PR TITLE
feat: add force model rebuild task

### DIFF
--- a/core/autotasks.go
+++ b/core/autotasks.go
@@ -70,13 +70,12 @@ VALUES (?, ?, 'queued', ?, ?, ?)`, jobID, mode, now, now, payloadRaw); err != ni
 	return enqueued, err
 }
 
-// modelRebuilding reports whether a model-touching job is running (build,
-// update-model, sync-build, full-sync-build), matching health's query.
+// modelRebuilding reports whether a model-touching job is running, matching health's query.
 func modelRebuilding(db dbx, now int64) (bool, error) {
 	var probe int
 	err := db.QueryRow(`SELECT 1 FROM curator_job
 WHERE state='running' AND started_at_ms>? AND job_type IN (
-    'build', 'update-model', 'sync-build', 'full-sync-build'
+    'build', 'force-build', 'update-model', 'sync-build', 'full-sync-build'
 ) LIMIT 1`, now-6*3_600_000).Scan(&probe)
 	if err == nil {
 		return true, nil

--- a/core/backend.go
+++ b/core/backend.go
@@ -116,7 +116,7 @@ func writeOutput(output jVal) {
 func taskModeNative(mode string) bool {
 	switch mode {
 	case "backup", "compact", "vacuum", "prepare", "sync-plays", "expand-refresh",
-		"build", "update-model", "sync-build", "full-sync-build":
+		"build", "force-build", "update-model", "sync-build", "full-sync-build":
 		return true
 	}
 	return false

--- a/core/daemon_test.go
+++ b/core/daemon_test.go
@@ -437,6 +437,12 @@ func TestTaskPermissionFailureDoesNotOpenSidecar(t *testing.T) {
 	}
 }
 
+func TestTaskModeNativeIncludesForceBuild(t *testing.T) {
+	if !taskModeNative("force-build") {
+		t.Fatal("force-build must be handled by the native task dispatcher")
+	}
+}
+
 func TestBackupValidationFailureRemovesSnapshot(t *testing.T) {
 	db, _ := openTempDB(t)
 	if err := migrate(db, 1_700_000_000_000); err != nil {

--- a/core/diagnostics.go
+++ b/core/diagnostics.go
@@ -12,7 +12,7 @@ import (
 // diagnosticJobTypes mirrors backend.py's DIAGNOSTIC_JOB_TYPES.
 var diagnosticJobTypes = map[string]bool{
 	"sync-build": true, "full-sync-build": true, "sync-plays": true,
-	"build": true, "update-model": true, "prepare": true,
+	"build": true, "force-build": true, "update-model": true, "prepare": true,
 	"backup": true, "compact": true, "vacuum": true, "expand-refresh": true,
 }
 

--- a/core/ops.go
+++ b/core/ops.go
@@ -29,6 +29,7 @@ var taskDisplayNames = map[string]string{
 	"sync-build":      "Sync and build recommendations",
 	"full-sync-build": "Full sync and build recommendations",
 	"build":           "Rebuild recommendation model",
+	"force-build":     "Force rebuild recommendation model",
 	"update-model":    "Apply recent Curator feedback",
 	"sync-plays":      "Sync recent plays",
 	"prepare":         "Prepare recommendation pages",

--- a/core/slate.go
+++ b/core/slate.go
@@ -214,7 +214,7 @@ func getSlateCore(db dbx, config jVal, lane string, count, page int64, impressio
 		return jvNull(), err
 	}
 	rebuilding, err := scanExists(db, `SELECT 1 FROM curator_job
-WHERE state='running' AND job_type IN ('build', 'update-model', 'sync-build', 'full-sync-build') LIMIT 1`)
+WHERE state='running' AND job_type IN ('build', 'force-build', 'update-model', 'sync-build', 'full-sync-build') LIMIT 1`)
 	if err != nil {
 		return jvNull(), err
 	}

--- a/core/tasks.go
+++ b/core/tasks.go
@@ -237,7 +237,7 @@ func runTaskMode(db dbx, pluginDir string, payload jVal, mode string, settings j
 		return taskSyncPlays(db, pluginDir, payload, settings)
 	case "expand-refresh":
 		return taskExpandRefresh(db, pluginDir, payload, settings)
-	case "build", "update-model":
+	case "build", "force-build", "update-model":
 		return taskBuild(db, pluginDir, payload, mode)
 	case "sync-build", "full-sync-build":
 		return taskSyncBuild(db, pluginDir, payload, mode, settings)
@@ -440,8 +440,14 @@ func taskBuild(db dbx, pluginDir string, payload jVal, mode string) (jVal, error
 			infoLog(fmt.Sprintf("Building recommendation model: %d%%", milestone*10))
 		}
 	}
-	if mode == "build" {
+	if mode == "build" || mode == "force-build" {
 		if err := withTxn(db, func(conn *sql.Conn) error {
+			if mode == "force-build" {
+				if _, err := conn.ExecContext(context.Background(),
+					`UPDATE model_version SET status='superseded' WHERE status='published'`); err != nil {
+					return err
+				}
+			}
 			return coordinatorRequest(conn, "manual_build", nowMs())
 		}); err != nil {
 			return jvNull(), err

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -3750,6 +3750,7 @@
     "sync-build": "Sync and build recommendations",
     "full-sync-build": "Full sync and build recommendations",
     build: "Rebuild recommendation model",
+    "force-build": "Force rebuild recommendation model",
     "update-model": "Apply recent Curator feedback",
     prepare: "Prepare recommendation pages",
     "sync-plays": "Sync recent plays",
@@ -3854,7 +3855,7 @@
     function summaryLine(job) {
       const summary = job.summary || {};
       const scenes = typeof summary.scene_count === "number" ? `${summary.scene_count} scenes` : "";
-      if (job.job_type === "build" || job.job_type === "update-model" || job.job_type === "sync-build" || job.job_type === "full-sync-build") {
+      if (job.job_type === "build" || job.job_type === "force-build" || job.job_type === "update-model" || job.job_type === "sync-build" || job.job_type === "full-sync-build") {
         return scenes ? `Model built · ${scenes}` : "Model built";
       }
       if (job.job_type === "backup") return "Backup created";
@@ -3915,7 +3916,8 @@
         "div",
         { className: "curator-tasks-runnow" },
         React.createElement("span", null, "Run now"),
-        React.createElement(Button, { size: "sm", variant: "primary", disabled: Boolean(starting), onClick: () => start("Sync and build recommendations") }, starting === "Sync and build recommendations" ? "Starting…" : "Sync and build recommendations")
+        React.createElement(Button, { size: "sm", variant: "primary", disabled: Boolean(starting), onClick: () => start("Sync and build recommendations") }, starting === "Sync and build recommendations" ? "Starting…" : "Sync and build recommendations"),
+        React.createElement(Button, { size: "sm", variant: "outline-danger", disabled: Boolean(starting), onClick: () => start("Force rebuild recommendation model") }, starting === "Force rebuild recommendation model" ? "Starting…" : "Force rebuild model")
       ),
       message && React.createElement("p", { className: "curator-header-message", role: "status" }, message),
       React.createElement(

--- a/plugin/stash-curator.yml
+++ b/plugin/stash-curator.yml
@@ -151,6 +151,10 @@ tasks:
     description: Force a recommendation refresh from already-synced data without contacting Stash.
     execArgs:
       - build
+  - name: Force rebuild recommendation model
+    description: Recompute and republish the model even when Curator would otherwise reuse the current artifact.
+    execArgs:
+      - force-build
   - name: Apply recent Curator feedback
     description: Publish pending feedback and playback signals without blocking the Curator page.
     execArgs:


### PR DESCRIPTION
Adds a supported force-rebuild task that supersedes the published model through Curator's normal lifecycle, then rebuilds it. Adds the Manage → Tasks button and job/status support.\n\nValidated with the focused core tests, repository verification stages, and an end-to-end live force rebuild.