### PR TITLE
fix: replace zombie curator workers

### DIFF
--- a/core/daemon_unix.go
+++ b/core/daemon_unix.go
@@ -38,13 +38,22 @@ func forceKillWorker(pid int) error {
 	return syscall.Kill(pid, syscall.SIGKILL)
 }
 
-// pidAlive reports whether a process with the given pid exists (signal 0).
+func procZombie(stat []byte) bool {
+	end := bytes.LastIndexByte(stat, ')')
+	return end >= 0 && len(stat) > end+2 && stat[end+2] == 'Z'
+}
+
+// pidAlive reports whether a non-zombie process with the given pid exists.
 func pidAlive(pid int) bool {
 	if pid <= 0 {
 		return false
 	}
 	err := syscall.Kill(pid, 0)
-	return err == nil || err == syscall.EPERM
+	if err != nil && err != syscall.EPERM {
+		return false
+	}
+	stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	return err != nil || !procZombie(stat)
 }
 
 // daemonSysProcAttr detaches the worker into its own session so it survives

--- a/core/daemon_unix_test.go
+++ b/core/daemon_unix_test.go
@@ -1,0 +1,14 @@
+//go:build unix
+
+package main
+
+import "testing"
+
+func TestProcZombie(t *testing.T) {
+	if !procZombie([]byte("42 (curator core) Z 1 2 3")) {
+		t.Fatal("zombie process not detected")
+	}
+	if procZombie([]byte("42 (curator core) S 1 2 3")) {
+		t.Fatal("live process reported as zombie")
+	}
+}


### PR DESCRIPTION
## Summary
- treat Linux zombie processes as dead worker PIDs
- allow the next task to replace stale worker state automatically
- cover `/proc/<pid>/stat` zombie parsing

## Validation
- `scripts/verify core`
- Live Stash: recovered a zombie PID and completed a normal model rebuild in 135.0s