### PR TITLE
perf: relax temporary artifact durability

### DIFF
--- a/core/artifacts_test.go
+++ b/core/artifacts_test.go
@@ -107,6 +107,25 @@ func TestAttachActiveArtifacts(t *testing.T) {
 	}
 }
 
+func TestCreateArtifactUsesEphemeralPragmas(t *testing.T) {
+	artifact, temporary, _, err := createArtifact(filepath.Join(t.TempDir(), "curator.sqlite3"), "model", "model-"+strings.Repeat("a", 20))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer discardArtifact(artifact, temporary)
+	var journalMode string
+	var synchronous int
+	if err := artifact.QueryRow("PRAGMA journal_mode").Scan(&journalMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := artifact.QueryRow("PRAGMA synchronous").Scan(&synchronous); err != nil {
+		t.Fatal(err)
+	}
+	if journalMode != "off" || synchronous != 0 {
+		t.Fatalf("artifact pragmas = journal_mode=%q synchronous=%d, want off/0", journalMode, synchronous)
+	}
+}
+
 // A registry pointing at a missing artifact fails with the Python-equivalent
 // message.
 func TestAttachActiveArtifactsMissingFile(t *testing.T) {

--- a/core/build_artifacts.go
+++ b/core/build_artifacts.go
@@ -181,6 +181,13 @@ func createArtifact(corePath, kind, identifier string) (dbx, string, string, err
 	if err != nil {
 		return nil, "", "", err
 	}
+	for _, pragma := range []string{"PRAGMA journal_mode = OFF", "PRAGMA synchronous = OFF"} {
+		if _, err := db.Exec(pragma); err != nil {
+			db.Close()
+			os.Remove(temporary)
+			return nil, "", "", err
+		}
+	}
 	if _, err := db.Exec(fmt.Sprintf("PRAGMA user_version=%d", artifactSchemaVersion)); err != nil {
 		db.Close()
 		os.Remove(temporary)


### PR DESCRIPTION
## Summary
- disable SQLite journaling and synchronous flushes only while building disposable artifact files
- keep validation and atomic publication unchanged
- cover the temporary connection pragmas

## Validation
- `scripts/verify full`
- Live idle-host A/B force rebuilds: normal 94.3s; tuned 86.6s and 89.6s (mean 88.1s, ~6.5% faster)
- Model published ready with identical lane counts