### PR TITLE
perf: keep temporary artifact stores in memory

### DIFF
--- a/core/artifacts_test.go
+++ b/core/artifacts_test.go
@@ -115,14 +115,18 @@ func TestCreateArtifactUsesEphemeralPragmas(t *testing.T) {
 	defer discardArtifact(artifact, temporary)
 	var journalMode string
 	var synchronous int
+	var tempStore int
 	if err := artifact.QueryRow("PRAGMA journal_mode").Scan(&journalMode); err != nil {
 		t.Fatal(err)
 	}
 	if err := artifact.QueryRow("PRAGMA synchronous").Scan(&synchronous); err != nil {
 		t.Fatal(err)
 	}
-	if journalMode != "off" || synchronous != 0 {
-		t.Fatalf("artifact pragmas = journal_mode=%q synchronous=%d, want off/0", journalMode, synchronous)
+	if err := artifact.QueryRow("PRAGMA temp_store").Scan(&tempStore); err != nil {
+		t.Fatal(err)
+	}
+	if journalMode != "off" || synchronous != 0 || tempStore != 2 {
+		t.Fatalf("artifact pragmas = journal_mode=%q synchronous=%d temp_store=%d, want off/0/2", journalMode, synchronous, tempStore)
 	}
 }
 

--- a/core/build_artifacts.go
+++ b/core/build_artifacts.go
@@ -181,7 +181,7 @@ func createArtifact(corePath, kind, identifier string) (dbx, string, string, err
 	if err != nil {
 		return nil, "", "", err
 	}
-	for _, pragma := range []string{"PRAGMA journal_mode = OFF", "PRAGMA synchronous = OFF"} {
+	for _, pragma := range []string{"PRAGMA journal_mode = OFF", "PRAGMA synchronous = OFF", "PRAGMA temp_store = MEMORY"} {
 		if _, err := db.Exec(pragma); err != nil {
 			db.Close()
 			os.Remove(temporary)


### PR DESCRIPTION
## Summary
- keep temporary SQLite B-trees in memory while building disposable artifacts
- retain temporary artifact durability and validation protections

## Validation
- `scripts/verify full`
- Live idle rebuilds: 84.4s and 72.2s, versus 88.1s mean after #273
- Peak RSS remained about 4.05 GiB; published model remained ready