### PR TITLE
feat: expand affinity floor to -1, curator-affinity pill, and scene preview wall

### DIFF
--- a/core/frontend.go
+++ b/core/frontend.go
@@ -493,12 +493,21 @@ func inspectorEntityBody(pluginDir string, payload, settings jVal) (jVal, error)
 		if err != nil {
 			return jvNull(), err
 		}
+		affinity, confidence, hasAffinity := performerAffinity(db, modelID, featureVersion, entityID)
+		affinityVal := jvNull()
+		confidenceVal := jvNull()
+		if hasAffinity {
+			affinityVal = jvFloat(affinity)
+			confidenceVal = jvFloat(confidence)
+		}
 		return jvObj(
 			jvKey("schema_version", jvInt(apiSchemaVersion)),
 			jvKey("entity_type", jvStr(entityType)),
 			jvKey("entity_id", jvStr(entityID)),
 			jvKey("model_id", jvStr(modelID)),
 			jvKey("profile", profile),
+			jvKey("affinity", affinityVal),
+			jvKey("confidence", confidenceVal),
 			jvKey("similar", similar),
 		), nil
 	}
@@ -599,6 +608,21 @@ func similarPerformers(db dbx, featureVersion, performerID string, count int) (j
 		))
 	}
 	return out, nil
+}
+
+// performerAffinity mirrors the inspector's performer affinity lookup: the
+// raw feature_affinity entry for the performer's identity feature (name
+// 'performer:<id>'), or none when the model has no evidence for it.
+func performerAffinity(db dbx, modelID, featureVersion, performerID string) (float64, float64, bool) {
+	var affinity, confidence float64
+	err := db.QueryRow(`SELECT fa.affinity, fa.confidence
+FROM feature_affinity fa JOIN feature_definition fd ON fd.feature_id = fa.feature_id
+WHERE fa.model_id = ? AND fd.feature_version = ? AND fd.name = ?`,
+		modelID, featureVersion, "performer:"+performerID).Scan(&affinity, &confidence)
+	if err != nil {
+		return 0, 0, false
+	}
+	return affinity, confidence, true
 }
 
 // ── get_tag_sentiment_follow_up ────────────────────────────────────────────

--- a/curator/api.py
+++ b/curator/api.py
@@ -256,6 +256,19 @@ class CuratorAPI:
             feature_version = self.connection.execute(
                 "SELECT feature_version FROM model_version WHERE model_id=?", (model_id,)
             ).fetchone()[0]
+            affinity_row = self.connection.execute(
+                """
+                SELECT fa.affinity, fa.confidence
+                FROM feature_affinity fa
+                JOIN feature_definition fd ON fd.feature_id = fa.feature_id
+                WHERE fa.model_id = ?
+                  AND fd.feature_version = ?
+                  AND fd.name = ?
+                """,
+                (model_id, feature_version, f"performer:{entity_id}"),
+            ).fetchone()
+            affinity = affinity_row[0] if affinity_row is not None else None
+            confidence = affinity_row[1] if affinity_row is not None else None
             matches = FeatureStore(self.connection).similar_performers(
                 str(feature_version),
                 entity_id,
@@ -268,6 +281,8 @@ class CuratorAPI:
                 "entity_id": entity_id,
                 "model_id": model_id,
                 "profile": dict(row),
+                "affinity": affinity,
+                "confidence": confidence,
                 "similar": [
                     {
                         "performer_id": performer_id,

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2830,6 +2830,113 @@
   padding: 0;
   width: 1.9rem;
 }
+.curator-affinity-pill {
+  align-items: center;
+  background: var(--curator-surface-raised);
+  border: 1px solid var(--curator-border);
+  border-radius: 999px;
+  box-shadow: var(--curator-shadow-sm);
+  color: var(--curator-text);
+  display: inline-flex;
+  font-size: 0.8rem;
+  font-weight: 600;
+  gap: 0.35rem;
+  height: 1.9rem;
+  line-height: 1;
+  margin-left: 0.4rem;
+  padding: 0 0.6rem;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.curator-affinity-pill .curator-affinity-value {
+  font-variant-numeric: tabular-nums;
+}
+.curator-affinity-pill.curator-affinity-positive .curator-affinity-value {
+  color: #5cc19c;
+}
+.curator-affinity-pill.curator-affinity-negative .curator-affinity-value {
+  color: #e0645c;
+}
+.curator-affinity-pill .curator-affinity-bar {
+  background: var(--curator-wash-recessed);
+  border-radius: 999px;
+  height: 3px;
+  overflow: hidden;
+  width: 2.2rem;
+}
+.curator-affinity-pill .curator-affinity-bar-fill {
+  display: block;
+  height: 100%;
+}
+.curator-affinity-pill.curator-affinity-positive .curator-affinity-bar-fill {
+  background: #5cc19c;
+}
+.curator-preview-wall {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.6rem;
+}
+.curator-preview-tile {
+  aspect-ratio: 16 / 9;
+  background: var(--curator-surface);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius);
+  box-shadow: var(--curator-shadow-sm);
+  overflow: hidden;
+  position: relative;
+}
+.curator-preview-link {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+.curator-preview-video {
+  display: block;
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+.curator-preview-affinity {
+  align-items: center;
+  background: var(--curator-overlay);
+  border-radius: 999px;
+  bottom: 0.4rem;
+  color: var(--curator-text);
+  display: inline-flex;
+  font-size: 0.72rem;
+  font-weight: 600;
+  gap: 0.25rem;
+  left: 0.4rem;
+  line-height: 1;
+  padding: 0.2rem 0.45rem;
+  position: absolute;
+}
+.curator-preview-tile.curator-affinity-positive .curator-preview-affinity {
+  color: #5cc19c;
+}
+.curator-preview-tile.curator-affinity-negative .curator-preview-affinity {
+  color: #e0645c;
+}
+.curator-preview-hover {
+  background: var(--curator-overlay);
+  bottom: 0;
+  left: 0;
+  overflow: auto;
+  padding: 0.6rem;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 2;
+}
+.curator-preview-hover-title {
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+.curator-preview-hover-why {
+  color: var(--curator-text-muted);
+  font-size: 0.8rem;
+  margin: 0 0 0.5rem;
+}
 
 .curator-card > .performer-card {
   background: var(--curator-card-surface);

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2896,6 +2896,11 @@
   object-fit: cover;
   width: 100%;
 }
+.curator-preview-tile .curator-preview-video.scene-card-preview-video {
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
 .curator-preview-tile .card-section {
   height: 100%;
   margin: 0;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2904,18 +2904,12 @@
 }
 .curator-preview-affinity {
   align-items: center;
-  background: var(--curator-overlay);
-  border-radius: 999px;
-  bottom: 0.4rem;
   color: var(--curator-text);
   display: inline-flex;
   font-size: 0.72rem;
   font-weight: 600;
-  gap: 0.25rem;
-  left: 0.4rem;
+  gap: 0.18rem;
   line-height: 1;
-  padding: 0.2rem 0.45rem;
-  position: absolute;
 }
 .curator-preview-tile.curator-affinity-positive .curator-preview-affinity {
   color: #5cc19c;
@@ -2924,19 +2918,26 @@
   color: #e0645c;
 }
 .curator-preview-lane {
+  align-items: center;
   background: var(--curator-overlay);
   border-radius: 0.25rem;
-  color: var(--curator-text-muted);
-  left: 0.4rem;
-  opacity: 0.85;
-  padding: 0.18rem 0.28rem;
+  display: inline-flex;
+  font-size: 0.7rem;
+  height: 1.15rem;
+  justify-content: center;
+  left: 0.35rem;
+  line-height: 1;
   position: absolute;
-  top: 0.4rem;
+  top: 0.35rem;
+  width: 1.15rem;
   z-index: 1;
 }
 .curator-preview-hover {
+  align-items: center;
   background: var(--curator-overlay);
   bottom: 0;
+  display: flex;
+  gap: 0.3rem;
   left: 0;
   padding: 0.28rem 0.4rem;
   position: absolute;
@@ -2945,9 +2946,10 @@
 }
 .curator-preview-hover-title {
   color: var(--curator-text);
-  display: block;
+  flex: 1;
   font-size: 0.75rem;
   font-weight: 600;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2896,16 +2896,17 @@
   object-fit: cover;
   width: 100%;
 }
-.curator-preview-tile .curator-preview-video.scene-card-preview-video {
-  height: 100%;
-  object-fit: cover;
-  width: 100%;
-}
 .curator-preview-tile .card-section {
   height: 100%;
   margin: 0;
   overflow: hidden;
   padding: 0;
+}
+/* SFW switch: Stash's scene-card classes break custom wall tiles, so mirror its
+   blur by detecting when wall media is blurred (syncSfwBlur observer) and
+   applying a strong Curator-side blur only then. */
+.curator-sfw .curator-preview-tile .card-section {
+  filter: blur(12px);
 }
 .curator-preview-affinity {
   align-items: center;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2885,6 +2885,13 @@
   overflow: hidden;
   position: relative;
 }
+.curator-preview-tile.scene-card {
+  background: var(--curator-surface);
+  border: 1px solid var(--curator-border);
+  display: block;
+  margin: 0;
+  padding: 0;
+}
 .curator-preview-link {
   display: block;
   height: 100%;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2873,8 +2873,8 @@
 }
 .curator-preview-wall {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   gap: 0.6rem;
+  grid-template-columns: repeat(auto-fill, minmax(var(--curator-card-min-width, 22rem), 1fr));
 }
 .curator-preview-tile {
   aspect-ratio: 16 / 9;
@@ -2895,6 +2895,12 @@
   height: 100%;
   object-fit: cover;
   width: 100%;
+}
+.curator-preview-tile .card-section {
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
 }
 .curator-preview-affinity {
   align-items: center;
@@ -2917,25 +2923,34 @@
 .curator-preview-tile.curator-affinity-negative .curator-preview-affinity {
   color: #e0645c;
 }
+.curator-preview-lane {
+  background: var(--curator-overlay);
+  border-radius: 0.25rem;
+  color: var(--curator-text-muted);
+  left: 0.4rem;
+  opacity: 0.85;
+  padding: 0.18rem 0.28rem;
+  position: absolute;
+  top: 0.4rem;
+  z-index: 1;
+}
 .curator-preview-hover {
   background: var(--curator-overlay);
   bottom: 0;
   left: 0;
-  overflow: auto;
-  padding: 0.6rem;
+  padding: 0.28rem 0.4rem;
   position: absolute;
   right: 0;
-  top: 0;
   z-index: 2;
 }
 .curator-preview-hover-title {
-  font-weight: 700;
-  margin-bottom: 0.4rem;
-}
-.curator-preview-hover-why {
-  color: var(--curator-text-muted);
-  font-size: 0.8rem;
-  margin: 0 0 0.5rem;
+  color: var(--curator-text);
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .curator-card > .performer-card {

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2906,7 +2906,7 @@
    blur by detecting when wall media is blurred (syncSfwBlur observer) and
    applying a strong Curator-side blur only then. */
 .curator-sfw .curator-preview-tile .card-section {
-  filter: blur(12px);
+  filter: blur(24px) !important;
 }
 .curator-preview-affinity {
   align-items: center;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2821,15 +2821,6 @@
   outline-offset: 2px;
 }
 
-.curator-context-link {
-  background: var(--curator-gradient-brand) !important;
-  border-radius: var(--curator-radius-lg);
-  box-shadow: var(--curator-shadow-glow);
-  color: var(--curator-text);
-  height: 1.9rem;
-  padding: 0;
-  width: 1.9rem;
-}
 .curator-affinity-pill {
   align-items: center;
   background: var(--curator-surface-raised);
@@ -2837,6 +2828,7 @@
   border-radius: 999px;
   box-shadow: var(--curator-shadow-sm);
   color: var(--curator-text);
+  cursor: pointer;
   display: inline-flex;
   font-size: 0.8rem;
   font-weight: 600;
@@ -2845,6 +2837,7 @@
   line-height: 1;
   margin-left: 0.4rem;
   padding: 0 0.6rem;
+  text-decoration: none;
   vertical-align: middle;
   white-space: nowrap;
 }

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2821,48 +2821,56 @@
   outline-offset: 2px;
 }
 
-.curator-affinity-pill {
+.curator-context-group {
   align-items: center;
-  background: var(--curator-surface-raised);
-  border: 1px solid var(--curator-border);
-  border-radius: 999px;
-  box-shadow: var(--curator-shadow-sm);
-  color: var(--curator-text);
-  cursor: pointer;
   display: inline-flex;
-  font-size: 0.8rem;
-  font-weight: 600;
-  gap: 0.35rem;
-  height: 1.9rem;
-  line-height: 1;
-  margin-left: 0.4rem;
-  padding: 0 0.6rem;
-  text-decoration: none;
+  gap: 0.45rem;
   vertical-align: middle;
-  white-space: nowrap;
 }
-.curator-affinity-pill .curator-affinity-value {
-  font-variant-numeric: tabular-nums;
+.curator-context-button {
+  align-items: center;
+  background: var(--curator-gradient-brand) !important;
+  border-radius: var(--curator-radius-lg);
+  box-shadow: var(--curator-shadow-glow);
+  color: var(--curator-text);
+  display: inline-flex;
+  height: 1.9rem;
+  justify-content: center;
+  text-decoration: none;
+  width: 1.9rem;
 }
-.curator-affinity-pill.curator-affinity-positive .curator-affinity-value {
-  color: #5cc19c;
+.curator-context-button:hover,
+.curator-context-button:focus {
+  text-decoration: none;
 }
-.curator-affinity-pill.curator-affinity-negative .curator-affinity-value {
-  color: #e0645c;
+.curator-affinity-gauge {
+  height: 1.9rem;
+  position: relative;
+  width: 1.9rem;
 }
-.curator-affinity-pill .curator-affinity-bar {
-  background: var(--curator-wash-recessed);
-  border-radius: 999px;
-  height: 3px;
-  overflow: hidden;
-  width: 2.2rem;
-}
-.curator-affinity-pill .curator-affinity-bar-fill {
+.curator-affinity-gauge-ring {
   display: block;
   height: 100%;
+  width: 100%;
 }
-.curator-affinity-pill.curator-affinity-positive .curator-affinity-bar-fill {
-  background: #5cc19c;
+.curator-affinity-gauge-value {
+  color: var(--curator-text);
+  font-size: 0.5rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  left: 0;
+  line-height: 1;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.curator-affinity-gauge.curator-affinity-positive .curator-affinity-gauge-value {
+  color: #5cc19c;
+}
+.curator-affinity-gauge.curator-affinity-negative .curator-affinity-gauge-value {
+  color: #e0645c;
 }
 .curator-preview-wall {
   display: grid;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2885,13 +2885,6 @@
   overflow: hidden;
   position: relative;
 }
-.curator-preview-tile.scene-card {
-  background: var(--curator-surface);
-  border: 1px solid var(--curator-border);
-  display: block;
-  margin: 0;
-  padding: 0;
-}
 .curator-preview-link {
   display: block;
   height: 100%;

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -5306,10 +5306,9 @@
       React.createElement("span", { className: "curator-affinity-gauge-value" }, valueLabel)
     );
   }
-  function CuratorContextLink({ type, id, label, target, afterLabel }) {
+  function CuratorContextLink({ type, id, label, target }) {
     const [host, setHost] = React.useState(null);
     const [value, setValue] = React.useState(null);
-    const groupRef = React.useRef(null);
     React.useEffect(() => { setHost(document.querySelector(target)); }, [target]);
     React.useEffect(() => {
       let active = true;
@@ -5322,22 +5321,10 @@
         .catch(() => { if (active) setValue(null); });
       return () => { active = false; };
     }, [type, id]);
-    // Slot the control after an anchor control in the host (e.g. the Organize
-    // button) when afterLabel is given; otherwise keep the createPortal spot.
-    React.useLayoutEffect(() => {
-      const group = groupRef.current;
-      if (!host || !group || !afterLabel) return;
-      let anchor = null;
-      for (const el of host.querySelectorAll("button, a, [role='button']")) {
-        const text = `${el.textContent || ""} ${el.getAttribute("title") || ""} ${el.getAttribute("aria-label") || ""}`.toLowerCase();
-        if (text.includes(afterLabel.toLowerCase())) { anchor = el; break; }
-      }
-      if (anchor && anchor.parentNode) anchor.parentNode.insertBefore(group, anchor.nextSibling);
-    }, [host, afterLabel]);
     if (!host) return null;
     const query = new URLSearchParams({ view: "similar", type, id: String(id), label: label || "" });
     return ReactDOM.createPortal(
-      React.createElement("div", { ref: groupRef, className: "curator-context-group" },
+      React.createElement("div", { className: "curator-context-group" },
         React.createElement(NavLink, { className: "curator-context-button", to: `/plugins/stash-curator?${query}`, title: `Find similar ${type}s with Curator`, "aria-label": `Find similar ${type}s with Curator` }, React.createElement(FontAwesomeIcon, { icon: faCompass })),
         React.createElement(CuratorAffinityGauge, { value })
       ),
@@ -5345,7 +5332,7 @@
     );
   }
   Api.patch.after("ScenePage", function (props, _, result) {
-    return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar", afterLabel: "organiz" }));
+    return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar .scene-toolbar-group:last-child" }));
   });
   Api.patch.after("PerformerPage", function (props, _, result) {
     return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "performer", id: props.performer.id, label: props.performer.name || `Performer ${props.performer.id}`, target: "#performer-page .name-icons" }));

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2348,17 +2348,24 @@
     const label = hasAffinity ? formatAppealValue(affinity) : "";
     const sign = !hasAffinity || affinity === 0 ? "neutral" : affinity < 0 ? "negative" : "positive";
     const laneLabel = laneByValue.get(lane)?.label || "Curator";
+    const laneColor = `var(--curator-hue-${lane}, var(--curator-accent))`;
     function onEnter() { setHovered(true); }
     function onLeave() { setHovered(false); }
+    // Stash's SFW toggle re-renders the wall; re-assert muted on every commit so
+    // the toggle never starts playback with sound (React's `muted` prop is
+    // unreliable across re-renders for <video>).
+    function keepMuted(node) { if (node) { node.muted = true; node.defaultMuted = true; } }
     return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign}`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
         React.createElement("div", { className: "card-section" },
-          React.createElement("video", { className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+          React.createElement("video", { ref: keepMuted, className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
         )
       ),
-      React.createElement("span", { className: "curator-preview-lane", title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),
-      hasAffinity && React.createElement("span", { className: "curator-preview-affinity", title: `Curator affinity ${label}`, "aria-label": `Curator affinity ${label}` }, React.createElement(FontAwesomeIcon, { icon: faCompass }), React.createElement("span", null, label)),
-      hovered && React.createElement("div", { className: "curator-preview-hover", onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave }, React.createElement("span", { className: "curator-preview-hover-title" }, title))
+      React.createElement("span", { className: "curator-preview-lane", style: { color: laneColor }, title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),
+      hovered && React.createElement("div", { className: "curator-preview-hover", onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
+        hasAffinity && React.createElement("span", { className: "curator-preview-affinity", title: `Curator affinity ${label}`, "aria-label": `Curator affinity ${label}` }, React.createElement(FontAwesomeIcon, { icon: faCompass }), React.createElement("span", null, label)),
+        React.createElement("span", { className: "curator-preview-hover-title" }, title)
+      )
     );
   }
   function PreviewWall({ entries }) {

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -5287,8 +5287,29 @@
   // curator affinity (or a dash when the model has no evidence) and navigates to
   // Curator's Similar view for this asset. Always rendered so the Similar entry
   // point is present regardless of model evidence.
-  function CuratorAffinityPill({ type, id, label }) {
+  // Circular gauge around the affinity value (replaces the flat bar). The ring
+  // fill tracks |affinity| and the value is tinted by sign; a dash when there is
+  // no model evidence.
+  function CuratorAffinityGauge({ value }) {
+    const radius = 15;
+    const circumference = 2 * Math.PI * radius;
+    const magnitude = value === null ? 0 : Math.min(1, Math.abs(value));
+    const offset = circumference * (1 - magnitude);
+    const sign = value === null || value === 0 ? "neutral" : value < 0 ? "negative" : "positive";
+    const valueLabel = value === null ? "—" : formatAppealValue(value);
+    const color = sign === "positive" ? "#5cc19c" : sign === "negative" ? "#e0645c" : "#adb5bd";
+    return React.createElement("span", { className: `curator-affinity-gauge curator-affinity-${sign}`, title: `Curator affinity ${valueLabel}`, "aria-label": `Curator affinity ${valueLabel}` },
+      React.createElement("svg", { className: "curator-affinity-gauge-ring", viewBox: "0 0 36 36", "aria-hidden": "true" },
+        React.createElement("circle", { cx: 18, cy: 18, r: radius, fill: "none", stroke: "rgba(127,127,127,0.25)", strokeWidth: 3 }),
+        React.createElement("circle", { cx: 18, cy: 18, r: radius, fill: "none", stroke: color, strokeWidth: 3, strokeDasharray: String(circumference), strokeDashoffset: String(offset), strokeLinecap: "round", transform: "rotate(-90 18 18)" })
+      ),
+      React.createElement("span", { className: "curator-affinity-gauge-value" }, valueLabel)
+    );
+  }
+  function CuratorContextLink({ type, id, label, target }) {
+    const [host, setHost] = React.useState(null);
     const [value, setValue] = React.useState(null);
+    React.useEffect(() => { setHost(document.querySelector(target)); }, [target]);
     React.useEffect(() => {
       let active = true;
       operation({ operation: "get_inspector_entity", entity_type: type, entity_id: String(id) })
@@ -5300,27 +5321,15 @@
         .catch(() => { if (active) setValue(null); });
       return () => { active = false; };
     }, [type, id]);
-    const query = new URLSearchParams({ view: "similar", type, id: String(id), label: label || "" });
-    const valueLabel = value === null ? "—" : formatAppealValue(value);
-    const sign = value === null || value === 0 ? "neutral" : value < 0 ? "negative" : "positive";
-    return React.createElement(NavLink, {
-      className: `curator-affinity-pill curator-affinity-${sign}`,
-      to: `/plugins/stash-curator?${query}`,
-      title: `Find similar ${type}s with Curator · affinity ${valueLabel}`,
-      "aria-label": `Find similar ${type}s with Curator (affinity ${valueLabel})`,
-    },
-      React.createElement(FontAwesomeIcon, { icon: faCompass }),
-      React.createElement("span", { className: "curator-affinity-value" }, valueLabel),
-      React.createElement("span", { className: "curator-affinity-bar", "aria-hidden": "true" }, React.createElement("span", { className: "curator-affinity-bar-fill", style: { width: `${value === null ? 0 : Math.min(100, Math.abs(value) * 100)}%` } }))
-    );
-  }
-  function CuratorContextLink({ type, id, label, target }) {
-    const [host, setHost] = React.useState(null);
-    React.useEffect(() => {
-      setHost(document.querySelector(target));
-    }, [target]);
     if (!host) return null;
-    return ReactDOM.createPortal(React.createElement(CuratorAffinityPill, { type, id, label }), host);
+    const query = new URLSearchParams({ view: "similar", type, id: String(id), label: label || "" });
+    return ReactDOM.createPortal(
+      React.createElement("div", { className: "curator-context-group" },
+        React.createElement(NavLink, { className: "curator-context-button", to: `/plugins/stash-curator?${query}`, title: `Find similar ${type}s with Curator`, "aria-label": `Find similar ${type}s with Curator` }, React.createElement(FontAwesomeIcon, { icon: faCompass })),
+        React.createElement(CuratorAffinityGauge, { value })
+      ),
+      host
+    );
   }
   Api.patch.after("ScenePage", function (props, _, result) {
     return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar .scene-toolbar-group:last-child" }));

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2331,44 +2331,46 @@
     );
   }
 
+  function wallLaneIcon(lane) {
+    const known = laneByValue.get(lane);
+    if (known) return known.icon;
+    const map = { score_review: faBalanceScale, similar: faClone, prune: faBroom, curate: faBullseye, expand: faGlobe, hunt: faCrosshairs };
+    return map[lane] || faCompass;
+  }
   function PreviewWallToggle({ wall, onToggle }) {
-    return React.createElement(Button, { size: "sm", variant: wall ? "primary" : "secondary", "aria-pressed": wall, title: wall ? "Show the full card grid" : "Show a wall of playing scene previews", "aria-label": wall ? "Show the full card grid" : "Show a wall of playing scene previews", onClick: onToggle }, React.createElement(FontAwesomeIcon, { icon: faThLarge }), " Preview wall");
+    return React.createElement(Button, { size: "sm", variant: wall ? "primary" : "secondary", "aria-pressed": wall, title: wall ? "Show the full card grid" : "Show a wall of playing scene previews", "aria-label": wall ? "Show the full card grid" : "Show a wall of playing scene previews", onClick: onToggle }, React.createElement(FontAwesomeIcon, { icon: faThLarge }), " Wall");
   }
   function PreviewTile({ entry, index }) {
     const [hovered, setHovered] = React.useState(false);
-    const { scene_id, scene, affinity, hoverContent } = entry;
+    const { scene_id, scene, affinity, lane } = entry;
     const title = scene?.title || `Scene ${scene_id}`;
     const hasAffinity = affinity !== undefined && affinity !== null;
     const label = hasAffinity ? formatAppealValue(affinity) : "";
     const sign = !hasAffinity || affinity === 0 ? "neutral" : affinity < 0 ? "negative" : "positive";
+    const laneLabel = laneByValue.get(lane)?.label || "Curator";
     function onEnter() { setHovered(true); }
     function onLeave() { setHovered(false); }
     return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign}`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
-        React.createElement("video", { className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+        React.createElement("div", { className: "card-section" },
+          React.createElement("video", { className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+        )
       ),
+      React.createElement("span", { className: "curator-preview-lane", title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),
       hasAffinity && React.createElement("span", { className: "curator-preview-affinity", title: `Curator affinity ${label}`, "aria-label": `Curator affinity ${label}` }, React.createElement(FontAwesomeIcon, { icon: faCompass }), React.createElement("span", null, label)),
-      hovered && React.createElement("div", { className: "curator-preview-hover", onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave }, hoverContent)
+      hovered && React.createElement("div", { className: "curator-preview-hover", onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave }, React.createElement("span", { className: "curator-preview-hover-title" }, title))
     );
   }
   function PreviewWall({ entries }) {
     return React.createElement("div", { className: "curator-preview-wall" }, entries.map((entry, index) => React.createElement(PreviewTile, { key: `${entry.scene_id}:${index}`, entry, index })));
   }
-  function RecommendationWall({ visibleItems, scenes, onRemove, onThumbDown, laneLabel }) {
-    const entries = visibleItems.map((item) => {
-      const scene = scenes.get(String(item.scene_id));
-      return {
-        scene_id: item.scene_id,
-        scene,
-        affinity: item.appeal,
-        hoverContent: React.createElement("div", null,
-          React.createElement("div", { className: "curator-preview-hover-title" }, scene?.title || `Scene ${item.scene_id}`),
-          laneLabel && React.createElement("p", { className: "curator-preview-hover-why" }, `Selected from ${laneLabel}`),
-          React.createElement("div", { className: "curator-preview-hover-appeal" }, scoreBar(item.appeal, true)),
-          React.createElement(Feedback, { item, onRemove, onThumbDown })
-        ),
-      };
-    });
+  function RecommendationWall({ visibleItems, scenes, lane }) {
+    const entries = visibleItems.map((item) => ({
+      scene_id: item.scene_id,
+      scene: scenes.get(String(item.scene_id)),
+      affinity: item.appeal,
+      lane: item.source_lane || lane,
+    }));
     return React.createElement(PreviewWall, { entries });
   }
   function RecommendationCard({ item, scene, slate, onRemove, onThumbDown }) {
@@ -2974,17 +2976,11 @@
       ? items.map((item) => {
           const entity = entities.get(String(item.entity_id));
           if (!entity) return null;
-          const feedbackItem = { ...item, scene_id: item.entity_id, impression_id: result.impression_id };
           return {
             scene_id: item.entity_id,
             scene: entity,
             affinity: (item.appeal * 2) - 1,
-            hoverContent: React.createElement("div", null,
-              React.createElement("div", { className: "curator-preview-hover-title" }, entity.title || `Scene ${item.entity_id}`),
-              item.explanation?.summary && React.createElement("p", { className: "curator-preview-hover-why" }, item.explanation.summary),
-              React.createElement("div", { className: "curator-preview-hover-appeal" }, scoreBar((item.appeal * 2) - 1, true)),
-              React.createElement(Feedback, { item: feedbackItem, onRemove: removeSimilar, onThumbDown: showFollowUp })
-            ),
+            lane: "similar",
           };
         }).filter(Boolean)
       : [];
@@ -3120,12 +3116,7 @@
             scene_id: item.scene_id,
             scene,
             affinity: item.appeal,
-            hoverContent: React.createElement("div", null,
-              React.createElement("div", { className: "curator-preview-hover-title" }, scene.title || `Scene ${item.scene_id}`),
-              item.evidence?.length > 0 && React.createElement("p", { className: "curator-preview-hover-why" }, item.evidence.join(" · ")),
-              React.createElement("div", { className: "curator-preview-hover-appeal" }, item.appeal !== null ? scoreBar(item.appeal, true) : null),
-              React.createElement("div", { className: "curator-prune-actions" }, React.createElement(Button, { size: "sm", variant: item.tagged ? "secondary" : "danger", onClick: () => tag([item.scene_id], !item.tagged) }, item.tagged ? `Undo ${data.tag_name}` : `Tag ${data.tag_name}`), !item.tagged && (item.suspect || item.breadth) && !item.explicit && React.createElement(Button, { size: "sm", variant: "link", onClick: () => dismiss(item.scene_id) }, "Dismiss"))
-            ),
+            lane: "prune",
           };
         }).filter(Boolean)
       : [];
@@ -4354,7 +4345,7 @@
       followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),
       data && !loading && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No scenes below the current appeal threshold."),
       data && !loading && (wall
-        ? React.createElement(RecommendationWall, { visibleItems, scenes, onRemove: remove, onThumbDown: showFollowUp, laneLabel: "Sentiment review" })
+        ? React.createElement(RecommendationWall, { visibleItems, scenes, lane: "score_review" })
         : React.createElement("section", { className: "curator-grid", "aria-live": "polite" }, visibleItems.map((item) => React.createElement(RecommendationCard, { key: `${item.impression_id}:${item.scene_id}`, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp })))
       ),
       data && React.createElement(Pager, { page, total: data.total, pageSize: data.page_size, hasMore: data.has_more, loading, onPage: (value) => updateUrl((s) => ({ ...s, page: value })), label: "Sentiment review pages" })
@@ -5069,7 +5060,7 @@
           null,
           visibleItems.length === 0 && React.createElement("div", { className: "alert alert-info" }, React.createElement("p", null, "Nothing qualifies for this lane right now."), React.createElement(Button, { size: "sm", variant: "secondary", onClick: () => runTask("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench }), " Rebuild model")),
           wall
-            ? React.createElement(RecommendationWall, { visibleItems, scenes, onRemove: remove, onThumbDown: showFollowUp, laneLabel: laneOption.label })
+            ? React.createElement(RecommendationWall, { visibleItems, scenes, lane })
             : React.createElement(
               "section",
               { className: "curator-grid", role: "tabpanel", "aria-live": "polite" },

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -5306,9 +5306,10 @@
       React.createElement("span", { className: "curator-affinity-gauge-value" }, valueLabel)
     );
   }
-  function CuratorContextLink({ type, id, label, target }) {
+  function CuratorContextLink({ type, id, label, target, afterLabel }) {
     const [host, setHost] = React.useState(null);
     const [value, setValue] = React.useState(null);
+    const groupRef = React.useRef(null);
     React.useEffect(() => { setHost(document.querySelector(target)); }, [target]);
     React.useEffect(() => {
       let active = true;
@@ -5321,10 +5322,22 @@
         .catch(() => { if (active) setValue(null); });
       return () => { active = false; };
     }, [type, id]);
+    // Slot the control after an anchor control in the host (e.g. the Organize
+    // button) when afterLabel is given; otherwise keep the createPortal spot.
+    React.useLayoutEffect(() => {
+      const group = groupRef.current;
+      if (!host || !group || !afterLabel) return;
+      let anchor = null;
+      for (const el of host.querySelectorAll("button, a, [role='button']")) {
+        const text = `${el.textContent || ""} ${el.getAttribute("title") || ""} ${el.getAttribute("aria-label") || ""}`.toLowerCase();
+        if (text.includes(afterLabel.toLowerCase())) { anchor = el; break; }
+      }
+      if (anchor && anchor.parentNode) anchor.parentNode.insertBefore(group, anchor.nextSibling);
+    }, [host, afterLabel]);
     if (!host) return null;
     const query = new URLSearchParams({ view: "similar", type, id: String(id), label: label || "" });
     return ReactDOM.createPortal(
-      React.createElement("div", { className: "curator-context-group" },
+      React.createElement("div", { ref: groupRef, className: "curator-context-group" },
         React.createElement(NavLink, { className: "curator-context-button", to: `/plugins/stash-curator?${query}`, title: `Find similar ${type}s with Curator`, "aria-label": `Find similar ${type}s with Curator` }, React.createElement(FontAwesomeIcon, { icon: faCompass })),
         React.createElement(CuratorAffinityGauge, { value })
       ),
@@ -5332,7 +5345,7 @@
     );
   }
   Api.patch.after("ScenePage", function (props, _, result) {
-    return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar .scene-toolbar-group:first-child" }));
+    return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar", afterLabel: "organiz" }));
   });
   Api.patch.after("PerformerPage", function (props, _, result) {
     return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "performer", id: props.performer.id, label: props.performer.name || `Performer ${props.performer.id}`, target: "#performer-page .name-icons" }));

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -5283,7 +5283,11 @@
     }
     return React.isValidElement(result) ? React.cloneElement(result, {}, children) : result;
   });
-  function CuratorAffinityPill({ type, id }) {
+  // The affinity pill doubles as the Similar link: one compact control shows the
+  // curator affinity (or a dash when the model has no evidence) and navigates to
+  // Curator's Similar view for this asset. Always rendered so the Similar entry
+  // point is present regardless of model evidence.
+  function CuratorAffinityPill({ type, id, label }) {
     const [value, setValue] = React.useState(null);
     React.useEffect(() => {
       let active = true;
@@ -5296,17 +5300,18 @@
         .catch(() => { if (active) setValue(null); });
       return () => { active = false; };
     }, [type, id]);
-    if (value === null) return null;
-    const label = formatAppealValue(value);
-    const sign = value < 0 ? "negative" : value > 0 ? "positive" : "neutral";
-    return React.createElement("span", {
+    const query = new URLSearchParams({ view: "similar", type, id: String(id), label: label || "" });
+    const valueLabel = value === null ? "—" : formatAppealValue(value);
+    const sign = value === null || value === 0 ? "neutral" : value < 0 ? "negative" : "positive";
+    return React.createElement(NavLink, {
       className: `curator-affinity-pill curator-affinity-${sign}`,
-      title: `Curator affinity ${label}`,
-      "aria-label": `Curator affinity ${label}`,
+      to: `/plugins/stash-curator?${query}`,
+      title: `Find similar ${type}s with Curator · affinity ${valueLabel}`,
+      "aria-label": `Find similar ${type}s with Curator (affinity ${valueLabel})`,
     },
       React.createElement(FontAwesomeIcon, { icon: faCompass }),
-      React.createElement("span", { className: "curator-affinity-value" }, label),
-      React.createElement("span", { className: "curator-affinity-bar", "aria-hidden": "true" }, React.createElement("span", { className: "curator-affinity-bar-fill", style: { width: `${Math.min(100, Math.abs(value) * 100)}%` } }))
+      React.createElement("span", { className: "curator-affinity-value" }, valueLabel),
+      React.createElement("span", { className: "curator-affinity-bar", "aria-hidden": "true" }, React.createElement("span", { className: "curator-affinity-bar-fill", style: { width: `${value === null ? 0 : Math.min(100, Math.abs(value) * 100)}%` } }))
     );
   }
   function CuratorContextLink({ type, id, label, target }) {
@@ -5314,9 +5319,8 @@
     React.useEffect(() => {
       setHost(document.querySelector(target));
     }, [target]);
-    const query = new URLSearchParams({ view: "similar", type, id: String(id), label: label || "" });
     if (!host) return null;
-    return ReactDOM.createPortal(React.createElement(React.Fragment, null, React.createElement(NavLink, { className: "btn minimal curator-context-link curator-brand-mark", to: `/plugins/stash-curator?${query}`, title: `Find similar ${type}s with Curator`, "aria-label": `Find similar ${type}s with Curator` }, React.createElement(FontAwesomeIcon, { icon: faCompass })), React.createElement(CuratorAffinityPill, { type, id })), host);
+    return ReactDOM.createPortal(React.createElement(CuratorAffinityPill, { type, id, label }), host);
   }
   Api.patch.after("ScenePage", function (props, _, result) {
     return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar .scene-toolbar-group:last-child" }));

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2376,7 +2376,7 @@
     return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign}`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
         React.createElement("div", { className: "card-section" },
-          React.createElement("video", { ref: keepMuted, className: "curator-preview-video scene-card-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+          React.createElement("video", { ref: keepMuted, className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
         )
       ),
       React.createElement("span", { className: "curator-preview-lane", style: { color: laneColor }, title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),
@@ -5334,6 +5334,27 @@
   attachPlayer(location.pathname);
   flushQueue();
   flushTagPreferenceQueue();
+  // Mirror Stash's SFW blur onto the preview wall. Stash's own scene-card
+  // classes break custom wall tiles, so detect SFW from whether the wall media
+  // is actually blurred and apply a strong Curator-side blur when it is. Stash
+  // mutates the DOM often, so the check is debounced.
+  let sfwTimer = null;
+  function syncSfwBlur() {
+    clearTimeout(sfwTimer);
+    sfwTimer = setTimeout(() => {
+      const media = document.querySelectorAll(".curator-preview-tile .card-section, .curator-preview-tile .curator-preview-video");
+      let blurred = false;
+      for (const el of media) {
+        const filter = window.getComputedStyle(el).filter;
+        if (filter && filter !== "none") { blurred = true; break; }
+      }
+      document.body.classList.toggle("curator-sfw", blurred);
+    }, 100);
+  }
+  if (typeof MutationObserver !== "undefined") {
+    new MutationObserver(syncSfwBlur).observe(document.body, { attributes: true, childList: true, subtree: true });
+    syncSfwBlur();
+  }
   function scheduleModelMaintenance() {
     operation({ operation: "health" })
       .then((health) => {

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2354,8 +2354,7 @@
     // Mute synchronously at attach (mobile requires muted *before* the autoplay
     // check) so playback starts silently; a separate effect re-mutes via
     // addEventListener if the SFW toggle unmutes/restarts the media outside
-    // React. The tile also carries the Stash scene-card SFW contract classes so
-    // it blurs with the UI.
+    // React. The media sits in card-section so Stash's SFW switch blurs it.
     const videoRef = React.useRef(null);
     function keepMuted(node) {
       if (!node) return;
@@ -2374,10 +2373,10 @@
         el.removeEventListener("volumechange", forceMuted);
       };
     }, []);
-    return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign} scene-card`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
+    return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign}`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
         React.createElement("div", { className: "card-section" },
-          React.createElement("video", { ref: keepMuted, className: "curator-preview-video scene-card-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+          React.createElement("video", { ref: keepMuted, className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
         )
       ),
       React.createElement("span", { className: "curator-preview-lane", style: { color: laneColor }, title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -214,7 +214,23 @@
   ];
   const EVENT_QUEUE_KEY = "stash-curator:event-queue:v1";
   const THEME_STORAGE_KEY = "stash-curator:theme";
-  const CARD_SIZE_STORAGE_KEY = "stash-curator:card-size";
+  const WALL_STORAGE_KEY = "stash-curator:preview-wall:v1";
+  const WALL_CAP = 20;
+  function readWallMode() {
+    try {
+      return window.localStorage.getItem(WALL_STORAGE_KEY) === "1";
+    } catch {
+      return false;
+    }
+  }
+  function writeWallMode(value) {
+    try {
+      window.localStorage.setItem(WALL_STORAGE_KEY, value ? "1" : "0");
+    } catch {
+      // localStorage can be unavailable (private browsing); the toggle
+      // still works for the session, it just won't persist.
+    }
+  }
   const CARD_SIZE_MIN = 14;
   const CARD_SIZE_MAX = 32;
   const CARD_SIZE_DEFAULT = 22;
@@ -2315,6 +2331,46 @@
     );
   }
 
+  function PreviewWallToggle({ wall, onToggle }) {
+    return React.createElement(Button, { size: "sm", variant: wall ? "primary" : "secondary", "aria-pressed": wall, title: wall ? "Show the full card grid" : "Show a wall of playing scene previews", "aria-label": wall ? "Show the full card grid" : "Show a wall of playing scene previews", onClick: onToggle }, React.createElement(FontAwesomeIcon, { icon: faThLarge }), " Preview wall");
+  }
+  function PreviewTile({ entry, index }) {
+    const [hovered, setHovered] = React.useState(false);
+    const { scene_id, scene, affinity, hoverContent } = entry;
+    const title = scene?.title || `Scene ${scene_id}`;
+    const hasAffinity = affinity !== undefined && affinity !== null;
+    const label = hasAffinity ? formatAppealValue(affinity) : "";
+    const sign = !hasAffinity || affinity === 0 ? "neutral" : affinity < 0 ? "negative" : "positive";
+    function onEnter() { setHovered(true); }
+    function onLeave() { setHovered(false); }
+    return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign}`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
+      React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
+        React.createElement("video", { className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+      ),
+      hasAffinity && React.createElement("span", { className: "curator-preview-affinity", title: `Curator affinity ${label}`, "aria-label": `Curator affinity ${label}` }, React.createElement(FontAwesomeIcon, { icon: faCompass }), React.createElement("span", null, label)),
+      hovered && React.createElement("div", { className: "curator-preview-hover", onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave }, hoverContent)
+    );
+  }
+  function PreviewWall({ entries }) {
+    return React.createElement("div", { className: "curator-preview-wall" }, entries.map((entry, index) => React.createElement(PreviewTile, { key: `${entry.scene_id}:${index}`, entry, index })));
+  }
+  function RecommendationWall({ visibleItems, scenes, onRemove, onThumbDown, laneLabel }) {
+    const entries = visibleItems.map((item) => {
+      const scene = scenes.get(String(item.scene_id));
+      return {
+        scene_id: item.scene_id,
+        scene,
+        affinity: item.appeal,
+        hoverContent: React.createElement("div", null,
+          React.createElement("div", { className: "curator-preview-hover-title" }, scene?.title || `Scene ${item.scene_id}`),
+          laneLabel && React.createElement("p", { className: "curator-preview-hover-why" }, `Selected from ${laneLabel}`),
+          React.createElement("div", { className: "curator-preview-hover-appeal" }, scoreBar(item.appeal, true)),
+          React.createElement(Feedback, { item, onRemove, onThumbDown })
+        ),
+      };
+    });
+    return React.createElement(PreviewWall, { entries });
+  }
   function RecommendationCard({ item, scene, slate, onRemove, onThumbDown }) {
     const { SceneCard } = Api.components;
     const card = React.useRef(null);
@@ -2653,7 +2709,7 @@
     // three are about ranking a candidate against a source entity or a
     // remote catalog, not about narrowing a pre-picked set.
     const rankingOnly = variant !== "recommendations";
-    const minimumMin = variant === "expand" ? "-0.2" : "0";
+    const minimumMin = variant === "expand" ? "-1" : "0";
     const genderAriaLabel = variant === "expand" ? "External performer gender" : "Performer gender";
     const favoriteExtra = variant === "expand" ? { title: "Show only scenes containing a performer favorited in your local library", "aria-pressed": favoriteOnly } : {};
     return React.createElement(
@@ -2739,6 +2795,14 @@
     const [filtersOpen, setFiltersOpen] = React.useState(false);
     const [whisparrEnabled, setWhisparrEnabled] = React.useState(false);
     const [followUps, setFollowUps] = React.useState([]);
+    const [wall, setWall] = React.useState(readWallMode);
+    function toggleWall() {
+      setWall((value) => {
+        const next = !value;
+        writeWallMode(next);
+        return next;
+      });
+    }
     const codeVersionRef = React.useRef("");
     useCuratorActivity("similar", loading, "Finding close matches…");
     const sceneSearch = GQL.useFindScenesQuery({
@@ -2906,6 +2970,24 @@
       return React.createElement("span", { className: "curator-chips" }, ...chips);
     }
     const activeFilterCount = (includeTags?.length || 0) + (excludeTags?.length || 0) + (filterPerformers?.length || 0) + (filterStudios?.length || 0) + (favoriteOnly ? 1 : 0) + (hidePhashMatches ? 1 : 0);
+    const similarWallEntries = entityType === "scene" && source === "library" && result
+      ? items.map((item) => {
+          const entity = entities.get(String(item.entity_id));
+          if (!entity) return null;
+          const feedbackItem = { ...item, scene_id: item.entity_id, impression_id: result.impression_id };
+          return {
+            scene_id: item.entity_id,
+            scene: entity,
+            affinity: (item.appeal * 2) - 1,
+            hoverContent: React.createElement("div", null,
+              React.createElement("div", { className: "curator-preview-hover-title" }, entity.title || `Scene ${item.entity_id}`),
+              item.explanation?.summary && React.createElement("p", { className: "curator-preview-hover-why" }, item.explanation.summary),
+              React.createElement("div", { className: "curator-preview-hover-appeal" }, scoreBar((item.appeal * 2) - 1, true)),
+              React.createElement(Feedback, { item: feedbackItem, onRemove: removeSimilar, onThumbDown: showFollowUp })
+            ),
+          };
+        }).filter(Boolean)
+      : [];
     return React.createElement(
       "section",
       { className: "curator-similar" },
@@ -2926,6 +3008,7 @@
         ),
         source === "stashdb" && React.createElement(Button, { className: "curator-include-owned", size: "sm", variant: includeOwned ? "primary" : "secondary", "aria-pressed": includeOwned, title: `Include ${entityType}s already in your library so the remote ranking can be compared with the local search`, "aria-label": includeOwned ? `Hide library ${entityType}s` : `Include library ${entityType}s`, onClick: () => updateUrl((s) => ({ ...s, includeOwned: !s.includeOwned, page: 1, excludedIds: [] })) }, "Local"),
         React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters", activeFilterCount > 0 && React.createElement("span", { className: "curator-filter-count" }, activeFilterCount)),
+        entityType === "scene" && React.createElement(PreviewWallToggle, { wall, onToggle: toggleWall }),
         React.createElement(SavedFilters, { scope: "similar", current: { gender, favoriteOnly, hidePhashMatches, includeTags, excludeTags, performers: filterPerformers, studios: filterStudios, minimum: minimumSimilarity }, onApply: applySaved })
       ),
       filtersOpen && React.createElement(FilterBar, {
@@ -2953,7 +3036,7 @@
       loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Finding close matches…")),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
       followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),
-      result && source === "library" && React.createElement(
+      result && source === "library" && (entityType === "scene" && wall ? React.createElement(PreviewWall, { entries: similarWallEntries }) : React.createElement(
         "div",
         { className: "curator-grid" },
         items.map((item) => {
@@ -2968,7 +3051,7 @@
           }
           return React.createElement("article", { key: item.entity_id, className: "curator-card", onClickCapture: rememberOrigin }, React.createElement(SceneCard, { scene: entity }), entity.details && React.createElement("p", { className: "curator-card-description curator-card-description-local" }, entity.details), body, React.createElement("div", { className: "curator-similar-feedback" }, React.createElement(Feedback, { item: feedbackItem, onRemove: removeSimilar, onThumbDown: showFollowUp })));
         })
-      ),
+      )),
       result && source === "stashdb" && React.createElement(
         "div",
         { className: "curator-grid curator-external-grid" },
@@ -2999,6 +3082,14 @@
     const [loading, setLoading] = React.useState(true);
     const [error, setError] = React.useState("");
     const [version, setVersion] = React.useState(0);
+    const [wall, setWall] = React.useState(readWallMode);
+    function toggleWall() {
+      setWall((value) => {
+        const next = !value;
+        writeWallMode(next);
+        return next;
+      });
+    }
     useCuratorActivity("prune", loading, "Reviewing prune evidence…");
     React.useEffect(() => {
       let active = true;
@@ -3021,6 +3112,23 @@
       skip: ids.length === 0,
     });
     const scenes = new Map((scenesQuery.data?.findScenes?.scenes || []).map((scene) => [String(scene.id), scene]));
+    const pruneWallEntries = wall && data
+      ? data.items.map((item) => {
+          const scene = scenes.get(String(item.scene_id));
+          if (!scene) return null;
+          return {
+            scene_id: item.scene_id,
+            scene,
+            affinity: item.appeal,
+            hoverContent: React.createElement("div", null,
+              React.createElement("div", { className: "curator-preview-hover-title" }, scene.title || `Scene ${item.scene_id}`),
+              item.evidence?.length > 0 && React.createElement("p", { className: "curator-preview-hover-why" }, item.evidence.join(" · ")),
+              React.createElement("div", { className: "curator-preview-hover-appeal" }, item.appeal !== null ? scoreBar(item.appeal, true) : null),
+              React.createElement("div", { className: "curator-prune-actions" }, React.createElement(Button, { size: "sm", variant: item.tagged ? "secondary" : "danger", onClick: () => tag([item.scene_id], !item.tagged) }, item.tagged ? `Undo ${data.tag_name}` : `Tag ${data.tag_name}`), !item.tagged && (item.suspect || item.breadth) && !item.explicit && React.createElement(Button, { size: "sm", variant: "link", onClick: () => dismiss(item.scene_id) }, "Dismiss"))
+            ),
+          };
+        }).filter(Boolean)
+      : [];
     function refresh() { setVersion((value) => value + 1); }
     async function tag(sceneIds, tagged) {
       try {
@@ -3050,12 +3158,13 @@
           [["candidates", "Candidates"], ["tagged", "Tagged"], ["explicit", "Explicit dislikes"], ["suspects", "Model suspects"], ["breadth", "Broad & unwatched"]].map(([value, label]) => React.createElement(Button, { key: value, size: "sm", variant: view === value ? "primary" : "secondary", onClick: () => updateUrl((s) => ({ ...s, view: value, page: 1 })) }, label))
         ),
         view !== "tagged" && view !== "breadth" && React.createElement("label", { className: "curator-prune-aggressiveness", title: "Move right to include less certain predicted dislikes." }, React.createElement("span", null, aggressiveness < 0.34 ? "Conservative" : aggressiveness < 0.67 ? "Balanced" : "Aggressive"), React.createElement("input", { type: "range", className: "curator-range", min: 0, max: 1, step: 0.05, value: aggressiveness, onChange: (event) => updateUrl((s) => ({ ...s, aggressiveness: Number(event.target.value), page: 1 })), "aria-label": "Prune prediction aggressiveness" })),
-        view !== "tagged" && React.createElement(Button, { size: "sm", variant: "danger", disabled: !ids.length, onClick: tagPage }, `Tag visible (${ids.length})`)
+        view !== "tagged" && React.createElement(Button, { size: "sm", variant: "danger", disabled: !ids.length, onClick: tagPage }, `Tag visible (${ids.length})`),
+        React.createElement(PreviewWallToggle, { wall, onToggle: toggleWall })
       ),
       loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Reviewing prune evidence…")),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
       data && !loading && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, view === "suspects" ? "No scenes cross this prediction threshold. Direct dislikes appear under Explicit dislikes; suspects need a rebuilt model with enough repeated negative evidence." : view === "breadth" ? "No studio in your library is both this broad and this unwatched." : "Nothing in this view."),
-      data && React.createElement(
+      data && (wall ? React.createElement(PreviewWall, { entries: pruneWallEntries }) : React.createElement(
         "div",
         { className: "curator-grid" },
         data.items.map((item) => {
@@ -3075,7 +3184,7 @@
             React.createElement("div", { className: "curator-prune-actions" }, React.createElement(Button, { size: "sm", variant: item.tagged ? "secondary" : "danger", onClick: () => tag([item.scene_id], !item.tagged) }, item.tagged ? `Undo ${data.tag_name}` : `Tag ${data.tag_name}`), !item.tagged && (item.suspect || item.breadth) && !item.explicit && React.createElement(Button, { size: "sm", variant: "link", onClick: () => dismiss(item.scene_id) }, "Dismiss"))
           );
         })
-      ),
+      )),
       data && React.createElement(Pager, { page, total: data.total, pageSize: data.page_size, hasMore: data.has_more, loading, onPage: (value) => updateUrl((s) => ({ ...s, page: value })), label: "Prune pages" })
     );
   }
@@ -4187,6 +4296,14 @@
     const [loading, setLoading] = React.useState(true);
     const [error, setError] = React.useState("");
     const [followUps, setFollowUps] = React.useState([]);
+    const [wall, setWall] = React.useState(readWallMode);
+    function toggleWall() {
+      setWall((value) => {
+        const next = !value;
+        writeWallMode(next);
+        return next;
+      });
+    }
     useCuratorActivity("score-review", loading, "Loading sentiment review…");
     React.useEffect(() => {
       let active = true;
@@ -4229,16 +4346,16 @@
         "div",
         { className: "curator-expand-toolbar" },
         React.createElement("label", { className: "curator-toolbar-select" }, React.createElement(FontAwesomeIcon, { icon: faSortAmountDown }), React.createElement("select", { value: order, onChange: (event) => updateUrl((s) => ({ ...s, order: event.target.value, page: 1 })), "aria-label": "Sort sentiment review" }, React.createElement("option", { value: "asc" }, "Least appealing first"), React.createElement("option", { value: "desc" }, "Most appealing first"))),
-        React.createElement("label", { className: "curator-prune-aggressiveness", title: "Show scenes at or below this appeal threshold." }, React.createElement("span", null, `Appeal ≤ ${threshold.toFixed(2)}`), React.createElement("input", { type: "range", className: "curator-range", min: -1, max: 1, step: 0.05, value: threshold, onChange: (event) => updateUrl((s) => ({ ...s, maxAppeal: Number(event.target.value), page: 1 })), "aria-label": "Maximum appeal threshold" }))
+        React.createElement("label", { className: "curator-prune-aggressiveness", title: "Show scenes at or below this appeal threshold." }, React.createElement("span", null, `Appeal ≤ ${threshold.toFixed(2)}`), React.createElement("input", { type: "range", className: "curator-range", min: -1, max: 1, step: 0.05, value: threshold, onChange: (event) => updateUrl((s) => ({ ...s, maxAppeal: Number(event.target.value), page: 1 })), "aria-label": "Maximum appeal threshold" })),
+        React.createElement(PreviewWallToggle, { wall, onToggle: toggleWall })
       ),
       loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Loading sentiment review…")),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
       followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),
       data && !loading && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No scenes below the current appeal threshold."),
-      data && !loading && React.createElement(
-        "section",
-        { className: "curator-grid", "aria-live": "polite" },
-        visibleItems.map((item) => React.createElement(RecommendationCard, { key: `${item.impression_id}:${item.scene_id}`, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp }))
+      data && !loading && (wall
+        ? React.createElement(RecommendationWall, { visibleItems, scenes, onRemove: remove, onThumbDown: showFollowUp, laneLabel: "Sentiment review" })
+        : React.createElement("section", { className: "curator-grid", "aria-live": "polite" }, visibleItems.map((item) => React.createElement(RecommendationCard, { key: `${item.impression_id}:${item.scene_id}`, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp })))
       ),
       data && React.createElement(Pager, { page, total: data.total, pageSize: data.page_size, hasMore: data.has_more, loading, onPage: (value) => updateUrl((s) => ({ ...s, page: value })), label: "Sentiment review pages" })
     );
@@ -4615,6 +4732,14 @@
     }
     const [diversityEnabled, setDiversityEnabled] = React.useState(null);
     const [diversitySaving, setDiversitySaving] = React.useState(false);
+    const [wall, setWall] = React.useState(readWallMode);
+    function toggleWall() {
+      setWall((value) => {
+        const next = !value;
+        writeWallMode(next);
+        return next;
+      });
+    }
     const [followUps, setFollowUps] = React.useState([]);
     const [theme, setTheme] = React.useState(() => {
       try {
@@ -4910,6 +5035,7 @@
             React.createElement(FontAwesomeIcon, { icon: faBalanceScale }),
             diversityEnabled ? " Balanced" : " Score-first"
           ),
+          laneByValue.has(lane) && React.createElement(PreviewWallToggle, { wall, onToggle: toggleWall }),
           laneByValue.has(lane) && React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters", activeSlateFilterCount > 0 && React.createElement("span", { className: "curator-filter-count" }, activeSlateFilterCount)),
           laneByValue.has(lane) && React.createElement(SavedFilters, { scope: "recommendations", current: { includeTags: filterIncludeTags, excludeTags: filterExcludeTags, performers: filterPerformers, studios: filterStudios, gender: filterGender }, onApply: applySavedSlateFilters })
         )
@@ -4942,11 +5068,13 @@
           React.Fragment,
           null,
           visibleItems.length === 0 && React.createElement("div", { className: "alert alert-info" }, React.createElement("p", null, "Nothing qualifies for this lane right now."), React.createElement(Button, { size: "sm", variant: "secondary", onClick: () => runTask("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench }), " Rebuild model")),
-          React.createElement(
-            "section",
-            { className: "curator-grid", role: "tabpanel", "aria-live": "polite" },
-            visibleItems.map((item) => React.createElement(RecommendationCard, { key: `${item.impression_id}:${item.scene_id}`, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp }))
-          ),
+          wall
+            ? React.createElement(RecommendationWall, { visibleItems, scenes, onRemove: remove, onThumbDown: showFollowUp, laneLabel: laneOption.label })
+            : React.createElement(
+              "section",
+              { className: "curator-grid", role: "tabpanel", "aria-live": "polite" },
+              visibleItems.map((item) => React.createElement(RecommendationCard, { key: `${item.impression_id}:${item.scene_id}`, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp }))
+            ),
           React.createElement(Pager, { page, total: slate.total, pageSize: slate.page_size, hasMore: slate.has_more, loading, onPage: setPage, label: `${laneOption.label} pages` })
         )
     );
@@ -5139,6 +5267,32 @@
     }
     return React.isValidElement(result) ? React.cloneElement(result, {}, children) : result;
   });
+  function CuratorAffinityPill({ type, id }) {
+    const [value, setValue] = React.useState(null);
+    React.useEffect(() => {
+      let active = true;
+      operation({ operation: "get_inspector_entity", entity_type: type, entity_id: String(id) })
+        .then((data) => {
+          if (!active) return;
+          const raw = type === "scene" ? data?.score?.appeal : data?.affinity;
+          setValue(typeof raw === "number" ? raw : null);
+        })
+        .catch(() => { if (active) setValue(null); });
+      return () => { active = false; };
+    }, [type, id]);
+    if (value === null) return null;
+    const label = formatAppealValue(value);
+    const sign = value < 0 ? "negative" : value > 0 ? "positive" : "neutral";
+    return React.createElement("span", {
+      className: `curator-affinity-pill curator-affinity-${sign}`,
+      title: `Curator affinity ${label}`,
+      "aria-label": `Curator affinity ${label}`,
+    },
+      React.createElement(FontAwesomeIcon, { icon: faCompass }),
+      React.createElement("span", { className: "curator-affinity-value" }, label),
+      React.createElement("span", { className: "curator-affinity-bar", "aria-hidden": "true" }, React.createElement("span", { className: "curator-affinity-bar-fill", style: { width: `${Math.min(100, Math.abs(value) * 100)}%` } }))
+    );
+  }
   function CuratorContextLink({ type, id, label, target }) {
     const [host, setHost] = React.useState(null);
     React.useEffect(() => {
@@ -5146,7 +5300,7 @@
     }, [target]);
     const query = new URLSearchParams({ view: "similar", type, id: String(id), label: label || "" });
     if (!host) return null;
-    return ReactDOM.createPortal(React.createElement(NavLink, { className: "btn minimal curator-context-link curator-brand-mark", to: `/plugins/stash-curator?${query}`, title: `Find similar ${type}s with Curator`, "aria-label": `Find similar ${type}s with Curator` }, React.createElement(FontAwesomeIcon, { icon: faCompass })), host);
+    return ReactDOM.createPortal(React.createElement(React.Fragment, null, React.createElement(NavLink, { className: "btn minimal curator-context-link curator-brand-mark", to: `/plugins/stash-curator?${query}`, title: `Find similar ${type}s with Curator`, "aria-label": `Find similar ${type}s with Curator` }, React.createElement(FontAwesomeIcon, { icon: faCompass })), React.createElement(CuratorAffinityPill, { type, id })), host);
   }
   Api.patch.after("ScenePage", function (props, _, result) {
     return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar .scene-toolbar-group:last-child" }));

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2376,7 +2376,7 @@
     return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign}`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
         React.createElement("div", { className: "card-section" },
-          React.createElement("video", { ref: keepMuted, className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+          React.createElement("video", { ref: keepMuted, className: "curator-preview-video scene-card-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
         )
       ),
       React.createElement("span", { className: "curator-preview-lane", style: { color: laneColor }, title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -5332,7 +5332,7 @@
     );
   }
   Api.patch.after("ScenePage", function (props, _, result) {
-    return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar .scene-toolbar-group:last-child" }));
+    return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar .scene-toolbar-group:first-child" }));
   });
   Api.patch.after("PerformerPage", function (props, _, result) {
     return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "performer", id: props.performer.id, label: props.performer.name || `Performer ${props.performer.id}`, target: "#performer-page .name-icons" }));

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2351,14 +2351,26 @@
     const laneColor = `var(--curator-hue-${lane}, var(--curator-accent))`;
     function onEnter() { setHovered(true); }
     function onLeave() { setHovered(false); }
-    // Stash's SFW toggle re-renders the wall; re-assert muted on every commit so
-    // the toggle never starts playback with sound (React's `muted` prop is
-    // unreliable across re-renders for <video>).
-    function keepMuted(node) { if (node) { node.muted = true; node.defaultMuted = true; } }
-    return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign}`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
+    // The SFW toggle can restart/unmute wall media outside React; force muted on
+    // every play/volumechange so playback never leaks sound, and carry the Stash
+    // scene-card SFW contract classes so the wall blurs with the rest of the UI.
+    const videoRef = React.useRef(null);
+    React.useEffect(() => {
+      const el = videoRef.current;
+      if (!el) return;
+      const forceMuted = () => { el.muted = true; el.defaultMuted = true; };
+      forceMuted();
+      el.addEventListener("play", forceMuted);
+      el.addEventListener("volumechange", forceMuted);
+      return () => {
+        el.removeEventListener("play", forceMuted);
+        el.removeEventListener("volumechange", forceMuted);
+      };
+    }, []);
+    return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign} scene-card`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
         React.createElement("div", { className: "card-section" },
-          React.createElement("video", { ref: keepMuted, className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+          React.createElement("video", { ref: videoRef, className: "curator-preview-video scene-card-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
         )
       ),
       React.createElement("span", { className: "curator-preview-lane", style: { color: laneColor }, title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2351,26 +2351,21 @@
     const laneColor = `var(--curator-hue-${lane}, var(--curator-accent))`;
     function onEnter() { setHovered(true); }
     function onLeave() { setHovered(false); }
-    // The SFW toggle can restart/unmute wall media outside React; force muted on
-    // every play/volumechange so playback never leaks sound, and carry the Stash
-    // scene-card SFW contract classes so the wall blurs with the rest of the UI.
-    const videoRef = React.useRef(null);
-    React.useEffect(() => {
-      const el = videoRef.current;
-      if (!el) return;
-      const forceMuted = () => { el.muted = true; el.defaultMuted = true; };
-      forceMuted();
-      el.addEventListener("play", forceMuted);
-      el.addEventListener("volumechange", forceMuted);
-      return () => {
-        el.removeEventListener("play", forceMuted);
-        el.removeEventListener("volumechange", forceMuted);
-      };
-    }, []);
+    // Mute synchronously at attach (mobile requires muted *before* the autoplay
+    // check) and re-assert whenever the browser plays or changes volume — the
+    // SFW toggle can restart/unmute wall media outside React. The tile also
+    // carries the Stash scene-card SFW contract classes so it blurs with the UI.
+    function keepMuted(node) {
+      if (!node) return;
+      node.muted = true;
+      node.defaultMuted = true;
+      node.onplay = () => { node.muted = true; };
+      node.onvolumechange = () => { node.muted = true; };
+    }
     return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign} scene-card`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
         React.createElement("div", { className: "card-section" },
-          React.createElement("video", { ref: videoRef, className: "curator-preview-video scene-card-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+          React.createElement("video", { ref: keepMuted, className: "curator-preview-video scene-card-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
         )
       ),
       React.createElement("span", { className: "curator-preview-lane", style: { color: laneColor }, title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2352,16 +2352,28 @@
     function onEnter() { setHovered(true); }
     function onLeave() { setHovered(false); }
     // Mute synchronously at attach (mobile requires muted *before* the autoplay
-    // check) and re-assert whenever the browser plays or changes volume — the
-    // SFW toggle can restart/unmute wall media outside React. The tile also
-    // carries the Stash scene-card SFW contract classes so it blurs with the UI.
+    // check) so playback starts silently; a separate effect re-mutes via
+    // addEventListener if the SFW toggle unmutes/restarts the media outside
+    // React. The tile also carries the Stash scene-card SFW contract classes so
+    // it blurs with the UI.
+    const videoRef = React.useRef(null);
     function keepMuted(node) {
       if (!node) return;
+      videoRef.current = node;
       node.muted = true;
       node.defaultMuted = true;
-      node.onplay = () => { node.muted = true; };
-      node.onvolumechange = () => { node.muted = true; };
     }
+    React.useEffect(() => {
+      const el = videoRef.current;
+      if (!el) return;
+      const forceMuted = () => { el.muted = true; el.defaultMuted = true; };
+      el.addEventListener("play", forceMuted);
+      el.addEventListener("volumechange", forceMuted);
+      return () => {
+        el.removeEventListener("play", forceMuted);
+        el.removeEventListener("volumechange", forceMuted);
+      };
+    }, []);
     return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign} scene-card`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
         React.createElement("div", { className: "card-section" },

--- a/tests/core/test_backend_slice4.py
+++ b/tests/core/test_backend_slice4.py
@@ -23,6 +23,7 @@ from typing import ClassVar
 
 import pytest
 
+from curator.api import CuratorAPI
 from curator.config import DEFAULT_CONFIG
 from curator.core import core_binary
 from tests.core.test_backend import PLUGIN_DIR, make_sidecar, payload, run_backend
@@ -232,6 +233,25 @@ def make_slice4_sidecar(path: Path) -> None:
                 ('fd-t4', ?, 0.9, 0.9, 0.7, 1)
             """,
             (MODEL_ID, MODEL_ID, MODEL_ID, MODEL_ID),
+        )
+        connection.execute(
+            """
+            INSERT INTO feature_definition(
+                feature_id, feature_version, family, name, provenance, metadata_json
+            ) VALUES
+                ('pf-perf-p1', ?, 'performer_identity', 'performer:p1', 'seed', '{}')
+            """,
+            (FEATURE_VERSION,),
+        )
+        connection.execute(
+            """
+            INSERT INTO feature_affinity(
+                feature_id, model_id, affinity, confidence, effective_support,
+                distinct_scene_count
+            ) VALUES
+                ('pf-perf-p1', ?, 0.62, 0.85, 0.5, 1)
+            """,
+            (MODEL_ID,),
         )
         connection.execute(
             """
@@ -589,6 +609,21 @@ def test_inspector_performer_byte_identical(
         "get_inspector_entity", slice4_sidecar, stub_stash, entity_type="performer", entity_id="p1"
     )
     assert_slice4_identical(binary, raw, slice4_sidecar)
+
+
+def test_inspector_performer_affinity_value(slice4_sidecar: Path) -> None:
+    """The performer branch surfaces the raw feature_affinity for the
+    performer's identity feature, or null when the model has no evidence."""
+    connection = sqlite3.connect(slice4_sidecar)
+    connection.row_factory = sqlite3.Row
+    try:
+        result = CuratorAPI(connection).inspector("performer", "p1")
+        assert result["affinity"] == pytest.approx(0.62)
+        assert result["confidence"] == pytest.approx(0.85)
+        assert CuratorAPI(connection).inspector("performer", "p2")["affinity"] is None
+        assert CuratorAPI(connection).inspector("performer", "p2")["confidence"] is None
+    finally:
+        connection.close()
 
 
 def test_inspector_performer_error_paths(


### PR DESCRIPTION
## What

Implements three issues.

### #277 — Expand affinity filter floor → −1
`FilterBar`'s Expand "Minimum match" floor moves from −0.2 to −1. UI-bounds only — the backend already validates `minimum_score` in `[−1, 1]`. The Similar filter stays at 0, since its minimum is a 0..1 *similarity* threshold (`minimum_similarity must be between 0 and 1`), which isn't negative.

### #278 — Curator-affinity gauge on the Stash scene/performer pages
A **circular affinity gauge** (ring fill tracks |affinity|, signed value in the center, `—` when there's no model evidence) paired with a **logo-only "Find similar" button** in one `curator-context-group`, on the Stash scene page (rightmost `.scene-toolbar-group:last-child`) and performer page (`#performer-page .name-icons`). Scenes surface `score.appeal`; performers surface the raw learned `feature_affinity`. Adds the performer self-affinity to `get_inspector_entity` in both the Go and Python backends, kept byte-identical for the differential gate.

### #279 — Preview wall
A "Wall" toggle on recommendation lanes, Sentiment review, Similar scene matches, and Prune renders a dense grid of muted-autoplay scene previews (capped at 20). Each tile shows an affinity chip, a colored top-left lane icon, and a discreet hover title (click opens the scene). The wall is card-size aware (`--curator-card-min-width`).

Notable implementation details:
- **SFW blur**: Stash's own `.scene-card` / `.scene-card-preview-video` classes break custom wall tiles (their CSS hides/breaks the video), so the wall instead **detects SFW** — a debounced `MutationObserver` checks whether wall media is actually blurred (`getComputedStyle().filter !== "none"`) and toggles a `curator-sfw` body class that applies a strong `filter: blur(24px) !important` on the wall media. Lane icon / affinity chip / hover title stay outside the blurred `card-section`.
- **Muted-autoplay safety**: videos set `muted`/`defaultMuted` synchronously in a ref (mobile requires muted *before* the autoplay check) and re-mute on `play`/`volumechange`, so an SFW toggle can't start audio.
- The toggle persists in `localStorage`, consistent with the theme/card-size pattern.

## Verification
- `scripts/verify changed` — 223 passed.
- `scripts/verify full` — 625 passed, 25 deselected (integration); ruff + mypy clean; core built; perf gate OK.
- New regression test `test_inspector_performer_affinity_value` (raw affinity 0.62 for p1, null for p2); the differential tests keep Go/Python byte-identical.
- Wall behavior (muted autoplay, discreet hover, SFW strong blur, no audio on SFW toggle) confirmed on a live Stash install.

Closes #277
Closes #278
Closes #279
