### PR TITLE
feat(expand): widen StashDB seed discovery and add configurable candidate limit

### DIFF
--- a/core/backend.go
+++ b/core/backend.go
@@ -115,7 +115,7 @@ func writeOutput(output jVal) {
 // unknown modes error like Python's "unknown Curator task" (runTaskMode).
 func taskModeNative(mode string) bool {
 	switch mode {
-	case "backup", "compact", "vacuum", "prepare", "sync-plays", "expand-refresh",
+	case "backup", "compact", "vacuum", "prepare", "sync-plays", "expand-refresh", "expand-rebuild",
 		"build", "force-build", "update-model", "sync-build", "full-sync-build":
 		return true
 	}

--- a/core/diagnostics.go
+++ b/core/diagnostics.go
@@ -13,7 +13,7 @@ import (
 var diagnosticJobTypes = map[string]bool{
 	"sync-build": true, "full-sync-build": true, "sync-plays": true,
 	"build": true, "force-build": true, "update-model": true, "prepare": true,
-	"backup": true, "compact": true, "vacuum": true, "expand-refresh": true,
+	"backup": true, "compact": true, "vacuum": true, "expand-refresh": true, "expand-rebuild": true,
 }
 
 func opGetDiagnostics(pluginDir string, payload jVal) (jVal, error) {

--- a/core/expand_refresh.go
+++ b/core/expand_refresh.go
@@ -350,10 +350,11 @@ func recentScene(scene jVal, cutoff string) bool {
 }
 
 // refreshSeeds mirrors ExpandService._seeds.
-func refreshSeeds(s *expandService, modelID, featureVersion string, links jVal) (jVal, error) {
+func refreshSeeds(s *expandService, clientURL, apiKey, modelID, featureVersion string, links jVal,
+	similarTopK, similarPerFavorite int, gender, ethnicity string) (jVal, error) {
 	topRows, err := s.db.Query(`
 SELECT scene_id FROM model_scene_score WHERE model_id=?
-ORDER BY appeal * confidence DESC LIMIT 100`, modelID)
+ORDER BY appeal * confidence DESC LIMIT 500`, modelID)
 	if err != nil {
 		return jvNull(), err
 	}
@@ -385,17 +386,42 @@ ORDER BY appeal * confidence DESC LIMIT 100`, modelID)
 		}
 		return externalIDs[i] < externalIDs[j]
 	})
-	performers := jvArr()
+	basePerformers := make([]string, 0, len(externalIDs))
 	for _, externalID := range externalIDs {
 		if evidence[externalID].strength > 0 {
-			performers.arr = append(performers.arr, jvStr(externalID))
+			basePerformers = append(basePerformers, externalID)
 		}
 	}
+	expandedPerformers := expandSimilarPerformers(s, clientURL, apiKey, basePerformers, evidence,
+		featureVersion, similarTopK, similarPerFavorite, gender, ethnicity)
+	performers := jvArr()
+	for _, externalID := range expandedPerformers {
+		performers.arr = append(performers.arr, jvStr(externalID))
+	}
+	playedRows, err := s.db.Query(`
+SELECT scene_id FROM source_scene ORDER BY play_count DESC, updated_at DESC LIMIT 200`)
+	if err != nil {
+		return jvNull(), err
+	}
+	var played []string
+	for playedRows.Next() {
+		var sceneID string
+		if err := playedRows.Scan(&sceneID); err != nil {
+			playedRows.Close()
+			return jvNull(), err
+		}
+		played = append(played, sceneID)
+	}
+	playedRows.Close()
+	if err := playedRows.Err(); err != nil {
+		return jvNull(), err
+	}
+	studioScope := dedupe(append(append([]string(nil), top...), played...))
 	studioSet := map[string]bool{}
-	if len(top) > 0 {
-		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(top)), ",")
-		args := make([]any, len(top))
-		for i, id := range top {
+	if len(studioScope) > 0 {
+		placeholders := strings.TrimSuffix(strings.Repeat("?,", len(studioScope)), ",")
+		args := make([]any, len(studioScope))
+		for i, id := range studioScope {
 			args[i] = id
 		}
 		rows, err := s.db.Query(fmt.Sprintf(
@@ -429,8 +455,8 @@ ORDER BY appeal * confidence DESC LIMIT 100`, modelID)
 		sortedStudios = append(sortedStudios, id)
 	}
 	sort.Strings(sortedStudios)
-	if len(sortedStudios) > 30 {
-		sortedStudios = sortedStudios[:30]
+	if len(sortedStudios) > 60 {
+		sortedStudios = sortedStudios[:60]
 	}
 	studiosArr := jvArr()
 	for _, id := range sortedStudios {
@@ -507,9 +533,81 @@ ORDER BY a.affinity * a.confidence DESC LIMIT 50`, modelID, featureVersion)
 	), nil
 }
 
+// expandSimilarPerformers mirrors ExpandService._expand_similar_performers:
+// chase the strongest favourites into StashDB and pull their closest look-alikes so
+// the seed set reaches performers the model has affinity for but has not seen.
+// Best-effort: any failure degrades to the base seed set.
+func expandSimilarPerformers(s *expandService, clientURL, apiKey string, base []string,
+	evidence map[string]*performerEvidence, featureVersion string, topK, perFavorite int,
+	gender, ethnicity string) []string {
+	if topK <= 0 || perFavorite <= 0 || len(base) == 0 {
+		return base
+	}
+	profiles, err := performerProfilesAll(s.db, featureVersion)
+	if err != nil || len(profiles) == 0 {
+		return base
+	}
+	weights := performerBlockWeightsMap()
+	recorded := time.Now().Format("2006-01-02")
+	ids := make([]string, 0, len(evidence))
+	for id := range evidence {
+		ids = append(ids, id)
+	}
+	sort.SliceStable(ids, func(i, j int) bool {
+		a, b := evidence[ids[i]], evidence[ids[j]]
+		if a.strength != b.strength {
+			return a.strength > b.strength
+		}
+		return ids[i] < ids[j]
+	})
+	type scoredPerformer struct {
+		sim float64
+		id  string
+	}
+	added := map[string]bool{}
+	var additions []string
+	limit := topK
+	if limit > len(ids) {
+		limit = len(ids)
+	}
+	for _, externalID := range ids[:limit] {
+		target, ok := profiles[evidence[externalID].localID]
+		if !ok {
+			continue
+		}
+		pool, err := fetchPerformerPool(clientURL, apiKey, target, gender, ethnicity, externalID)
+		if err != nil {
+			continue
+		}
+		var scored []scoredPerformer
+		for _, performer := range pool {
+			profile := expandProfile(performer, jvStr(recorded))
+			if len(profileConflicts(profile, target)) > 0 {
+				continue
+			}
+			sim, _ := profileMatch(profile, target, weights)
+			scored = append(scored, scoredPerformer{sim: sim, id: performer.get("id").asString()})
+		}
+		sort.SliceStable(scored, func(i, j int) bool { return scored[i].sim > scored[j].sim })
+		for i := 0; i < perFavorite && i < len(scored); i++ {
+			eid := scored[i].id
+			if _, known := evidence[eid]; known || added[eid] {
+				continue
+			}
+			added[eid] = true
+			additions = append(additions, eid)
+		}
+	}
+	if len(additions) == 0 {
+		return base
+	}
+	return append(append([]string(nil), base...), additions...)
+}
+
 // expandRefresh mirrors ExpandService.refresh and returns the summary dict.
 func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int,
-	gender string, wildcard bool, nowMs int64, progress func(processed, total int)) (jVal, error) {
+	gender, ethnicity string, wildcard bool, candidateLimit int, similarTopK, similarPerFavorite int,
+	forceFull bool, nowMs int64, progress func(processed, total int)) (jVal, error) {
 	fetchedAtMs := nowMs
 	// The taxonomy check and seed load used to be markerless: on a large
 	// library the bar sat at 5% for the whole stretch. The 50/150 ticks
@@ -539,7 +637,8 @@ func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int
 	if progress != nil {
 		progress(150, 1000)
 	}
-	seeds, err := refreshSeeds(s, modelID, featureVersion, links)
+	seeds, err := refreshSeeds(s, clientURL, apiKey, modelID, featureVersion, links,
+		similarTopK, similarPerFavorite, gender, ethnicity)
 	if err != nil {
 		return jvNull(), err
 	}
@@ -558,7 +657,14 @@ func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int
 	} else if err != nil && err != sql.ErrNoRows {
 		return jvNull(), err
 	}
-	if since != "" && !supportsIncrementalFetch(clientURL, apiKey) {
+	if forceFull {
+		// A force rebuild is the dev escape hatch for scenes a watermark could never
+		// surface: it ignores the incremental cursor and re-fetches the whole window.
+		since = ""
+	} else if since != "" && !supportsIncrementalFetch(clientURL, apiKey) {
+		// The live stashdb instance predates the updated_at SceneQueryInput field, so
+		// the watermark queries would fail validation; fall back to a full fetch there
+		// while newer instances keep the incremental behavior.
 		since = ""
 	}
 	rows := &sceneRows{m: map[string]jVal{}}
@@ -580,7 +686,7 @@ func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int
 	if wildcard {
 		active++
 	}
-	perSource := maxInt(1, int(math.Ceil(1000.0/float64(maxInt(1, active)))))
+	perSource := maxInt(1, int(math.Ceil(float64(candidateLimit)/float64(maxInt(1, active)))))
 	type querySpec struct {
 		source string
 		values []string
@@ -686,12 +792,14 @@ ON CONFLICT(entity_type, external_id) DO UPDATE SET
 		}
 		if _, err := conn.ExecContext(ctx, `
 DELETE FROM external_entity
-WHERE entity_type='scene' AND pool='candidate' AND (
+WHERE entity_type='scene' AND pool IN ('candidate', 'explore') AND (
     (json_extract(payload_json, '$.release_date') IS NOT NULL
      AND json_extract(payload_json, '$.release_date') < ?)
     OR (json_extract(payload_json, '$.release_date') IS NULL
         AND json_extract(payload_json, '$.production_date') IS NOT NULL
         AND json_extract(payload_json, '$.production_date') < ?)
+) AND external_id NOT IN (
+    SELECT external_id FROM external_shortlist WHERE entity_type='scene'
 )`, cutoff, cutoff); err != nil {
 			return err
 		}

--- a/core/frontend.go
+++ b/core/frontend.go
@@ -493,12 +493,21 @@ func inspectorEntityBody(pluginDir string, payload, settings jVal) (jVal, error)
 		if err != nil {
 			return jvNull(), err
 		}
+		affinity, confidence, hasAffinity := performerAffinity(db, modelID, featureVersion, entityID)
+		affinityVal := jvNull()
+		confidenceVal := jvNull()
+		if hasAffinity {
+			affinityVal = jvFloat(affinity)
+			confidenceVal = jvFloat(confidence)
+		}
 		return jvObj(
 			jvKey("schema_version", jvInt(apiSchemaVersion)),
 			jvKey("entity_type", jvStr(entityType)),
 			jvKey("entity_id", jvStr(entityID)),
 			jvKey("model_id", jvStr(modelID)),
 			jvKey("profile", profile),
+			jvKey("affinity", affinityVal),
+			jvKey("confidence", confidenceVal),
 			jvKey("similar", similar),
 		), nil
 	}
@@ -599,6 +608,21 @@ func similarPerformers(db dbx, featureVersion, performerID string, count int) (j
 		))
 	}
 	return out, nil
+}
+
+// performerAffinity mirrors the inspector's performer affinity lookup: the
+// raw feature_affinity entry for the performer's identity feature (name
+// 'performer:<id>'), or none when the model has no evidence for it.
+func performerAffinity(db dbx, modelID, featureVersion, performerID string) (float64, float64, bool) {
+	var affinity, confidence float64
+	err := db.QueryRow(`SELECT fa.affinity, fa.confidence
+FROM feature_affinity fa JOIN feature_definition fd ON fd.feature_id = fa.feature_id
+WHERE fa.model_id = ? AND fd.feature_version = ? AND fd.name = ?`,
+		modelID, featureVersion, "performer:"+performerID).Scan(&affinity, &confidence)
+	if err != nil {
+		return 0, 0, false
+	}
+	return affinity, confidence, true
 }
 
 // ── get_tag_sentiment_follow_up ────────────────────────────────────────────

--- a/core/settings.go
+++ b/core/settings.go
@@ -26,6 +26,9 @@ var defaultPluginConfig = jvObj(
 	jvKey("expand_horizon_days", jvInt(90)),
 	jvKey("expand_gender", jvStr("FEMALE")),
 	jvKey("expand_wildcard", jvBool(false)),
+	jvKey("expand_candidate_limit", jvInt(1000)),
+	jvKey("expand_similar_seed_top_k", jvInt(20)),
+	jvKey("expand_similar_seed_per_favorite", jvInt(5)),
 	jvKey("auto_tasks_enabled", jvBool(false)),
 	jvKey("schedule_expand_refresh_enabled", jvBool(false)),
 	jvKey("schedule_expand_refresh_interval_hours", jvInt(24)),
@@ -64,6 +67,9 @@ var settingMapping = []struct {
 	{"expandHorizonDays", "expand_horizon_days", convInt},
 	{"expandGender", "expand_gender", convStr},
 	{"expandWildcard", "expand_wildcard", convBool},
+	{"expandCandidateLimit", "expand_candidate_limit", convInt},
+	{"expandSimilarSeedTopK", "expand_similar_seed_top_k", convInt},
+	{"expandSimilarSeedPerFavorite", "expand_similar_seed_per_favorite", convInt},
 	{"autoTasksEnabled", "auto_tasks_enabled", convBool},
 	{"scheduleExpandRefreshEnabled", "schedule_expand_refresh_enabled", convBool},
 	{"scheduleExpandRefreshIntervalHours", "schedule_expand_refresh_interval_hours", convFloat},
@@ -298,6 +304,33 @@ func validateConfig(values jVal) error {
 	}
 	if v := values.get("expand_wildcard"); v.kind != jNull && v.kind != jBool {
 		return fmt.Errorf("expand_wildcard must be true or false")
+	}
+	if v := values.get("expand_candidate_limit"); v.kind != jNull {
+		if !isJSONInt(v) {
+			return fmt.Errorf("expand_candidate_limit must be an integer from 100 to 10000")
+		}
+		n := pythonInt(v)
+		if n < 100 || n > 10000 {
+			return fmt.Errorf("expand_candidate_limit must be an integer from 100 to 10000")
+		}
+	}
+	if v := values.get("expand_similar_seed_top_k"); v.kind != jNull {
+		if !isJSONInt(v) {
+			return fmt.Errorf("expand_similar_seed_top_k must be an integer from 0 to 200")
+		}
+		n := pythonInt(v)
+		if n < 0 || n > 200 {
+			return fmt.Errorf("expand_similar_seed_top_k must be an integer from 0 to 200")
+		}
+	}
+	if v := values.get("expand_similar_seed_per_favorite"); v.kind != jNull {
+		if !isJSONInt(v) {
+			return fmt.Errorf("expand_similar_seed_per_favorite must be an integer from 0 to 50")
+		}
+		n := pythonInt(v)
+		if n < 0 || n > 50 {
+			return fmt.Errorf("expand_similar_seed_per_favorite must be an integer from 0 to 50")
+		}
 	}
 	return nil
 }

--- a/core/tasks.go
+++ b/core/tasks.go
@@ -237,6 +237,8 @@ func runTaskMode(db dbx, pluginDir string, payload jVal, mode string, settings j
 		return taskSyncPlays(db, pluginDir, payload, settings)
 	case "expand-refresh":
 		return taskExpandRefresh(db, pluginDir, payload, settings)
+	case "expand-rebuild":
+		return taskExpandRebuild(db, pluginDir, payload, settings)
 	case "build", "force-build", "update-model":
 		return taskBuild(db, pluginDir, payload, mode)
 	case "sync-build", "full-sync-build":
@@ -325,11 +327,56 @@ func taskExpandRefresh(db dbx, pluginDir string, payload jVal, settings jVal) (j
 	}
 	var summary jVal
 	err = pythonSpan("task.expand_refresh", func() error {
+		summary, err = expandRefresh(db, base, apiKey, links,
+			int(pythonInt(cfg.get("expand_horizon_days"))),
+			cfg.get("expand_gender").asString(),
+			"",
+			cfg.get("expand_wildcard").truthy(),
+			int(pythonInt(cfg.get("expand_candidate_limit"))),
+			int(pythonInt(cfg.get("expand_similar_seed_top_k"))),
+			int(pythonInt(cfg.get("expand_similar_seed_per_favorite"))),
+			false,
+			nowMs(), mappedProgress(0.08, 0.98))
+		return err
+	})
+	if err != nil {
+		return jvNull(), err
+	}
+	progressLog(0.98)
+	return summary, nil
+}
+
+// taskExpandRebuild mirrors backend.py's expand-rebuild mode: a full,
+// non-incremental refresh that re-pulls the whole window and ignores the
+// watermark, so scenes a recent incremental pass missed are re-fetched.
+func taskExpandRebuild(db dbx, pluginDir string, payload jVal, settings jVal) (jVal, error) {
+	progressLog(0.05)
+	config, err := sidecarConfig(db)
+	if err != nil {
+		return jvNull(), err
+	}
+	cfg := config.get("config")
+	infoLog("Force rebuilding full Expand candidate window")
+	base, apiKey, err := stashdbClient(payload)
+	if err != nil {
+		return jvNull(), err
+	}
+	links, err := externalLinksRefresh(payload, db, mappedProgress(0.05, 0.08))
+	if err != nil {
+		return jvNull(), err
+	}
+	var summary jVal
+	err = pythonSpan("task.expand_rebuild", func() error {
 		var err error
 		summary, err = expandRefresh(db, base, apiKey, links,
 			int(pythonInt(cfg.get("expand_horizon_days"))),
 			cfg.get("expand_gender").asString(),
+			"",
 			cfg.get("expand_wildcard").truthy(),
+			int(pythonInt(cfg.get("expand_candidate_limit"))),
+			int(pythonInt(cfg.get("expand_similar_seed_top_k"))),
+			int(pythonInt(cfg.get("expand_similar_seed_per_favorite"))),
+			true,
 			nowMs(), mappedProgress(0.08, 0.98))
 		return err
 	})

--- a/curator/api.py
+++ b/curator/api.py
@@ -39,6 +39,9 @@ DEFAULT_PLUGIN_CONFIG: dict[str, object] = {
     "expand_horizon_days": 90,
     "expand_gender": "FEMALE",
     "expand_wildcard": False,
+    "expand_candidate_limit": 1_000,
+    "expand_similar_seed_top_k": 20,
+    "expand_similar_seed_per_favorite": 5,
     "auto_tasks_enabled": False,
     "schedule_expand_refresh_enabled": False,
     "schedule_expand_refresh_interval_hours": 24,
@@ -1259,6 +1262,9 @@ class CuratorAPI:
             "expand_horizon_days",
             "expand_gender",
             "expand_wildcard",
+            "expand_candidate_limit",
+            "expand_similar_seed_top_k",
+            "expand_similar_seed_per_favorite",
             "auto_tasks_enabled",
             "schedule_expand_refresh_enabled",
             "schedule_expand_refresh_interval_hours",
@@ -1333,3 +1339,18 @@ class CuratorAPI:
         wildcard = values.get("expand_wildcard")
         if wildcard is not None and not isinstance(wildcard, bool):
             raise ValueError("expand_wildcard must be true or false")
+        candidate_limit = values.get("expand_candidate_limit")
+        if candidate_limit is not None and (
+            not isinstance(candidate_limit, int) or not 100 <= candidate_limit <= 10_000
+        ):
+            raise ValueError("expand_candidate_limit must be an integer from 100 to 10000")
+        similar_top_k = values.get("expand_similar_seed_top_k")
+        if similar_top_k is not None and (
+            not isinstance(similar_top_k, int) or not 0 <= similar_top_k <= 200
+        ):
+            raise ValueError("expand_similar_seed_top_k must be an integer from 0 to 200")
+        similar_per_favorite = values.get("expand_similar_seed_per_favorite")
+        if similar_per_favorite is not None and (
+            not isinstance(similar_per_favorite, int) or not 0 <= similar_per_favorite <= 50
+        ):
+            raise ValueError("expand_similar_seed_per_favorite must be an integer from 0 to 50")

--- a/curator/api.py
+++ b/curator/api.py
@@ -256,6 +256,19 @@ class CuratorAPI:
             feature_version = self.connection.execute(
                 "SELECT feature_version FROM model_version WHERE model_id=?", (model_id,)
             ).fetchone()[0]
+            affinity_row = self.connection.execute(
+                """
+                SELECT fa.affinity, fa.confidence
+                FROM feature_affinity fa
+                JOIN feature_definition fd ON fd.feature_id = fa.feature_id
+                WHERE fa.model_id = ?
+                  AND fd.feature_version = ?
+                  AND fd.name = ?
+                """,
+                (model_id, feature_version, f"performer:{entity_id}"),
+            ).fetchone()
+            affinity = affinity_row[0] if affinity_row is not None else None
+            confidence = affinity_row[1] if affinity_row is not None else None
             matches = FeatureStore(self.connection).similar_performers(
                 str(feature_version),
                 entity_id,
@@ -268,6 +281,8 @@ class CuratorAPI:
                 "entity_id": entity_id,
                 "model_id": model_id,
                 "profile": dict(row),
+                "affinity": affinity,
+                "confidence": confidence,
                 "similar": [
                     {
                         "performer_id": performer_id,

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -262,6 +262,10 @@ class ExpandService:
         gender: str = "FEMALE",
         wildcard: bool = False,
         candidate_limit: int = 1_000,
+        similar_top_k: int = 20,
+        similar_per_favorite: int = 5,
+        ethnicity: str = "",
+        force_full: bool = False,
         now_ms: int | None = None,
         progress: Callable[[int, int], None] | None = None,
     ) -> dict[str, object]:
@@ -284,7 +288,16 @@ class ExpandService:
         feature_version = str(model[0])
         if progress:
             progress(150, 1_000)
-        seeds = self._seeds(model_id, feature_version, links)
+        seeds = self._seeds(
+            client,
+            model_id,
+            feature_version,
+            links,
+            similar_top_k=similar_top_k,
+            similar_per_favorite=similar_per_favorite,
+            gender=gender,
+            ethnicity=ethnicity,
+        )
         if progress:
             progress(200, 1_000)
         cache = self.connection.execute(
@@ -297,7 +310,11 @@ class ExpandService:
             since = datetime.fromtimestamp(int(cache["fetched_at_ms"]) / 1000, UTC).strftime(
                 "%Y-%m-%dT%H:%M:%SZ"
             )
-        if since is not None and not self._supports_incremental_fetch(client):
+        # A force rebuild is the dev escape hatch for scenes a watermark could never
+        # surface: it ignores the incremental cursor and re-fetches the whole window.
+        if force_full:
+            since = None
+        elif since is not None and not self._supports_incremental_fetch(client):
             # The live stashdb instance predates the updated_at SceneQueryInput field, so
             # the watermark queries would fail validation; fall back to a full fetch there
             # while newer instances keep the incremental behavior.
@@ -363,18 +380,22 @@ class ExpandService:
                     for item in items
                 ),
             )
-            # Candidates fetched while recent age out of the discovery window; drop them so
-            # an incremental refresh cannot grow the pool without bound.
+            # Scenes fetched while recent age out of the discovery window; drop them so an
+            # incremental refresh cannot grow the pool without bound. The explore rows from
+            # hunts and similar probes age out the same way (they re-fetch on demand), but
+            # anything the user shortlisted is preserved.
             cutoff_iso = cutoff.isoformat()
             self.connection.execute(
                 """
                 DELETE FROM external_entity
-                WHERE entity_type='scene' AND pool='candidate' AND (
+                WHERE entity_type='scene' AND pool IN ('candidate', 'explore') AND (
                     (json_extract(payload_json, '$.release_date') IS NOT NULL
                      AND json_extract(payload_json, '$.release_date') < ?)
                     OR (json_extract(payload_json, '$.release_date') IS NULL
                         AND json_extract(payload_json, '$.production_date') IS NOT NULL
                         AND json_extract(payload_json, '$.production_date') < ?)
+                ) AND external_id NOT IN (
+                    SELECT external_id FROM external_shortlist WHERE entity_type='scene'
                 )
                 """,
                 (cutoff_iso, cutoff_iso),
@@ -1691,14 +1712,23 @@ class ExpandService:
         return result
 
     def _seeds(
-        self, model_id: str, feature_version: str, links: dict[str, dict[str, str]]
+        self,
+        client: GraphQLClient,
+        model_id: str,
+        feature_version: str,
+        links: dict[str, dict[str, str]],
+        *,
+        similar_top_k: int = 20,
+        similar_per_favorite: int = 5,
+        gender: str = "",
+        ethnicity: str = "",
     ) -> dict[str, list[str]]:
         top = [
             str(row[0])
             for row in self.connection.execute(
                 """
                 SELECT scene_id FROM model_scene_score WHERE model_id=?
-                ORDER BY appeal * confidence DESC LIMIT 100
+                ORDER BY appeal * confidence DESC LIMIT 500
                 """,
                 (model_id,),
             )
@@ -1711,15 +1741,44 @@ class ExpandService:
             )
             if float(item["strength"]) > 0
         ]
-        studios = {
-            links["studios"][str(row[0])]
-            for row in self.connection.execute(
-                f"SELECT DISTINCT studio_id FROM source_scene WHERE scene_id IN "
-                f"({','.join('?' for _ in top)}) AND studio_id IS NOT NULL",
-                top,
+        # A performer outside the library but similar to the user's own favorites never
+        # reaches the seed set through evidence alone (that only sees local performers).
+        # Chase the strongest favorites into StashDB and pull their closest look-alikes so
+        # the pool reaches scenes by performers the model has affinity for but has not seen.
+        if client is not None and similar_top_k > 0 and similar_per_favorite > 0 and performers:
+            performers = self._expand_similar_performers(
+                client,
+                performers,
+                evidence,
+                model_id,
+                feature_version,
+                links,
+                similar_top_k,
+                similar_per_favorite,
+                gender,
+                ethnicity,
             )
-            if str(row[0]) in links["studios"]
-        }
+        played = [
+            str(row[0])
+            for row in self.connection.execute(
+                """
+                SELECT scene_id FROM source_scene
+                ORDER BY play_count DESC, updated_at DESC LIMIT 200
+                """
+            )
+        ]
+        studio_scope = list(dict.fromkeys((*top, *played)))
+        studios: set[str] = set()
+        if studio_scope:
+            studios = {
+                links["studios"][str(row[0])]
+                for row in self.connection.execute(
+                    f"SELECT DISTINCT studio_id FROM source_scene WHERE scene_id IN "
+                    f"({','.join('?' for _ in studio_scope)}) AND studio_id IS NOT NULL",
+                    studio_scope,
+                )
+                if str(row[0]) in links["studios"]
+            }
         local_tags = [
             str(row[0]).removeprefix("tag:")
             for row in self.connection.execute(
@@ -1749,9 +1808,60 @@ class ExpandService:
         ]
         return {
             "performers": performers,
-            "studios": sorted(studios)[:30],
+            "studios": sorted(studios)[:60],
             "tags": tags,
         }
+
+    def _expand_similar_performers(
+        self,
+        client: GraphQLClient,
+        base: list[str],
+        evidence: dict[str, dict[str, Any]],
+        model_id: str,
+        feature_version: str,
+        links: dict[str, dict[str, str]],
+        top_k: int,
+        per_favorite: int,
+        gender: str,
+        ethnicity: str,
+    ) -> list[str]:
+        # Best-effort enrichment: it must never fail an Expand refresh. A lookup-alike pass
+        # is only worth the seed breadth it adds, so any failure (a StashDB instance that
+        # predates a query, a missing profile, or a broken response) degrades to base seeds.
+        try:
+            profiles = FeatureStore(self.connection).performer_profiles(feature_version)
+        except Exception:
+            return base
+        if not profiles:
+            return base
+        weights = dict(DEFAULT_CONFIG.feature.performer_block_weights)
+        recorded = date.today().isoformat()
+        additions: list[str] = []
+        ranked = sorted(
+            evidence.items(), key=lambda value: (-float(value[1]["strength"]), value[0])
+        )
+        for external_id, info in ranked[:top_k]:
+            target = profiles.get(info["local_id"])
+            if target is None:
+                continue
+            try:
+                pool = self._fetch_performer_pool(
+                    client, target, gender, ethnicity, performed_with=external_id
+                )
+            except (GraphQLError, KeyError, TypeError):
+                continue
+            scored: list[tuple[float, str]] = []
+            for performer in pool:
+                profile = self._profile(performer, recorded)
+                if self._profile_conflicts(profile, target):
+                    continue
+                similarity, _match, _coverage = self._profile_match(profile, target, weights)
+                scored.append((similarity, str(performer["id"])))
+            scored.sort(key=lambda value: value[0], reverse=True)
+            for _similarity, external in scored[:per_favorite]:
+                if external not in evidence and external not in additions:
+                    additions.append(external)
+        return list(dict.fromkeys((*base, *additions)))
 
     @staticmethod
     def _fetch(

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -522,6 +522,9 @@ def _apply_plugin_settings(connection: Any, settings: dict[str, Any]) -> None:
         "expandHorizonDays": ("expand_horizon_days", int),
         "expandGender": ("expand_gender", str),
         "expandWildcard": ("expand_wildcard", bool),
+        "expandCandidateLimit": ("expand_candidate_limit", int),
+        "expandSimilarSeedTopK": ("expand_similar_seed_top_k", int),
+        "expandSimilarSeedPerFavorite": ("expand_similar_seed_per_favorite", int),
         "ignoredTags": ("ignored_tags", str),
     }
     overrides = {
@@ -1070,6 +1073,7 @@ DIAGNOSTIC_JOB_TYPES = {
     "compact",
     "vacuum",
     "expand-refresh",
+    "expand-rebuild",
 }
 
 # Task mode → yml display name, mirroring the Go side's taskDisplayNames so
@@ -1085,6 +1089,7 @@ TASK_DISPLAY_NAMES = {
     "compact": "Compact legacy Curator data",
     "vacuum": "Vacuum compacted Curator data",
     "expand-refresh": "Refresh Expand cache",
+    "expand-rebuild": "Force rebuild Expand cache",
 }
 
 
@@ -1772,6 +1777,36 @@ def _run_task_body(
                     horizon_days=int(config["expand_horizon_days"]),
                     gender=str(config["expand_gender"]),
                     wildcard=bool(config["expand_wildcard"]),
+                    candidate_limit=int(config["expand_candidate_limit"]),
+                    similar_top_k=int(config["expand_similar_seed_top_k"]),
+                    similar_per_favorite=int(config["expand_similar_seed_per_favorite"]),
+                    progress=_mapped_progress(0.08, 0.98),
+                )
+            _progress(0.98)
+        elif mode == "expand-rebuild":
+            # Developer escape hatch: a full, non-incremental refresh that ignores the
+            # watermark so scenes a recent incremental pass missed are re-pulled across the
+            # whole horizon window. Bounded by the same candidate_limit and seeds.
+            _progress(0.05)
+            config = CuratorAPI(connection).config()["config"]
+            assert isinstance(config, dict)
+            _log("i", "Force rebuilding full Expand candidate window")
+            with span("python", "task.expand_rebuild"):
+                summary = ExpandService(connection).refresh(
+                    _stashdb(payload),
+                    _external_links(
+                        payload,
+                        connection,
+                        refresh=True,
+                        progress=_mapped_progress(0.05, 0.08),
+                    ),
+                    horizon_days=int(config["expand_horizon_days"]),
+                    gender=str(config["expand_gender"]),
+                    wildcard=bool(config["expand_wildcard"]),
+                    candidate_limit=int(config["expand_candidate_limit"]),
+                    similar_top_k=int(config["expand_similar_seed_top_k"]),
+                    similar_per_favorite=int(config["expand_similar_seed_per_favorite"]),
+                    force_full=True,
                     progress=_mapped_progress(0.08, 0.98),
                 )
             _progress(0.98)

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2830,6 +2830,113 @@
   padding: 0;
   width: 1.9rem;
 }
+.curator-affinity-pill {
+  align-items: center;
+  background: var(--curator-surface-raised);
+  border: 1px solid var(--curator-border);
+  border-radius: 999px;
+  box-shadow: var(--curator-shadow-sm);
+  color: var(--curator-text);
+  display: inline-flex;
+  font-size: 0.8rem;
+  font-weight: 600;
+  gap: 0.35rem;
+  height: 1.9rem;
+  line-height: 1;
+  margin-left: 0.4rem;
+  padding: 0 0.6rem;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+.curator-affinity-pill .curator-affinity-value {
+  font-variant-numeric: tabular-nums;
+}
+.curator-affinity-pill.curator-affinity-positive .curator-affinity-value {
+  color: #5cc19c;
+}
+.curator-affinity-pill.curator-affinity-negative .curator-affinity-value {
+  color: #e0645c;
+}
+.curator-affinity-pill .curator-affinity-bar {
+  background: var(--curator-wash-recessed);
+  border-radius: 999px;
+  height: 3px;
+  overflow: hidden;
+  width: 2.2rem;
+}
+.curator-affinity-pill .curator-affinity-bar-fill {
+  display: block;
+  height: 100%;
+}
+.curator-affinity-pill.curator-affinity-positive .curator-affinity-bar-fill {
+  background: #5cc19c;
+}
+.curator-preview-wall {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 0.6rem;
+}
+.curator-preview-tile {
+  aspect-ratio: 16 / 9;
+  background: var(--curator-surface);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius);
+  box-shadow: var(--curator-shadow-sm);
+  overflow: hidden;
+  position: relative;
+}
+.curator-preview-link {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+.curator-preview-video {
+  display: block;
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+.curator-preview-affinity {
+  align-items: center;
+  background: var(--curator-overlay);
+  border-radius: 999px;
+  bottom: 0.4rem;
+  color: var(--curator-text);
+  display: inline-flex;
+  font-size: 0.72rem;
+  font-weight: 600;
+  gap: 0.25rem;
+  left: 0.4rem;
+  line-height: 1;
+  padding: 0.2rem 0.45rem;
+  position: absolute;
+}
+.curator-preview-tile.curator-affinity-positive .curator-preview-affinity {
+  color: #5cc19c;
+}
+.curator-preview-tile.curator-affinity-negative .curator-preview-affinity {
+  color: #e0645c;
+}
+.curator-preview-hover {
+  background: var(--curator-overlay);
+  bottom: 0;
+  left: 0;
+  overflow: auto;
+  padding: 0.6rem;
+  position: absolute;
+  right: 0;
+  top: 0;
+  z-index: 2;
+}
+.curator-preview-hover-title {
+  font-weight: 700;
+  margin-bottom: 0.4rem;
+}
+.curator-preview-hover-why {
+  color: var(--curator-text-muted);
+  font-size: 0.8rem;
+  margin: 0 0 0.5rem;
+}
 
 .curator-card > .performer-card {
   background: var(--curator-card-surface);

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2896,6 +2896,11 @@
   object-fit: cover;
   width: 100%;
 }
+.curator-preview-tile .curator-preview-video.scene-card-preview-video {
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
 .curator-preview-tile .card-section {
   height: 100%;
   margin: 0;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2904,18 +2904,12 @@
 }
 .curator-preview-affinity {
   align-items: center;
-  background: var(--curator-overlay);
-  border-radius: 999px;
-  bottom: 0.4rem;
   color: var(--curator-text);
   display: inline-flex;
   font-size: 0.72rem;
   font-weight: 600;
-  gap: 0.25rem;
-  left: 0.4rem;
+  gap: 0.18rem;
   line-height: 1;
-  padding: 0.2rem 0.45rem;
-  position: absolute;
 }
 .curator-preview-tile.curator-affinity-positive .curator-preview-affinity {
   color: #5cc19c;
@@ -2924,19 +2918,26 @@
   color: #e0645c;
 }
 .curator-preview-lane {
+  align-items: center;
   background: var(--curator-overlay);
   border-radius: 0.25rem;
-  color: var(--curator-text-muted);
-  left: 0.4rem;
-  opacity: 0.85;
-  padding: 0.18rem 0.28rem;
+  display: inline-flex;
+  font-size: 0.7rem;
+  height: 1.15rem;
+  justify-content: center;
+  left: 0.35rem;
+  line-height: 1;
   position: absolute;
-  top: 0.4rem;
+  top: 0.35rem;
+  width: 1.15rem;
   z-index: 1;
 }
 .curator-preview-hover {
+  align-items: center;
   background: var(--curator-overlay);
   bottom: 0;
+  display: flex;
+  gap: 0.3rem;
   left: 0;
   padding: 0.28rem 0.4rem;
   position: absolute;
@@ -2945,9 +2946,10 @@
 }
 .curator-preview-hover-title {
   color: var(--curator-text);
-  display: block;
+  flex: 1;
   font-size: 0.75rem;
   font-weight: 600;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2896,16 +2896,17 @@
   object-fit: cover;
   width: 100%;
 }
-.curator-preview-tile .curator-preview-video.scene-card-preview-video {
-  height: 100%;
-  object-fit: cover;
-  width: 100%;
-}
 .curator-preview-tile .card-section {
   height: 100%;
   margin: 0;
   overflow: hidden;
   padding: 0;
+}
+/* SFW switch: Stash's scene-card classes break custom wall tiles, so mirror its
+   blur by detecting when wall media is blurred (syncSfwBlur observer) and
+   applying a strong Curator-side blur only then. */
+.curator-sfw .curator-preview-tile .card-section {
+  filter: blur(12px);
 }
 .curator-preview-affinity {
   align-items: center;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2885,6 +2885,13 @@
   overflow: hidden;
   position: relative;
 }
+.curator-preview-tile.scene-card {
+  background: var(--curator-surface);
+  border: 1px solid var(--curator-border);
+  display: block;
+  margin: 0;
+  padding: 0;
+}
 .curator-preview-link {
   display: block;
   height: 100%;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2873,8 +2873,8 @@
 }
 .curator-preview-wall {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
   gap: 0.6rem;
+  grid-template-columns: repeat(auto-fill, minmax(var(--curator-card-min-width, 22rem), 1fr));
 }
 .curator-preview-tile {
   aspect-ratio: 16 / 9;
@@ -2895,6 +2895,12 @@
   height: 100%;
   object-fit: cover;
   width: 100%;
+}
+.curator-preview-tile .card-section {
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  padding: 0;
 }
 .curator-preview-affinity {
   align-items: center;
@@ -2917,25 +2923,34 @@
 .curator-preview-tile.curator-affinity-negative .curator-preview-affinity {
   color: #e0645c;
 }
+.curator-preview-lane {
+  background: var(--curator-overlay);
+  border-radius: 0.25rem;
+  color: var(--curator-text-muted);
+  left: 0.4rem;
+  opacity: 0.85;
+  padding: 0.18rem 0.28rem;
+  position: absolute;
+  top: 0.4rem;
+  z-index: 1;
+}
 .curator-preview-hover {
   background: var(--curator-overlay);
   bottom: 0;
   left: 0;
-  overflow: auto;
-  padding: 0.6rem;
+  padding: 0.28rem 0.4rem;
   position: absolute;
   right: 0;
-  top: 0;
   z-index: 2;
 }
 .curator-preview-hover-title {
-  font-weight: 700;
-  margin-bottom: 0.4rem;
-}
-.curator-preview-hover-why {
-  color: var(--curator-text-muted);
-  font-size: 0.8rem;
-  margin: 0 0 0.5rem;
+  color: var(--curator-text);
+  display: block;
+  font-size: 0.75rem;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .curator-card > .performer-card {

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2906,7 +2906,7 @@
    blur by detecting when wall media is blurred (syncSfwBlur observer) and
    applying a strong Curator-side blur only then. */
 .curator-sfw .curator-preview-tile .card-section {
-  filter: blur(12px);
+  filter: blur(24px) !important;
 }
 .curator-preview-affinity {
   align-items: center;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2821,15 +2821,6 @@
   outline-offset: 2px;
 }
 
-.curator-context-link {
-  background: var(--curator-gradient-brand) !important;
-  border-radius: var(--curator-radius-lg);
-  box-shadow: var(--curator-shadow-glow);
-  color: var(--curator-text);
-  height: 1.9rem;
-  padding: 0;
-  width: 1.9rem;
-}
 .curator-affinity-pill {
   align-items: center;
   background: var(--curator-surface-raised);
@@ -2837,6 +2828,7 @@
   border-radius: 999px;
   box-shadow: var(--curator-shadow-sm);
   color: var(--curator-text);
+  cursor: pointer;
   display: inline-flex;
   font-size: 0.8rem;
   font-weight: 600;
@@ -2845,6 +2837,7 @@
   line-height: 1;
   margin-left: 0.4rem;
   padding: 0 0.6rem;
+  text-decoration: none;
   vertical-align: middle;
   white-space: nowrap;
 }

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2821,48 +2821,56 @@
   outline-offset: 2px;
 }
 
-.curator-affinity-pill {
+.curator-context-group {
   align-items: center;
-  background: var(--curator-surface-raised);
-  border: 1px solid var(--curator-border);
-  border-radius: 999px;
-  box-shadow: var(--curator-shadow-sm);
-  color: var(--curator-text);
-  cursor: pointer;
   display: inline-flex;
-  font-size: 0.8rem;
-  font-weight: 600;
-  gap: 0.35rem;
-  height: 1.9rem;
-  line-height: 1;
-  margin-left: 0.4rem;
-  padding: 0 0.6rem;
-  text-decoration: none;
+  gap: 0.45rem;
   vertical-align: middle;
-  white-space: nowrap;
 }
-.curator-affinity-pill .curator-affinity-value {
-  font-variant-numeric: tabular-nums;
+.curator-context-button {
+  align-items: center;
+  background: var(--curator-gradient-brand) !important;
+  border-radius: var(--curator-radius-lg);
+  box-shadow: var(--curator-shadow-glow);
+  color: var(--curator-text);
+  display: inline-flex;
+  height: 1.9rem;
+  justify-content: center;
+  text-decoration: none;
+  width: 1.9rem;
 }
-.curator-affinity-pill.curator-affinity-positive .curator-affinity-value {
-  color: #5cc19c;
+.curator-context-button:hover,
+.curator-context-button:focus {
+  text-decoration: none;
 }
-.curator-affinity-pill.curator-affinity-negative .curator-affinity-value {
-  color: #e0645c;
+.curator-affinity-gauge {
+  height: 1.9rem;
+  position: relative;
+  width: 1.9rem;
 }
-.curator-affinity-pill .curator-affinity-bar {
-  background: var(--curator-wash-recessed);
-  border-radius: 999px;
-  height: 3px;
-  overflow: hidden;
-  width: 2.2rem;
-}
-.curator-affinity-pill .curator-affinity-bar-fill {
+.curator-affinity-gauge-ring {
   display: block;
   height: 100%;
+  width: 100%;
 }
-.curator-affinity-pill.curator-affinity-positive .curator-affinity-bar-fill {
-  background: #5cc19c;
+.curator-affinity-gauge-value {
+  color: var(--curator-text);
+  font-size: 0.5rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  left: 0;
+  line-height: 1;
+  position: absolute;
+  right: 0;
+  text-align: center;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.curator-affinity-gauge.curator-affinity-positive .curator-affinity-gauge-value {
+  color: #5cc19c;
+}
+.curator-affinity-gauge.curator-affinity-negative .curator-affinity-gauge-value {
+  color: #e0645c;
 }
 .curator-preview-wall {
   display: grid;

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2885,13 +2885,6 @@
   overflow: hidden;
   position: relative;
 }
-.curator-preview-tile.scene-card {
-  background: var(--curator-surface);
-  border: 1px solid var(--curator-border);
-  display: block;
-  margin: 0;
-  padding: 0;
-}
 .curator-preview-link {
   display: block;
   height: 100%;

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -5306,10 +5306,9 @@
       React.createElement("span", { className: "curator-affinity-gauge-value" }, valueLabel)
     );
   }
-  function CuratorContextLink({ type, id, label, target, afterLabel }) {
+  function CuratorContextLink({ type, id, label, target }) {
     const [host, setHost] = React.useState(null);
     const [value, setValue] = React.useState(null);
-    const groupRef = React.useRef(null);
     React.useEffect(() => { setHost(document.querySelector(target)); }, [target]);
     React.useEffect(() => {
       let active = true;
@@ -5322,22 +5321,10 @@
         .catch(() => { if (active) setValue(null); });
       return () => { active = false; };
     }, [type, id]);
-    // Slot the control after an anchor control in the host (e.g. the Organize
-    // button) when afterLabel is given; otherwise keep the createPortal spot.
-    React.useLayoutEffect(() => {
-      const group = groupRef.current;
-      if (!host || !group || !afterLabel) return;
-      let anchor = null;
-      for (const el of host.querySelectorAll("button, a, [role='button']")) {
-        const text = `${el.textContent || ""} ${el.getAttribute("title") || ""} ${el.getAttribute("aria-label") || ""}`.toLowerCase();
-        if (text.includes(afterLabel.toLowerCase())) { anchor = el; break; }
-      }
-      if (anchor && anchor.parentNode) anchor.parentNode.insertBefore(group, anchor.nextSibling);
-    }, [host, afterLabel]);
     if (!host) return null;
     const query = new URLSearchParams({ view: "similar", type, id: String(id), label: label || "" });
     return ReactDOM.createPortal(
-      React.createElement("div", { ref: groupRef, className: "curator-context-group" },
+      React.createElement("div", { className: "curator-context-group" },
         React.createElement(NavLink, { className: "curator-context-button", to: `/plugins/stash-curator?${query}`, title: `Find similar ${type}s with Curator`, "aria-label": `Find similar ${type}s with Curator` }, React.createElement(FontAwesomeIcon, { icon: faCompass })),
         React.createElement(CuratorAffinityGauge, { value })
       ),
@@ -5345,7 +5332,7 @@
     );
   }
   Api.patch.after("ScenePage", function (props, _, result) {
-    return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar", afterLabel: "organiz" }));
+    return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar .scene-toolbar-group:last-child" }));
   });
   Api.patch.after("PerformerPage", function (props, _, result) {
     return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "performer", id: props.performer.id, label: props.performer.name || `Performer ${props.performer.id}`, target: "#performer-page .name-icons" }));

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2348,17 +2348,24 @@
     const label = hasAffinity ? formatAppealValue(affinity) : "";
     const sign = !hasAffinity || affinity === 0 ? "neutral" : affinity < 0 ? "negative" : "positive";
     const laneLabel = laneByValue.get(lane)?.label || "Curator";
+    const laneColor = `var(--curator-hue-${lane}, var(--curator-accent))`;
     function onEnter() { setHovered(true); }
     function onLeave() { setHovered(false); }
+    // Stash's SFW toggle re-renders the wall; re-assert muted on every commit so
+    // the toggle never starts playback with sound (React's `muted` prop is
+    // unreliable across re-renders for <video>).
+    function keepMuted(node) { if (node) { node.muted = true; node.defaultMuted = true; } }
     return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign}`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
         React.createElement("div", { className: "card-section" },
-          React.createElement("video", { className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+          React.createElement("video", { ref: keepMuted, className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
         )
       ),
-      React.createElement("span", { className: "curator-preview-lane", title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),
-      hasAffinity && React.createElement("span", { className: "curator-preview-affinity", title: `Curator affinity ${label}`, "aria-label": `Curator affinity ${label}` }, React.createElement(FontAwesomeIcon, { icon: faCompass }), React.createElement("span", null, label)),
-      hovered && React.createElement("div", { className: "curator-preview-hover", onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave }, React.createElement("span", { className: "curator-preview-hover-title" }, title))
+      React.createElement("span", { className: "curator-preview-lane", style: { color: laneColor }, title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),
+      hovered && React.createElement("div", { className: "curator-preview-hover", onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
+        hasAffinity && React.createElement("span", { className: "curator-preview-affinity", title: `Curator affinity ${label}`, "aria-label": `Curator affinity ${label}` }, React.createElement(FontAwesomeIcon, { icon: faCompass }), React.createElement("span", null, label)),
+        React.createElement("span", { className: "curator-preview-hover-title" }, title)
+      )
     );
   }
   function PreviewWall({ entries }) {

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -5287,8 +5287,29 @@
   // curator affinity (or a dash when the model has no evidence) and navigates to
   // Curator's Similar view for this asset. Always rendered so the Similar entry
   // point is present regardless of model evidence.
-  function CuratorAffinityPill({ type, id, label }) {
+  // Circular gauge around the affinity value (replaces the flat bar). The ring
+  // fill tracks |affinity| and the value is tinted by sign; a dash when there is
+  // no model evidence.
+  function CuratorAffinityGauge({ value }) {
+    const radius = 15;
+    const circumference = 2 * Math.PI * radius;
+    const magnitude = value === null ? 0 : Math.min(1, Math.abs(value));
+    const offset = circumference * (1 - magnitude);
+    const sign = value === null || value === 0 ? "neutral" : value < 0 ? "negative" : "positive";
+    const valueLabel = value === null ? "—" : formatAppealValue(value);
+    const color = sign === "positive" ? "#5cc19c" : sign === "negative" ? "#e0645c" : "#adb5bd";
+    return React.createElement("span", { className: `curator-affinity-gauge curator-affinity-${sign}`, title: `Curator affinity ${valueLabel}`, "aria-label": `Curator affinity ${valueLabel}` },
+      React.createElement("svg", { className: "curator-affinity-gauge-ring", viewBox: "0 0 36 36", "aria-hidden": "true" },
+        React.createElement("circle", { cx: 18, cy: 18, r: radius, fill: "none", stroke: "rgba(127,127,127,0.25)", strokeWidth: 3 }),
+        React.createElement("circle", { cx: 18, cy: 18, r: radius, fill: "none", stroke: color, strokeWidth: 3, strokeDasharray: String(circumference), strokeDashoffset: String(offset), strokeLinecap: "round", transform: "rotate(-90 18 18)" })
+      ),
+      React.createElement("span", { className: "curator-affinity-gauge-value" }, valueLabel)
+    );
+  }
+  function CuratorContextLink({ type, id, label, target }) {
+    const [host, setHost] = React.useState(null);
     const [value, setValue] = React.useState(null);
+    React.useEffect(() => { setHost(document.querySelector(target)); }, [target]);
     React.useEffect(() => {
       let active = true;
       operation({ operation: "get_inspector_entity", entity_type: type, entity_id: String(id) })
@@ -5300,27 +5321,15 @@
         .catch(() => { if (active) setValue(null); });
       return () => { active = false; };
     }, [type, id]);
-    const query = new URLSearchParams({ view: "similar", type, id: String(id), label: label || "" });
-    const valueLabel = value === null ? "—" : formatAppealValue(value);
-    const sign = value === null || value === 0 ? "neutral" : value < 0 ? "negative" : "positive";
-    return React.createElement(NavLink, {
-      className: `curator-affinity-pill curator-affinity-${sign}`,
-      to: `/plugins/stash-curator?${query}`,
-      title: `Find similar ${type}s with Curator · affinity ${valueLabel}`,
-      "aria-label": `Find similar ${type}s with Curator (affinity ${valueLabel})`,
-    },
-      React.createElement(FontAwesomeIcon, { icon: faCompass }),
-      React.createElement("span", { className: "curator-affinity-value" }, valueLabel),
-      React.createElement("span", { className: "curator-affinity-bar", "aria-hidden": "true" }, React.createElement("span", { className: "curator-affinity-bar-fill", style: { width: `${value === null ? 0 : Math.min(100, Math.abs(value) * 100)}%` } }))
-    );
-  }
-  function CuratorContextLink({ type, id, label, target }) {
-    const [host, setHost] = React.useState(null);
-    React.useEffect(() => {
-      setHost(document.querySelector(target));
-    }, [target]);
     if (!host) return null;
-    return ReactDOM.createPortal(React.createElement(CuratorAffinityPill, { type, id, label }), host);
+    const query = new URLSearchParams({ view: "similar", type, id: String(id), label: label || "" });
+    return ReactDOM.createPortal(
+      React.createElement("div", { className: "curator-context-group" },
+        React.createElement(NavLink, { className: "curator-context-button", to: `/plugins/stash-curator?${query}`, title: `Find similar ${type}s with Curator`, "aria-label": `Find similar ${type}s with Curator` }, React.createElement(FontAwesomeIcon, { icon: faCompass })),
+        React.createElement(CuratorAffinityGauge, { value })
+      ),
+      host
+    );
   }
   Api.patch.after("ScenePage", function (props, _, result) {
     return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar .scene-toolbar-group:last-child" }));

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2331,44 +2331,46 @@
     );
   }
 
+  function wallLaneIcon(lane) {
+    const known = laneByValue.get(lane);
+    if (known) return known.icon;
+    const map = { score_review: faBalanceScale, similar: faClone, prune: faBroom, curate: faBullseye, expand: faGlobe, hunt: faCrosshairs };
+    return map[lane] || faCompass;
+  }
   function PreviewWallToggle({ wall, onToggle }) {
-    return React.createElement(Button, { size: "sm", variant: wall ? "primary" : "secondary", "aria-pressed": wall, title: wall ? "Show the full card grid" : "Show a wall of playing scene previews", "aria-label": wall ? "Show the full card grid" : "Show a wall of playing scene previews", onClick: onToggle }, React.createElement(FontAwesomeIcon, { icon: faThLarge }), " Preview wall");
+    return React.createElement(Button, { size: "sm", variant: wall ? "primary" : "secondary", "aria-pressed": wall, title: wall ? "Show the full card grid" : "Show a wall of playing scene previews", "aria-label": wall ? "Show the full card grid" : "Show a wall of playing scene previews", onClick: onToggle }, React.createElement(FontAwesomeIcon, { icon: faThLarge }), " Wall");
   }
   function PreviewTile({ entry, index }) {
     const [hovered, setHovered] = React.useState(false);
-    const { scene_id, scene, affinity, hoverContent } = entry;
+    const { scene_id, scene, affinity, lane } = entry;
     const title = scene?.title || `Scene ${scene_id}`;
     const hasAffinity = affinity !== undefined && affinity !== null;
     const label = hasAffinity ? formatAppealValue(affinity) : "";
     const sign = !hasAffinity || affinity === 0 ? "neutral" : affinity < 0 ? "negative" : "positive";
+    const laneLabel = laneByValue.get(lane)?.label || "Curator";
     function onEnter() { setHovered(true); }
     function onLeave() { setHovered(false); }
     return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign}`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
-        React.createElement("video", { className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+        React.createElement("div", { className: "card-section" },
+          React.createElement("video", { className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+        )
       ),
+      React.createElement("span", { className: "curator-preview-lane", title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),
       hasAffinity && React.createElement("span", { className: "curator-preview-affinity", title: `Curator affinity ${label}`, "aria-label": `Curator affinity ${label}` }, React.createElement(FontAwesomeIcon, { icon: faCompass }), React.createElement("span", null, label)),
-      hovered && React.createElement("div", { className: "curator-preview-hover", onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave }, hoverContent)
+      hovered && React.createElement("div", { className: "curator-preview-hover", onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave }, React.createElement("span", { className: "curator-preview-hover-title" }, title))
     );
   }
   function PreviewWall({ entries }) {
     return React.createElement("div", { className: "curator-preview-wall" }, entries.map((entry, index) => React.createElement(PreviewTile, { key: `${entry.scene_id}:${index}`, entry, index })));
   }
-  function RecommendationWall({ visibleItems, scenes, onRemove, onThumbDown, laneLabel }) {
-    const entries = visibleItems.map((item) => {
-      const scene = scenes.get(String(item.scene_id));
-      return {
-        scene_id: item.scene_id,
-        scene,
-        affinity: item.appeal,
-        hoverContent: React.createElement("div", null,
-          React.createElement("div", { className: "curator-preview-hover-title" }, scene?.title || `Scene ${item.scene_id}`),
-          laneLabel && React.createElement("p", { className: "curator-preview-hover-why" }, `Selected from ${laneLabel}`),
-          React.createElement("div", { className: "curator-preview-hover-appeal" }, scoreBar(item.appeal, true)),
-          React.createElement(Feedback, { item, onRemove, onThumbDown })
-        ),
-      };
-    });
+  function RecommendationWall({ visibleItems, scenes, lane }) {
+    const entries = visibleItems.map((item) => ({
+      scene_id: item.scene_id,
+      scene: scenes.get(String(item.scene_id)),
+      affinity: item.appeal,
+      lane: item.source_lane || lane,
+    }));
     return React.createElement(PreviewWall, { entries });
   }
   function RecommendationCard({ item, scene, slate, onRemove, onThumbDown }) {
@@ -2974,17 +2976,11 @@
       ? items.map((item) => {
           const entity = entities.get(String(item.entity_id));
           if (!entity) return null;
-          const feedbackItem = { ...item, scene_id: item.entity_id, impression_id: result.impression_id };
           return {
             scene_id: item.entity_id,
             scene: entity,
             affinity: (item.appeal * 2) - 1,
-            hoverContent: React.createElement("div", null,
-              React.createElement("div", { className: "curator-preview-hover-title" }, entity.title || `Scene ${item.entity_id}`),
-              item.explanation?.summary && React.createElement("p", { className: "curator-preview-hover-why" }, item.explanation.summary),
-              React.createElement("div", { className: "curator-preview-hover-appeal" }, scoreBar((item.appeal * 2) - 1, true)),
-              React.createElement(Feedback, { item: feedbackItem, onRemove: removeSimilar, onThumbDown: showFollowUp })
-            ),
+            lane: "similar",
           };
         }).filter(Boolean)
       : [];
@@ -3120,12 +3116,7 @@
             scene_id: item.scene_id,
             scene,
             affinity: item.appeal,
-            hoverContent: React.createElement("div", null,
-              React.createElement("div", { className: "curator-preview-hover-title" }, scene.title || `Scene ${item.scene_id}`),
-              item.evidence?.length > 0 && React.createElement("p", { className: "curator-preview-hover-why" }, item.evidence.join(" · ")),
-              React.createElement("div", { className: "curator-preview-hover-appeal" }, item.appeal !== null ? scoreBar(item.appeal, true) : null),
-              React.createElement("div", { className: "curator-prune-actions" }, React.createElement(Button, { size: "sm", variant: item.tagged ? "secondary" : "danger", onClick: () => tag([item.scene_id], !item.tagged) }, item.tagged ? `Undo ${data.tag_name}` : `Tag ${data.tag_name}`), !item.tagged && (item.suspect || item.breadth) && !item.explicit && React.createElement(Button, { size: "sm", variant: "link", onClick: () => dismiss(item.scene_id) }, "Dismiss"))
-            ),
+            lane: "prune",
           };
         }).filter(Boolean)
       : [];
@@ -4354,7 +4345,7 @@
       followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),
       data && !loading && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No scenes below the current appeal threshold."),
       data && !loading && (wall
-        ? React.createElement(RecommendationWall, { visibleItems, scenes, onRemove: remove, onThumbDown: showFollowUp, laneLabel: "Sentiment review" })
+        ? React.createElement(RecommendationWall, { visibleItems, scenes, lane: "score_review" })
         : React.createElement("section", { className: "curator-grid", "aria-live": "polite" }, visibleItems.map((item) => React.createElement(RecommendationCard, { key: `${item.impression_id}:${item.scene_id}`, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp })))
       ),
       data && React.createElement(Pager, { page, total: data.total, pageSize: data.page_size, hasMore: data.has_more, loading, onPage: (value) => updateUrl((s) => ({ ...s, page: value })), label: "Sentiment review pages" })
@@ -5069,7 +5060,7 @@
           null,
           visibleItems.length === 0 && React.createElement("div", { className: "alert alert-info" }, React.createElement("p", null, "Nothing qualifies for this lane right now."), React.createElement(Button, { size: "sm", variant: "secondary", onClick: () => runTask("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench }), " Rebuild model")),
           wall
-            ? React.createElement(RecommendationWall, { visibleItems, scenes, onRemove: remove, onThumbDown: showFollowUp, laneLabel: laneOption.label })
+            ? React.createElement(RecommendationWall, { visibleItems, scenes, lane })
             : React.createElement(
               "section",
               { className: "curator-grid", role: "tabpanel", "aria-live": "polite" },

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -5306,9 +5306,10 @@
       React.createElement("span", { className: "curator-affinity-gauge-value" }, valueLabel)
     );
   }
-  function CuratorContextLink({ type, id, label, target }) {
+  function CuratorContextLink({ type, id, label, target, afterLabel }) {
     const [host, setHost] = React.useState(null);
     const [value, setValue] = React.useState(null);
+    const groupRef = React.useRef(null);
     React.useEffect(() => { setHost(document.querySelector(target)); }, [target]);
     React.useEffect(() => {
       let active = true;
@@ -5321,10 +5322,22 @@
         .catch(() => { if (active) setValue(null); });
       return () => { active = false; };
     }, [type, id]);
+    // Slot the control after an anchor control in the host (e.g. the Organize
+    // button) when afterLabel is given; otherwise keep the createPortal spot.
+    React.useLayoutEffect(() => {
+      const group = groupRef.current;
+      if (!host || !group || !afterLabel) return;
+      let anchor = null;
+      for (const el of host.querySelectorAll("button, a, [role='button']")) {
+        const text = `${el.textContent || ""} ${el.getAttribute("title") || ""} ${el.getAttribute("aria-label") || ""}`.toLowerCase();
+        if (text.includes(afterLabel.toLowerCase())) { anchor = el; break; }
+      }
+      if (anchor && anchor.parentNode) anchor.parentNode.insertBefore(group, anchor.nextSibling);
+    }, [host, afterLabel]);
     if (!host) return null;
     const query = new URLSearchParams({ view: "similar", type, id: String(id), label: label || "" });
     return ReactDOM.createPortal(
-      React.createElement("div", { className: "curator-context-group" },
+      React.createElement("div", { ref: groupRef, className: "curator-context-group" },
         React.createElement(NavLink, { className: "curator-context-button", to: `/plugins/stash-curator?${query}`, title: `Find similar ${type}s with Curator`, "aria-label": `Find similar ${type}s with Curator` }, React.createElement(FontAwesomeIcon, { icon: faCompass })),
         React.createElement(CuratorAffinityGauge, { value })
       ),
@@ -5332,7 +5345,7 @@
     );
   }
   Api.patch.after("ScenePage", function (props, _, result) {
-    return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar .scene-toolbar-group:first-child" }));
+    return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar", afterLabel: "organiz" }));
   });
   Api.patch.after("PerformerPage", function (props, _, result) {
     return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "performer", id: props.performer.id, label: props.performer.name || `Performer ${props.performer.id}`, target: "#performer-page .name-icons" }));

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -4042,7 +4042,8 @@
         { className: "curator-tasks-runnow" },
         React.createElement("span", null, "Run now"),
         React.createElement(Button, { size: "sm", variant: "primary", disabled: Boolean(starting), onClick: () => start("Sync and build recommendations") }, starting === "Sync and build recommendations" ? "Starting…" : "Sync and build recommendations"),
-        React.createElement(Button, { size: "sm", variant: "outline-danger", disabled: Boolean(starting), onClick: () => start("Force rebuild recommendation model") }, starting === "Force rebuild recommendation model" ? "Starting…" : "Force rebuild model")
+        React.createElement(Button, { size: "sm", variant: "outline-danger", disabled: Boolean(starting), onClick: () => start("Force rebuild recommendation model") }, starting === "Force rebuild recommendation model" ? "Starting…" : "Force rebuild model"),
+        React.createElement(Button, { size: "sm", variant: "secondary", disabled: Boolean(starting), onClick: () => start("Force rebuild Expand cache") }, starting === "Force rebuild Expand cache" ? "Starting…" : "Force rebuild Expand cache")
       ),
       message && React.createElement("p", { className: "curator-header-message", role: "status" }, message),
       React.createElement(
@@ -4423,6 +4424,9 @@
         { key: "expandWildcard", configKey: "expand_wildcard", type: "BOOLEAN", label: "Expand popularity wildcard", description: "Include a small trending/popular sample outside preference-derived seeds." },
         { key: "expandGender", configKey: "expand_gender", type: "SELECT", options: SETTINGS_GENDER_OPTIONS, label: "External performer gender", description: "Default StashDB gender filter for Expand and Similar. Default Female; choose All genders for no filter." },
         { key: "expandHorizonDays", configKey: "expand_horizon_days", type: "NUMBER", label: "Expand recent-release horizon (days)", description: "Recent-release window used by Expand. Default 90." },
+        { key: "expandCandidateLimit", configKey: "expand_candidate_limit", type: "NUMBER", label: "Expand candidate limit", description: "Maximum StashDB scenes fetched per Expand refresh, split across seed sources. Default 1000; raise to reduce fetch truncation at the cost of a slower refresh." },
+        { key: "expandSimilarSeedTopK", configKey: "expand_similar_seed_top_k", type: "NUMBER", label: "Expand similar-performer seed top-K", description: "Chase look-alikes for the K strongest favourite performers into the Expand seed set. 0 disables. Default 20." },
+        { key: "expandSimilarSeedPerFavorite", configKey: "expand_similar_seed_per_favorite", type: "NUMBER", label: "Expand similar-performer seeds per favourite", description: "How many closest look-alikes per favourite are added as Expand seeds. 0 disables. Default 5." },
       ],
     },
     {

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -5283,7 +5283,11 @@
     }
     return React.isValidElement(result) ? React.cloneElement(result, {}, children) : result;
   });
-  function CuratorAffinityPill({ type, id }) {
+  // The affinity pill doubles as the Similar link: one compact control shows the
+  // curator affinity (or a dash when the model has no evidence) and navigates to
+  // Curator's Similar view for this asset. Always rendered so the Similar entry
+  // point is present regardless of model evidence.
+  function CuratorAffinityPill({ type, id, label }) {
     const [value, setValue] = React.useState(null);
     React.useEffect(() => {
       let active = true;
@@ -5296,17 +5300,18 @@
         .catch(() => { if (active) setValue(null); });
       return () => { active = false; };
     }, [type, id]);
-    if (value === null) return null;
-    const label = formatAppealValue(value);
-    const sign = value < 0 ? "negative" : value > 0 ? "positive" : "neutral";
-    return React.createElement("span", {
+    const query = new URLSearchParams({ view: "similar", type, id: String(id), label: label || "" });
+    const valueLabel = value === null ? "—" : formatAppealValue(value);
+    const sign = value === null || value === 0 ? "neutral" : value < 0 ? "negative" : "positive";
+    return React.createElement(NavLink, {
       className: `curator-affinity-pill curator-affinity-${sign}`,
-      title: `Curator affinity ${label}`,
-      "aria-label": `Curator affinity ${label}`,
+      to: `/plugins/stash-curator?${query}`,
+      title: `Find similar ${type}s with Curator · affinity ${valueLabel}`,
+      "aria-label": `Find similar ${type}s with Curator (affinity ${valueLabel})`,
     },
       React.createElement(FontAwesomeIcon, { icon: faCompass }),
-      React.createElement("span", { className: "curator-affinity-value" }, label),
-      React.createElement("span", { className: "curator-affinity-bar", "aria-hidden": "true" }, React.createElement("span", { className: "curator-affinity-bar-fill", style: { width: `${Math.min(100, Math.abs(value) * 100)}%` } }))
+      React.createElement("span", { className: "curator-affinity-value" }, valueLabel),
+      React.createElement("span", { className: "curator-affinity-bar", "aria-hidden": "true" }, React.createElement("span", { className: "curator-affinity-bar-fill", style: { width: `${value === null ? 0 : Math.min(100, Math.abs(value) * 100)}%` } }))
     );
   }
   function CuratorContextLink({ type, id, label, target }) {
@@ -5314,9 +5319,8 @@
     React.useEffect(() => {
       setHost(document.querySelector(target));
     }, [target]);
-    const query = new URLSearchParams({ view: "similar", type, id: String(id), label: label || "" });
     if (!host) return null;
-    return ReactDOM.createPortal(React.createElement(React.Fragment, null, React.createElement(NavLink, { className: "btn minimal curator-context-link curator-brand-mark", to: `/plugins/stash-curator?${query}`, title: `Find similar ${type}s with Curator`, "aria-label": `Find similar ${type}s with Curator` }, React.createElement(FontAwesomeIcon, { icon: faCompass })), React.createElement(CuratorAffinityPill, { type, id })), host);
+    return ReactDOM.createPortal(React.createElement(CuratorAffinityPill, { type, id, label }), host);
   }
   Api.patch.after("ScenePage", function (props, _, result) {
     return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar .scene-toolbar-group:last-child" }));

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2376,7 +2376,7 @@
     return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign}`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
         React.createElement("div", { className: "card-section" },
-          React.createElement("video", { ref: keepMuted, className: "curator-preview-video scene-card-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+          React.createElement("video", { ref: keepMuted, className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
         )
       ),
       React.createElement("span", { className: "curator-preview-lane", style: { color: laneColor }, title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),
@@ -5334,6 +5334,27 @@
   attachPlayer(location.pathname);
   flushQueue();
   flushTagPreferenceQueue();
+  // Mirror Stash's SFW blur onto the preview wall. Stash's own scene-card
+  // classes break custom wall tiles, so detect SFW from whether the wall media
+  // is actually blurred and apply a strong Curator-side blur when it is. Stash
+  // mutates the DOM often, so the check is debounced.
+  let sfwTimer = null;
+  function syncSfwBlur() {
+    clearTimeout(sfwTimer);
+    sfwTimer = setTimeout(() => {
+      const media = document.querySelectorAll(".curator-preview-tile .card-section, .curator-preview-tile .curator-preview-video");
+      let blurred = false;
+      for (const el of media) {
+        const filter = window.getComputedStyle(el).filter;
+        if (filter && filter !== "none") { blurred = true; break; }
+      }
+      document.body.classList.toggle("curator-sfw", blurred);
+    }, 100);
+  }
+  if (typeof MutationObserver !== "undefined") {
+    new MutationObserver(syncSfwBlur).observe(document.body, { attributes: true, childList: true, subtree: true });
+    syncSfwBlur();
+  }
   function scheduleModelMaintenance() {
     operation({ operation: "health" })
       .then((health) => {

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2354,8 +2354,7 @@
     // Mute synchronously at attach (mobile requires muted *before* the autoplay
     // check) so playback starts silently; a separate effect re-mutes via
     // addEventListener if the SFW toggle unmutes/restarts the media outside
-    // React. The tile also carries the Stash scene-card SFW contract classes so
-    // it blurs with the UI.
+    // React. The media sits in card-section so Stash's SFW switch blurs it.
     const videoRef = React.useRef(null);
     function keepMuted(node) {
       if (!node) return;
@@ -2374,10 +2373,10 @@
         el.removeEventListener("volumechange", forceMuted);
       };
     }, []);
-    return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign} scene-card`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
+    return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign}`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
         React.createElement("div", { className: "card-section" },
-          React.createElement("video", { ref: keepMuted, className: "curator-preview-video scene-card-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+          React.createElement("video", { ref: keepMuted, className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
         )
       ),
       React.createElement("span", { className: "curator-preview-lane", style: { color: laneColor }, title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -214,7 +214,23 @@
   ];
   const EVENT_QUEUE_KEY = "stash-curator:event-queue:v1";
   const THEME_STORAGE_KEY = "stash-curator:theme";
-  const CARD_SIZE_STORAGE_KEY = "stash-curator:card-size";
+  const WALL_STORAGE_KEY = "stash-curator:preview-wall:v1";
+  const WALL_CAP = 20;
+  function readWallMode() {
+    try {
+      return window.localStorage.getItem(WALL_STORAGE_KEY) === "1";
+    } catch {
+      return false;
+    }
+  }
+  function writeWallMode(value) {
+    try {
+      window.localStorage.setItem(WALL_STORAGE_KEY, value ? "1" : "0");
+    } catch {
+      // localStorage can be unavailable (private browsing); the toggle
+      // still works for the session, it just won't persist.
+    }
+  }
   const CARD_SIZE_MIN = 14;
   const CARD_SIZE_MAX = 32;
   const CARD_SIZE_DEFAULT = 22;
@@ -2315,6 +2331,46 @@
     );
   }
 
+  function PreviewWallToggle({ wall, onToggle }) {
+    return React.createElement(Button, { size: "sm", variant: wall ? "primary" : "secondary", "aria-pressed": wall, title: wall ? "Show the full card grid" : "Show a wall of playing scene previews", "aria-label": wall ? "Show the full card grid" : "Show a wall of playing scene previews", onClick: onToggle }, React.createElement(FontAwesomeIcon, { icon: faThLarge }), " Preview wall");
+  }
+  function PreviewTile({ entry, index }) {
+    const [hovered, setHovered] = React.useState(false);
+    const { scene_id, scene, affinity, hoverContent } = entry;
+    const title = scene?.title || `Scene ${scene_id}`;
+    const hasAffinity = affinity !== undefined && affinity !== null;
+    const label = hasAffinity ? formatAppealValue(affinity) : "";
+    const sign = !hasAffinity || affinity === 0 ? "neutral" : affinity < 0 ? "negative" : "positive";
+    function onEnter() { setHovered(true); }
+    function onLeave() { setHovered(false); }
+    return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign}`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
+      React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
+        React.createElement("video", { className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+      ),
+      hasAffinity && React.createElement("span", { className: "curator-preview-affinity", title: `Curator affinity ${label}`, "aria-label": `Curator affinity ${label}` }, React.createElement(FontAwesomeIcon, { icon: faCompass }), React.createElement("span", null, label)),
+      hovered && React.createElement("div", { className: "curator-preview-hover", onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave }, hoverContent)
+    );
+  }
+  function PreviewWall({ entries }) {
+    return React.createElement("div", { className: "curator-preview-wall" }, entries.map((entry, index) => React.createElement(PreviewTile, { key: `${entry.scene_id}:${index}`, entry, index })));
+  }
+  function RecommendationWall({ visibleItems, scenes, onRemove, onThumbDown, laneLabel }) {
+    const entries = visibleItems.map((item) => {
+      const scene = scenes.get(String(item.scene_id));
+      return {
+        scene_id: item.scene_id,
+        scene,
+        affinity: item.appeal,
+        hoverContent: React.createElement("div", null,
+          React.createElement("div", { className: "curator-preview-hover-title" }, scene?.title || `Scene ${item.scene_id}`),
+          laneLabel && React.createElement("p", { className: "curator-preview-hover-why" }, `Selected from ${laneLabel}`),
+          React.createElement("div", { className: "curator-preview-hover-appeal" }, scoreBar(item.appeal, true)),
+          React.createElement(Feedback, { item, onRemove, onThumbDown })
+        ),
+      };
+    });
+    return React.createElement(PreviewWall, { entries });
+  }
   function RecommendationCard({ item, scene, slate, onRemove, onThumbDown }) {
     const { SceneCard } = Api.components;
     const card = React.useRef(null);
@@ -2653,7 +2709,7 @@
     // three are about ranking a candidate against a source entity or a
     // remote catalog, not about narrowing a pre-picked set.
     const rankingOnly = variant !== "recommendations";
-    const minimumMin = variant === "expand" ? "-0.2" : "0";
+    const minimumMin = variant === "expand" ? "-1" : "0";
     const genderAriaLabel = variant === "expand" ? "External performer gender" : "Performer gender";
     const favoriteExtra = variant === "expand" ? { title: "Show only scenes containing a performer favorited in your local library", "aria-pressed": favoriteOnly } : {};
     return React.createElement(
@@ -2739,6 +2795,14 @@
     const [filtersOpen, setFiltersOpen] = React.useState(false);
     const [whisparrEnabled, setWhisparrEnabled] = React.useState(false);
     const [followUps, setFollowUps] = React.useState([]);
+    const [wall, setWall] = React.useState(readWallMode);
+    function toggleWall() {
+      setWall((value) => {
+        const next = !value;
+        writeWallMode(next);
+        return next;
+      });
+    }
     const codeVersionRef = React.useRef("");
     useCuratorActivity("similar", loading, "Finding close matches…");
     const sceneSearch = GQL.useFindScenesQuery({
@@ -2906,6 +2970,24 @@
       return React.createElement("span", { className: "curator-chips" }, ...chips);
     }
     const activeFilterCount = (includeTags?.length || 0) + (excludeTags?.length || 0) + (filterPerformers?.length || 0) + (filterStudios?.length || 0) + (favoriteOnly ? 1 : 0) + (hidePhashMatches ? 1 : 0);
+    const similarWallEntries = entityType === "scene" && source === "library" && result
+      ? items.map((item) => {
+          const entity = entities.get(String(item.entity_id));
+          if (!entity) return null;
+          const feedbackItem = { ...item, scene_id: item.entity_id, impression_id: result.impression_id };
+          return {
+            scene_id: item.entity_id,
+            scene: entity,
+            affinity: (item.appeal * 2) - 1,
+            hoverContent: React.createElement("div", null,
+              React.createElement("div", { className: "curator-preview-hover-title" }, entity.title || `Scene ${item.entity_id}`),
+              item.explanation?.summary && React.createElement("p", { className: "curator-preview-hover-why" }, item.explanation.summary),
+              React.createElement("div", { className: "curator-preview-hover-appeal" }, scoreBar((item.appeal * 2) - 1, true)),
+              React.createElement(Feedback, { item: feedbackItem, onRemove: removeSimilar, onThumbDown: showFollowUp })
+            ),
+          };
+        }).filter(Boolean)
+      : [];
     return React.createElement(
       "section",
       { className: "curator-similar" },
@@ -2926,6 +3008,7 @@
         ),
         source === "stashdb" && React.createElement(Button, { className: "curator-include-owned", size: "sm", variant: includeOwned ? "primary" : "secondary", "aria-pressed": includeOwned, title: `Include ${entityType}s already in your library so the remote ranking can be compared with the local search`, "aria-label": includeOwned ? `Hide library ${entityType}s` : `Include library ${entityType}s`, onClick: () => updateUrl((s) => ({ ...s, includeOwned: !s.includeOwned, page: 1, excludedIds: [] })) }, "Local"),
         React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters", activeFilterCount > 0 && React.createElement("span", { className: "curator-filter-count" }, activeFilterCount)),
+        entityType === "scene" && React.createElement(PreviewWallToggle, { wall, onToggle: toggleWall }),
         React.createElement(SavedFilters, { scope: "similar", current: { gender, favoriteOnly, hidePhashMatches, includeTags, excludeTags, performers: filterPerformers, studios: filterStudios, minimum: minimumSimilarity }, onApply: applySaved })
       ),
       filtersOpen && React.createElement(FilterBar, {
@@ -2953,7 +3036,7 @@
       loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Finding close matches…")),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
       followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),
-      result && source === "library" && React.createElement(
+      result && source === "library" && (entityType === "scene" && wall ? React.createElement(PreviewWall, { entries: similarWallEntries }) : React.createElement(
         "div",
         { className: "curator-grid" },
         items.map((item) => {
@@ -2968,7 +3051,7 @@
           }
           return React.createElement("article", { key: item.entity_id, className: "curator-card", onClickCapture: rememberOrigin }, React.createElement(SceneCard, { scene: entity }), entity.details && React.createElement("p", { className: "curator-card-description curator-card-description-local" }, entity.details), body, React.createElement("div", { className: "curator-similar-feedback" }, React.createElement(Feedback, { item: feedbackItem, onRemove: removeSimilar, onThumbDown: showFollowUp })));
         })
-      ),
+      )),
       result && source === "stashdb" && React.createElement(
         "div",
         { className: "curator-grid curator-external-grid" },
@@ -2999,6 +3082,14 @@
     const [loading, setLoading] = React.useState(true);
     const [error, setError] = React.useState("");
     const [version, setVersion] = React.useState(0);
+    const [wall, setWall] = React.useState(readWallMode);
+    function toggleWall() {
+      setWall((value) => {
+        const next = !value;
+        writeWallMode(next);
+        return next;
+      });
+    }
     useCuratorActivity("prune", loading, "Reviewing prune evidence…");
     React.useEffect(() => {
       let active = true;
@@ -3021,6 +3112,23 @@
       skip: ids.length === 0,
     });
     const scenes = new Map((scenesQuery.data?.findScenes?.scenes || []).map((scene) => [String(scene.id), scene]));
+    const pruneWallEntries = wall && data
+      ? data.items.map((item) => {
+          const scene = scenes.get(String(item.scene_id));
+          if (!scene) return null;
+          return {
+            scene_id: item.scene_id,
+            scene,
+            affinity: item.appeal,
+            hoverContent: React.createElement("div", null,
+              React.createElement("div", { className: "curator-preview-hover-title" }, scene.title || `Scene ${item.scene_id}`),
+              item.evidence?.length > 0 && React.createElement("p", { className: "curator-preview-hover-why" }, item.evidence.join(" · ")),
+              React.createElement("div", { className: "curator-preview-hover-appeal" }, item.appeal !== null ? scoreBar(item.appeal, true) : null),
+              React.createElement("div", { className: "curator-prune-actions" }, React.createElement(Button, { size: "sm", variant: item.tagged ? "secondary" : "danger", onClick: () => tag([item.scene_id], !item.tagged) }, item.tagged ? `Undo ${data.tag_name}` : `Tag ${data.tag_name}`), !item.tagged && (item.suspect || item.breadth) && !item.explicit && React.createElement(Button, { size: "sm", variant: "link", onClick: () => dismiss(item.scene_id) }, "Dismiss"))
+            ),
+          };
+        }).filter(Boolean)
+      : [];
     function refresh() { setVersion((value) => value + 1); }
     async function tag(sceneIds, tagged) {
       try {
@@ -3050,12 +3158,13 @@
           [["candidates", "Candidates"], ["tagged", "Tagged"], ["explicit", "Explicit dislikes"], ["suspects", "Model suspects"], ["breadth", "Broad & unwatched"]].map(([value, label]) => React.createElement(Button, { key: value, size: "sm", variant: view === value ? "primary" : "secondary", onClick: () => updateUrl((s) => ({ ...s, view: value, page: 1 })) }, label))
         ),
         view !== "tagged" && view !== "breadth" && React.createElement("label", { className: "curator-prune-aggressiveness", title: "Move right to include less certain predicted dislikes." }, React.createElement("span", null, aggressiveness < 0.34 ? "Conservative" : aggressiveness < 0.67 ? "Balanced" : "Aggressive"), React.createElement("input", { type: "range", className: "curator-range", min: 0, max: 1, step: 0.05, value: aggressiveness, onChange: (event) => updateUrl((s) => ({ ...s, aggressiveness: Number(event.target.value), page: 1 })), "aria-label": "Prune prediction aggressiveness" })),
-        view !== "tagged" && React.createElement(Button, { size: "sm", variant: "danger", disabled: !ids.length, onClick: tagPage }, `Tag visible (${ids.length})`)
+        view !== "tagged" && React.createElement(Button, { size: "sm", variant: "danger", disabled: !ids.length, onClick: tagPage }, `Tag visible (${ids.length})`),
+        React.createElement(PreviewWallToggle, { wall, onToggle: toggleWall })
       ),
       loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Reviewing prune evidence…")),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
       data && !loading && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, view === "suspects" ? "No scenes cross this prediction threshold. Direct dislikes appear under Explicit dislikes; suspects need a rebuilt model with enough repeated negative evidence." : view === "breadth" ? "No studio in your library is both this broad and this unwatched." : "Nothing in this view."),
-      data && React.createElement(
+      data && (wall ? React.createElement(PreviewWall, { entries: pruneWallEntries }) : React.createElement(
         "div",
         { className: "curator-grid" },
         data.items.map((item) => {
@@ -3075,7 +3184,7 @@
             React.createElement("div", { className: "curator-prune-actions" }, React.createElement(Button, { size: "sm", variant: item.tagged ? "secondary" : "danger", onClick: () => tag([item.scene_id], !item.tagged) }, item.tagged ? `Undo ${data.tag_name}` : `Tag ${data.tag_name}`), !item.tagged && (item.suspect || item.breadth) && !item.explicit && React.createElement(Button, { size: "sm", variant: "link", onClick: () => dismiss(item.scene_id) }, "Dismiss"))
           );
         })
-      ),
+      )),
       data && React.createElement(Pager, { page, total: data.total, pageSize: data.page_size, hasMore: data.has_more, loading, onPage: (value) => updateUrl((s) => ({ ...s, page: value })), label: "Prune pages" })
     );
   }
@@ -4187,6 +4296,14 @@
     const [loading, setLoading] = React.useState(true);
     const [error, setError] = React.useState("");
     const [followUps, setFollowUps] = React.useState([]);
+    const [wall, setWall] = React.useState(readWallMode);
+    function toggleWall() {
+      setWall((value) => {
+        const next = !value;
+        writeWallMode(next);
+        return next;
+      });
+    }
     useCuratorActivity("score-review", loading, "Loading sentiment review…");
     React.useEffect(() => {
       let active = true;
@@ -4229,16 +4346,16 @@
         "div",
         { className: "curator-expand-toolbar" },
         React.createElement("label", { className: "curator-toolbar-select" }, React.createElement(FontAwesomeIcon, { icon: faSortAmountDown }), React.createElement("select", { value: order, onChange: (event) => updateUrl((s) => ({ ...s, order: event.target.value, page: 1 })), "aria-label": "Sort sentiment review" }, React.createElement("option", { value: "asc" }, "Least appealing first"), React.createElement("option", { value: "desc" }, "Most appealing first"))),
-        React.createElement("label", { className: "curator-prune-aggressiveness", title: "Show scenes at or below this appeal threshold." }, React.createElement("span", null, `Appeal ≤ ${threshold.toFixed(2)}`), React.createElement("input", { type: "range", className: "curator-range", min: -1, max: 1, step: 0.05, value: threshold, onChange: (event) => updateUrl((s) => ({ ...s, maxAppeal: Number(event.target.value), page: 1 })), "aria-label": "Maximum appeal threshold" }))
+        React.createElement("label", { className: "curator-prune-aggressiveness", title: "Show scenes at or below this appeal threshold." }, React.createElement("span", null, `Appeal ≤ ${threshold.toFixed(2)}`), React.createElement("input", { type: "range", className: "curator-range", min: -1, max: 1, step: 0.05, value: threshold, onChange: (event) => updateUrl((s) => ({ ...s, maxAppeal: Number(event.target.value), page: 1 })), "aria-label": "Maximum appeal threshold" })),
+        React.createElement(PreviewWallToggle, { wall, onToggle: toggleWall })
       ),
       loading && React.createElement("div", { className: "curator-loading", role: "status" }, React.createElement("span", null, "Loading sentiment review…")),
       error && React.createElement("div", { className: "alert alert-danger" }, error),
       followUps.map((followUp) => React.createElement(TagSentimentFollowUp, { key: followUp.scene_id, followUp, onDismiss: () => setFollowUps((current) => current.filter((item) => item.scene_id !== followUp.scene_id)) })),
       data && !loading && data.items.length === 0 && React.createElement("div", { className: "alert alert-info" }, "No scenes below the current appeal threshold."),
-      data && !loading && React.createElement(
-        "section",
-        { className: "curator-grid", "aria-live": "polite" },
-        visibleItems.map((item) => React.createElement(RecommendationCard, { key: `${item.impression_id}:${item.scene_id}`, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp }))
+      data && !loading && (wall
+        ? React.createElement(RecommendationWall, { visibleItems, scenes, onRemove: remove, onThumbDown: showFollowUp, laneLabel: "Sentiment review" })
+        : React.createElement("section", { className: "curator-grid", "aria-live": "polite" }, visibleItems.map((item) => React.createElement(RecommendationCard, { key: `${item.impression_id}:${item.scene_id}`, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp })))
       ),
       data && React.createElement(Pager, { page, total: data.total, pageSize: data.page_size, hasMore: data.has_more, loading, onPage: (value) => updateUrl((s) => ({ ...s, page: value })), label: "Sentiment review pages" })
     );
@@ -4615,6 +4732,14 @@
     }
     const [diversityEnabled, setDiversityEnabled] = React.useState(null);
     const [diversitySaving, setDiversitySaving] = React.useState(false);
+    const [wall, setWall] = React.useState(readWallMode);
+    function toggleWall() {
+      setWall((value) => {
+        const next = !value;
+        writeWallMode(next);
+        return next;
+      });
+    }
     const [followUps, setFollowUps] = React.useState([]);
     const [theme, setTheme] = React.useState(() => {
       try {
@@ -4910,6 +5035,7 @@
             React.createElement(FontAwesomeIcon, { icon: faBalanceScale }),
             diversityEnabled ? " Balanced" : " Score-first"
           ),
+          laneByValue.has(lane) && React.createElement(PreviewWallToggle, { wall, onToggle: toggleWall }),
           laneByValue.has(lane) && React.createElement(Button, { size: "sm", variant: filtersOpen ? "primary" : "secondary", "aria-expanded": filtersOpen, onClick: () => setFiltersOpen((value) => !value) }, React.createElement(FontAwesomeIcon, { icon: faFilter }), " Filters", activeSlateFilterCount > 0 && React.createElement("span", { className: "curator-filter-count" }, activeSlateFilterCount)),
           laneByValue.has(lane) && React.createElement(SavedFilters, { scope: "recommendations", current: { includeTags: filterIncludeTags, excludeTags: filterExcludeTags, performers: filterPerformers, studios: filterStudios, gender: filterGender }, onApply: applySavedSlateFilters })
         )
@@ -4942,11 +5068,13 @@
           React.Fragment,
           null,
           visibleItems.length === 0 && React.createElement("div", { className: "alert alert-info" }, React.createElement("p", null, "Nothing qualifies for this lane right now."), React.createElement(Button, { size: "sm", variant: "secondary", onClick: () => runTask("Rebuild recommendation model") }, React.createElement(FontAwesomeIcon, { icon: faWrench }), " Rebuild model")),
-          React.createElement(
-            "section",
-            { className: "curator-grid", role: "tabpanel", "aria-live": "polite" },
-            visibleItems.map((item) => React.createElement(RecommendationCard, { key: `${item.impression_id}:${item.scene_id}`, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp }))
-          ),
+          wall
+            ? React.createElement(RecommendationWall, { visibleItems, scenes, onRemove: remove, onThumbDown: showFollowUp, laneLabel: laneOption.label })
+            : React.createElement(
+              "section",
+              { className: "curator-grid", role: "tabpanel", "aria-live": "polite" },
+              visibleItems.map((item) => React.createElement(RecommendationCard, { key: `${item.impression_id}:${item.scene_id}`, item, scene: scenes.get(String(item.scene_id)), slate, onRemove: remove, onThumbDown: showFollowUp }))
+            ),
           React.createElement(Pager, { page, total: slate.total, pageSize: slate.page_size, hasMore: slate.has_more, loading, onPage: setPage, label: `${laneOption.label} pages` })
         )
     );
@@ -5139,6 +5267,32 @@
     }
     return React.isValidElement(result) ? React.cloneElement(result, {}, children) : result;
   });
+  function CuratorAffinityPill({ type, id }) {
+    const [value, setValue] = React.useState(null);
+    React.useEffect(() => {
+      let active = true;
+      operation({ operation: "get_inspector_entity", entity_type: type, entity_id: String(id) })
+        .then((data) => {
+          if (!active) return;
+          const raw = type === "scene" ? data?.score?.appeal : data?.affinity;
+          setValue(typeof raw === "number" ? raw : null);
+        })
+        .catch(() => { if (active) setValue(null); });
+      return () => { active = false; };
+    }, [type, id]);
+    if (value === null) return null;
+    const label = formatAppealValue(value);
+    const sign = value < 0 ? "negative" : value > 0 ? "positive" : "neutral";
+    return React.createElement("span", {
+      className: `curator-affinity-pill curator-affinity-${sign}`,
+      title: `Curator affinity ${label}`,
+      "aria-label": `Curator affinity ${label}`,
+    },
+      React.createElement(FontAwesomeIcon, { icon: faCompass }),
+      React.createElement("span", { className: "curator-affinity-value" }, label),
+      React.createElement("span", { className: "curator-affinity-bar", "aria-hidden": "true" }, React.createElement("span", { className: "curator-affinity-bar-fill", style: { width: `${Math.min(100, Math.abs(value) * 100)}%` } }))
+    );
+  }
   function CuratorContextLink({ type, id, label, target }) {
     const [host, setHost] = React.useState(null);
     React.useEffect(() => {
@@ -5146,7 +5300,7 @@
     }, [target]);
     const query = new URLSearchParams({ view: "similar", type, id: String(id), label: label || "" });
     if (!host) return null;
-    return ReactDOM.createPortal(React.createElement(NavLink, { className: "btn minimal curator-context-link curator-brand-mark", to: `/plugins/stash-curator?${query}`, title: `Find similar ${type}s with Curator`, "aria-label": `Find similar ${type}s with Curator` }, React.createElement(FontAwesomeIcon, { icon: faCompass })), host);
+    return ReactDOM.createPortal(React.createElement(React.Fragment, null, React.createElement(NavLink, { className: "btn minimal curator-context-link curator-brand-mark", to: `/plugins/stash-curator?${query}`, title: `Find similar ${type}s with Curator`, "aria-label": `Find similar ${type}s with Curator` }, React.createElement(FontAwesomeIcon, { icon: faCompass })), React.createElement(CuratorAffinityPill, { type, id })), host);
   }
   Api.patch.after("ScenePage", function (props, _, result) {
     return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar .scene-toolbar-group:last-child" }));

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2376,7 +2376,7 @@
     return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign}`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
         React.createElement("div", { className: "card-section" },
-          React.createElement("video", { ref: keepMuted, className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+          React.createElement("video", { ref: keepMuted, className: "curator-preview-video scene-card-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
         )
       ),
       React.createElement("span", { className: "curator-preview-lane", style: { color: laneColor }, title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -5332,7 +5332,7 @@
     );
   }
   Api.patch.after("ScenePage", function (props, _, result) {
-    return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar .scene-toolbar-group:last-child" }));
+    return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "scene", id: props.scene.id, label: props.scene.title || `Scene ${props.scene.id}`, target: ".scene-tabs .scene-toolbar .scene-toolbar-group:first-child" }));
   });
   Api.patch.after("PerformerPage", function (props, _, result) {
     return React.createElement(React.Fragment, null, result, React.createElement(CuratorContextLink, { type: "performer", id: props.performer.id, label: props.performer.name || `Performer ${props.performer.id}`, target: "#performer-page .name-icons" }));

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2351,14 +2351,26 @@
     const laneColor = `var(--curator-hue-${lane}, var(--curator-accent))`;
     function onEnter() { setHovered(true); }
     function onLeave() { setHovered(false); }
-    // Stash's SFW toggle re-renders the wall; re-assert muted on every commit so
-    // the toggle never starts playback with sound (React's `muted` prop is
-    // unreliable across re-renders for <video>).
-    function keepMuted(node) { if (node) { node.muted = true; node.defaultMuted = true; } }
-    return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign}`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
+    // The SFW toggle can restart/unmute wall media outside React; force muted on
+    // every play/volumechange so playback never leaks sound, and carry the Stash
+    // scene-card SFW contract classes so the wall blurs with the rest of the UI.
+    const videoRef = React.useRef(null);
+    React.useEffect(() => {
+      const el = videoRef.current;
+      if (!el) return;
+      const forceMuted = () => { el.muted = true; el.defaultMuted = true; };
+      forceMuted();
+      el.addEventListener("play", forceMuted);
+      el.addEventListener("volumechange", forceMuted);
+      return () => {
+        el.removeEventListener("play", forceMuted);
+        el.removeEventListener("volumechange", forceMuted);
+      };
+    }, []);
+    return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign} scene-card`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
         React.createElement("div", { className: "card-section" },
-          React.createElement("video", { ref: keepMuted, className: "curator-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+          React.createElement("video", { ref: videoRef, className: "curator-preview-video scene-card-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
         )
       ),
       React.createElement("span", { className: "curator-preview-lane", style: { color: laneColor }, title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2351,26 +2351,21 @@
     const laneColor = `var(--curator-hue-${lane}, var(--curator-accent))`;
     function onEnter() { setHovered(true); }
     function onLeave() { setHovered(false); }
-    // The SFW toggle can restart/unmute wall media outside React; force muted on
-    // every play/volumechange so playback never leaks sound, and carry the Stash
-    // scene-card SFW contract classes so the wall blurs with the rest of the UI.
-    const videoRef = React.useRef(null);
-    React.useEffect(() => {
-      const el = videoRef.current;
-      if (!el) return;
-      const forceMuted = () => { el.muted = true; el.defaultMuted = true; };
-      forceMuted();
-      el.addEventListener("play", forceMuted);
-      el.addEventListener("volumechange", forceMuted);
-      return () => {
-        el.removeEventListener("play", forceMuted);
-        el.removeEventListener("volumechange", forceMuted);
-      };
-    }, []);
+    // Mute synchronously at attach (mobile requires muted *before* the autoplay
+    // check) and re-assert whenever the browser plays or changes volume — the
+    // SFW toggle can restart/unmute wall media outside React. The tile also
+    // carries the Stash scene-card SFW contract classes so it blurs with the UI.
+    function keepMuted(node) {
+      if (!node) return;
+      node.muted = true;
+      node.defaultMuted = true;
+      node.onplay = () => { node.muted = true; };
+      node.onvolumechange = () => { node.muted = true; };
+    }
     return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign} scene-card`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
         React.createElement("div", { className: "card-section" },
-          React.createElement("video", { ref: videoRef, className: "curator-preview-video scene-card-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
+          React.createElement("video", { ref: keepMuted, className: "curator-preview-video scene-card-preview-video", src: `/scene/${scene_id}/preview`, poster: `/scene/${scene_id}/screenshot`, muted: true, defaultMuted: true, loop: true, playsInline: true, autoPlay: index < WALL_CAP, preload: index < WALL_CAP ? "auto" : "none" })
         )
       ),
       React.createElement("span", { className: "curator-preview-lane", style: { color: laneColor }, title: laneLabel, "aria-label": laneLabel }, React.createElement(FontAwesomeIcon, { icon: wallLaneIcon(lane) })),

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2352,16 +2352,28 @@
     function onEnter() { setHovered(true); }
     function onLeave() { setHovered(false); }
     // Mute synchronously at attach (mobile requires muted *before* the autoplay
-    // check) and re-assert whenever the browser plays or changes volume — the
-    // SFW toggle can restart/unmute wall media outside React. The tile also
-    // carries the Stash scene-card SFW contract classes so it blurs with the UI.
+    // check) so playback starts silently; a separate effect re-mutes via
+    // addEventListener if the SFW toggle unmutes/restarts the media outside
+    // React. The tile also carries the Stash scene-card SFW contract classes so
+    // it blurs with the UI.
+    const videoRef = React.useRef(null);
     function keepMuted(node) {
       if (!node) return;
+      videoRef.current = node;
       node.muted = true;
       node.defaultMuted = true;
-      node.onplay = () => { node.muted = true; };
-      node.onvolumechange = () => { node.muted = true; };
     }
+    React.useEffect(() => {
+      const el = videoRef.current;
+      if (!el) return;
+      const forceMuted = () => { el.muted = true; el.defaultMuted = true; };
+      el.addEventListener("play", forceMuted);
+      el.addEventListener("volumechange", forceMuted);
+      return () => {
+        el.removeEventListener("play", forceMuted);
+        el.removeEventListener("volumechange", forceMuted);
+      };
+    }, []);
     return React.createElement("article", { className: `curator-preview-tile curator-affinity-${sign} scene-card`, onMouseEnter: onEnter, onMouseLeave: onLeave, onFocus: onEnter, onBlur: onLeave },
       React.createElement("a", { className: "curator-preview-link", href: `/scenes/${scene_id}`, title },
         React.createElement("div", { className: "card-section" },

--- a/plugin/stash-curator.yml
+++ b/plugin/stash-curator.yml
@@ -118,6 +118,18 @@ settings:
     displayName: Expand popularity wildcard
     description: Include a small trending/popular sample outside preference-derived seeds.
     type: BOOLEAN
+  expandCandidateLimit:
+    displayName: Expand candidate limit
+    description: Maximum number of StashDB scenes fetched per Expand refresh, split across seed sources. Default 1000; raise to reduce fetch truncation at the cost of a slower refresh.
+    type: NUMBER
+  expandSimilarSeedTopK:
+    displayName: Expand similar-performer seed top-K
+    description: Chase look-alikes for the K strongest favourite performers into the Expand seed set. 0 disables. Default 20.
+    type: NUMBER
+  expandSimilarSeedPerFavorite:
+    displayName: Expand similar-performer seeds per favourite
+    description: How many closest look-alikes per favourite are added as Expand seeds. 0 disables. Default 5.
+    type: NUMBER
   whisparrUrl:
     displayName: Whisparr v3 URL
     description: Optional Whisparr base URL used by Expand scene actions.
@@ -183,6 +195,10 @@ tasks:
     description: Refresh promising StashDB scenes and performers without affecting library sync.
     execArgs:
       - expand-refresh
+  - name: Force rebuild Expand cache
+    description: Full non-incremental Expand rebuild that re-fetches the whole recent window, capturing scenes a watermark refresh may have missed. Developer use; slower than a normal refresh.
+    execArgs:
+      - expand-rebuild
 hooks:
   - name: Sync changed entity
     description: Import or remove a single entity after a Stash create, update, or delete, so the sidecar stays current without a full sync.

--- a/tests/core/test_backend_slice4.py
+++ b/tests/core/test_backend_slice4.py
@@ -23,6 +23,7 @@ from typing import ClassVar
 
 import pytest
 
+from curator.api import CuratorAPI
 from curator.config import DEFAULT_CONFIG
 from curator.core import core_binary
 from tests.core.test_backend import PLUGIN_DIR, make_sidecar, payload, run_backend
@@ -232,6 +233,25 @@ def make_slice4_sidecar(path: Path) -> None:
                 ('fd-t4', ?, 0.9, 0.9, 0.7, 1)
             """,
             (MODEL_ID, MODEL_ID, MODEL_ID, MODEL_ID),
+        )
+        connection.execute(
+            """
+            INSERT INTO feature_definition(
+                feature_id, feature_version, family, name, provenance, metadata_json
+            ) VALUES
+                ('pf-perf-p1', ?, 'performer_identity', 'performer:p1', 'seed', '{}')
+            """,
+            (FEATURE_VERSION,),
+        )
+        connection.execute(
+            """
+            INSERT INTO feature_affinity(
+                feature_id, model_id, affinity, confidence, effective_support,
+                distinct_scene_count
+            ) VALUES
+                ('pf-perf-p1', ?, 0.62, 0.85, 0.5, 1)
+            """,
+            (MODEL_ID,),
         )
         connection.execute(
             """
@@ -589,6 +609,21 @@ def test_inspector_performer_byte_identical(
         "get_inspector_entity", slice4_sidecar, stub_stash, entity_type="performer", entity_id="p1"
     )
     assert_slice4_identical(binary, raw, slice4_sidecar)
+
+
+def test_inspector_performer_affinity_value(slice4_sidecar: Path) -> None:
+    """The performer branch surfaces the raw feature_affinity for the
+    performer's identity feature, or null when the model has no evidence."""
+    connection = sqlite3.connect(slice4_sidecar)
+    connection.row_factory = sqlite3.Row
+    try:
+        result = CuratorAPI(connection).inspector("performer", "p1")
+        assert result["affinity"] == pytest.approx(0.62)
+        assert result["confidence"] == pytest.approx(0.85)
+        assert CuratorAPI(connection).inspector("performer", "p2")["affinity"] is None
+        assert CuratorAPI(connection).inspector("performer", "p2")["confidence"] is None
+    finally:
+        connection.close()
 
 
 def test_inspector_performer_error_paths(

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -287,6 +287,7 @@ def test_expand_refresh_is_bounded_owned_filtered_and_cached(tmp_path: Path) -> 
         links,
         now_ms=REFERENCE_MS,
         candidate_limit=10,
+        similar_top_k=0,
         progress=lambda processed, total: progress.append((processed, total)),
     )
 
@@ -521,7 +522,7 @@ def test_refresh_is_incremental_and_preserves_the_candidate_pool(tmp_path: Path)
     service = ExpandService(connection)
     client = NoChangeStashDB()
 
-    first = service.refresh(client, links, now_ms=REFERENCE_MS, candidate_limit=10)
+    first = service.refresh(client, links, now_ms=REFERENCE_MS, candidate_limit=10, similar_top_k=0)
     assert first["incremental"] is False
     assert not any("updated_at" in item for item in client.inputs)
 
@@ -529,7 +530,9 @@ def test_refresh_is_incremental_and_preserves_the_candidate_pool(tmp_path: Path)
     # the previous fetched_at and keeps every existing row.
     client.changed = False
     client.inputs.clear()
-    second = service.refresh(client, links, now_ms=REFERENCE_MS + 86_400_000, candidate_limit=10)
+    second = service.refresh(
+        client, links, now_ms=REFERENCE_MS + 86_400_000, candidate_limit=10, similar_top_k=0
+    )
     assert second["incremental"] is True
     assert client.inputs
     assert all("updated_at" in item for item in client.inputs)
@@ -573,6 +576,112 @@ def test_refresh_preserves_explore_rows_from_hunts_and_similar(tmp_path: Path) -
         ]
         == 1
     )
+
+
+class SeedExpansionStashDB(FakeStashDB):
+    """Dispatches the performer-pool popularity query in addition to scene queries."""
+
+    def execute(self, document: str, variables: dict[str, object]):
+        input_data = variables["input"]
+        if input_data.get("sort") == "POPULARITY":
+            self.inputs.append(input_data)
+            lookalike = {
+                "id": "lookalike-performer",
+                "name": "Lookalike Performer",
+                "gender": "FEMALE",
+                "ethnicity": "Caucasian",
+                "hair_color": "Brown",
+                "eye_color": "Blue",
+                "height": 170,
+                "scene_count": 200,
+                "tattoos": [],
+                "piercings": [],
+                "images": [],
+            }
+            return {"queryPerformers": {"performers": [lookalike]}}
+        return super().execute(document, variables)
+
+
+def test_seed_expansion_chases_similar_performers_into_scenes(tmp_path: Path) -> None:
+    """A performer StashDB ranks near the user's own favourites is pulled into the
+    seed set even though she is not in the local library, and her scenes are then
+    fetched (issue: scenes by look-alike performers were invisible to Expand)."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    links = {
+        "scenes": {},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {},
+    }
+    client = SeedExpansionStashDB()
+    ExpandService(connection).refresh(client, links, now_ms=REFERENCE_MS, candidate_limit=100)
+    scene_queries = [item for item in client.inputs if item.get("sort") == "DATE"]
+    assert scene_queries
+    assert any(
+        "lookalike-performer" in (item.get("performers", {}).get("value") or [])
+        for item in scene_queries
+    )
+
+
+def test_refresh_ages_out_explore_rows_but_preserves_shortlisted(tmp_path: Path) -> None:
+    """The explore pool ages out with the candidate pool, so on-demand hunts cannot
+    grow the sidecar without bound, but anything the user pinned survives."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    links = {
+        "scenes": {"old-good": "owned-external-scene"},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {},
+    }
+    service = ExpandService(connection)
+    service.refresh(FakeStashDB(), links, now_ms=REFERENCE_MS, candidate_limit=10, similar_top_k=0)
+    service._merge_external(
+        "scene",
+        [
+            {
+                "id": "old-explore",
+                "payload": {"release_date": "2020-01-01"},
+                "score": 0.5,
+                "sources": ["similar"],
+            },
+            {
+                "id": "recent-explore",
+                "payload": {"release_date": date.today().isoformat()},
+                "score": 0.5,
+                "sources": ["similar"],
+            },
+            {
+                "id": "shortlisted-old",
+                "payload": {"release_date": "2020-01-01"},
+                "score": 0.5,
+                "sources": ["similar"],
+            },
+        ],
+    )
+    connection.execute(
+        "INSERT INTO external_shortlist(entity_type, external_id, payload_json, score, "
+        "added_at_ms) VALUES ('scene', 'shortlisted-old', '{}', 0.5, 0)"
+    )
+    connection.commit()
+
+    service.refresh(
+        NoChangeStashDB(),
+        links,
+        now_ms=REFERENCE_MS + 86_400_000,
+        candidate_limit=10,
+        similar_top_k=0,
+    )
+
+    pools = {
+        str(row["external_id"]): str(row["pool"])
+        for row in connection.execute(
+            "SELECT external_id, pool FROM external_entity WHERE external_id IN "
+            "('old-explore','recent-explore','shortlisted-old')"
+        )
+    }
+    assert "old-explore" not in pools
+    assert pools["recent-explore"] == "explore"
+    assert pools["shortlisted-old"] == "explore"
 
 
 def test_rescore_candidates_refreshes_stored_scores_after_a_model_change(
@@ -667,7 +776,7 @@ def test_expand_pages_and_preserves_cache_during_outage(tmp_path: Path) -> None:
     client = PagedStashDB()
     service = ExpandService(connection)
 
-    service.refresh(client, links, now_ms=REFERENCE_MS, candidate_limit=2)
+    service.refresh(client, links, now_ms=REFERENCE_MS, candidate_limit=2, similar_top_k=0)
     assert [item["id"] for item in service.results("scene")["items"]] == [
         "external-scene-1",
         "external-scene-2",


### PR DESCRIPTION
Widens the StashDB discovery pool so it reaches scenes whose performers are similar to the user's favourites, even when those performers aren't in the local library.

## What changed
- **Multi-hop seed expansion**: chase the strongest favourites into StashDB and pull their closest profile look-alikes into the seed set, so scenes by similar-but-unknown performers surface.
- **Wider studio seeds**: derived from top-500 model scenes + top-200 played scenes (cap raised 30→60).
- **Configurable**: `expand_candidate_limit`, `expand_similar_seed_top_k`, `expand_similar_seed_per_favorite`.
- **Explore pool ages out** with the candidate pool; shortlisted rows are preserved (prevents unbounded sidecar growth).
- **Dev-only "Force rebuild Expand cache" task** — a full, non-incremental refresh that ignores the watermark.
- Python oracle and the Go core (the shipped runtime) kept in step; parity tests updated and passing.

## Verification
- `scripts/verify full` passes: 627 tests, Python↔Go parity suite, formatting/lint, packaging, perf gate.
- New regression tests cover the similar-performer seed expansion and explore age-out.

## Note
This branch also carries the committed fixes for #277, #278, and #279 (those issues are already closed); this PR lands them in `main` together with the Expand change.