### PR TITLE
refactor: drop dead numpy kernel helpers and stale fallback comments

### DIFF
--- a/core/main.go
+++ b/core/main.go
@@ -1,12 +1,12 @@
 // Command curator-core is the optional compiled accelerator for Stash Curator.
 //
-// It has two modes. The kernel mode replaces numpy's role in the model build:
-// the content-neighbor and performer-similarity kernels mirror the production
-// Python implementations in curator/model/builder.py with identical semantics,
-// reading feature rows directly from the SQLite feature artifact (see
-// content.go, performer.go, multi_hop.go). The backend mode (the full Go
-// backend port) implements the raw-plugin interface on stdin/stdout — the
-// same contract plugin/backend.py serves — for every operation, task mode,
+// It has two modes. The kernel mode mirrors the model build's similarity and
+// multi-hop PageRank semantics: the content-neighbor and performer-similarity
+// kernels match the reference implementations in curator/model/builder.py with
+// equivalent results, reading feature rows directly from the SQLite feature
+// artifact (see content.go, performer.go, multi_hop.go). The backend mode (the
+// full Go backend port) implements the raw-plugin interface on stdin/stdout —
+// the same contract plugin/backend.py serves — for every operation, task mode,
 // and the entity-sync hook mode the frontend or Stash can invoke
 // (backend.go, ops.go, tasks.go, entity_hook.go, frontend.go). Unknown
 // operations and task modes error with the Python backend's exact messages.

--- a/core/scoring_fingerprint.go
+++ b/core/scoring_fingerprint.go
@@ -6,4 +6,4 @@
 
 package main
 
-const scoringFingerprint = "b5d0b5d7ac27e5e0"
+const scoringFingerprint = "4c8311b549b1d6a2"

--- a/curator/model/builder.py
+++ b/curator/model/builder.py
@@ -455,69 +455,6 @@ def _entity_dormancy_rows(
     return rows
 
 
-def _numpy_cosine_matrix(
-    np: Any,
-    values: Any,
-    known_values: Any,
-    confidences: Any,
-    known_confidences: Any,
-    norms: Any,
-    known_norms: Any,
-) -> Any:
-    """Vectorized block cosine for profile blocks that use the shared-key dot product.
-
-    Matches the pure-Python _cosine: dot over shared keys divided by the product of
-    norms, scaled by the mean of the pairwise minimum confidences, clamped to [0, 1].
-    """
-    dot = values @ known_values.T
-    # Shared counts never exceed the feature count, so float32 is exact and uses the
-    # BLAS matmul path; the confidence mean is then computed in float64.
-    shared = ((values != 0).astype(np.float32) @ (known_values != 0).astype(np.float32).T).astype(
-        np.float64
-    )
-    confidence_sum = np.zeros((values.shape[0], known_values.shape[0]), dtype=np.float64)
-    for column in range(values.shape[1]):
-        if not confidences[:, column].any() or not known_confidences[:, column].any():
-            continue
-        confidence_sum += np.minimum.outer(confidences[:, column], known_confidences[:, column])
-    with np.errstate(divide="ignore", invalid="ignore"):
-        confidence = np.where(shared > 0, confidence_sum / shared, 0.0)
-        cosine = dot / (norms[:, None] * known_norms[None, :]) * confidence
-    return np.clip(cosine, 0.0, 1.0)
-
-
-def _numpy_numeric_matrix(
-    np: Any,
-    values: Any,
-    known_values: Any,
-    confidences: Any,
-    known_confidences: Any,
-    scales: Any,
-) -> tuple[Any, Any]:
-    """Vectorized numeric-block closeness and shared-key counts.
-
-    Mirrors the pure-Python _numeric: each shared key contributes
-    exp(-abs difference / scale) * min confidence; the block value is the mean over
-    the shared keys.
-    """
-    value = np.zeros((values.shape[0], known_values.shape[0]), dtype=np.float64)
-    count = np.zeros_like(value)
-    for column in range(values.shape[1]):
-        both = np.outer(values[:, column] != 0, known_values[:, column] != 0)
-        if not both.any():
-            continue
-        closeness = np.exp(
-            -np.abs(np.subtract.outer(values[:, column], known_values[:, column])) / scales[column]
-        )
-        value += (
-            closeness
-            * np.minimum.outer(confidences[:, column], known_confidences[:, column])
-            * both
-        )
-        count += both
-    return value, count
-
-
 class PreferenceModelBuilder:
     def __init__(
         self,
@@ -1718,7 +1655,7 @@ class PreferenceModelBuilder:
     ) -> _NeighborEvidence:
         """Derive evidence fields from the selected neighbor tuples.
 
-        Shared by the numpy and compiled-core paths so the post-selection math
+        Shared by the compiled-core and oracle paths so the post-selection math
         stays identical by construction.
         """
         denominator = sum(item[2] for item in selected)
@@ -1764,7 +1701,7 @@ class PreferenceModelBuilder:
         label_mean: float,
         progress_total: int,
     ) -> dict[str, _NeighborEvidence]:
-        """Content-neighbor evidence via the compiled core (numpy's role).
+        """Content-neighbor evidence via the compiled core.
 
         The binary reads the content feature rows from the feature artifact and
         derives the preference vectors itself, so this path takes the same
@@ -1849,7 +1786,7 @@ class PreferenceModelBuilder:
         scene_features: dict[str, tuple[StoredFeature, ...]],
         affinities: dict[str, _Affinity],
     ) -> dict[str, dict[str, object]]:
-        """Performer-similarity scores via the compiled core (numpy's role).
+        """Performer-similarity scores via the compiled core.
 
         The binary reads the performer profiles from the feature artifact; the
         result dict is already the production format.

--- a/curator/model/fingerprint.py
+++ b/curator/model/fingerprint.py
@@ -5,4 +5,4 @@ Identifies the scoring code that produced a model artifact. Regenerate with
 script's MANIFEST.
 """
 
-SCORING_FINGERPRINT = "b5d0b5d7ac27e5e0"
+SCORING_FINGERPRINT = "4c8311b549b1d6a2"

--- a/curator/optional_deps.py
+++ b/curator/optional_deps.py
@@ -1,8 +1,9 @@
-"""Optional accelerated dependencies with a pure-Python fallback.
+"""Optional accelerated dependency (numpy) for the dev/test oracle.
 
-The plugin ships without third-party packages. When the "Install optional
-dependencies" task has installed numpy into the plugin-local venv, the accelerated
-model stages use it; every other environment keeps the pure-Python implementations.
+The compiled core is the single runtime implementation, so numpy is not shipped
+or used by the plugin. It is imported by the differential-test oracle
+(`tests/oracle.py`) so the Go kernels can be pinned against an independent
+reference on seeded synthetic corpora.
 """
 
 from __future__ import annotations

--- a/scripts/verify
+++ b/scripts/verify
@@ -17,9 +17,10 @@ pytest_not_integration() (
 )
 
 # ── compiled core (Go) ─────────────────────────────────────────────────
-# Go is a dev/build dependency only; the shipped plugin never needs it (the
-# binary is optional acceleration, the pure-Python fallback stays intact).
-# A missing Go toolchain skips the core checks; a failing build fails the run.
+# Go is a dev/build dependency only; the compiled core is the single runtime
+# implementation, so the shipped plugin requires it (a missing binary fails
+# build stages loudly). A missing Go toolchain skips the core checks; a
+# failing build fails the run.
 core_build_and_check() {
   if ! command -v go >/dev/null 2>&1; then
     echo "[verify] go toolchain not found; skipping compiled-core checks (the full gate and plugin packaging require Go)" >&2


### PR DESCRIPTION
## Summary

The Go `curator-core` binary is now the single runtime implementation: the shipped plugin zip carries only the per-arch binaries plus a stdlib launcher, and `run_core` raises on a missing binary (no Python fallback). Yet the repo still held two remnants of the retired Python runtime path.

This change removes the dead code and corrects the stale comments, without touching the correctness oracle.

## Changes

- **`curator/model/builder.py`** — delete the two dead numpy helper functions `_numpy_cosine_matrix` / `_numpy_numeric_matrix` (zero callers). Reword `_content_neighbors` / `_performer_similarity_scores` / `_assemble_evidence` docstrings that claimed a numpy path / "numpy's role".
- **`core/main.go`** — reword "kernel mode replaces numpy's role" to describe the Go kernels as the implementation (not numpy's substitute).
- **`scripts/verify`** — correct the comment claiming a pure-Python fallback stays intact; the compiled core is required and a missing binary fails the build loudly.
- **`curator/optional_deps.py`** — docstring now describes numpy as the dev/test oracle dependency, not a runtime accelerator.

## Scope decisions

- **Kept the oracle.** `tests/oracle.py` and the differential gates (`tests/core/test_*`, `tests/model/test_*`) are the independent reference proving the Go kernels are correct. Deleting them would make the Go tests self-referential, so they stay. numpy remains a dev-only dependency for exactly that reason.
- **Skipped historical docs.** `docs/handover.md` and `docs/decisions/002-runtime-swap-planning.md` are delivery/decision records, not current spec; edited them would be revisionist.
- **Fingerprint regenerated.** `builder.py` is one of the scoring-fingerprint sources, so `curator/model/fingerprint.py` + `core/scoring_fingerprint.go` advanced to `4c8311b549b1d6a2` (in sync, `verify full --check` passes).

## Verification

- `scripts/verify changed` — Go core built, differential gate **224 passed**, ruff format/lint clean.
- `scripts/verify full` — **628 passed**, 25 deselected, mypy clean (62 files), ruff clean, perf gate OK (29975 ms within 2.5x budget), scoring fingerprint current.
- The 2 numpy `RuntimeWarning` lines (divide-by-zero in the oracle's masked-NaN handling) are pre-existing and documented — unrelated to this change.