### PR TITLE
fix: ignore the accidental core/core build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ htmlcov/
 
 # Compiled core build output (Go module lives in core/, binaries are generated)
 core/bin/
+core/core


### PR DESCRIPTION
## Summary

The cleanup PR (#285) was squash-merged and its `.gitignore` change was lost in resolution. This adds the missing `core/core` ignore rule on top of the merged `main`.

`core/core` was an accidental 18MB `go build` artifact committed into `core/` (never produced by `scripts/build_core.sh`, which writes to `core/bin/`). It is now removed from all history; this rule prevents it being re-committed.

## Change

- `.gitignore`: add `core/core` alongside the existing `core/bin/`.

## Verification

Docs/config-only (one `.gitignore` line). `scripts/verify changed` format/lint check is the relevant gate; no test-surface change.