### PR TITLE
feat(expand): broaden StashDB discovery and harden worker/task UX

### DIFF
--- a/core/backend.go
+++ b/core/backend.go
@@ -137,6 +137,8 @@ func dispatch(pluginDir string, payload jVal) (jVal, error) {
 	switch operation {
 	case "health":
 		return opHealth(pluginDir, payload)
+	case "restart_worker":
+		return opRestartWorker(pluginDir, payload)
 	case "round_trip":
 		return opRoundTrip(pluginDir, payload)
 	case "get_config":

--- a/core/daemon.go
+++ b/core/daemon.go
@@ -468,6 +468,49 @@ func ensureWorker(pluginDir string, payload jVal, settings jVal) error {
 	return spawnWorkerFn(pluginDir)
 }
 
+// restartWorker force-restarts the resident Curator worker. Unlike the
+// stale-generation rotation (rotateStaleWorker), it stops a live worker
+// unconditionally, so a wedged current-generation worker — a stuck 'running'
+// curator_job row with a live heartbeat, e.g. a backup that never advances —
+// can be cleared on demand instead of requiring a plugin/container reload.
+// It recovers orphaned job rows, then respawns a fresh worker when schedules
+// or auto tasks need one. Best-effort: on any failure the next Curator
+// invocation spawns the worker as before.
+func restartWorker(pluginDir string, payload, settings jVal, db dbx) (jVal, error) {
+	pid, hasPid := readWorkerPid(pluginDir)
+	restarted := false
+	if hasPid && workerPidAliveFn(pid) && workerPidIsWorkerFn(pid, pluginDir) {
+		if err := stopWorkerFn(pid); err != nil {
+			return jvNull(), fmt.Errorf("could not stop Curator worker %d: %w", pid, err)
+		}
+		restarted = true
+	}
+	if hasPid {
+		// Always clear the pid marker (a live worker we stopped, or a stale
+		// pid pointing at a dead/unrelated process) so a fresh worker can
+		// spawn without the successor's stale-owner guard refusing it.
+		_ = os.Remove(workerPidPath(pluginDir))
+	}
+	recoverOrphanJobs(db, nowMs())
+	// Spawn a fresh worker when schedules/auto tasks need one. ensureAutoWorker
+	// reuses a live pid only when its generation matches; after the stop above
+	// the pid is gone, so it spawns the current binary.
+	ensureAutoWorker(pluginDir, payload, settings, db)
+	newPid, _ := readWorkerPid(pluginDir)
+	result := jvObj(
+		jvKey("restarted", jvBool(restarted)),
+		jvKey("stopped_pid", jvNull()),
+		jvKey("worker_pid", jvNull()),
+	)
+	if hasPid {
+		result.set("stopped_pid", jvInt(int64(pid)))
+	}
+	if newPid > 0 {
+		result.set("worker_pid", jvInt(int64(newPid)))
+	}
+	return result, nil
+}
+
 // runDaemon is the worker main loop, served by `curator-core <pluginDir>
 // daemon`. It claims queued jobs one at a time, executes them with the same
 // mode bodies the inline path uses, heartbeats and reports progress through

--- a/core/daemon_test.go
+++ b/core/daemon_test.go
@@ -391,6 +391,130 @@ func TestHandoverWorkerSpawnsSuccessor(t *testing.T) {
 	}
 }
 
+func TestRestartWorkerForceRestartsWedgedWorker(t *testing.T) {
+	db, path := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	const now = int64(1_787_900_000_000)
+	pinTime(t, now, func() {
+		if _, err := db.Exec(`UPDATE curator_config SET config_json=?, updated_at_ms=? WHERE singleton=1`,
+			`{"auto_tasks_enabled": true}`, now); err != nil {
+			t.Fatal(err)
+		}
+	})
+	pluginDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(pluginDir, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A live worker pid (the daemon we are force-restarting).
+	pid := os.Getpid()
+	if err := os.WriteFile(workerPidPath(pluginDir), []byte(strconv.Itoa(pid)), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A stalled running backup job (the wedge) the restart must recover.
+	if _, err := db.Exec(`INSERT INTO curator_job(job_id, job_type, state, started_at_ms, heartbeat_at_ms)
+VALUES ('stuck', 'backup', 'running', ?, ?)`, now-3_600_000, now-3_600_000); err != nil {
+		t.Fatal(err)
+	}
+	previousAlive := workerPidAliveFn
+	previousOwner := workerPidIsWorkerFn
+	previousStop := stopWorkerFn
+	previousSpawn := spawnWorkerFn
+	stopCalls := 0
+	spawnCalls := 0
+	workerPidAliveFn = func(int) bool { return true }
+	workerPidIsWorkerFn = func(int, string) bool { return true }
+	stopWorkerFn = func(int) error { stopCalls++; return nil }
+	spawnWorkerFn = func(string) error { spawnCalls++; return nil }
+	defer func() {
+		workerPidAliveFn = previousAlive
+		workerPidIsWorkerFn = previousOwner
+		stopWorkerFn = previousStop
+		spawnWorkerFn = previousSpawn
+	}()
+
+	pinTime(t, now, func() {
+		result, err := restartWorker(pluginDir, taskPayload(path, "restart_worker"), jvObj(), db)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if stopCalls != 1 {
+			t.Fatalf("stop calls = %d, want 1 (force restart a live worker)", stopCalls)
+		}
+		if !result.get("restarted").b {
+			t.Fatalf("restarted = %v, want true", result.get("restarted").b)
+		}
+		if result.get("stopped_pid").num != strconv.Itoa(pid) {
+			t.Fatalf("stopped_pid = %q, want %d", result.get("stopped_pid").num, pid)
+		}
+		if jobState(t, db, "stuck") != "failed" {
+			t.Fatalf("stuck row recovered to %q, want failed", jobState(t, db, "stuck"))
+		}
+		if spawnCalls != 1 {
+			t.Fatalf("spawn calls = %d, want 1 (auto tasks enabled)", spawnCalls)
+		}
+	})
+}
+
+func TestRestartWorkerNoLiveWorkerIgnoresStalePid(t *testing.T) {
+	db, path := openTempDB(t)
+	if err := migrate(db, 1_700_000_000_000); err != nil {
+		t.Fatal(err)
+	}
+	const now = int64(1_787_900_000_000)
+	pinTime(t, now, func() {
+		if _, err := db.Exec(`UPDATE curator_config SET config_json=?, updated_at_ms=? WHERE singleton=1`,
+			`{"auto_tasks_enabled": false}`, now); err != nil {
+			t.Fatal(err)
+		}
+	})
+	pluginDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(pluginDir, "data"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A pid file pointing at a dead process (stale metadata).
+	if err := os.WriteFile(workerPidPath(pluginDir), []byte("999999"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	previousAlive := workerPidAliveFn
+	previousOwner := workerPidIsWorkerFn
+	previousStop := stopWorkerFn
+	previousSpawn := spawnWorkerFn
+	stopCalls := 0
+	spawnCalls := 0
+	workerPidAliveFn = func(int) bool { return false }
+	workerPidIsWorkerFn = func(int, string) bool { return true }
+	stopWorkerFn = func(int) error { stopCalls++; return nil }
+	spawnWorkerFn = func(string) error { spawnCalls++; return nil }
+	defer func() {
+		workerPidAliveFn = previousAlive
+		workerPidIsWorkerFn = previousOwner
+		stopWorkerFn = previousStop
+		spawnWorkerFn = previousSpawn
+	}()
+
+	pinTime(t, now, func() {
+		result, err := restartWorker(pluginDir, taskPayload(path, "restart_worker"), jvObj(), db)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if stopCalls != 0 {
+			t.Fatalf("stop calls = %d, want 0 (no live worker)", stopCalls)
+		}
+		if result.get("restarted").b {
+			t.Fatalf("restarted = %v, want false", result.get("restarted").b)
+		}
+		// A stale pid marker is cleared so a later ensure worker can spawn.
+		if _, err := os.Stat(workerPidPath(pluginDir)); !os.IsNotExist(err) {
+			t.Fatalf("stale pid file not removed: %v", err)
+		}
+		if spawnCalls != 0 {
+			t.Fatalf("spawn calls = %d, want 0 (auto tasks disabled)", spawnCalls)
+		}
+	})
+}
+
 func TestWorkerUpdateWatcherDetectsReplacement(t *testing.T) {
 	pluginDir := t.TempDir()
 	name := "curator-core-" + runtime.GOOS + "-" + runtime.GOARCH

--- a/core/expand_refresh.go
+++ b/core/expand_refresh.go
@@ -521,7 +521,7 @@ ORDER BY a.affinity * a.confidence DESC LIMIT 50`, modelID, featureVersion)
 	for _, id := range merged {
 		if externalID, ok := resolved[id]; ok {
 			tagsArr.arr = append(tagsArr.arr, jvStr(externalID))
-			if len(tagsArr.arr) >= 20 {
+			if len(tagsArr.arr) >= 50 {
 				break
 			}
 		}
@@ -691,6 +691,7 @@ func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int
 		source string
 		values []string
 		limit  int64
+		sort   string
 	}
 	var queries []querySpec
 	for _, filter := range filters {
@@ -699,11 +700,24 @@ func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int
 			for _, v := range filter.values.arr {
 				values = append(values, v.asString())
 			}
-			queries = append(queries, querySpec{filter.source, values, int64(perSource)})
+			// A full refresh samples each seed source by recency AND by popularity so
+			// interesting scenes older than the newest N are not truncated out (a date-only
+			// pool is recency-biased). An incremental refresh walks the watermark, where the
+			// UPDATED_AT sort makes both probes identical, so it keeps one probe per source.
+			if since != "" {
+				queries = append(queries, querySpec{filter.source, values, int64(perSource), "DATE"})
+			} else {
+				half := int64(perSource) / 2
+				if half < 1 {
+					half = 1
+				}
+				queries = append(queries, querySpec{filter.source, values, half, "DATE"})
+				queries = append(queries, querySpec{filter.source, values, half, "POPULARITY"})
+			}
 		}
 	}
 	if wildcard {
-		queries = append(queries, querySpec{"wildcard", nil, minInt64(100, int64(perSource))})
+		queries = append(queries, querySpec{"wildcard", nil, minInt64(100, int64(perSource)), "TRENDING"})
 	}
 	specs := make([]fetchPageSpec, 0, len(queries))
 	for _, query := range queries {
@@ -712,7 +726,7 @@ func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int
 			values:   query.values,
 			limit:    query.limit,
 			modifier: "INCLUDES",
-			sort:     "DATE",
+			sort:     query.sort,
 			since:    since,
 		})
 	}

--- a/core/ops.go
+++ b/core/ops.go
@@ -586,6 +586,21 @@ WHERE state='running' AND started_at_ms>? AND job_type IN (
 	), nil
 }
 
+// opRestartWorker force-restarts the resident Curator worker: it stops a live
+// worker unconditionally, recovers orphaned curator_job rows, and spawns a
+// fresh worker when schedules/auto tasks need one. A wedged worker (a stuck
+// 'running' job with a live heartbeat) is the target case — the existing
+// stale-generation rotation never restarts a current-generation worker.
+func opRestartWorker(pluginDir string, payload jVal) (jVal, error) {
+	settings := pluginSettings(payload)
+	db, err := openSidecar(pluginDir, payload, settings, true)
+	if err != nil {
+		return jvNull(), err
+	}
+	defer db.Close()
+	return restartWorker(pluginDir, payload, settings, db)
+}
+
 // requireKey mimics Python's dict subscript on health's GraphQL fields: a
 // missing key raises KeyError whose str() is the quoted key name.
 func requireKey(v jVal, key string) (jVal, error) {

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -328,11 +328,24 @@ class ExpandService:
         )
         active = sum(bool(values) for _, values in filters) + int(wildcard)
         per_source = max(1, math.ceil(candidate_limit / max(1, active)))
-        queries = [(source, values, per_source) for source, values in filters if values]
+        queries = []
+        for source, values in filters:
+            if not values:
+                continue
+            # A full refresh samples each seed source by recency AND by popularity so
+            # interesting scenes older than the newest N are not truncated out (a date-only
+            # pool is recency-biased). An incremental refresh walks the watermark, where the
+            # UPDATED_AT sort makes both probes identical, so it keeps one probe per source.
+            if since is not None:
+                queries.append((source, values, per_source, "DATE"))
+            else:
+                half = max(1, per_source // 2)
+                queries.append((source, values, half, "DATE"))
+                queries.append((source, values, half, "POPULARITY"))
         if wildcard:
-            queries.append(("wildcard", [], min(100, per_source)))
-        for position, (source, values, limit) in enumerate(queries, 1):
-            self._fetch(client, rows, sources, source, values, limit, since=since)
+            queries.append(("wildcard", [], min(100, per_source), "TRENDING"))
+        for position, (source, values, limit, sort) in enumerate(queries, 1):
+            self._fetch(client, rows, sources, source, values, limit, sort=sort, since=since)
             if progress:
                 progress(200 + round(450 * position / max(1, len(queries))), 1_000)
         if progress and not queries:
@@ -1804,7 +1817,7 @@ class ExpandService:
         local_tags = list(dict.fromkeys((*direct_tags, *local_tags)))
         resolved = self._external_tag_ids(set(local_tags))
         tags = list(dict.fromkeys(resolved[value] for value in local_tags if value in resolved))[
-            :20
+            :50
         ]
         return {
             "performers": performers,

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -3958,7 +3958,7 @@
     }
     React.useEffect(() => {
       refresh();
-      const timer = setInterval(refresh, 5000);
+      const timer = setInterval(refresh, 4000);
       return () => clearInterval(timer);
     }, []);
     const active = jobs.filter((job) => job.state === "queued" || job.state === "running");
@@ -4032,6 +4032,23 @@
         setStarting("");
       }
     }
+    async function restartWorker() {
+      setStarting("Restart worker");
+      setMessage("");
+      try {
+        const result = await operation({ operation: "restart_worker" });
+        setMessage(
+          result.restarted
+            ? `Worker restarted${result.stopped_pid ? ` (stopped pid ${result.stopped_pid})` : ""}.`
+            : "Worker was not running; ensured one is available."
+        );
+        setTimeout(refresh, 1000);
+      } catch (failure) {
+        setMessage(failure.message);
+      } finally {
+        setStarting("");
+      }
+    }
     return React.createElement(
       "div",
       { className: "curator-tasks-panel" },
@@ -4057,6 +4074,7 @@
             ? `Last task: ${TASK_MODE_LABELS[last.job_type] || last.job_type} · ${formatTimeAgo(last.finished_at_ms || last.started_at_ms)}`
             : "No tasks yet"
       ),
+      React.createElement(Button, { size: "sm", variant: "outline-secondary", disabled: Boolean(starting), onClick: restartWorker }, starting === "Restart worker" ? "Restarting…" : "Restart worker"),
       jobs.length === 0 && !error && React.createElement("p", { role: "status" }, "No tasks yet."),
       active.length > 0 && React.createElement(
         "section",
@@ -4096,19 +4114,31 @@
         setMessage(error.message);
       }
     }
+    // Poll continuously so the indicator and health pill update without a
+    // manual refresh. The old effect armed a one-shot setTimeout when idle,
+    // whose trigger (the active-job boolean) never changed after it fired —
+    // so once one idle poll ran the chain never re-armed and the UI froze
+    // until the user refreshed the page (a task started while idle never
+    // appeared). A ref keeps the latest refreshStatus so a model change
+    // still clears the slate cache / refreshes recommendations.
+    const refreshRef = React.useRef(refreshStatus);
+    refreshRef.current = refreshStatus;
     React.useEffect(() => {
-      refreshStatus();
+      let cancelled = false;
+      let timer;
+      const poll = async () => {
+        try {
+          await refreshRef.current();
+        } finally {
+          if (!cancelled) timer = setTimeout(poll, 4000);
+        }
+      };
+      poll();
+      return () => {
+        cancelled = true;
+        clearTimeout(timer);
+      };
     }, []);
-    React.useEffect(() => {
-      // One extra poll shortly after the last active job leaves Stash's queue
-      // so the completed curator_job row (and its summary) is picked up.
-      if (!health?.active_jobs?.length && !health?.active_job) {
-        const timer = setTimeout(refreshStatus, 5000);
-        return () => clearTimeout(timer);
-      }
-      const timer = setInterval(refreshStatus, 5000);
-      return () => clearInterval(timer);
-    }, [Boolean(health?.active_jobs?.length || health?.active_job)]);
 
     async function start(taskName) {
       try {
@@ -4197,7 +4227,9 @@
           : health?.model_pending ? "pending"
             : hasSynced ? "ready" : "idle";
     const pillLabel = {
-      running: "Running",
+      running: activeJob
+        ? `${TASK_MODE_LABELS[activeJob.job_type] || "Curator task"}${activeJob.progress != null ? ` · ${Math.round(activeJob.progress * 100)}%` : ""}`
+        : "Running",
       failed: "Failed",
       rebuilding: "Rebuilding",
       pending: `${health?.model_pending_events || 0} pending`,

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -71,8 +71,8 @@ class PagedStashDB(FakeStashDB):
         input_data = variables["input"]
         assert isinstance(input_data, dict)
         page = int(input_data["page"])
-        scene = result["queryScenes"]["scenes"][1]
-        scene = {**scene, "id": f"external-scene-{page}"}
+        sort = str(input_data.get("sort", "DATE"))
+        scene = {**result["queryScenes"]["scenes"][1], "id": f"external-scene-{sort}-{page}"}
         return {"queryScenes": {"count": 2, "scenes": [scene]}}
 
 
@@ -297,7 +297,7 @@ def test_expand_refresh_is_bounded_owned_filtered_and_cached(tmp_path: Path) -> 
         "taxonomy_refreshed": False,
         "incremental": False,
     }
-    assert 1 <= len(client.inputs) <= 3
+    assert len(client.inputs) == 4  # performers + studios x 2 probes each (DATE + POPULARITY)
     assert [processed for processed, _ in progress] == sorted(
         processed for processed, _ in progress
     )
@@ -583,7 +583,7 @@ class SeedExpansionStashDB(FakeStashDB):
 
     def execute(self, document: str, variables: dict[str, object]):
         input_data = variables["input"]
-        if input_data.get("sort") == "POPULARITY":
+        if "queryPerformers" in document:
             self.inputs.append(input_data)
             lookalike = {
                 "id": "lookalike-performer",
@@ -621,6 +621,55 @@ def test_seed_expansion_chases_similar_performers_into_scenes(tmp_path: Path) ->
         "lookalike-performer" in (item.get("performers", {}).get("value") or [])
         for item in scene_queries
     )
+
+
+def test_refresh_samples_each_seed_source_by_recency_and_popularity(tmp_path: Path) -> None:
+    """A full refresh probes every active seed source by BOTH recency (DATE) and
+    popularity, so interesting-but-not-new scenes are not truncated out of the
+    cache. Before this, a date-only pool only kept the newest matches."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    links = {
+        "scenes": {},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {"studio-1": "external-studio"},
+    }
+    client = FakeStashDB()
+    ExpandService(connection).refresh(
+        client, links, now_ms=REFERENCE_MS, candidate_limit=100, similar_top_k=0
+    )
+    dates = [item for item in client.inputs if item.get("sort") == "DATE"]
+    popular = [item for item in client.inputs if item.get("sort") == "POPULARITY"]
+    assert len(dates) == 2  # performers + studios
+    assert len(popular) == 2
+    assert all(("performers" in item or "studios" in item) for item in client.inputs)
+
+
+def test_incremental_refresh_keeps_single_probe_per_seed_source(tmp_path: Path) -> None:
+    """An incremental refresh walks the updated_at watermark, where the DATE and
+    POPULARITY sorts are equivalent, so it issues one UPDATED_AT probe per source
+    rather than duplicating the fetch."""
+    connection = _database(tmp_path / "curator.sqlite3")
+    PreferenceModelBuilder(connection, clock_ms=lambda: REFERENCE_MS).build()
+    links = {
+        "scenes": {},
+        "performers": {"p1": "known-external-performer"},
+        "studios": {"studio-1": "external-studio"},
+    }
+    client = FakeStashDB()
+    service = ExpandService(connection)
+    service.refresh(client, links, now_ms=REFERENCE_MS, candidate_limit=100, similar_top_k=0)
+    client.inputs.clear()
+    service.refresh(
+        client, links, now_ms=REFERENCE_MS + 86_400_000, candidate_limit=100, similar_top_k=0
+    )
+    incremental = [
+        item
+        for item in client.inputs
+        if item.get("sort") == "UPDATED_AT" and ("performers" in item or "studios" in item)
+    ]
+    assert len(incremental) == 2  # performers + studios, one probe each
+    assert all("updated_at" in item for item in incremental)
 
 
 def test_refresh_ages_out_explore_rows_but_preserves_shortlisted(tmp_path: Path) -> None:
@@ -778,16 +827,16 @@ def test_expand_pages_and_preserves_cache_during_outage(tmp_path: Path) -> None:
 
     service.refresh(client, links, now_ms=REFERENCE_MS, candidate_limit=2, similar_top_k=0)
     assert [item["id"] for item in service.results("scene")["items"]] == [
-        "external-scene-1",
-        "external-scene-2",
+        "external-scene-DATE-1",
+        "external-scene-POPULARITY-1",
     ]
     first = service.results("scene", count=1)
     second = service.results("scene", page=2, count=1)
     assert first["has_more"] is True
     assert first["total"] == 2
     assert [first["items"][0]["id"], second["items"][0]["id"]] == [
-        "external-scene-1",
-        "external-scene-2",
+        "external-scene-DATE-1",
+        "external-scene-POPULARITY-1",
     ]
     assert second["has_more"] is False
     assert len(client.inputs) == 2
@@ -799,8 +848,8 @@ def test_expand_pages_and_preserves_cache_during_outage(tmp_path: Path) -> None:
     else:
         raise AssertionError("offline refresh should fail")
     assert [item["id"] for item in service.results("scene")["items"]] == [
-        "external-scene-1",
-        "external-scene-2",
+        "external-scene-DATE-1",
+        "external-scene-POPULARITY-1",
     ]
 
 


### PR DESCRIPTION
## Summary

Broadens Expand cache discovery and hardens the worker/task UX so those broader candidates are observable.

### 1. Expand discovery broadening
- Each active seed source (performers / studios / tags) is now fetched with **both** a `DATE` (recency) and a `POPULARITY` (relevance) probe on a full refresh, so older-but-relevant scenes that match a seed are no longer truncated out by the newest-N cut. An incremental refresh keeps a single `UPDATED_AT` probe per source (the two sorts are equivalent there).
- Content-tag seeds widened from the top-20 to the top-50 positive-affinity tags, so more taste-relevant scenes match at least one seed.
- Per-source budget is split between the two probes, so `expand_candidate_limit` still bounds fetch work; extra candidates are still scored by the model (precision preserved — this is a recall improvement).

### 2. Worker restart control
- New `restart_worker` op: stops a live Curator worker unconditionally (SIGTERM → SIGKILL), clears the pid marker, recovers orphaned `curator_job` rows, and respawns a fresh worker when schedules/auto tasks need one. This clears a **wedged current-generation worker** (e.g. a stuck `backup` job), which the existing stale-generation rotation does not cover.
- "Restart worker" button in **Manage → Tasks**.

### 3. Live task status
- Fixed a polling bug: the status poll used a one-shot `setTimeout` when idle, so after one idle tick the poll chain never re-armed and the top-right indicator / health pill froze until a manual page refresh (a task started while idle never appeared). Now it polls continuously (4s) via a self-rescheduling loop.
- The health pill now shows the running task + progress directly (e.g. "Force rebuild Expand cache · 42%") instead of just "Running".
- `TasksPanel` poll 5s → 4s.

## Why
Expand candidates were being fetched but not surfaced: the discovery only sampled recency, and the worker could wedge (no force-restart path) while the UI froze (no live polling) so a started task never appeared — compounded by a removed `start` handler in the TasksPanel that made the "Run now" buttons throw `ReferenceError`.

## Files
- `core/expand_refresh.go`, `curator/expand.py`, `tests/test_expand.py` — discovery breadth (Go + Python oracle, parity kept).
- `core/backend.go`, `core/ops.go`, `core/daemon.go`, `core/daemon_test.go` — `restart_worker` op + tests.
- `plugin/stash-curator.js` — restart button, live polling, health-pill task label, TasksPanel `start` restore.

## Verification
- `scripts/verify full` — **628 passed**; ruff/mypy clean; `build_plugin` produced the zip; perf gate OK.
- `scripts/verify changed` — core differential gate **224 passed**.
- Live: `restart_worker` returned `{restarted: true}` and a fresh worker came up; API-triggered `force-build` and `expand-rebuild` ran to completion and reported in `get_job_status`.