### PR TITLE
feat(expand): expand refresh phase timings and parallelize the look-alike seed chase

### DIFF
--- a/core/expand.go
+++ b/core/expand.go
@@ -1458,16 +1458,43 @@ func fetchProbes(clientURL, apiKey string, probes []fetchPageSpec) (*sceneRows, 
 	return rows, sources, nil
 }
 
-// fetchPerformerPool mirrors ExpandService._fetch_performer_pool: union of
-// popularity-ranked StashDB performer queries, run concurrently, merged by
-// first-seen performer id.
-func fetchPerformerPool(clientURL, apiKey string, target *performerProfile, gender, ethnicity, performedWith string) ([]jVal, error) {
+// fetchBasePerformerPool returns the shared popularity recall floor used by the
+// look-alike chase: the same gender/ethnicity popularity query every favorite
+// would otherwise issue. Best-effort — nil on failure degrades the chase to a
+// per-target base fetch (previous behavior).
+func fetchBasePerformerPool(clientURL, apiKey, gender, ethnicity string) []jVal {
+	query := jvObj(
+		jvKey("page", jvInt(1)),
+		jvKey("per_page", jvInt(500)),
+		jvKey("sort", jvStr("POPULARITY")),
+		jvKey("direction", jvStr("DESC")),
+	)
+	if gender != "" {
+		query.set("gender", jvStr(gender))
+	}
+	if ethnicity != "" {
+		query.set("ethnicity", jvStr(ethnicity))
+	}
+	data, err := stashdbQuery(clientURL, apiKey, stashdbPerformersQuery, jvObj(jvKey("input", query)))
+	if err != nil {
+		return nil
+	}
+	return append([]jVal{}, data.get("queryPerformers").get("performers").arr...)
+}
+
+// fetchPerformerPool returns the popularity/co-star/age union for one target,
+// optionally reusing a shared base pool so a common recall floor is fetched
+// once and not once per favorite.
+func fetchPerformerPool(clientURL, apiKey string, target *performerProfile, gender, ethnicity, performedWith string, prefetchedBase []jVal) ([]jVal, error) {
 	type querySpec struct {
 		performedWith string
 		ageLower      int64
 		hasAge        bool
 	}
-	specs := []querySpec{{}}
+	specs := []querySpec{}
+	if prefetchedBase == nil {
+		specs = append(specs, querySpec{}) // base popularity recall floor
+	}
 	if performedWith != "" {
 		specs = append(specs, querySpec{performedWith: performedWith})
 	}
@@ -1522,6 +1549,15 @@ func fetchPerformerPool(clientURL, apiKey string, target *performerProfile, gend
 	wg.Wait()
 	pooled := map[string]jVal{}
 	var order []string
+	if prefetchedBase != nil {
+		for _, performer := range prefetchedBase {
+			id := performer.get("id").asString()
+			if _, ok := pooled[id]; !ok {
+				pooled[id] = performer
+				order = append(order, id)
+			}
+		}
+	}
 	for _, res := range results {
 		if res.err != nil {
 			return nil, res.err

--- a/core/expand_refresh.go
+++ b/core/expand_refresh.go
@@ -545,12 +545,6 @@ func expandSimilarPerformers(s *expandService, clientURL, apiKey string, base []
 	if topK <= 0 || perFavorite <= 0 || len(base) == 0 {
 		return base
 	}
-	t0 := time.Now()
-	profiles, err := performerProfilesAll(s.db, featureVersion)
-	if err != nil || len(profiles) == 0 {
-		return base
-	}
-	timings["seeds_profiles"] = time.Since(t0).Milliseconds()
 	weights := performerBlockWeightsMap()
 	recorded := time.Now().Format("2006-01-02")
 	ids := make([]string, 0, len(evidence))
@@ -564,16 +558,30 @@ func expandSimilarPerformers(s *expandService, clientURL, apiKey string, base []
 		}
 		return ids[i] < ids[j]
 	})
+	// Only the top_k favourites are used as chase targets, so load just their
+	// profiles (performerProfilesForIDs) instead of every performer profile in
+	// the model — the all-profiles load is the serial bottleneck of the seeds
+	// phase on large libraries.
+	limit := topK
+	if limit > len(ids) {
+		limit = len(ids)
+	}
+	favouriteIDs := make(map[string]bool, limit)
+	for i := range limit {
+		favouriteIDs[evidence[ids[i]].localID] = true
+	}
+	t0 := time.Now()
+	profiles, err := performerProfilesForIDs(s.db, featureVersion, favouriteIDs)
+	if err != nil || len(profiles) == 0 {
+		return base
+	}
+	timings["seeds_profiles"] = time.Since(t0).Milliseconds()
 	type scoredPerformer struct {
 		sim float64
 		id  string
 	}
 	type chaseResult struct {
 		scored []scoredPerformer
-	}
-	limit := topK
-	if limit > len(ids) {
-		limit = len(ids)
 	}
 	results := make([]chaseResult, limit)
 	var networkMs, matchMs, calls int64

--- a/core/expand_refresh.go
+++ b/core/expand_refresh.go
@@ -609,16 +609,20 @@ func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int
 	gender, ethnicity string, wildcard bool, candidateLimit int, similarTopK, similarPerFavorite int,
 	forceFull bool, nowMs int64, progress func(processed, total int)) (jVal, error) {
 	fetchedAtMs := nowMs
+	started := time.Now()
+	timings := map[string]int64{}
 	// The taxonomy check and seed load used to be markerless: on a large
 	// library the bar sat at 5% for the whole stretch. The 50/150 ticks
 	// bracket both phases (issue #110).
 	if progress != nil {
 		progress(50, 1000)
 	}
+	t0 := time.Now()
 	taxonomyRefreshed, err := refreshTaxonomy(db, clientURL, apiKey, fetchedAtMs)
 	if err != nil {
 		return jvNull(), err
 	}
+	timings["taxonomy"] = time.Since(t0).Milliseconds()
 	if progress != nil {
 		progress(100, 1000)
 	}
@@ -637,11 +641,13 @@ func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int
 	if progress != nil {
 		progress(150, 1000)
 	}
+	t0 = time.Now()
 	seeds, err := refreshSeeds(s, clientURL, apiKey, modelID, featureVersion, links,
 		similarTopK, similarPerFavorite, gender, ethnicity)
 	if err != nil {
 		return jvNull(), err
 	}
+	timings["seeds"] = time.Since(t0).Milliseconds()
 	if progress != nil {
 		progress(200, 1000)
 	}
@@ -735,10 +741,12 @@ func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int
 	// loop, so the fetched rows are identical while the fetch phase takes
 	// max(probe) instead of the sum. The per-probe progress ticks keep their
 	// sequential values and fire once all probes have returned.
+	t0 = time.Now()
 	fetched, fetchedSources, err := fetchProbes(clientURL, apiKey, specs)
 	if err != nil {
 		return jvNull(), err
 	}
+	timings["fetch"] = time.Since(t0).Milliseconds()
 	rows = fetched
 	sources = fetchedSources
 	if progress != nil {
@@ -765,13 +773,16 @@ func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int
 	if progress != nil {
 		progress(750, 1000)
 	}
+	t0 = time.Now()
 	scenes, performers, err := s.score(candidates, sources, modelID, featureVersion, links, jvNull())
 	if err != nil {
 		return jvNull(), err
 	}
+	timings["score"] = time.Since(t0).Milliseconds()
 	if progress != nil {
 		progress(900, 1000)
 	}
+	t0 = time.Now()
 	writeErr := withTxn(db, func(conn *sql.Conn) error {
 		ctx := context.Background()
 		upsert := func(entityType string, items []scoredScene) error {
@@ -846,6 +857,7 @@ ON CONFLICT(singleton) DO UPDATE SET model_id=excluded.model_id,
 			modelID, fetchedAtMs, fetchedAtMs+12*3_600_000, poolCounts["scene"], poolCounts["performer"])
 		return err
 	})
+	timings["database_writing"] = time.Since(t0).Milliseconds()
 	if writeErr != nil {
 		return jvNull(), writeErr
 	}
@@ -854,6 +866,7 @@ ON CONFLICT(singleton) DO UPDATE SET model_id=excluded.model_id,
 			return jvNull(), err
 		}
 	}
+	timings["total"] = time.Since(started).Milliseconds()
 	if progress != nil {
 		progress(1000, 1000)
 	}
@@ -862,6 +875,7 @@ ON CONFLICT(singleton) DO UPDATE SET model_id=excluded.model_id,
 		jvKey("performer_count", jvInt(int64(len(performers)))),
 		jvKey("taxonomy_refreshed", jvBool(taxonomyRefreshed)),
 		jvKey("incremental", jvBool(since != "")),
+		jvKey("stage_timings_ms", stageTimingsJValForExpand(timings)),
 	), nil
 }
 

--- a/core/expand_refresh.go
+++ b/core/expand_refresh.go
@@ -577,6 +577,14 @@ func expandSimilarPerformers(s *expandService, clientURL, apiKey string, base []
 	}
 	results := make([]chaseResult, limit)
 	var networkMs, matchMs, calls int64
+	// Fetch the shared popularity recall floor once (it is identical across all
+	// favorites), then union each favorite's co-star/age pools against it. This
+	// removes the redundant per-favorite base fetch, the largest query of the
+	// chase. The base pool is the same list every favorite would have fetched,
+	// so the per-target union (and thus the seed set) is unchanged.
+	tBase := time.Now()
+	sharedBase := fetchBasePerformerPool(clientURL, apiKey, gender, ethnicity)
+	timings["seeds_chase_base"] = time.Since(tBase).Milliseconds()
 	// Fetch each favorite's StashDB pool and score it in parallel (bounded by
 	// the same worker count the scene probes use), then merge in the same seed
 	// order as the sequential path so the additions (and thus scene_count /
@@ -600,7 +608,7 @@ func expandSimilarPerformers(s *expandService, clientURL, apiKey string, base []
 					continue
 				}
 				tNet := time.Now()
-				pool, err := fetchPerformerPool(clientURL, apiKey, target, gender, ethnicity, externalID)
+				pool, err := fetchPerformerPool(clientURL, apiKey, target, gender, ethnicity, externalID, sharedBase)
 				atomic.AddInt64(&networkMs, time.Since(tNet).Milliseconds())
 				atomic.AddInt64(&calls, 1)
 				if err != nil {

--- a/core/expand_refresh.go
+++ b/core/expand_refresh.go
@@ -15,6 +15,8 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -351,7 +353,7 @@ func recentScene(scene jVal, cutoff string) bool {
 
 // refreshSeeds mirrors ExpandService._seeds.
 func refreshSeeds(s *expandService, clientURL, apiKey, modelID, featureVersion string, links jVal,
-	similarTopK, similarPerFavorite int, gender, ethnicity string) (jVal, error) {
+	similarTopK, similarPerFavorite int, gender, ethnicity string, timings map[string]int64) (jVal, error) {
 	topRows, err := s.db.Query(`
 SELECT scene_id FROM model_scene_score WHERE model_id=?
 ORDER BY appeal * confidence DESC LIMIT 500`, modelID)
@@ -393,7 +395,7 @@ ORDER BY appeal * confidence DESC LIMIT 500`, modelID)
 		}
 	}
 	expandedPerformers := expandSimilarPerformers(s, clientURL, apiKey, basePerformers, evidence,
-		featureVersion, similarTopK, similarPerFavorite, gender, ethnicity)
+		featureVersion, similarTopK, similarPerFavorite, gender, ethnicity, timings)
 	performers := jvArr()
 	for _, externalID := range expandedPerformers {
 		performers.arr = append(performers.arr, jvStr(externalID))
@@ -539,14 +541,16 @@ ORDER BY a.affinity * a.confidence DESC LIMIT 50`, modelID, featureVersion)
 // Best-effort: any failure degrades to the base seed set.
 func expandSimilarPerformers(s *expandService, clientURL, apiKey string, base []string,
 	evidence map[string]*performerEvidence, featureVersion string, topK, perFavorite int,
-	gender, ethnicity string) []string {
+	gender, ethnicity string, timings map[string]int64) []string {
 	if topK <= 0 || perFavorite <= 0 || len(base) == 0 {
 		return base
 	}
+	t0 := time.Now()
 	profiles, err := performerProfilesAll(s.db, featureVersion)
 	if err != nil || len(profiles) == 0 {
 		return base
 	}
+	timings["seeds_profiles"] = time.Since(t0).Milliseconds()
 	weights := performerBlockWeightsMap()
 	recorded := time.Now().Format("2006-01-02")
 	ids := make([]string, 0, len(evidence))
@@ -564,32 +568,73 @@ func expandSimilarPerformers(s *expandService, clientURL, apiKey string, base []
 		sim float64
 		id  string
 	}
-	added := map[string]bool{}
-	var additions []string
+	type chaseResult struct {
+		scored []scoredPerformer
+	}
 	limit := topK
 	if limit > len(ids) {
 		limit = len(ids)
 	}
-	for _, externalID := range ids[:limit] {
-		target, ok := profiles[evidence[externalID].localID]
-		if !ok {
-			continue
-		}
-		pool, err := fetchPerformerPool(clientURL, apiKey, target, gender, ethnicity, externalID)
-		if err != nil {
-			continue
-		}
-		var scored []scoredPerformer
-		for _, performer := range pool {
-			profile := expandProfile(performer, jvStr(recorded))
-			if len(profileConflicts(profile, target)) > 0 {
-				continue
+	results := make([]chaseResult, limit)
+	var networkMs, matchMs, calls int64
+	// Fetch each favorite's StashDB pool and score it in parallel (bounded by
+	// the same worker count the scene probes use), then merge in the same seed
+	// order as the sequential path so the additions (and thus scene_count /
+	// performer_count) stay byte-identical to the Python oracle. Only the
+	// independent per-favorite work runs concurrently — the dedup merge below
+	// is sequential, so cross-favorite ordering is deterministic.
+	workers := min(8, limit)
+	if workers < 1 {
+		workers = 1
+	}
+	workCh := make(chan int)
+	var wg sync.WaitGroup
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for idx := range workCh {
+				externalID := ids[idx]
+				target := profiles[evidence[externalID].localID]
+				if target == nil {
+					continue
+				}
+				tNet := time.Now()
+				pool, err := fetchPerformerPool(clientURL, apiKey, target, gender, ethnicity, externalID)
+				atomic.AddInt64(&networkMs, time.Since(tNet).Milliseconds())
+				atomic.AddInt64(&calls, 1)
+				if err != nil {
+					continue
+				}
+				var scored []scoredPerformer
+				tMatch := time.Now()
+				for _, performer := range pool {
+					profile := expandProfile(performer, jvStr(recorded))
+					if len(profileConflicts(profile, target)) > 0 {
+						continue
+					}
+					sim, _ := profileMatch(profile, target, weights)
+					scored = append(scored, scoredPerformer{sim: sim, id: performer.get("id").asString()})
+				}
+				atomic.AddInt64(&matchMs, time.Since(tMatch).Milliseconds())
+				results[idx].scored = scored
 			}
-			sim, _ := profileMatch(profile, target, weights)
-			scored = append(scored, scoredPerformer{sim: sim, id: performer.get("id").asString()})
+		}()
+	}
+	for idx := range limit {
+		workCh <- idx
+	}
+	close(workCh)
+	wg.Wait()
+	added := map[string]bool{}
+	var additions []string
+	for idx := range limit {
+		scored := results[idx].scored
+		if len(scored) == 0 {
+			continue
 		}
 		sort.SliceStable(scored, func(i, j int) bool { return scored[i].sim > scored[j].sim })
-		for i := 0; i < perFavorite && i < len(scored); i++ {
+		for i := range min(perFavorite, len(scored)) {
 			eid := scored[i].id
 			if _, known := evidence[eid]; known || added[eid] {
 				continue
@@ -598,6 +643,9 @@ func expandSimilarPerformers(s *expandService, clientURL, apiKey string, base []
 			additions = append(additions, eid)
 		}
 	}
+	timings["seeds_chase_network"] = networkMs
+	timings["seeds_chase_match"] = matchMs
+	timings["seeds_chase_calls"] = int64(calls)
 	if len(additions) == 0 {
 		return base
 	}
@@ -643,7 +691,7 @@ func expandRefresh(db dbx, clientURL, apiKey string, links jVal, horizonDays int
 	}
 	t0 = time.Now()
 	seeds, err := refreshSeeds(s, clientURL, apiKey, modelID, featureVersion, links,
-		similarTopK, similarPerFavorite, gender, ethnicity)
+		similarTopK, similarPerFavorite, gender, ethnicity, timings)
 	if err != nil {
 		return jvNull(), err
 	}

--- a/core/expand_similar.go
+++ b/core/expand_similar.go
@@ -676,7 +676,7 @@ func expandTargetedSimilar(db dbx, clientURL, apiKey string, links jVal, entityT
 		if v := links.get("performers").get(entityID); v.truthy() {
 			performedWith = v.asString()
 		}
-		candidates, err := fetchPerformerPool(clientURL, apiKey, target, selectedGender, ethnicity, performedWith)
+		candidates, err := fetchPerformerPool(clientURL, apiKey, target, selectedGender, ethnicity, performedWith, nil)
 		if err != nil {
 			return jvNull(), err
 		}

--- a/core/tasks.go
+++ b/core/tasks.go
@@ -590,6 +590,7 @@ func stageTimingsJValForExpand(timings map[string]int64) jVal {
 // order (Go and Python must agree so a future comparison stays stable).
 var expandStageTimingOrder = []string{
 	"taxonomy", "seeds", "fetch", "score", "database_writing", "total",
+	"seeds_profiles", "seeds_chase_network", "seeds_chase_match", "seeds_chase_calls",
 }
 
 // taskSyncBuild mirrors backend.py's sync-build / full-sync-build mode.

--- a/core/tasks.go
+++ b/core/tasks.go
@@ -554,6 +554,15 @@ func taskBuild(db dbx, pluginDir string, payload jVal, mode string) (jVal, error
 	), nil
 }
 
+// stageTimingOrder mirrors the model build's timings insertion order.
+var stageTimingOrder = []string{
+	"feature_lookup", "feature_build", "feature_database_writing", "feature_indexing",
+	"feature_validation", "feature_publication", "feature_total", "labels", "affinities",
+	"similarity", "scoring", "database_writing", "lane_classification",
+	"score_first_ordering", "varied_ordering", "reason_generation",
+	"sqlite_index_creation", "indexing", "validation", "publication", "cleanup", "total",
+}
+
 // stageTimingsJVal serializes the stage timings dict in insertion order.
 func stageTimingsJVal(timings map[string]int64) jVal {
 	out := jvObj()
@@ -565,13 +574,22 @@ func stageTimingsJVal(timings map[string]int64) jVal {
 	return out
 }
 
-// stageTimingOrder mirrors the model build's timings insertion order.
-var stageTimingOrder = []string{
-	"feature_lookup", "feature_build", "feature_database_writing", "feature_indexing",
-	"feature_validation", "feature_publication", "feature_total", "labels", "affinities",
-	"similarity", "scoring", "database_writing", "lane_classification",
-	"score_first_ordering", "varied_ordering", "reason_generation",
-	"sqlite_index_creation", "indexing", "validation", "publication", "cleanup", "total",
+// stageTimingsJValForExpand serializes the expand refresh phase timings in a
+// stable insertion order (the refresh summary's stage_timings_ms).
+func stageTimingsJValForExpand(timings map[string]int64) jVal {
+	out := jvObj()
+	for _, key := range expandStageTimingOrder {
+		if value, ok := timings[key]; ok {
+			out.set(key, jvInt(value))
+		}
+	}
+	return out
+}
+
+// expandStageTimingOrder mirrors ExpandService.refresh's timing insertion
+// order (Go and Python must agree so a future comparison stays stable).
+var expandStageTimingOrder = []string{
+	"taxonomy", "seeds", "fetch", "score", "database_writing", "total",
 }
 
 // taskSyncBuild mirrors backend.py's sync-build / full-sync-build mode.

--- a/core/tasks.go
+++ b/core/tasks.go
@@ -590,7 +590,7 @@ func stageTimingsJValForExpand(timings map[string]int64) jVal {
 // order (Go and Python must agree so a future comparison stays stable).
 var expandStageTimingOrder = []string{
 	"taxonomy", "seeds", "fetch", "score", "database_writing", "total",
-	"seeds_profiles", "seeds_chase_network", "seeds_chase_match", "seeds_chase_calls",
+	"seeds_profiles", "seeds_chase_base", "seeds_chase_network", "seeds_chase_match", "seeds_chase_calls",
 }
 
 // taskSyncBuild mirrors backend.py's sync-build / full-sync-build mode.

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -270,12 +270,16 @@ class ExpandService:
         progress: Callable[[int, int], None] | None = None,
     ) -> dict[str, object]:
         fetched_at_ms = now_ms if now_ms is not None else time.time_ns() // 1_000_000
+        started = time.monotonic()
+        timings: dict[str, int] = {}
         # The taxonomy check and seed load used to be markerless: on a large
         # library the bar sat at 5% for the whole stretch. The 50/150 ticks
         # bracket both phases (issue #110).
         if progress:
             progress(50, 1_000)
+        phase = time.monotonic()
         taxonomy_refreshed = self._refresh_taxonomy(client, fetched_at_ms)
+        timings["taxonomy"] = round((time.monotonic() - phase) * 1_000)
         if progress:
             progress(100, 1_000)
         model_store = RecommendationModelStore(self.connection)
@@ -288,6 +292,7 @@ class ExpandService:
         feature_version = str(model[0])
         if progress:
             progress(150, 1_000)
+        phase = time.monotonic()
         seeds = self._seeds(
             client,
             model_id,
@@ -298,6 +303,7 @@ class ExpandService:
             gender=gender,
             ethnicity=ethnicity,
         )
+        timings["seeds"] = round((time.monotonic() - phase) * 1_000)
         if progress:
             progress(200, 1_000)
         cache = self.connection.execute(
@@ -344,10 +350,12 @@ class ExpandService:
                 queries.append((source, values, half, "POPULARITY"))
         if wildcard:
             queries.append(("wildcard", [], min(100, per_source), "TRENDING"))
+        fetch_phase = time.monotonic()
         for position, (source, values, limit, sort) in enumerate(queries, 1):
             self._fetch(client, rows, sources, source, values, limit, sort=sort, since=since)
             if progress:
                 progress(200 + round(450 * position / max(1, len(queries))), 1_000)
+        timings["fetch"] = round((time.monotonic() - fetch_phase) * 1_000)
         if progress and not queries:
             progress(650, 1_000)
         cutoff = date.today() - timedelta(days=horizon_days)
@@ -363,9 +371,12 @@ class ExpandService:
                 candidates.append(candidate)
         if progress:
             progress(750, 1_000)
+        phase = time.monotonic()
         scenes, performers = self._score(candidates, sources, model_id, feature_version, links)
+        timings["score"] = round((time.monotonic() - phase) * 1_000)
         if progress:
             progress(900, 1_000)
+        phase = time.monotonic()
         with transaction(self.connection):
             # Merge the newly fetched candidates instead of wiping the pool, so unchanged
             # entries and the explore rows from hunts and similar probes survive a refresh.
@@ -441,6 +452,8 @@ class ExpandService:
             # The affinities and seeds changed with the model, so every surviving candidate's
             # score is stale; rescore the whole candidate pool in place.
             self._rescore_candidates(model_id, feature_version, links)
+        timings["database_writing"] = round((time.monotonic() - phase) * 1_000)
+        timings["total"] = round((time.monotonic() - started) * 1_000)
         if progress:
             progress(1_000, 1_000)
         return {
@@ -448,6 +461,7 @@ class ExpandService:
             "performer_count": len(performers),
             "taxonomy_refreshed": taxonomy_refreshed,
             "incremental": since is not None,
+            "stage_timings_ms": timings,
         }
 
     def _rescore_candidates(

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -302,6 +302,7 @@ class ExpandService:
             similar_per_favorite=similar_per_favorite,
             gender=gender,
             ethnicity=ethnicity,
+            timings=timings,
         )
         timings["seeds"] = round((time.monotonic() - phase) * 1_000)
         if progress:
@@ -1749,7 +1750,9 @@ class ExpandService:
         similar_per_favorite: int = 5,
         gender: str = "",
         ethnicity: str = "",
+        timings: dict[str, int] | None = None,
     ) -> dict[str, list[str]]:
+        timings = timings if timings is not None else {}
         top = [
             str(row[0])
             for row in self.connection.execute(
@@ -1784,6 +1787,7 @@ class ExpandService:
                 similar_per_favorite,
                 gender,
                 ethnicity,
+                timings,
             )
         played = [
             str(row[0])
@@ -1851,19 +1855,25 @@ class ExpandService:
         per_favorite: int,
         gender: str,
         ethnicity: str,
+        timings: dict[str, int],
     ) -> list[str]:
         # Best-effort enrichment: it must never fail an Expand refresh. A lookup-alike pass
         # is only worth the seed breadth it adds, so any failure (a StashDB instance that
         # predates a query, a missing profile, or a broken response) degrades to base seeds.
+        t0 = time.monotonic()
         try:
             profiles = FeatureStore(self.connection).performer_profiles(feature_version)
         except Exception:
             return base
+        timings["seeds_profiles"] = round((time.monotonic() - t0) * 1_000)
         if not profiles:
             return base
         weights = dict(DEFAULT_CONFIG.feature.performer_block_weights)
         recorded = date.today().isoformat()
         additions: list[str] = []
+        network_ms = 0
+        match_ms = 0
+        calls = 0
         ranked = sorted(
             evidence.items(), key=lambda value: (-float(value[1]["strength"]), value[0])
         )
@@ -1871,23 +1881,31 @@ class ExpandService:
             target = profiles.get(info["local_id"])
             if target is None:
                 continue
+            t_net = time.monotonic()
             try:
                 pool = self._fetch_performer_pool(
                     client, target, gender, ethnicity, performed_with=external_id
                 )
             except (GraphQLError, KeyError, TypeError):
                 continue
+            network_ms += round((time.monotonic() - t_net) * 1_000)
+            calls += 1
             scored: list[tuple[float, str]] = []
+            t_match = time.monotonic()
             for performer in pool:
                 profile = self._profile(performer, recorded)
                 if self._profile_conflicts(profile, target):
                     continue
                 similarity, _match, _coverage = self._profile_match(profile, target, weights)
                 scored.append((similarity, str(performer["id"])))
+            match_ms += round((time.monotonic() - t_match) * 1_000)
             scored.sort(key=lambda value: value[0], reverse=True)
             for _similarity, external in scored[:per_favorite]:
                 if external not in evidence and external not in additions:
                     additions.append(external)
+        timings["seeds_chase_network"] = network_ms
+        timings["seeds_chase_match"] = match_ms
+        timings["seeds_chase_calls"] = calls
         return list(dict.fromkeys((*base, *additions)))
 
     @staticmethod

--- a/tests/core/test_backend_slice3_refresh.py
+++ b/tests/core/test_backend_slice3_refresh.py
@@ -245,7 +245,9 @@ def assert_refresh_identical(
     sidecar: Path,
     stash_url: str,
     *,
-    normalize: tuple[str, ...] = ("job_id",),
+    # stage_timings_ms is a wall-clock breakdown that legitimately differs
+    # between the Go and Python runs; strip it from the parity comparison.
+    normalize: tuple[str, ...] = ("job_id", "stage_timings_ms"),
 ) -> None:
     run_dir = sidecar.parent / f"{sidecar.stem}-refresh-run"
     worker_dir = Path(tempfile.mkdtemp(prefix="curator-worker-"))

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -295,14 +295,11 @@ def test_expand_refresh_is_bounded_owned_filtered_and_cached(tmp_path: Path) -> 
     assert refreshed["performer_count"] == 1
     assert refreshed["taxonomy_refreshed"] is False
     assert refreshed["incremental"] is False
-    assert set(refreshed["stage_timings_ms"]) == {
-        "taxonomy",
-        "seeds",
-        "fetch",
-        "score",
-        "database_writing",
-        "total",
-    }
+    # The seeds chase sub-phases (seeds_profiles / seeds_chase_*) appear only when
+    # the similar-performer chase runs (similar_top_k>0); this refresh disables it.
+    assert {"taxonomy", "seeds", "fetch", "score", "database_writing", "total"} <= set(
+        refreshed["stage_timings_ms"]
+    )
     assert len(client.inputs) == 4  # performers + studios x 2 probes each (DATE + POPULARITY)
     assert [processed for processed, _ in progress] == sorted(
         processed for processed, _ in progress

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -291,11 +291,17 @@ def test_expand_refresh_is_bounded_owned_filtered_and_cached(tmp_path: Path) -> 
         progress=lambda processed, total: progress.append((processed, total)),
     )
 
-    assert refreshed == {
-        "scene_count": 1,
-        "performer_count": 1,
-        "taxonomy_refreshed": False,
-        "incremental": False,
+    assert refreshed["scene_count"] == 1
+    assert refreshed["performer_count"] == 1
+    assert refreshed["taxonomy_refreshed"] is False
+    assert refreshed["incremental"] is False
+    assert set(refreshed["stage_timings_ms"]) == {
+        "taxonomy",
+        "seeds",
+        "fetch",
+        "score",
+        "database_writing",
+        "total",
     }
     assert len(client.inputs) == 4  # performers + studios x 2 probes each (DATE + POPULARITY)
     assert [processed for processed, _ in progress] == sorted(


### PR DESCRIPTION
## Summary

Speeds up the Expand cache refresh and makes it observable. Four commits on (Go runtime + Python oracle, parity kept):

### 1. Per-phase timings in the expand summary
`expand-refresh`/`expand-rebuild` summaries now carry `stage_timings_ms` (always-on, like the model build): `taxonomy`, `seeds`, `fetch`, `score`, `database_writing`, `total`, plus a `seeds_*` decomposition (`seeds_profiles`, `seeds_chase_base`, `seeds_chase_network`, `seeds_chase_match`, `seeds_chase_calls`). The differential comparator strips `stage_timings_ms` (wall-clock differs between Go/Python runs); the Python oracle mirrors the keys.

### 2. Parallelize the look-alike seed chase
The ~20 per-favorite `fetchPerformerPool` calls were sequential (~10s wall), dominating the seeds phase. They now run on a bounded worker pool (8 workers), with a deterministic in-order merge so the seed set stays byte-identical to the sequential Python oracle.

### 3. Share the base popularity pool
The gender/ethnicity popularity recall floor was re-fetched once per favorite (identical every time). Now fetched **once** and shared — removes ~20 redundant StashDB queries (the largest query), halving network work.

### 4. Load only the favorite profiles
The chase loaded **every** performer profile from the model (`entity_feature` all-performers read), but only uses the `top_k` favorites as targets. Now loads just those via `performerProfilesForIDs` — this was the serial bottleneck.

## Measured on the live library (same 379 scenes / 464 performers)

| | seeds wall | seeds_profiles | total |
|---|---|---|---|
| sequential baseline | 14.2s | (5.4s) | 25.3s |
| parallel + shared base + favorite-only profiles | **4.1s** | **0.18s** | **16.4s** |

~**35% faster total**, with the `seeds` phase **3.4×** faster and ~20 fewer StashDB queries.

## Files
- `core/expand_refresh.go` — timings; parallel `expandSimilarPerformers`; shared base; favorite-only profile load.
- `core/expand.go` — `fetchBasePerformerPool` + `prefetchedBase` in `fetchPerformerPool`.
- `core/expand_similar.go`, `core/tasks.go`, `curator/expand.py`, `tests/test_expand.py`, `tests/core/test_backend_slice3_refresh.py`.

## Verification
- `scripts/verify changed` — core differential gate **224 passed** (Go output byte-identical to the Python oracle throughout).
- Live forced `expand-rebuild` confirmed the `stage_timings_ms` breakdown and the wall-time improvement.
