### PR TITLE
perf(expand): reuse cached external links so the expand refresh doesn't re-walk the library

### DIFF
--- a/core/daemon.go
+++ b/core/daemon.go
@@ -448,7 +448,10 @@ func ensureWorker(pluginDir string, payload jVal, settings jVal) error {
 		}
 		return nil
 	}
-	db, err := openSidecar(pluginDir, payload, settings, true)
+	// The worker coordination here only migrates the sidecar and checks the
+	// queue; the published-model artifact is attached per-job (when a task
+	// actually needs it) inside the worker, not while deciding to spawn one.
+	db, err := openSidecar(pluginDir, payload, settings, false)
 	if err != nil {
 		return fmt.Errorf("could not open sidecar to recover worker: %w", err)
 	}

--- a/core/tasks.go
+++ b/core/tasks.go
@@ -321,7 +321,11 @@ func taskExpandRefresh(db dbx, pluginDir string, payload jVal, settings jVal) (j
 	if err != nil {
 		return jvNull(), err
 	}
-	links, err := externalLinksRefresh(payload, db, mappedProgress(0.05, 0.08))
+	// Reuse the cached external-links map (refreshed by sync-build and the
+	// entity hooks) instead of re-walking the whole library through Stash on
+	// every expand refresh — the walk dominates the refresh cost on large
+	// libraries. The Python oracle does the same (_external_links refresh=False).
+	links, err := externalLinks(payload, db)
 	if err != nil {
 		return jvNull(), err
 	}
@@ -361,7 +365,11 @@ func taskExpandRebuild(db dbx, pluginDir string, payload jVal, settings jVal) (j
 	if err != nil {
 		return jvNull(), err
 	}
-	links, err := externalLinksRefresh(payload, db, mappedProgress(0.05, 0.08))
+	// Reuse the cached external-links map (refreshed by sync-build and the
+	// entity hooks) instead of re-walking the whole library through Stash on
+	// every expand refresh — the walk dominates the refresh cost on large
+	// libraries. The Python oracle does the same (_external_links refresh=False).
+	links, err := externalLinks(payload, db)
 	if err != nil {
 		return jvNull(), err
 	}


### PR DESCRIPTION
## Summary

Two related fixes to the Expand refresh, so the background worker cold-start and the refresh wall time reflect the *actual* work rather than avoidable overhead.

### 1. Reuse the cached external-links map (the big one)
`taskExpandRefresh` and `taskExpandRebuild` were calling `externalLinksRefresh`, which **re-walks the entire library through Stash's GraphQL** (paged, ~500/page) on **every** expand refresh to collect the StashDB ID links. On a ~30k-scene library that's ~60+ network round-trips → **~19s** before the refresh even starts.

They now call `externalLinks(payload, db)`, which **reuses the cached map** (refreshed by sync-build and the entity hooks, which keep newly-linked entities current). This matches what the Python oracle already does (`_external_links(..., refresh=False)`), so parity is preserved.

Measured live (same workload):
| | enq→finish | pre-run gap |
|---|---|---|
| before | 40.2s | 20.0s |
| **after** | **19.1s** | **0.9s** |

The pre-run gap drops from 20s to 0.9s; the remaining ~19s is the actual expand work (fetch/score/seeds), not overhead.

### 2. Don't attach the model artifact when deciding to spawn the worker
`ensureWorker` (the enqueue path) opened the sidecar **with** the artifact attach (`openSidecar(..., true)`) just to check the queue and recover orphans. Attaching the published-model artifact there is unnecessary (the worker attaches it per-job when a task actually needs it), so it now opens with `attach=false`. Saves an artifact attach on the enqueue path of every cold task.

## Files
- `core/tasks.go` — `taskExpandRefresh`/`taskExpandRebuild` use the cached `externalLinks`.
- `core/daemon.go` — `ensureWorker` opens the sidecar without the artifact attach.

## Verification
- `scripts/verify changed` — **224 passed** (Go output byte-identical to the Python oracle, confirming the cached-links behavior matches Python).
- Live: `expand-rebuild` pre-run gap **20.0s → 0.9s**, enq→finish **40.2s → 19.1s**.
- Go unit tests pass; instrumentation (added only for the measurement) was reverted.

## Background
Profiling showed the cold-start "gap" wasn't the model artifact (local SSD, ~3ms) or the sidecar open (~2ms) — it was the external-links walk running before `expandRefresh`. The code already caches the links; the expand task was simply ignoring the cache.
