### PR TITLE
fix(hunt): search local and StashDB performers together

### DIFF
--- a/core/expand_ops.go
+++ b/core/expand_ops.go
@@ -370,7 +370,7 @@ func getStashdbPerformerSearchBody(pluginDir string, payload, settings jVal) (jV
 	search := jvObj(
 		jvKey("page", jvInt(1)),
 		jvKey("per_page", jvInt(limit)),
-		jvKey("names", jvObj(jvKey("value", jvStr(query)), jvKey("modifier", jvStr("INCLUDES")))),
+		jvKey("names", jvStr(query)),
 	)
 	data, err := stashdbQuery(clientURL, apiKey, stashdbPerformerSearchQuery, jvObj(jvKey("input", search)))
 	if err != nil {

--- a/curator/expand.py
+++ b/curator/expand.py
@@ -515,7 +515,7 @@ class ExpandService:
                 "input": {
                     "page": 1,
                     "per_page": limit,
-                    "names": {"value": query, "modifier": "INCLUDES"},
+                    "names": query,
                 }
             },
         )["queryPerformers"]["performers"]

--- a/plugin/stash-curator.css
+++ b/plugin/stash-curator.css
@@ -2511,15 +2511,34 @@
 }
 
 .curator-token-options button {
+  align-items: center;
   background: transparent;
   border: 0;
   color: var(--curator-text);
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
   padding: 0.35rem 0.5rem;
   text-align: left;
+  width: 100%;
 }
 
 .curator-token-options button:hover {
   background: var(--curator-surface-raised);
+}
+
+.curator-token-source-badge {
+  background: var(--curator-wash-recessed);
+  border: 1px solid var(--curator-border);
+  border-radius: var(--curator-radius-sm);
+  color: var(--curator-text);
+  flex: 0 0 auto;
+  font-size: 0.7rem;
+  font-weight: 600;
+  line-height: 1.1;
+  padding: 0.1rem 0.45rem;
+  text-transform: uppercase;
+  white-space: nowrap;
 }
 
 .curator-match-filter input {

--- a/plugin/stash-curator.js
+++ b/plugin/stash-curator.js
@@ -2630,50 +2630,70 @@
     );
   }
 
-  function FilterTokens({ kind, label, values, onChange, disabled = false, external = false }) {
+  function FilterTokens({ kind, label, values, onChange, disabled = false, searchBoth = false }) {
     const [query, setQuery] = React.useState("");
-    const [externalResults, setExternalResults] = React.useState([]);
+    const [remoteResults, setRemoteResults] = React.useState([]);
     const variables = { filter: { q: query, per_page: 8 } };
     const tags = GQL.useFindTagsQuery({ variables, skip: kind !== "tag" || !query || disabled });
     const studios = GQL.useFindStudiosQuery({ variables, skip: kind !== "studio" || !query || disabled });
-    const performers = GQL.useFindPerformersQuery({ variables, skip: kind !== "performer" || external || !query || disabled });
-    // Issue #218: external mode searches StashDB performers by name (debounced)
-    // so the local completion path never hits the network per keystroke.
+    const performers = GQL.useFindPerformersQuery({ variables, skip: kind !== "performer" || !query || disabled });
+    // Issue #218: searchBoth also searches StashDB performers by name
+    // (debounced) so local completions render immediately and the remote
+    // results fill in as they arrive; the debounce keeps StashDB traffic off
+    // the per-keystroke path.
     React.useEffect(() => {
-      if (kind !== "performer" || !external || !query || disabled) {
-        setExternalResults([]);
+      if (kind !== "performer" || !searchBoth || !query || disabled) {
+        setRemoteResults([]);
         return undefined;
       }
       let active = true;
       const timer = setTimeout(() => {
         operation({ operation: "get_stashdb_performer_search", query, limit: 8 }).then(
-          (result) => { if (active) setExternalResults(result.items || []); },
-          () => { if (active) setExternalResults([]); }
+          (result) => { if (active) setRemoteResults(result.items || []); },
+          () => { if (active) setRemoteResults([]); }
         );
       }, 300);
       return () => { active = false; clearTimeout(timer); };
-    }, [kind, external, query, disabled]);
-    const options = external && kind === "performer"
-      ? externalResults.map((item) => ({ ...item, external: true }))
+    }, [kind, searchBoth, query, disabled]);
+    const localPerformers = kind === "performer" ? (performers.data?.findPerformers?.performers || []) : [];
+    const options = kind === "performer"
+      ? searchBoth
+        ? (() => {
+            const seen = new Set();
+            const merged = [];
+            for (const item of localPerformers) {
+              const id = String(item.id);
+              if (seen.has(id)) continue;
+              seen.add(id);
+              merged.push({ ...item, source: "local" });
+            }
+            for (const item of remoteResults) {
+              const id = String(item.id);
+              if (seen.has(id)) continue;
+              seen.add(id);
+              merged.push({ ...item, source: "remote", external: true });
+            }
+            return merged;
+          })()
+        : localPerformers
       : kind === "tag"
         ? tags.data?.findTags?.tags || []
         : kind === "studio"
           ? studios.data?.findStudios?.studios || []
-          : performers.data?.findPerformers?.performers || [];
+          : [];
     function add(item) {
       if (!values.some((value) => String(value.id) === String(item.id))) onChange([...values, item]);
       setQuery("");
     }
-    function optionLabel(item) {
-      if (!external || kind !== "performer" || !item.disambiguation) return item.name;
-      return `${item.name} (${item.disambiguation})`;
+    function optionText(item) {
+      return item.external && item.disambiguation ? `${item.name} (${item.disambiguation})` : item.name;
     }
     return React.createElement(
       "label",
       { className: "curator-token-filter" },
       React.createElement("span", null, label),
       React.createElement("div", { className: "curator-token-input" }, values.map((item) => React.createElement("button", { key: item.id, type: "button", title: `Remove ${item.name}`, onClick: () => onChange(values.filter((value) => value.id !== item.id)) }, item.name, " ×")), disabled ? null : React.createElement("input", { value: query, onChange: (event) => setQuery(event.target.value), onKeyDown: (event) => { if (event.key === "Enter" && options.length > 0) { event.preventDefault(); add(options[0]); } }, placeholder: values.length ? "Add…" : `Search ${label.toLowerCase()}…` })),
-      query && options.length > 0 && React.createElement("div", { className: "curator-token-options" }, options.map((item) => React.createElement("button", { key: item.id, type: "button", onClick: () => add(item) }, optionLabel(item))))
+      query && options.length > 0 && React.createElement("div", { className: "curator-token-options" }, options.map((item) => React.createElement("button", { key: item.id, type: "button", onClick: () => add(item) }, React.createElement("span", { className: "curator-token-option-name" }, optionText(item)), searchBoth && React.createElement("span", { className: "curator-token-source-badge" }, item.source === "remote" ? "StashDB" : "Library"))))
     );
   }
 
@@ -3220,7 +3240,6 @@
         performer: null,
         huntView: "unlinked",
         huntSort: "date",
-        huntExternal: false,
         includeTags: initialFilters.includeTags || [],
         excludeTags: initialFilters.excludeTags || [],
         hidePhashMatches: initialFilters.hidePhashMatches !== false,
@@ -3231,13 +3250,12 @@
           param: "performer",
           parse: (search) => {
             const id = search.get("performer");
-            return id ? { id, name: search.get("label") || id, external: true } : null;
+            return id ? { id, name: search.get("label") || id, external: search.get("ext") === "1" } : null;
           },
-          serialize: (value) => value ? { performer: String(value.id), label: value.name && value.name !== String(value.id) ? value.name : "" } : { performer: "", label: "" },
+          serialize: (value) => value ? { performer: String(value.id), label: value.name && value.name !== String(value.id) ? value.name : "", ext: value.external ? "1" : "" } : { performer: "", label: "" },
         },
         huntView: urlStringField("hunt_view", "unlinked", (value) => ["all", "linked", "unlinked"].includes(value)),
         huntSort: urlStringField("hunt_sort", "date", (value) => ["date", "score"].includes(value)),
-        huntExternal: urlBoolField("hunt_ext", false),
         includeTags: urlListField("hunt_include_tags", initialFilters.includeTags || []),
         excludeTags: urlListField("hunt_exclude_tags", initialFilters.excludeTags || []),
         hidePhashMatches: urlBoolField("hunt_hide_phash", initialFilters.hidePhashMatches !== false),
@@ -3279,7 +3297,7 @@
       },
     }, [huntOnly, initialFilters]);
     const [urlState, updateUrl] = useUrlState(expandSpec);
-    const { entityType, sort, performerId, favoriteOnly, gender, includeTags, excludeTags, performers, studios, minimumScore, hidePhashMatches, page, performer: huntPerformer, huntView, huntSort, huntExternal } = urlState;
+    const { entityType, sort, performerId, favoriteOnly, gender, includeTags, excludeTags, performers, studios, minimumScore, hidePhashMatches, page, performer: huntPerformer, huntView, huntSort } = urlState;
     const [filtersOpen, setFiltersOpen] = React.useState(false);
     const [filterVersion, setFilterVersion] = React.useState(0);
     const [data, setData] = React.useState(null);
@@ -3404,11 +3422,10 @@
       entityType === "hunt" && React.createElement(
         "div",
         { className: "curator-hunt-controls" },
-        // Issue #218: search StashDB performers directly instead of only
-        // local performers linked to StashDB. Local stays the default and
-        // the checkbox keeps completions off the network until enabled.
-        React.createElement("label", { className: "curator-toolbar-check" }, React.createElement("input", { type: "checkbox", checked: huntExternal, onChange: (event) => updateUrl((s) => ({ ...s, page: 1, performer: null, huntExternal: event.target.checked })) }), " Search StashDB"),
-        React.createElement(FilterTokens, { kind: "performer", label: huntPerformer?.external ? "External performer on StashDB" : "Local performer with a StashDB link", values: huntPerformer ? [huntPerformer] : [], onChange: selectHuntPerformer, disabled: Boolean(huntPerformer?.external), external: huntExternal }),
+        // Issue #218: the picker searches both local performers and StashDB
+        // performers. Local completions render immediately and StashDB results
+        // fill in as they arrive; each dropdown option is tagged by source.
+        React.createElement(FilterTokens, { kind: "performer", searchBoth: true, label: huntPerformer?.external ? "External performer on StashDB" : huntPerformer ? "Local performer with a StashDB link" : "Search library or StashDB performers", values: huntPerformer ? [huntPerformer] : [], onChange: selectHuntPerformer, disabled: Boolean(huntPerformer?.external) }),
         data?.ready && React.createElement("div", { className: "btn-group", role: "group", "aria-label": "Performer Hunt view" }, [["all", `All ${huntCounts.all}`], ["linked", `In library ${huntCounts.linked}`], ["unlinked", `Not linked locally ${huntCounts.unlinked}`]].map(([value, label]) => React.createElement(Button, { key: value, size: "sm", variant: huntView === value ? "primary" : "secondary", onClick: () => updateUrl((s) => ({ ...s, page: 1, huntView: value })) }, label))),
         data?.ready && React.createElement("label", { className: "curator-toolbar-select" }, React.createElement(FontAwesomeIcon, { icon: faSortAmountDown }), React.createElement("select", { value: huntSort, onChange: (event) => updateUrl((s) => ({ ...s, page: 1, huntSort: event.target.value })), "aria-label": "Sort Performer Hunt results" }, React.createElement("option", { value: "date" }, "Release date"), React.createElement("option", { value: "score" }, "Preference score")))
       ),

--- a/tests/core/test_backend_slice2.py
+++ b/tests/core/test_backend_slice2.py
@@ -326,8 +326,8 @@ class _StubExpand(BaseHTTPRequestHandler):
             return {"data": {"queryPerformers": {"performers": pool}}}
         if operation == "CuratorPerformerSearch":
             input_data = json.loads(body)["variables"]["input"]
-            names = input_data.get("names", {})
-            needle = str(names.get("value", "")).casefold()
+            names = input_data.get("names", "")
+            needle = str(names).casefold()
             pool = [
                 {
                     "id": performer["id"],

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -878,11 +878,12 @@ def test_plugin_performer_hunt_keeps_results_and_reuses_external_cards() -> None
 
     assert 'operation: "get_performer_hunt"' in source
     assert 'value: "hunt"' in source
-    # Issue #218: the picker can search StashDB performers directly; the
-    # checkbox keeps local completions off the network.
+    # Issue #218: the picker always searches local performers and StashDB
+    # performers together, tagging each dropdown option by source.
     assert 'operation: "get_stashdb_performer_search"' in source
-    assert '" Search StashDB"' in source
-    assert "external: huntExternal" in source
+    assert "searchBoth: true" in source
+    assert "curator-token-source-badge" in source
+    assert 'item.source === "remote" ? "StashDB" : "Library"' in source
     assert "icon: faCrosshairs" in source
     assert 'initialType: "hunt", huntOnly: true' in source
     assert '["all", `All ${huntCounts.all}`]' in source

--- a/tests/test_expand.py
+++ b/tests/test_expand.py
@@ -1947,3 +1947,55 @@ def test_blocked_term_excludes_remote_pool_scenes(tmp_path: Path) -> None:
     )
     connection.commit()
     assert ExpandService(connection).results("scene")["items"] == []
+
+
+class PerformerSearchStashDB:
+    """A StashDB client that records the performer-search input. The live
+    PerformerQueryInput.names is a bare String (not a StringCriterionInput), so
+    the Performer Hunt picker search must send the name directly; a
+    {value, modifier} object fails GraphQL validation with 'cannot use map as
+    String'."""
+
+    def __init__(self) -> None:
+        self.inputs: list[dict[str, object]] = []
+
+    def execute(self, _document: str, variables: dict[str, object]) -> dict[str, object]:
+        input_data = variables["input"]
+        assert isinstance(input_data, dict)
+        self.inputs.append(input_data)
+        return {
+            "queryPerformers": {
+                "performers": [
+                    {
+                        "id": "performer-1",
+                        "name": "Koda Monroe",
+                        "aliases": [],
+                        "disambiguation": None,
+                        "scene_count": 3,
+                        "images": [],
+                    }
+                ]
+            }
+        }
+
+
+def test_stashdb_performer_search_sends_names_as_plain_string(tmp_path: Path) -> None:
+    """Issue #218: StashDB's PerformerQueryInput.names is a bare String, so the
+    Performer Hunt picker search must send the query string directly instead of
+    a {value, modifier} criterion object (which fails validation against the
+    live schema)."""
+    client = PerformerSearchStashDB()
+    items = ExpandService(_database(tmp_path / "curator.sqlite3")).stashdb_performer_search(
+        client, "koda monro", limit=8
+    )
+    assert items["items"] == [
+        {
+            "id": "performer-1",
+            "name": "Koda Monroe",
+            "aliases": [],
+            "disambiguation": None,
+            "scene_count": 3,
+            "images": [],
+        }
+    ]
+    assert client.inputs == [{"page": 1, "per_page": 8, "names": "koda monro"}]


### PR DESCRIPTION
## Problem

The Performer Hunt "Search StashDB" picker silently returned nothing. StashDB's live
`PerformerQueryInput.names` is a **bare `String`**, not a `StringCriterionInput`, so the
query payload `names: { value, modifier: "INCLUDES" }` was rejected at GraphQL validation:

```
{"errors":[{"message":"cannot use map as String","path":["variable","input","names"]}]}
```

The op failed and the frontend swallowed the error, so the user saw no results and no message.

## Changes

**Backend — send the name as a string**
- `core/expand_ops.go`, `curator/expand.py`: `stashdb_performer_search` now sends `"names": <query>` instead of the criterion object.
- `tests/core/test_backend_slice2.py`: StashDB stub parses the string shape.
- `tests/test_expand.py`: regression test asserting the outgoing `{ page, per_page, names }` payload.

**Frontend — combined local + StashDB search**
- `plugin/stash-curator.js`: the picker now always searches **local performers (immediate)** and **StashDB performers (debounced, as they arrive)**; each dropdown option carries a source badge on the right (`Library` / `StashDB`). Removed the "Search StashDB" checkbox and the `hunt_external` URL field; the selected performer's source round-trips through the URL.
- `plugin/stash-curator.css`: `.curator-token-source-badge` — a dedicated class so it does not collide with the existing `.curator-source-badge` lane badge (which is `position: absolute` and overlapped the result text).
- `tests/plugin/test_runtime.py`: source assertions updated.

## Verification

- `node --check` on the plugin JS; CSS brace balance; `git diff --check` clean.
- `tests/plugin/test_runtime.py`: 49 passed.
- Backend: `test_get_stashdb_performer_search_byte_identical` + full `tests/test_expand.py` / `tests/core/test_backend_slice2.py` passed against the compiled core.

Not an installed-fix claim: the plugin was rebuilt and deployed to the local install path; a live retest of the search is the remaining verification step.