### PR TITLE
fix: refresh external-links cache when the linked library changes

### DIFF
--- a/core/links.go
+++ b/core/links.go
@@ -178,18 +178,19 @@ func externalLinksImpl(payload jVal, db dbx, refresh bool, progress func(process
 	state := ""
 	var err error
 	if db != nil {
+		state, err = externalLinksState(payload)
+		if err != nil {
+			return jvNull(), err
+		}
 		if !refresh {
-			// ponytail: cache until explicit refresh; add TTL or entity-hook invalidation if
-			// newly linked entities must appear without a manual refresh.
-			if cached, ok, err := cachedExternalLinks(db, ""); err != nil {
+			// Reuse the last scan while the linked library is unchanged: the
+			// saved state is compared against the current one, and a mismatch
+			// falls through to the walk so newly-linked entities appear.
+			if cached, ok, err := cachedExternalLinks(db, state); err != nil {
 				return jvNull(), err
 			} else if ok {
 				return cached, nil
 			}
-		}
-		state, err = externalLinksState(payload)
-		if err != nil {
-			return jvNull(), err
 		}
 	}
 	base, headers := stashConnection(payload)

--- a/plugin/backend.py
+++ b/plugin/backend.py
@@ -271,13 +271,14 @@ def _external_links(
     walk (issue #110: the expand-refresh bar used to sit at 5% for the whole
     library walk).
     """
+    state = _external_links_state(payload) if connection is not None else ""
     if connection is not None and not refresh:
-        # ponytail: cache until explicit refresh; add TTL or entity-hook invalidation if
-        # newly linked entities must appear without a manual refresh.
-        cached = _cached_external_links(connection, None)
+        # Reuse the last scan while the linked library is unchanged: the saved
+        # state is compared against the current one, and a mismatch falls
+        # through to the walk so newly-linked entities appear.
+        cached = _cached_external_links(connection, state)
         if cached is not None:
             return cached
-    state = _external_links_state(payload) if connection is not None else ""
     result: dict[str, dict[str, str]] = {
         "scenes": {},
         "scene_ids": {},

--- a/tests/plugin/test_runtime.py
+++ b/tests/plugin/test_runtime.py
@@ -1656,14 +1656,14 @@ def test_external_links_reuse_the_last_scan_until_explicit_refresh(
 
     state["updated_at"] = "2026-02-02T00:00:00Z"
     module._external_links({}, connection)
-    assert scanned == 2, "normal reads should not revalidate a cached library"
+    assert scanned == 3, "a changed library state must trigger a re-walk"
 
     state["count"] = 2
     module._external_links({}, connection)
-    assert scanned == 2, "normal reads should not revalidate a cached library"
+    assert scanned == 4, "a changed library count must trigger a re-walk"
 
     module._external_links({}, connection, refresh=True)
-    assert scanned == 3, "the refresh task must force a rescan after library changes"
+    assert scanned == 5, "the refresh task must force a rescan after library changes"
 
 
 def test_every_user_visible_empty_and_error_message_is_defensive() -> None:


### PR DESCRIPTION
## What

The `external_links` cache (local → StashDB IDs + scene phashes, used to exclude already-owned scenes from Expand/Similar) was reused **unconditionally**: `cachedExternalLinks` was called with an empty/`None` state, which skips the stored-state comparison and returns the cached map forever. Scenes linked to StashDB **after** the last scan weren't recognized as owned and kept appearing as recommendations.

## Fix

Validate the cache against the current linked-library state (count + latest `updated_at` per kind) on each read, and re-walk only when it changed. A batch of new links coalesces into a single snapshot walk; routine edits (ratings/tags/titles) don't change the linked-set state, so they cause no scan.

- `core/links.go` — `externalLinksImpl` computes the state first and compares it in `cachedExternalLinks`.
- `plugin/backend.py` — mirrors exactly in `_external_links` (Python oracle parity).
- `tests/plugin/test_runtime.py` — `test_external_links_reuse_the_last_scan_until_explicit_refresh` now asserts a changed library state (`updated_at`/`count`) triggers a re-walk, while an unchanged state still reuses the cache.

## Verification

- Go core builds; `go vet` + `gofmt` clean.
- Python `ruff check` + `ruff format --check` clean.
- Updated regression test passes.
- Go↔Python cache-write parity and entity-hook byte-identity differential tests pass.
- Installed build verified: a scene linked to StashDB after the fix is recognized as already-owned and excluded.